### PR TITLE
Fixed bug in JobPanel and EagleBoardImporter

### DIFF
--- a/src/main/java/org/openpnp/gui/JobPanel.java
+++ b/src/main/java/org/openpnp/gui/JobPanel.java
@@ -654,20 +654,22 @@ public class JobPanel extends JPanel {
         try {
             Board importedBoard = boardImporter
                     .importBoard((Frame) getTopLevelAncestor());
-            Board existingBoard = getSelectedBoardLocation().getBoard();
-            for (Placement placement : importedBoard.getPlacements()) {
-                existingBoard.addPlacement(placement);
+            if (importedBoard != null) {
+                Board existingBoard = getSelectedBoardLocation().getBoard();
+                for (Placement placement : importedBoard.getPlacements()) {
+                    existingBoard.addPlacement(placement);
+                }
+                for (BoardPad pad : importedBoard.getSolderPastePads()) {
+                    // TODO: This is a temporary hack until we redesign the importer
+                    // interface to be more intuitive. The Gerber importer tends
+                    // to return everything in Inches, so this is a method to
+                    // try to get it closer to what the user expects to see.
+                    pad.setLocation(pad.getLocation().convertToUnits(getSelectedBoardLocation().getLocation().getUnits()));
+                    existingBoard.addSolderPastePad(pad);
+                }
+                jobPlacementsPanel.setBoardLocation(getSelectedBoardLocation());
+                jobPastePanel.setBoardLocation(getSelectedBoardLocation());
             }
-            for (BoardPad pad : importedBoard.getSolderPastePads()) {
-                // TODO: This is a temporary hack until we redesign the importer
-                // interface to be more intuitive. The Gerber importer tends
-                // to return everything in Inches, so this is a method to
-                // try to get it closer to what the user expects to see.
-                pad.setLocation(pad.getLocation().convertToUnits(getSelectedBoardLocation().getLocation().getUnits()));
-                existingBoard.addSolderPastePad(pad);
-            }
-            jobPlacementsPanel.setBoardLocation(getSelectedBoardLocation());
-            jobPastePanel.setBoardLocation(getSelectedBoardLocation());
         }
         catch (Exception e) {
             MessageBoxes.errorBox(getTopLevelAncestor(), "Import Failed", e);

--- a/src/main/java/org/openpnp/gui/importer/EagleBoardImporter.java
+++ b/src/main/java/org/openpnp/gui/importer/EagleBoardImporter.java
@@ -193,7 +193,7 @@ public class EagleBoardImporter implements BoardImporter {
 					        0,
 					        rotation));
 					
-					//placement now contains where the package is on the PCB, we need to work out whre the pads
+					//placement now contains where the package is on the PCB, we need to work out where the pads
 					//are relative to the 'placement'
 					Configuration cfg = Configuration.get();
 		            if (cfg != null && createMissingParts) {
@@ -201,23 +201,33 @@ public class EagleBoardImporter implements BoardImporter {
 		                String packageId = element.getPackage(); //Package
 		                String libraryId = element.getLibrary(); //Library that contains the package
 		                
+		                String pkgId  = libraryId + "-" + packageId;
+		                
 		                String partId = libraryId + "-" + packageId;
 		                if (value.trim().length() > 0) {
 		                    partId += "-" + value;
 		                }
+		                
 		                Part part = cfg.getPart(partId);
-		                if (part == null) {
-		                    part = new Part(partId);
-		                    Package pkg = cfg.getPackage(packageId);
+		                Package pkg = cfg.getPackage(pkgId);
+		                
+		                if ((part == null) || (pkg == null)) {
+		                    
 		                    if (pkg == null) {
-		                        pkg = new Package(libraryId + "-" + packageId);
-		                        
+		                        pkg = new Package(pkgId);
             		            cfg.addPackage(pkg); //save the package in the configuration file
+            		            if (part != null) {
+            		            	cfg.removePart(part);//we have to remove the part so we can re-add it with the correct package & library
+            		            	part = null;
+            		            }
+            		            
+		                    }
+		                	if (part == null) {
+		                		part = new Part(partId);
             			        part.setPackage(pkg);
             			        part.setLibrary(libraryId);
-
-            			        cfg.addPart(part);
-		                    }
+            			        cfg.addPart(part); //save the package in the configuration file
+		                	}
 		                }
 		                placement.setPart(part);
 		                

--- a/src/main/java/org/openpnp/gui/importer/EagleBoardImporter.java
+++ b/src/main/java/org/openpnp/gui/importer/EagleBoardImporter.java
@@ -114,6 +114,9 @@ public class EagleBoardImporter implements BoardImporter {
 		double mmMinCreamFrame_number = 0;
 		String mmMaxCreamFrame_string;
 		double mmMaxCreamFrame_number = 0;
+		String libraryId = "";
+		String packageId = "";
+		Part part = null;
 		
 		List<BoardPad> pads = new ArrayList<BoardPad>();
 		
@@ -198,8 +201,8 @@ public class EagleBoardImporter implements BoardImporter {
 					Configuration cfg = Configuration.get();
 		            if (cfg != null && createMissingParts) {
 		                String value = element.getValue(); // Value
-		                String packageId = element.getPackage(); //Package
-		                String libraryId = element.getLibrary(); //Library that contains the package
+		                packageId = element.getPackage(); //Package
+		                libraryId = element.getLibrary(); //Library that contains the package
 		                
 		                String pkgId  = libraryId + "-" + packageId;
 		                
@@ -208,7 +211,7 @@ public class EagleBoardImporter implements BoardImporter {
 		                    partId += "-" + value;
 		                }
 		                
-		                Part part = cfg.getPart(partId);
+		                part = cfg.getPart(partId);
 		                Package pkg = cfg.getPackage(pkgId);
 		                
 		                if ((part == null) || (pkg == null)) {
@@ -225,15 +228,11 @@ public class EagleBoardImporter implements BoardImporter {
 		                	if (part == null) {
 		                		part = new Part(partId);
             			        part.setPackage(pkg);
-<<<<<<< HEAD
-            			        part.setLibrary(libraryId);
+// TODO            			        part.setLibrary(libraryId);
             			        cfg.addPart(part); //save the package in the configuration file
 		                	}
-=======
-
             			        cfg.addPart(part);
 		                    }
->>>>>>> 47b2d6aef2fbbd25662d1372931f0e57845a4ad6
 		                }
 		                placement.setPart(part);
 		                
@@ -322,7 +321,7 @@ public class EagleBoardImporter implements BoardImporter {
                         				}
                         			}
                         		}
-                        	}
+  //                      	}
                         }
 		            }
 


### PR DESCRIPTION
Fixed bug in JobPanel where it would crash with NULL error if you "cancel" out of the board importer dialog.  Note this was not trapped as an exception by Java so I have to explicitly test for "null"

Hopefully fixed a bug where after importing a board that has parts that are not already in my Parts and Packages they are not created.