### PR TITLE
Enforce Locale.US on many String.formats. 

### DIFF
--- a/gui/src/main/java/org/openpnp/gui/MachineControlsPanel.java
+++ b/gui/src/main/java/org/openpnp/gui/MachineControlsPanel.java
@@ -34,6 +34,7 @@ import java.awt.Window;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.util.Hashtable;
+import java.util.Locale;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
@@ -206,16 +207,16 @@ public class MachineControlsPanel extends JPanel {
 		
 		
 		if (!textFieldX.hasFocus()) {
-			textFieldX.setText(String.format(configuration.getLengthDisplayFormat(), x));
+			textFieldX.setText(String.format(Locale.US,configuration.getLengthDisplayFormat(), x));
 		}
 		if (!textFieldY.hasFocus()) {
-			textFieldY.setText(String.format(configuration.getLengthDisplayFormat(), y));
+			textFieldY.setText(String.format(Locale.US,configuration.getLengthDisplayFormat(), y));
 		}
 		if (!textFieldZ.hasFocus()) {
-			textFieldZ.setText(String.format(configuration.getLengthDisplayFormat(), z));
+			textFieldZ.setText(String.format(Locale.US,configuration.getLengthDisplayFormat(), z));
 		}
 		if (!textFieldC.hasFocus()) {
-			textFieldC.setText(String.format(configuration.getLengthDisplayFormat(), c));
+			textFieldC.setText(String.format(Locale.US,configuration.getLengthDisplayFormat(), c));
 		}
 	}
 	

--- a/gui/src/main/java/org/openpnp/gui/TableScanner.java
+++ b/gui/src/main/java/org/openpnp/gui/TableScanner.java
@@ -320,8 +320,8 @@ public class TableScanner extends JDialog implements Runnable {
 		@Override
 		public void actionPerformed(ActionEvent e) {
 			Camera camera = MainFrame.cameraPanel.getSelectedCamera();
-			txtStartX.setText(String.format("%2.3f", camera.getLocation().getX()));
-			txtStartY.setText(String.format("%2.3f", camera.getLocation().getY()));
+			txtStartX.setText(String.format(Locale.US,"%2.3f", camera.getLocation().getX()));
+			txtStartY.setText(String.format(Locale.US,"%2.3f", camera.getLocation().getY()));
 		}
 	};
 	
@@ -329,8 +329,8 @@ public class TableScanner extends JDialog implements Runnable {
 		@Override
 		public void actionPerformed(ActionEvent e) {
             Camera camera = MainFrame.cameraPanel.getSelectedCamera();
-			txtEndX.setText(String.format("%2.3f", camera.getLocation().getX()));
-			txtEndY.setText(String.format("%2.3f", camera.getLocation().getY()));
+			txtEndX.setText(String.format(Locale.US,"%2.3f", camera.getLocation().getX()));
+			txtEndY.setText(String.format(Locale.US,"%2.3f", camera.getLocation().getY()));
 		}
 	};
 	

--- a/gui/src/main/java/org/openpnp/gui/components/CameraView.java
+++ b/gui/src/main/java/org/openpnp/gui/components/CameraView.java
@@ -42,6 +42,7 @@ import java.awt.image.BufferedImage;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
@@ -1058,7 +1059,7 @@ public class CameraView extends JComponent implements CameraListener {
 			double heightInUnits = selection.height
 					* camera.getUnitsPerPixel().getY();
 
-			String text = String.format("%dpx, %dpx\n%2.3f%s, %2.3f%s",
+			String text = String.format(Locale.US,"%dpx, %dpx\n%2.3f%s, %2.3f%s",
 					(int) selection.getWidth(), (int) selection.getHeight(),
 					widthInUnits, camera.getUnitsPerPixel().getUnits()
 							.getShortName(), heightInUnits, camera

--- a/gui/src/main/java/org/openpnp/gui/components/ComponentDecorators.java
+++ b/gui/src/main/java/org/openpnp/gui/components/ComponentDecorators.java
@@ -25,6 +25,7 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.FocusAdapter;
 import java.awt.event.FocusEvent;
+import java.util.Locale;
 
 import javax.swing.JTextField;
 
@@ -88,6 +89,6 @@ public class ComponentDecorators {
 			length.setUnits(Configuration.get().getSystemUnits());
 		}
 		length = length.convertToUnits(Configuration.get().getSystemUnits());
-		textField.setText(String.format(Configuration.get().getLengthDisplayFormat(), length.getValue()));
+		textField.setText(String.format(Locale.US,Configuration.get().getLengthDisplayFormat(), length.getValue()));
 	}
 }

--- a/gui/src/main/java/org/openpnp/gui/importer/EagleMountsmdUlpImporter.java
+++ b/gui/src/main/java/org/openpnp/gui/importer/EagleMountsmdUlpImporter.java
@@ -139,6 +139,7 @@ public class EagleMountsmdUlpImporter implements BoardImporter {
 			placement.setSide(side);
 			placements.add(placement);
 		}
+		reader.close();
 		return placements;
 	}
 	

--- a/gui/src/main/java/org/openpnp/gui/importer/KicadPosImporter.java
+++ b/gui/src/main/java/org/openpnp/gui/importer/KicadPosImporter.java
@@ -156,6 +156,7 @@ public class KicadPosImporter implements BoardImporter {
 			placement.setSide(side);
 			placements.add(placement);
 		}
+		reader.close();
 		return placements;
 	}
 	

--- a/gui/src/main/java/org/openpnp/gui/support/DoubleConverter.java
+++ b/gui/src/main/java/org/openpnp/gui/support/DoubleConverter.java
@@ -21,6 +21,8 @@
 
 package org.openpnp.gui.support;
 
+import java.util.Locale;
+
 import org.jdesktop.beansbinding.Converter;
 
 public class DoubleConverter extends Converter<Double, String> {
@@ -32,7 +34,7 @@ public class DoubleConverter extends Converter<Double, String> {
 	
 	@Override
 	public String convertForward(Double arg0) {
-		return String.format(format, arg0);
+		return String.format(Locale.US,format, arg0);
 	}
 
 	@Override

--- a/gui/src/main/java/org/openpnp/gui/support/Helpers.java
+++ b/gui/src/main/java/org/openpnp/gui/support/Helpers.java
@@ -23,6 +23,7 @@ package org.openpnp.gui.support;
 
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.Locale;
 
 import javax.swing.JTable;
 import javax.swing.JTextField;
@@ -38,16 +39,16 @@ public class Helpers {
 	
 	public static void copyLocationIntoTextFields(Location l, JTextField x, JTextField y, JTextField z, JTextField rotation) {
 		if (x != null) {
-			x.setText(String.format(Configuration.get().getLengthDisplayFormat(), l.getLengthX().getValue()));
+			x.setText(String.format(Locale.US,Configuration.get().getLengthDisplayFormat(), l.getLengthX().getValue()));
 		}
 		if (y != null) {
-			y.setText(String.format(Configuration.get().getLengthDisplayFormat(), l.getLengthY().getValue()));
+			y.setText(String.format(Locale.US,Configuration.get().getLengthDisplayFormat(), l.getLengthY().getValue()));
 		}
 		if (z != null) {
-			z.setText(String.format(Configuration.get().getLengthDisplayFormat(), l.getLengthZ().getValue()));
+			z.setText(String.format(Locale.US,Configuration.get().getLengthDisplayFormat(), l.getLengthZ().getValue()));
 		}
 		if (rotation != null) {
-			rotation.setText(String.format(Configuration.get().getLengthDisplayFormat(), l.getRotation()));
+			rotation.setText(String.format(Locale.US,Configuration.get().getLengthDisplayFormat(), l.getRotation()));
 		}
 	}
 	

--- a/gui/src/main/java/org/openpnp/gui/support/IntegerConverter.java
+++ b/gui/src/main/java/org/openpnp/gui/support/IntegerConverter.java
@@ -21,6 +21,8 @@
 
 package org.openpnp.gui.support;
 
+import java.util.Locale;
+
 import org.jdesktop.beansbinding.Converter;
 
 public class IntegerConverter extends Converter<Integer, String> {
@@ -36,7 +38,7 @@ public class IntegerConverter extends Converter<Integer, String> {
 	
 	@Override
 	public String convertForward(Integer arg0) {
-		return String.format(format, arg0);
+		return String.format(Locale.US,format, arg0);
 	}
 
 	@Override

--- a/gui/src/main/java/org/openpnp/gui/support/LengthCellValue.java
+++ b/gui/src/main/java/org/openpnp/gui/support/LengthCellValue.java
@@ -21,6 +21,8 @@
 
 package org.openpnp.gui.support;
 
+import java.util.Locale;
+
 import org.openpnp.model.Configuration;
 import org.openpnp.model.Length;
 
@@ -76,14 +78,14 @@ public class LengthCellValue {
 	public String toString() {
 		Length l = length;
 		if (l.getUnits() == null) {
-			return String.format(configuration.getLengthDisplayFormatWithUnits(), l.getValue(), "?");
+			return String.format(Locale.US,configuration.getLengthDisplayFormatWithUnits(), l.getValue(), "?");
 		}
 		if (displayNativeUnits && l.getUnits() != configuration.getSystemUnits()) {
-			return String.format(configuration.getLengthDisplayFormatWithUnits(), l.getValue(), l.getUnits().getShortName());
+			return String.format(Locale.US,configuration.getLengthDisplayFormatWithUnits(), l.getValue(), l.getUnits().getShortName());
 		}
 		else {
 			l = l.convertToUnits(configuration.getSystemUnits());
-			return String.format(configuration.getLengthDisplayFormat(), l.getValue());
+			return String.format(Locale.US,configuration.getLengthDisplayFormat(), l.getValue());
 		}
 	}
 }

--- a/gui/src/main/java/org/openpnp/gui/support/LengthConverter.java
+++ b/gui/src/main/java/org/openpnp/gui/support/LengthConverter.java
@@ -21,6 +21,8 @@
 
 package org.openpnp.gui.support;
 
+import java.util.Locale;
+
 import org.jdesktop.beansbinding.Converter;
 import org.openpnp.model.Configuration;
 import org.openpnp.model.Length;
@@ -29,7 +31,7 @@ public class LengthConverter extends Converter<Length, String> {
 	@Override
 	public String convertForward(Length length) {
 		length = length.convertToUnits(Configuration.get().getSystemUnits());
-		return String.format(Configuration.get().getLengthDisplayFormat(), length.getValue());
+		return String.format(Locale.US,Configuration.get().getLengthDisplayFormat(), length.getValue());
 	}
 	
 	@Override

--- a/gui/src/main/java/org/openpnp/gui/tablemodel/BoardLocationsTableModel.java
+++ b/gui/src/main/java/org/openpnp/gui/tablemodel/BoardLocationsTableModel.java
@@ -21,6 +21,8 @@
 
 package org.openpnp.gui.tablemodel;
 
+import java.util.Locale;
+
 import javax.swing.table.AbstractTableModel;
 
 import org.openpnp.gui.support.LengthCellValue;
@@ -145,7 +147,7 @@ public class BoardLocationsTableModel extends AbstractTableModel {
 		case 4:
 			return new LengthCellValue(loc.getLengthZ());
 		case 5:
-			return String.format(configuration.getLengthDisplayFormat(), loc.getRotation(), "");
+			return String.format(Locale.US,configuration.getLengthDisplayFormat(), loc.getRotation(), "");
 		default:
 			return null;
 		}

--- a/gui/src/main/java/org/openpnp/gui/tablemodel/PlacementsTableModel.java
+++ b/gui/src/main/java/org/openpnp/gui/tablemodel/PlacementsTableModel.java
@@ -21,6 +21,8 @@
 
 package org.openpnp.gui.tablemodel;
 
+import java.util.Locale;
+
 import javax.swing.table.AbstractTableModel;
 
 import org.openpnp.gui.support.LengthCellValue;
@@ -140,7 +142,7 @@ public class PlacementsTableModel extends AbstractTableModel {
 		case 4:
 			return new LengthCellValue(loc.getLengthY(), true);
 		case 5:
-			return String.format(configuration.getLengthDisplayFormat(), loc.getRotation());
+			return String.format(Locale.US,configuration.getLengthDisplayFormat(), loc.getRotation());
 		case 6:
 		    return placement.isPlace();
 		default:

--- a/gui/src/main/java/org/openpnp/gui/wizards/CameraConfigurationWizard.java
+++ b/gui/src/main/java/org/openpnp/gui/wizards/CameraConfigurationWizard.java
@@ -24,6 +24,7 @@ package org.openpnp.gui.wizards;
 import java.awt.Color;
 import java.awt.Rectangle;
 import java.awt.event.ActionEvent;
+import java.util.Locale;
 
 import javax.swing.AbstractAction;
 import javax.swing.Action;
@@ -146,8 +147,8 @@ public class CameraConfigurationWizard extends AbstractConfigurationWizard {
 			}
 			cameraView.setSelectionEnabled(false);
 			Rectangle selection = cameraView.getSelection();
-			textFieldUppX.setText(String.format(Configuration.get().getLengthDisplayFormat(), (1.0 / selection.width)));
-			textFieldUppY.setText(String.format(Configuration.get().getLengthDisplayFormat(), (1.0 / selection.height)));
+			textFieldUppX.setText(String.format(Locale.US,Configuration.get().getLengthDisplayFormat(), (1.0 / selection.width)));
+			textFieldUppY.setText(String.format(Locale.US,Configuration.get().getLengthDisplayFormat(), (1.0 / selection.height)));
 		}
 	};
 	

--- a/gui/src/main/java/org/openpnp/machine/reference/camera/TableScannerCamera.java
+++ b/gui/src/main/java/org/openpnp/machine/reference/camera/TableScannerCamera.java
@@ -35,6 +35,7 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.TreeSet;
 
@@ -612,7 +613,7 @@ public class TableScannerCamera extends ReferenceCamera implements Runnable {
 		
 		@Override
 		public String toString() {
-			return String.format("[%2.3f, %2.3f (%d, %d)]", x, y, tileX, tileY);
+			return String.format(Locale.US,"[%2.3f, %2.3f (%d, %d)]", x, y, tileX, tileY);
 		}
 
 		@Override

--- a/gui/src/main/java/org/openpnp/machine/reference/driver/SimulatorDriver.java
+++ b/gui/src/main/java/org/openpnp/machine/reference/driver/SimulatorDriver.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.io.PrintStream;
 import java.net.Socket;
 import java.util.HashMap;
+import java.util.Locale;
 
 import javax.swing.Action;
 
@@ -142,7 +143,7 @@ public class SimulatorDriver implements ReferenceDriver {
             throw new Exception("Don't know what " + hm.toString() + " is.");
         }
         
-        send(String.format("m,%s,%f,%f,%f,%f", movable, location.getX(), location.getY(), location.getZ(), location.getRotation()));
+        send(String.format(Locale.US,"m,%s,%f,%f,%f,%f", movable, location.getX(), location.getY(), location.getZ(), location.getRotation()));
         
         // Now that movement is complete, update the stored Location to the new
         // Location, unless the incoming Location specified an axis with a value

--- a/gui/src/main/java/org/openpnp/machine/reference/driver/wizards/TinygDriverConfigurationWizard.java
+++ b/gui/src/main/java/org/openpnp/machine/reference/driver/wizards/TinygDriverConfigurationWizard.java
@@ -1,5 +1,7 @@
 package org.openpnp.machine.reference.driver.wizards;
 
+import java.util.Locale;
+
 import javax.swing.BoxLayout;
 import javax.swing.JCheckBox;
 import javax.swing.JComboBox;
@@ -641,21 +643,21 @@ public class TinygDriverConfigurationWizard extends AbstractConfigurationWizard 
         
         // TODO: Check for response errors in these methods.
         private int getConfigInt(String name) throws Exception {
-            JsonObject o = driver.sendCommand(String.format("{\"%s\":\"\"}", name));
+            JsonObject o = driver.sendCommand(String.format(Locale.US,"{\"%s\":\"\"}", name));
             return o.get(name).getAsInt();
         }
         
         private void setConfigInt(String name, int v) throws Exception {
-            JsonObject o = driver.sendCommand(String.format("{\"%s\":%d}", name, v));
+            JsonObject o = driver.sendCommand(String.format(Locale.US,"{\"%s\":%d}", name, v));
         }
         
         private double getConfigDouble(String name) throws Exception {
-            JsonObject o = driver.sendCommand(String.format("{\"%s\":\"\"}", name));
+            JsonObject o = driver.sendCommand(String.format(Locale.US,"{\"%s\":\"\"}", name));
             return o.get(name).getAsDouble();
         }
         
         private void setConfigDouble(String name, double v) throws Exception {
-            JsonObject o = driver.sendCommand(String.format("{\"%s\":%f}", name, v));
+            JsonObject o = driver.sendCommand(String.format(Locale.US,"{\"%s\":%f}", name, v));
         }
         
         private boolean getConfigBoolean(String name) throws Exception {

--- a/gui/src/main/java/org/openpnp/model/Length.java
+++ b/gui/src/main/java/org/openpnp/model/Length.java
@@ -21,6 +21,8 @@
 
 package org.openpnp.model;
 
+import java.util.Locale;
+
 import org.simpleframework.xml.Attribute;
 
 
@@ -167,7 +169,7 @@ public class Length {
 	
 	@Override
 	public String toString() {
-		return String.format("%2.3f%s", value, units.getShortName());
+		return String.format(Locale.US,"%2.3f%s", value, units.getShortName());
 	}
 	
 	/**
@@ -181,7 +183,7 @@ public class Length {
 		if (fmt == null) {
 			return toString();
 		}
-		return String.format(fmt, value, units.getShortName());
+		return String.format(Locale.US,fmt, value, units.getShortName());
 	}
 	
 	@Override

--- a/gui/src/main/java/org/openpnp/model/Location.java
+++ b/gui/src/main/java/org/openpnp/model/Location.java
@@ -21,6 +21,8 @@
 
 package org.openpnp.model;
 
+import java.util.Locale;
+
 import org.simpleframework.xml.Attribute;
 
 /**
@@ -228,7 +230,7 @@ public class Location {
 	
 	@Override
 	public String toString() {
-		return String.format("units %s, x %f, y %f, z %f, rotation %f", units.getShortName(), x, y, z, rotation);
+		return String.format(Locale.US,"units %s, x %f, y %f, z %f, rotation %f", units.getShortName(), x, y, z, rotation);
 	}
 	
 	public Point getXyPoint() {

--- a/gui/src/main/java/org/openpnp/model/Point.java
+++ b/gui/src/main/java/org/openpnp/model/Point.java
@@ -21,6 +21,8 @@
 
 package org.openpnp.model;
 
+import java.util.Locale;
+
 import org.simpleframework.xml.Attribute;
 
 public class Point {
@@ -60,6 +62,6 @@ public class Point {
 	
 	@Override
 	public String toString() {
-		return String.format("%f, %f", x, y);
+		return String.format(Locale.US,"%f, %f", x, y);
 	}
 }


### PR DESCRIPTION
Not doing this, cause numbers to be displayed with "," (comma) instead of "." (dot) in some locales. And the number parsers can not cope with that and drop numbers after the dot. Which makes all the input fields not really usable in locales with "," as number separator. 
