### PR TITLE
solves issue #178 (error picking a strip located at 180 degrees

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/feeder/ReferenceStripFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/ReferenceStripFeeder.java
@@ -271,17 +271,18 @@ public class ReferenceStripFeeder extends ReferenceFeeder {
     // Stolen from StackOverflow
     static public double getAngleFromPoint(Location firstPoint,
             Location secondPoint) {
+    	double angle = 0.0;
         // above 0 to 180 degrees
         if ((secondPoint.getX() > firstPoint.getX())) {
-            return (Math.atan2((secondPoint.getX() - firstPoint.getX()),
+            angle = (Math.atan2((secondPoint.getX() - firstPoint.getX()),
                     (firstPoint.getY() - secondPoint.getY())) * 180 / Math.PI);
         }
         // above 180 degrees to 360/0
-        else if ((secondPoint.getX() < firstPoint.getX())) {
-            return 360 - (Math.atan2((firstPoint.getX() - secondPoint.getX()),
+        else if ((secondPoint.getX() <= firstPoint.getX())) {
+            angle = 360 - (Math.atan2((firstPoint.getX() - secondPoint.getX()),
                     (firstPoint.getY() - secondPoint.getY())) * 180 / Math.PI);
         }
-        return Math.atan2(0, 0);
+        return angle;
     }
 	
 	public TapeType getTapeType() {


### PR DESCRIPTION
When the strip is located at 180 degrees and the X coordinates of the two holes are the same (for example if they are put manually), the code computes the angle as atan(0,0), because the two if conditions are false. I have changed the second condition to <= to compute the correct angle based on the Y coordinates.
