### PR TITLE
added dwell on drivers for timing on gcode executor (microcontroller) instead of PC, 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 doc
 bin
 target
+code
 
 installers
 .settings

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@ doc
 bin
 target
 code
+old
+dead
 
 installers
 .settings
@@ -9,4 +11,5 @@ installers
 .idea
 *.iml
 .classpath
+err
 src/main/resources/icons/src/Soft_Scraps_by_deleket

--- a/src/main/java/org/firepick/driver/FireStepDriver.java
+++ b/src/main/java/org/firepick/driver/FireStepDriver.java
@@ -33,6 +33,7 @@ import java.util.List;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.TimeoutException;
+import java.util.List;
 
 import javax.swing.Action;
 
@@ -81,6 +82,7 @@ public class FireStepDriver extends AbstractSerialPortDriver implements Runnable
 	private String connectedVersion;
 	private Queue<String> responseQueue = new ConcurrentLinkedQueue<String>();
 	
+	private boolean enabled;
 	@Override
 	public void setEnabled(boolean enabled) throws Exception {
 	    if (enabled) {
@@ -119,6 +121,7 @@ public class FireStepDriver extends AbstractSerialPortDriver implements Runnable
 	    		}
 	    	}
 	    }
+		this.enabled=enabled;
 	}
 	
 	@Override
@@ -475,15 +478,48 @@ public class FireStepDriver extends AbstractSerialPortDriver implements Runnable
 		}
 	}
 	
-	private List<String> drainResponseQueue() {
-		List<String> responses = new ArrayList<String>();
-		String response;
-		while ((response = responseQueue.poll()) != null) {
-			responses.add(response);
-		}
-		return responses;
-	}
+                List<String> responses = new ArrayList<String>();
+
+        @Override
+        public List<String> Msg() { return responses; }
+
+        private List<String> drainResponseQueue() {
+                responses.clear();
+                String response;
+                while ((response = responseQueue.poll()) != null) {
+                        responses.add(response);
+                }
+                return responses;
+        }
+
+
 	
+        @Override
+        public void dwell(double seconds) throws Exception {
+		seconds*=1000;
+		Thread.sleep((long)seconds);
+        }
+
+        @Override
+        public void dwell() throws Exception {
+						
+        }
+
+        @Override
+        public boolean GCode(String command) throws Exception {
+                return  GCode(command, -1);
+        }
+
+        @Override
+        public boolean GCode(String command, long timeout) throws Exception {
+                if(connected&&enabled) {
+                        sendCommand(command, timeout);
+                        return true;
+                }
+                        return false;
+        }
+
+
 	@Override
 	public Wizard getConfigurationWizard() {
 		//return null;

--- a/src/main/java/org/openpnp/machine/reference/ReferenceActuator.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceActuator.java
@@ -99,6 +99,11 @@ public class ReferenceActuator extends AbstractActuator implements ReferenceHead
     }
 
     @Override
+    public void dwell(long ms) throws Exception {
+		driver.dwell(ms/1000.);
+    }
+
+    @Override
     public void moveTo(Location location, double speed) throws Exception {
 		logger.debug("{}.moveTo({}, {})", new Object[] { getName(), location, speed } );
 		driver.moveTo(this, location, speed);

--- a/src/main/java/org/openpnp/machine/reference/ReferenceCamera.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceCamera.java
@@ -76,6 +76,11 @@ public abstract class ReferenceCamera extends AbstractCamera implements Referenc
             }
         });
     }
+
+    @Override
+    public void dwell(long time) throws Exception {
+	driver.dwell(time/1000.); 
+    }
     
     @Override
     public Location getHeadOffsets() {

--- a/src/main/java/org/openpnp/machine/reference/ReferenceDriver.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceDriver.java
@@ -22,6 +22,7 @@
 package org.openpnp.machine.reference;
 
 import java.io.Closeable;
+import java.util.List;
 
 import org.openpnp.model.Location;
 import org.openpnp.spi.PropertySheetHolder;
@@ -94,6 +95,7 @@ public interface ReferenceDriver extends WizardConfigurable, PropertySheetHolder
      */
     public void place(ReferenceNozzle nozzle) throws Exception;
 
+
     /**
      * Actuates a machine defined object with a boolean state.
      * 
@@ -112,6 +114,7 @@ public interface ReferenceDriver extends WizardConfigurable, PropertySheetHolder
      */
     public void actuate(ReferenceActuator actuator, double value) throws Exception;
 
+    
     /**
      * Attempts to enable the Driver, turning on all outputs.
      * 
@@ -121,4 +124,27 @@ public interface ReferenceDriver extends WizardConfigurable, PropertySheetHolder
     public void setEnabled(boolean enabled) throws Exception;
     
     public void dispense(ReferencePasteDispenser dispenser, Location startLocation, Location endLocation, long dispenseTimeMilliseconds) throws Exception;
+
+    /**
+     * waits until motion is finished
+     * 
+     * @throws Exception
+     */
+	public  void dwell()  throws Exception;
+    
+    /**
+     * waits Seconds and returns after
+     * 
+     * @throws Exception
+     */
+	public  void dwell(double Seconds)  throws Exception;
+
+    /**
+     *  Gcode interface
+     * 
+     * @throws Exception
+     */
+	public  boolean GCode(String command) throws Exception ;
+	public  boolean GCode(String command, long timeout) throws Exception;
+	public  List<String> Msg(); 
 }

--- a/src/main/java/org/openpnp/machine/reference/ReferenceJobProcessor.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceJobProcessor.java
@@ -281,7 +281,7 @@ public class ReferenceJobProcessor extends AbstractJobProcessor {
 
                 try {
                     camera.moveTo(feeder.getPickLocation().derive(null, null, Double.NaN, null), 1.0);
-                    Thread.sleep(750);
+                    camera.dwell(750);
                 }
                 catch (Exception e) {
                     fireJobEncounteredError(JobError.MachineMovementError, e.getMessage());
@@ -306,7 +306,7 @@ public class ReferenceJobProcessor extends AbstractJobProcessor {
 
                 try {
                     camera.moveTo(placementLocation.derive(null, null, Double.NaN, null), 1.0);
-                    Thread.sleep(750);
+                    camera.dwell(750);
                 }
                 catch (Exception e) {
                     fireJobEncounteredError(JobError.MachineMovementError, e.getMessage());

--- a/src/main/java/org/openpnp/machine/reference/ReferenceNozzle.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceNozzle.java
@@ -110,6 +110,12 @@ public class ReferenceNozzle extends AbstractNozzle implements
     }
 
     @Override
+    public void dwell(long time) throws Exception {
+        	driver.dwell(pickDwellMilliseconds/1000.);
+
+    }
+
+    @Override
     public void pick() throws Exception {
 		logger.debug("{}.pick()", getName());
 		if (nozzleTip == null) {
@@ -117,7 +123,7 @@ public class ReferenceNozzle extends AbstractNozzle implements
 		}
 		driver.pick(this);
         machine.fireMachineHeadActivity(head);
-        Thread.sleep(pickDwellMilliseconds);
+        	dwell(pickDwellMilliseconds);
     }
 
     @Override
@@ -128,13 +134,13 @@ public class ReferenceNozzle extends AbstractNozzle implements
         }
 		driver.place(this);
         machine.fireMachineHeadActivity(head);
-        Thread.sleep(placeDwellMilliseconds);
+        	driver.dwell(placeDwellMilliseconds/1000.);
     }
 
     @Override
     public void moveTo(Location location, double speed) throws Exception {
         logger.debug("{}.moveTo({}, {})", new Object[] { getName(), location, speed } );
-        if (limitRotation && !Double.isNaN(location.getRotation()) && Math.abs(location.getRotation()) > 180) {
+        while (limitRotation && !Double.isNaN(location.getRotation()) && Math.abs(location.getRotation()) > 180) {
             if (location.getRotation() < 0) {
                 location = location.derive(null, null, null, location.getRotation() + 360);
             }

--- a/src/main/java/org/openpnp/machine/reference/ReferencePasteDispenser.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferencePasteDispenser.java
@@ -61,6 +61,11 @@ public class ReferencePasteDispenser extends AbstractPasteDispenser implements
     }
 
     @Override
+    public void dwell(long ms) throws Exception {
+        driver.dwell(ms/1000.);
+    }
+
+    @Override
     public void moveTo(Location location, double speed) throws Exception {
         logger.debug("{}.moveTo({}, {})", new Object[] { getName(), location, speed } );
         driver.moveTo(this, location, speed);

--- a/src/main/java/org/openpnp/machine/reference/camera/wizards/LtiCivilCameraConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/camera/wizards/LtiCivilCameraConfigurationWizard.java
@@ -23,6 +23,7 @@ package org.openpnp.machine.reference.camera.wizards;
 
 import java.awt.Color;
 
+
 import javax.swing.JCheckBox;
 import javax.swing.JComboBox;
 import javax.swing.JLabel;

--- a/src/main/java/org/openpnp/machine/reference/driver/NullDriver.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/NullDriver.java
@@ -27,6 +27,9 @@ import java.util.HashMap;
 import javax.swing.Action;
 import javax.swing.Icon;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.openpnp.gui.support.PropertySheetWizardAdapter;
 import org.openpnp.gui.support.Wizard;
 import org.openpnp.machine.reference.ReferenceActuator;
@@ -281,6 +284,34 @@ public class NullDriver implements ReferenceDriver {
         logger.debug("setEnabled({})", enabled);
         this.enabled = enabled;
     }
+
+        @Override
+        public void dwell(double seconds) throws Exception {
+		seconds*=1000;
+		Thread.sleep((long)seconds);
+        }
+
+        @Override
+        public void dwell() throws Exception {
+        }
+
+        @Override
+        public boolean GCode(String command) throws Exception {
+                return  true;
+        }
+
+        @Override
+        public boolean GCode(String command, long timeout) throws Exception {
+                        return true;
+        }
+
+
+        @Override
+        public List<String> Msg() { return new ArrayList<String>(); }
+
+
+
+
 
     @Override
     public Wizard getConfigurationWizard() {

--- a/src/main/java/org/openpnp/machine/reference/driver/SimulatorDriver.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/SimulatorDriver.java
@@ -27,6 +27,8 @@ import java.io.PrintStream;
 import java.net.Socket;
 import java.util.HashMap;
 import java.util.Locale;
+import java.util.ArrayList;
+import java.util.List;
 
 import javax.swing.Action;
 import javax.swing.Icon;
@@ -249,6 +251,35 @@ public class SimulatorDriver implements ReferenceDriver {
             e.printStackTrace();
         }
     }
+
+        @Override
+        public void dwell(double seconds) throws Exception {
+		seconds*=1000;
+		Thread.sleep((long)seconds);
+        }
+
+        @Override
+        public void dwell() throws Exception {
+        }
+
+        @Override
+        public boolean GCode(String command) throws Exception {
+                return  GCode(command, -1);
+        }
+
+        @Override
+        public boolean GCode(String command, long timeout) throws Exception {
+                        return true;
+        }
+
+
+        @Override
+        public List<String> Msg() { return new ArrayList<String>(); }
+
+
+
+
+
     
     @Override
     public Wizard getConfigurationWizard() {

--- a/src/main/java/org/openpnp/machine/reference/feeder/ReferenceTapeFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/ReferenceTapeFeeder.java
@@ -218,7 +218,7 @@ public class ReferenceTapeFeeder extends ReferenceFeeder {
 //		head.moveTo(head.getX(), head.getY(), z, head.getC());
 		
 		// Settle the camera
-		Thread.sleep(camera.getSettleTimeMs());
+		camera.dwell(camera.getSettleTimeMs());
 		
 		VisionProvider visionProvider = camera.getVisionProvider();
 		

--- a/src/main/java/org/openpnp/model/Location.java
+++ b/src/main/java/org/openpnp/model/Location.java
@@ -113,9 +113,8 @@ public class Location {
 	}
 
 	public double getLinearDistanceTo(double x, double y) {
-		return (Math.sqrt(Math.pow(this.x - x, 2) + Math.pow(this.y - x, 2 )));
+		return (Math.sqrt(Math.pow(this.x - x, 2) + Math.pow(this.y - y, 2)));
 	}
-	
 	
 	public double getXyzDistanceTo(Location location) {
 	    location = location.convertToUnits(getUnits());
@@ -134,9 +133,6 @@ public class Location {
 		return new Length(z, units);
 	}
 	
-	public Location get() {
-        	return new Location(units, x , y ,z ,rotation ).convertToUnits(LengthUnit.Millimeters);
-	}
 	/**
 	 * Returns a new Location with the given Location's X, Y, and Z components
 	 * subtracted from this Location's X, Y, and Z components. Rotation is left
@@ -252,8 +248,6 @@ public class Location {
                 rotation == null ? this.rotation : rotation
 	            );
 	}
-
-	
 	
 	/**
 	 * Returns a new Location with this Location's X and Y rotated by angle.

--- a/src/main/java/org/openpnp/model/Location.java
+++ b/src/main/java/org/openpnp/model/Location.java
@@ -113,8 +113,9 @@ public class Location {
 	}
 
 	public double getLinearDistanceTo(double x, double y) {
-		return (Math.sqrt(Math.pow(this.x - x, 2) + Math.pow(this.y - y, 2)));
+		return (Math.sqrt(Math.pow(this.x - x, 2) + Math.pow(this.y - x, 2 )));
 	}
+	
 	
 	public double getXyzDistanceTo(Location location) {
 	    location = location.convertToUnits(getUnits());
@@ -133,6 +134,9 @@ public class Location {
 		return new Length(z, units);
 	}
 	
+	public Location get() {
+        	return new Location(units, x , y ,z ,rotation ).convertToUnits(LengthUnit.Millimeters);
+	}
 	/**
 	 * Returns a new Location with the given Location's X, Y, and Z components
 	 * subtracted from this Location's X, Y, and Z components. Rotation is left
@@ -248,6 +252,8 @@ public class Location {
                 rotation == null ? this.rotation : rotation
 	            );
 	}
+
+	
 	
 	/**
 	 * Returns a new Location with this Location's X and Y rotated by angle.

--- a/src/main/java/org/openpnp/model/Part.java
+++ b/src/main/java/org/openpnp/model/Part.java
@@ -87,6 +87,10 @@ public class Part extends AbstractModelObject implements Identifiable {
 	public Length getHeight() {
 		return new Length(height, heightUnits);
 	}
+
+	public Length getRadius() {
+		return new Length(5,heightUnits);
+	}
 	
 	public void setHeight(Length height) {
 		Object oldValue = getHeight();

--- a/src/main/java/org/openpnp/spi/Camera.java
+++ b/src/main/java/org/openpnp/spi/Camera.java
@@ -110,4 +110,5 @@ public interface Camera extends Identifiable, Named, HeadMountable, WizardConfig
 	 */
 	public long getSettleTimeMs();
 	public void setSettleTimeMs(long settleTimeMs);
+
 }

--- a/src/main/java/org/openpnp/spi/Movable.java
+++ b/src/main/java/org/openpnp/spi/Movable.java
@@ -16,4 +16,5 @@ public interface Movable extends Locatable {
     public void moveTo(Location location, double speed) throws Exception;
     
     public void moveToSafeZ(double speed) throws Exception;
+    public void dwell(long ms) throws Exception;
 }

--- a/src/main/java/org/openpnp/spi/base/AbstractCamera.java
+++ b/src/main/java/org/openpnp/spi/base/AbstractCamera.java
@@ -129,7 +129,7 @@ public abstract class AbstractCamera implements Camera {
     
     public BufferedImage settleAndCapture() {
     	try {
-    		Thread.sleep(getSettleTimeMs());
+    		dwell(getSettleTimeMs());
     	}
     	catch (Exception e) {
     		

--- a/src/main/java/org/openpnp/util/MovableUtils.java
+++ b/src/main/java/org/openpnp/util/MovableUtils.java
@@ -20,4 +20,18 @@ public class MovableUtils {
         hm.moveTo(location.derive(null, null, Double.NaN, null), speed);
         hm.moveTo(location, speed);
     }
+
+    public static void move(HeadMountable hm, Location location, double speed) throws Exception {
+	// TODO make optimisation 
+	// TODO make check for movement
+        hm.moveToSafeZ(speed);
+        hm.moveTo(location.derive(null, null, Double.NaN, null), speed);
+        hm.moveTo(location, speed);
+    }
+
+	public static void dwell(long milliseconds) throws Exception {
+		Thread.sleep(milliseconds);
+	}
 }
+
+

--- a/src/main/java/org/openpnp/vision/FiducialLocator.java
+++ b/src/main/java/org/openpnp/vision/FiducialLocator.java
@@ -114,7 +114,7 @@ public class FiducialLocator {
         BufferedImage template = createTemplate(camera.getUnitsPerPixel(), footprint);
         
         // Wait for camera to settle
-        Thread.sleep(camera.getSettleTimeMs());
+        camera.dwell(camera.getSettleTimeMs());
         // Perform vision operation
         return getBestTemplateMatch(camera, template);
     }
@@ -175,7 +175,7 @@ public class FiducialLocator {
         
         for (int i = 0; i < 3; i++) {
             // Wait for camera to settle
-            Thread.sleep(camera.getSettleTimeMs());
+            camera.dwell(camera.getSettleTimeMs());
             // Perform vision operation
             location = getBestTemplateMatch(camera, template);
             if (location == null) {

--- a/src/test/java/VisionUtilsTest.java
+++ b/src/test/java/VisionUtilsTest.java
@@ -169,6 +169,11 @@ public class VisionUtilsTest {
         }
 
         @Override
+        public void dwell(long ms) throws Exception {
+		Thread.sleep(ms);
+        }
+
+        @Override
         public int getHeight() {
             return 480;
         }

--- a/src/test/java/org/openpnp/machine/reference/driver/test/TestDriver.java
+++ b/src/test/java/org/openpnp/machine/reference/driver/test/TestDriver.java
@@ -1,6 +1,8 @@
 package org.openpnp.machine.reference.driver.test;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
 import javax.swing.Action;
 import javax.swing.Icon;
@@ -117,6 +119,40 @@ public class TestDriver implements ReferenceDriver {
         logger.debug("setEnabled({})", enabled);
         delegate.setEnabled(enabled);
     }
+
+
+        @Override
+        public List<String> Msg() { 
+        	logger.debug("Msg()");
+        return	delegate.Msg();
+	}
+
+
+        @Override
+        public void dwell(double seconds) throws Exception {
+        	logger.debug("dwell({})", seconds);
+        	delegate.dwell(seconds);
+        }
+
+        @Override
+        public void dwell() throws Exception {
+        	logger.debug("dwell()" );
+        	delegate.dwell();
+        }
+
+        @Override
+        public boolean GCode(String command) throws Exception {
+        	logger.debug("GCode({})", command);
+        return	delegate.GCode(command);
+            // TODO Auto-generated method stub
+        }
+
+        @Override
+        public boolean GCode(String command, long timeout) throws Exception {
+        	logger.debug("GCode(},{})", command,timeout);
+        return	delegate.GCode(command,timeout);
+            // TODO Auto-generated method stub
+        }
     
     public static class TestDriverDelegate implements ReferenceDriver {
 
@@ -220,7 +256,32 @@ public class TestDriver implements ReferenceDriver {
             // TODO Auto-generated method stub
             
         }
-    }
+
+        @Override
+        public List<String> Msg() { return new ArrayList<String>(); }
+
+        @Override
+        public void dwell(double seconds) throws Exception {
+            // TODO Auto-generated method stub
+        }
+
+        @Override
+        public void dwell() throws Exception {
+            // TODO Auto-generated method stub
+        }
+
+        @Override
+        public boolean GCode(String command) throws Exception {
+            // TODO Auto-generated method stub
+		return true;
+        }
+
+        @Override
+        public boolean GCode(String command, long timeout) throws Exception {
+            // TODO Auto-generated method stub
+		return true;
+        }
+}
 
     @Override
     public String getPropertySheetHolderTitle() {
@@ -257,4 +318,5 @@ public class TestDriver implements ReferenceDriver {
         // TODO Auto-generated method stub
         
     }
+
 }


### PR DESCRIPTION
I have not touched the driver behavior , it's still uses the "new" driver
model where the move must complete before call returns from moveTo .
I have only added code that if removing that, other timing code works.


Introduced driver dwell for not "old" driver model where commands
are asyncron and . 
The advantage is, that timing is not depend on PC, but are timed by microcontroller and this allow faster execution and less poblems with camera timing.
Further GCode interface and Msg interface was added. The intended purpose
beside switching coordinates on some JobPlanner is for test and setup purposes.
As example, automatic test sequences that move machine and test accuracy
increasing feed rate or acceleration automatically.
For drivers, as example the Firepick driver, the support is missing,
there have the own tests. For other drivers, it should work.
In the case you discover driver wait seconds instead of milliseconds,
the code inside dwell need to be changed. I have checked several driver docs,
but not double checked.