### PR TITLE
Simplify the generics declaration by using the diamond operator ("<>") to reduce the verbosity of generics code.

### DIFF
--- a/src/main/java/org/firepick/driver/FireStepDriver.java
+++ b/src/main/java/org/firepick/driver/FireStepDriver.java
@@ -79,7 +79,7 @@ public class FireStepDriver extends AbstractSerialPortDriver implements Runnable
 	private Object commandLock = new Object();
 	private boolean connected;
 	private String connectedVersion;
-	private Queue<String> responseQueue = new ConcurrentLinkedQueue<String>();
+	private Queue<String> responseQueue = new ConcurrentLinkedQueue<>();
 	
 	@Override
 	public void setEnabled(boolean enabled) throws Exception {
@@ -476,7 +476,7 @@ public class FireStepDriver extends AbstractSerialPortDriver implements Runnable
 	}
 	
 	private List<String> drainResponseQueue() {
-		List<String> responses = new ArrayList<String>();
+		List<String> responses = new ArrayList<>();
 		String response;
 		while ((response = responseQueue.poll()) != null) {
 			responses.add(response);

--- a/src/main/java/org/firepick/driver/MarlinDriver.java
+++ b/src/main/java/org/firepick/driver/MarlinDriver.java
@@ -67,7 +67,7 @@ public class MarlinDriver extends AbstractSerialPortDriver implements Runnable {
 	private Object commandLock = new Object();
 	private boolean connected;
 	private double connectedVersion;
-	private Queue<String> responseQueue = new ConcurrentLinkedQueue<String>();
+	private Queue<String> responseQueue = new ConcurrentLinkedQueue<>();
 	
 //	public MarlinDriver() {
 //        Configuration.get().addListener(new ConfigurationListener.Adapter() {
@@ -369,7 +369,7 @@ public class MarlinDriver extends AbstractSerialPortDriver implements Runnable {
 	}
 
 	private List<String> drainResponseQueue() {
-		List<String> responses = new ArrayList<String>();
+		List<String> responses = new ArrayList<>();
 		String response;
 		while ((response = responseQueue.poll()) != null) {
 			responses.add(response);

--- a/src/main/java/org/firepick/driver/SmoothieDriver.java
+++ b/src/main/java/org/firepick/driver/SmoothieDriver.java
@@ -68,7 +68,7 @@ public class SmoothieDriver extends AbstractSerialPortDriver implements Runnable
 	private Object commandLock = new Object();
 	private boolean connected;
 	//private double connectedVersion;
-	private Queue<String> responseQueue = new ConcurrentLinkedQueue<String>();
+	private Queue<String> responseQueue = new ConcurrentLinkedQueue<>();
 	
 //	public SmootiheDriver() {
 //        Configuration.get().addListener(new ConfigurationListener.Adapter() {
@@ -366,7 +366,7 @@ public class SmoothieDriver extends AbstractSerialPortDriver implements Runnable
 	}
 
 	private List<String> drainResponseQueue() {
-		List<String> responses = new ArrayList<String>();
+		List<String> responses = new ArrayList<>();
 		String response;
 		while ((response = responseQueue.poll()) != null) {
 			responses.add(response);

--- a/src/main/java/org/openpnp/experiments/FiducialTest.java
+++ b/src/main/java/org/openpnp/experiments/FiducialTest.java
@@ -80,7 +80,7 @@ public class FiducialTest {
     static public Point fiducial(Mat gray, int min, int max) throws Exception {
         final List<MatOfPoint> contours = new ArrayList<>();
         // final List<Rect> box = new ArrayList<>();
-        final List<RotatedRect> box = new ArrayList<RotatedRect>();
+        final List<RotatedRect> box = new ArrayList<>();
         final List<Double> dist = new ArrayList<>();
         final Mat dummy = new Mat();
         // final Mat gray= OpenCvUtils.toMat(image,Highgui.IMREAD_GRAYSCALE);

--- a/src/main/java/org/openpnp/gui/CamerasPanel.java
+++ b/src/main/java/org/openpnp/gui/CamerasPanel.java
@@ -144,7 +144,7 @@ public class CamerasPanel extends JPanel implements WizardContainer {
 		headsComboBox = new JComboBox();
 		
 		table = new AutoSelectTextTable(tableModel);
-		tableSorter = new TableRowSorter<CamerasTableModel>(tableModel);
+		tableSorter = new TableRowSorter<>(tableModel);
 		table.getColumnModel().getColumn(2).setCellEditor(new DefaultCellEditor(lookingComboBox));
 		table.getColumnModel().getColumn(3).setCellEditor(new DefaultCellEditor(headsComboBox));
 		
@@ -280,10 +280,10 @@ public class CamerasPanel extends JPanel implements WizardContainer {
 		
 		@Override
 		public void actionPerformed(ActionEvent arg0) {
-			ClassSelectionDialog<Camera> dialog = new ClassSelectionDialog<Camera>(
-					JOptionPane.getFrameForComponent(CamerasPanel.this), 
-					"Select Camera...", 
-					"Please select a Camera implemention from the list below.", 
+			ClassSelectionDialog<Camera> dialog = new ClassSelectionDialog<>(
+					JOptionPane.getFrameForComponent(CamerasPanel.this),
+					"Select Camera...",
+					"Please select a Camera implemention from the list below.",
 					configuration.getMachine().getCompatibleCameraClasses());
 			dialog.setVisible(true);
 			Class<? extends Camera> cameraClass = dialog.getSelectedClass();

--- a/src/main/java/org/openpnp/gui/FeedersPanel.java
+++ b/src/main/java/org/openpnp/gui/FeedersPanel.java
@@ -151,7 +151,7 @@ public class FeedersPanel extends JPanel implements WizardContainer {
 		panel_1.add(searchTextField);
 		searchTextField.setColumns(15);
 		table = new AutoSelectTextTable(tableModel);
-		tableSorter = new TableRowSorter<FeedersTableModel>(tableModel);
+		tableSorter = new TableRowSorter<>(tableModel);
 
 		final JSplitPane splitPane = new JSplitPane();
 		splitPane.setContinuousLayout(true);
@@ -278,7 +278,7 @@ public class FeedersPanel extends JPanel implements WizardContainer {
 				return;
 			}
 
-			ClassSelectionDialog<Feeder> dialog = new ClassSelectionDialog<Feeder>(
+			ClassSelectionDialog<Feeder> dialog = new ClassSelectionDialog<>(
 					JOptionPane.getFrameForComponent(FeedersPanel.this),
 					"Select Feeder...",
 					"Please select a Feeder implemention from the list below.",

--- a/src/main/java/org/openpnp/gui/JobPastePanel.java
+++ b/src/main/java/org/openpnp/gui/JobPastePanel.java
@@ -194,7 +194,7 @@ public class JobPastePanel extends JPanel {
     }
     
     public List<BoardPad> getSelections() {
-        ArrayList<BoardPad> rows = new ArrayList<BoardPad>();
+        ArrayList<BoardPad> rows = new ArrayList<>();
         if (boardLocation == null) {
             return rows;
         }
@@ -222,7 +222,7 @@ public class JobPastePanel extends JPanel {
             padClasses.add(Pad.Ellipse.class);
             // See note on Pad.Line
 //            padClasses.add(Pad.Line.class);
-            ClassSelectionDialog<Pad> dialog = new ClassSelectionDialog<Pad>(
+            ClassSelectionDialog<Pad> dialog = new ClassSelectionDialog<>(
                     JOptionPane.getFrameForComponent(JobPastePanel.this),
                     "Select Pad...",
                     "Please select a pad type from the list below.",

--- a/src/main/java/org/openpnp/gui/JobPlacementsPanel.java
+++ b/src/main/java/org/openpnp/gui/JobPlacementsPanel.java
@@ -246,7 +246,7 @@ public class JobPlacementsPanel extends JPanel {
     }
     
     public List<Placement> getSelections() {
-        ArrayList<Placement> placements = new ArrayList<Placement>();
+        ArrayList<Placement> placements = new ArrayList<>();
         if (boardLocation == null) {
             return placements;
         }

--- a/src/main/java/org/openpnp/gui/MachineControlsPanel.java
+++ b/src/main/java/org/openpnp/gui/MachineControlsPanel.java
@@ -176,7 +176,7 @@ public class MachineControlsPanel extends JPanel {
 	
 	private void setUnits(LengthUnit units) {
 		if (units == LengthUnit.Millimeters) {
-			Hashtable<Integer, JLabel> incrementsLabels = new Hashtable<Integer, JLabel>();
+			Hashtable<Integer, JLabel> incrementsLabels = new Hashtable<>();
 			incrementsLabels.put(1, new JLabel("0.01"));
 			incrementsLabels.put(2, new JLabel("0.1"));
 			incrementsLabels.put(3, new JLabel("1.0"));
@@ -185,7 +185,7 @@ public class MachineControlsPanel extends JPanel {
 			sliderIncrements.setLabelTable(incrementsLabels);
 		}
 		else if (units == LengthUnit.Inches) {
-			Hashtable<Integer, JLabel> incrementsLabels = new Hashtable<Integer, JLabel>();
+			Hashtable<Integer, JLabel> incrementsLabels = new Hashtable<>();
 			incrementsLabels.put(1, new JLabel("0.001"));
 			incrementsLabels.put(2, new JLabel("0.01"));
 			incrementsLabels.put(3, new JLabel("0.1"));

--- a/src/main/java/org/openpnp/gui/MachineSetupPanel.java
+++ b/src/main/java/org/openpnp/gui/MachineSetupPanel.java
@@ -211,7 +211,7 @@ public class MachineSetupPanel extends JPanel implements WizardContainer {
     public class PropertySheetHolderTreeNode implements TreeNode {
         private final PropertySheetHolder obj;
         private final TreeNode parent;
-        private final ArrayList<PropertySheetHolderTreeNode> children = new ArrayList<PropertySheetHolderTreeNode>();
+        private final ArrayList<PropertySheetHolderTreeNode> children = new ArrayList<>();
         
         public PropertySheetHolderTreeNode(PropertySheetHolder obj, TreeNode parent) {
             this.obj = obj;

--- a/src/main/java/org/openpnp/gui/MainFrame.java
+++ b/src/main/java/org/openpnp/gui/MainFrame.java
@@ -297,7 +297,7 @@ public class MainFrame extends JFrame {
 		panel.add(machineControlsPanel);
 
 		// Add global hotkeys for the arrow keys
-		final Map<KeyStroke, Action> hotkeyActionMap = new HashMap<KeyStroke, Action>();
+		final Map<KeyStroke, Action> hotkeyActionMap = new HashMap<>();
 
 		int mask = KeyEvent.CTRL_DOWN_MASK;
 		

--- a/src/main/java/org/openpnp/gui/PackagesPanel.java
+++ b/src/main/java/org/openpnp/gui/PackagesPanel.java
@@ -95,7 +95,7 @@ public class PackagesPanel extends JPanel {
 		
 		setLayout(new BorderLayout(0, 0));
 		packagesTableModel = new PackagesTableModel(configuration);
-		packagesTableSorter = new TableRowSorter<PackagesTableModel>(packagesTableModel);
+		packagesTableSorter = new TableRowSorter<>(packagesTableModel);
 
 		JPanel toolbarAndSearch = new JPanel();
 		add(toolbarAndSearch, BorderLayout.NORTH);

--- a/src/main/java/org/openpnp/gui/PartsPanel.java
+++ b/src/main/java/org/openpnp/gui/PartsPanel.java
@@ -82,7 +82,7 @@ public class PartsPanel extends JPanel {
 		
 		setLayout(new BorderLayout(0, 0));
 		partsTableModel = new PartsTableModel();
-		partsTableSorter = new TableRowSorter<PartsTableModel>(partsTableModel);
+		partsTableSorter = new TableRowSorter<>(partsTableModel);
 
 		JPanel panel_5 = new JPanel();
 		add(panel_5, BorderLayout.NORTH);

--- a/src/main/java/org/openpnp/gui/components/CameraPanel.java
+++ b/src/main/java/org/openpnp/gui/components/CameraPanel.java
@@ -44,7 +44,7 @@ public class CameraPanel extends JPanel {
 	private static final String SHOW_NONE_ITEM = "Show None";
 	private static final String SHOW_ALL_ITEM = "Show All";
 
-	private Map<Camera, CameraView> cameraViews = new LinkedHashMap<Camera, CameraView>();
+	private Map<Camera, CameraView> cameraViews = new LinkedHashMap<>();
 
 	private JComboBox camerasCombo;
 	private JPanel camerasPanel;

--- a/src/main/java/org/openpnp/gui/components/CameraView.java
+++ b/src/main/java/org/openpnp/gui/components/CameraView.java
@@ -105,7 +105,7 @@ public class CameraView extends JComponent implements CameraListener {
 	 */
 	private int maximumFps;
 
-	private LinkedHashMap<Object, Reticle> reticles = new LinkedHashMap<Object, Reticle>();
+	private LinkedHashMap<Object, Reticle> reticles = new LinkedHashMap<>();
 
 	private JPopupMenu popupMenu;
 
@@ -181,7 +181,7 @@ public class CameraView extends JComponent implements CameraListener {
 	
 	private boolean showImageInfo;
 	
-	private List<CameraViewActionListener> actionListeners = new ArrayList<CameraViewActionListener>();
+	private List<CameraViewActionListener> actionListeners = new ArrayList<>();
 	
 	private CameraViewFilter cameraViewFilter;
 	
@@ -732,7 +732,7 @@ public class CameraView extends JComponent implements CameraListener {
 		g2d.setStroke(new BasicStroke(1.0f));
 		g2d.setFont(g2d.getFont().deriveFont(12.0f));
 		String[] lines = text.split("\n");
-		List<TextLayout> textLayouts = new ArrayList<TextLayout>();
+		List<TextLayout> textLayouts = new ArrayList<>();
 		int textWidth = 0, textHeight = 0;
 		for (String line : lines) {
 			TextLayout textLayout = new TextLayout(line, g2d.getFont(),
@@ -782,7 +782,7 @@ public class CameraView extends JComponent implements CameraListener {
         g2d.setStroke(new BasicStroke(1.0f));
         g2d.setFont(g2d.getFont().deriveFont(12.0f));
         String[] lines = text.split("\n");
-        List<TextLayout> textLayouts = new ArrayList<TextLayout>();
+        List<TextLayout> textLayouts = new ArrayList<>();
         int textWidth = 0, textHeight = 0;
         for (String line : lines) {
             TextLayout textLayout = new TextLayout(line, g2d.getFont(),

--- a/src/main/java/org/openpnp/gui/components/ClassSelectionDialog.java
+++ b/src/main/java/org/openpnp/gui/components/ClassSelectionDialog.java
@@ -98,7 +98,7 @@ public class ClassSelectionDialog<T> extends JDialog {
 		DefaultListModel listModel = new DefaultListModel();
 		list.setModel(listModel);
 		for (Class<? extends T> clz : classes) {
-			listModel.addElement(new ClassListItem<T>(clz));
+			listModel.addElement(new ClassListItem<>(clz));
 		}
 
 		list.addListSelectionListener(new ListSelectionListener() {

--- a/src/main/java/org/openpnp/gui/importer/EagleBoardImporter.java
+++ b/src/main/java/org/openpnp/gui/importer/EagleBoardImporter.java
@@ -118,9 +118,9 @@ public class EagleBoardImporter implements BoardImporter {
 		String packageId = "";
 		Part part = null;
 		
-		List<BoardPad> pads = new ArrayList<BoardPad>();
+		List<BoardPad> pads = new ArrayList<>();
 		
-		ArrayList<Placement> placements = new ArrayList<Placement>();
+		ArrayList<Placement> placements = new ArrayList<>();
 		//we don't use the 'side' parameter as we can read this from the .brd file
 		//in the future we could use the side parameter to restrict this from only parsing one side or the other or both
 		
@@ -564,7 +564,7 @@ public class EagleBoardImporter implements BoardImporter {
             public void actionPerformed(ActionEvent e) {
                 boardFile = new File(textFieldBoardFile.getText());
                 board = new Board();
-                List<Placement> placements = new ArrayList<Placement>();
+                List<Placement> placements = new ArrayList<>();
                 try {
                     if (boardFile.exists()) {
                     	if (chckbxImportTop.isSelected() && chckbxImportBottom.isSelected())

--- a/src/main/java/org/openpnp/gui/importer/EagleMountsmdUlpImporter.java
+++ b/src/main/java/org/openpnp/gui/importer/EagleMountsmdUlpImporter.java
@@ -93,7 +93,7 @@ public class EagleMountsmdUlpImporter implements BoardImporter {
     
 	private static List<Placement> parseFile(File file, Side side, boolean createMissingParts) throws Exception {
 		BufferedReader reader = new BufferedReader(new InputStreamReader(new FileInputStream(file)));
-		ArrayList<Placement> placements = new ArrayList<Placement>();
+		ArrayList<Placement> placements = new ArrayList<>();
 		String line;
 		while ((line = reader.readLine()) != null) {
 			line = line.trim();
@@ -291,7 +291,7 @@ public class EagleMountsmdUlpImporter implements BoardImporter {
                 topFile = new File(textFieldTopFile.getText());
                 bottomFile = new File(textFieldBottomFile.getText());
                 board = new Board();
-                List<Placement> placements = new ArrayList<Placement>();
+                List<Placement> placements = new ArrayList<>();
                 try {
                     if (topFile.exists()) {
                         placements.addAll(parseFile(topFile, Side.Top, chckbxCreateMissingParts.isSelected()));

--- a/src/main/java/org/openpnp/gui/importer/KicadPosImporter.java
+++ b/src/main/java/org/openpnp/gui/importer/KicadPosImporter.java
@@ -93,7 +93,7 @@ public class KicadPosImporter implements BoardImporter {
 	
 	private static List<Placement> parseFile(File file, Side side, boolean createMissingParts) throws Exception {
 		BufferedReader reader = new BufferedReader(new InputStreamReader(new FileInputStream(file)));
-		ArrayList<Placement> placements = new ArrayList<Placement>();
+		ArrayList<Placement> placements = new ArrayList<>();
 		String line;
 
 //		See: http://bazaar.launchpad.net/~kicad-product-committers/kicad/product/view/head:/pcbnew/exporters/gen_modules_placefile.cpp
@@ -305,7 +305,7 @@ public class KicadPosImporter implements BoardImporter {
 	            topFile = new File(textFieldTopFile.getText());
 	            bottomFile = new File(textFieldBottomFile.getText());
 	            board = new Board();
-	            List<Placement> placements = new ArrayList<Placement>();
+	            List<Placement> placements = new ArrayList<>();
 	            try {
 	                if (topFile.exists()) {
 	                    placements.addAll(parseFile(topFile, Side.Top, chckbxCreateMissingParts.isSelected()));

--- a/src/main/java/org/openpnp/gui/importer/NamedCSVImporter.java
+++ b/src/main/java/org/openpnp/gui/importer/NamedCSVImporter.java
@@ -238,7 +238,7 @@ for ( String as[]; (as = csvParser.getLine()) != null; )
 
 	private static List<Placement> parseFile(File file, boolean createMissingParts) throws Exception {
 		BufferedReader reader = new BufferedReader(new InputStreamReader(new FileInputStream(file)));
-		ArrayList<Placement> placements = new ArrayList<Placement>();
+		ArrayList<Placement> placements = new ArrayList<>();
 		String line;
 
 		for(int i=0;i++<10&&(line = reader.readLine()) != null;) {
@@ -425,7 +425,7 @@ for ( String as[]; (as = csvParser.getLine()) != null; )
 		    logger.debug("Parsing "+textFieldTopFile.getText()+" CSV FIle");
 	            topFile = new File(textFieldTopFile.getText());
 	            board = new Board();
-	            List<Placement> placements = new ArrayList<Placement>();
+	            List<Placement> placements = new ArrayList<>();
 	            try {
 	                if (topFile.exists()) {
 	                    placements.addAll(parseFile(topFile, chckbxCreateMissingParts.isSelected()));

--- a/src/main/java/org/openpnp/gui/support/AbstractConfigurationWizard.java
+++ b/src/main/java/org/openpnp/gui/support/AbstractConfigurationWizard.java
@@ -53,7 +53,7 @@ public abstract class AbstractConfigurationWizard extends JPanel implements Wiza
 	protected JPanel contentPanel;
 	private JScrollPane scrollPane;
 	
-	private List<WrappedBinding> wrappedBindings = new ArrayList<WrappedBinding>();
+	private List<WrappedBinding> wrappedBindings = new ArrayList<>();
 	private ApplyResetBindingListener listener;
 	
 	public AbstractConfigurationWizard() {

--- a/src/main/java/org/openpnp/gui/support/ActionGroup.java
+++ b/src/main/java/org/openpnp/gui/support/ActionGroup.java
@@ -27,7 +27,7 @@ import java.util.Set;
 import javax.swing.Action;
 
 public class ActionGroup {
-	private Set<Action> actions = new HashSet<Action>();
+	private Set<Action> actions = new HashSet<>();
 	
 	public ActionGroup(Action... actions) {
 		for (Action action : actions) {

--- a/src/main/java/org/openpnp/gui/support/Helpers.java
+++ b/src/main/java/org/openpnp/gui/support/Helpers.java
@@ -74,7 +74,7 @@ public class Helpers {
 	 * @param propertyName The name of a String property.
 	 */
 	public static String createUniqueName(String prefix, Collection existingObjects, String propertyName) {
-		HashSet<String> names = new HashSet<String>();
+		HashSet<String> names = new HashSet<>();
 		BeanProperty<Object, String> property = BeanProperty.create(propertyName);
 		for (Object o : existingObjects) {
 			if (o != null) {

--- a/src/main/java/org/openpnp/gui/support/IdentifiableListCellRenderer.java
+++ b/src/main/java/org/openpnp/gui/support/IdentifiableListCellRenderer.java
@@ -31,7 +31,7 @@ import org.openpnp.model.Identifiable;
 
 @SuppressWarnings("serial")
 public class IdentifiableListCellRenderer<T extends Identifiable> extends DefaultListCellRenderer {
-	IdentifiableObjectToStringConverter<T> converter = new IdentifiableObjectToStringConverter<T>();
+	IdentifiableObjectToStringConverter<T> converter = new IdentifiableObjectToStringConverter<>();
 	
 	@Override
 	public Component getListCellRendererComponent(JList arg0, Object arg1,

--- a/src/main/java/org/openpnp/gui/support/IdentifiableTableCellRenderer.java
+++ b/src/main/java/org/openpnp/gui/support/IdentifiableTableCellRenderer.java
@@ -27,7 +27,7 @@ import org.openpnp.model.Identifiable;
 
 @SuppressWarnings("serial")
 public class IdentifiableTableCellRenderer<T extends Identifiable> extends DefaultTableCellRenderer {
-	IdentifiableObjectToStringConverter<T> converter = new IdentifiableObjectToStringConverter<T>();
+	IdentifiableObjectToStringConverter<T> converter = new IdentifiableObjectToStringConverter<>();
 	
 	@Override
 	protected void setValue(Object value) {

--- a/src/main/java/org/openpnp/gui/support/JBindings.java
+++ b/src/main/java/org/openpnp/gui/support/JBindings.java
@@ -50,7 +50,7 @@ public class JBindings {
 			String sourcePropertyName, 
 			TS component, 
 			String targetPropertyName) {
-		return new WrappedBinding<SS, SV, TS, TV>(source, sourcePropertyName, component, targetPropertyName, null, (BindingListener[]) null);
+		return new WrappedBinding<>(source, sourcePropertyName, component, targetPropertyName, null, (BindingListener[]) null);
 	}
 	
 	public static <SS, SV, TS extends JComponent, TV> WrappedBinding<SS, SV, TS, TV> bind(
@@ -59,7 +59,7 @@ public class JBindings {
 			TS component, 
 			String targetPropertyName, 
 			Converter<SV, TV> converter) {
-		return new WrappedBinding<SS, SV, TS, TV>(source, sourcePropertyName, component, targetPropertyName, converter, (BindingListener[]) null);
+		return new WrappedBinding<>(source, sourcePropertyName, component, targetPropertyName, converter, (BindingListener[]) null);
 	}
 
 	public static <SS, SV, TS extends JComponent, TV> WrappedBinding<SS, SV, TS, TV> bind(
@@ -69,7 +69,7 @@ public class JBindings {
 			String targetPropertyName, 
 			Converter<SV, TV> converter,
 			BindingListener... listeners) {
-		return new WrappedBinding<SS, SV, TS, TV>(source, sourcePropertyName, component, targetPropertyName, converter, listeners);
+		return new WrappedBinding<>(source, sourcePropertyName, component, targetPropertyName, converter, listeners);
 	}
 
 	public static <SS, SV, TS extends JComponent, TV> WrappedBinding<SS, SV, TS, TV> bind(
@@ -78,7 +78,7 @@ public class JBindings {
 			TS component, 
 			String targetPropertyName, 
 			BindingListener... listeners) {
-		return new WrappedBinding<SS, SV, TS, TV>(source, sourcePropertyName, component, targetPropertyName, null, listeners);
+		return new WrappedBinding<>(source, sourcePropertyName, component, targetPropertyName, null, listeners);
 	}
 
 	public static class WrappedBinding<SS, SV, TS extends JComponent, TV> {
@@ -100,7 +100,7 @@ public class JBindings {
 				BindingListener... listeners) {
 			this.source = source;
 			this.sourceProperty = BeanProperty.create(sourcePropertyName);
-			this.wrapper = new Wrapper<SV>(sourceProperty.getValue(source));
+			this.wrapper = new Wrapper<>(sourceProperty.getValue(source));
 			BeanProperty<Wrapper<SV>, SV> wrapperProperty = BeanProperty.create("value");
 			BeanProperty<TS, TV> targetProperty = BeanProperty.create(targetPropertyName);
 			wrappedBinding = Bindings.createAutoBinding(

--- a/src/main/java/org/openpnp/gui/support/PackagesComboBoxModel.java
+++ b/src/main/java/org/openpnp/gui/support/PackagesComboBoxModel.java
@@ -32,7 +32,7 @@ import org.openpnp.model.Configuration;
 
 @SuppressWarnings("serial")
 public class PackagesComboBoxModel extends DefaultComboBoxModel implements PropertyChangeListener {
-	private IdentifiableComparator<org.openpnp.model.Package> comparator = new IdentifiableComparator<org.openpnp.model.Package>();
+	private IdentifiableComparator<org.openpnp.model.Package> comparator = new IdentifiableComparator<>();
 
 	public PackagesComboBoxModel() {
 		addAllElements();
@@ -40,7 +40,7 @@ public class PackagesComboBoxModel extends DefaultComboBoxModel implements Prope
 	}
 	
 	private void addAllElements() {
-		ArrayList<org.openpnp.model.Package> packages = new ArrayList<org.openpnp.model.Package>(Configuration.get().getPackages());
+		ArrayList<org.openpnp.model.Package> packages = new ArrayList<>(Configuration.get().getPackages());
 		Collections.sort(packages, comparator);
 		for (org.openpnp.model.Package pkg : packages) {
 			addElement(pkg);

--- a/src/main/java/org/openpnp/gui/support/PartConverter.java
+++ b/src/main/java/org/openpnp/gui/support/PartConverter.java
@@ -27,7 +27,7 @@ import org.openpnp.model.Part;
 
 public class PartConverter extends Converter<Part, String> {
 	private Configuration configuration; 
-	private IdentifiableObjectToStringConverter<Part> toStringConverter = new IdentifiableObjectToStringConverter<Part>();
+	private IdentifiableObjectToStringConverter<Part> toStringConverter = new IdentifiableObjectToStringConverter<>();
 	
 	public PartConverter(Configuration configuration) {
 		this.configuration = configuration;

--- a/src/main/java/org/openpnp/gui/support/PartsComboBoxModel.java
+++ b/src/main/java/org/openpnp/gui/support/PartsComboBoxModel.java
@@ -33,7 +33,7 @@ import org.openpnp.model.Part;
 
 @SuppressWarnings("serial")
 public class PartsComboBoxModel extends DefaultComboBoxModel implements PropertyChangeListener {
-	private IdentifiableComparator<Part> comparator = new IdentifiableComparator<Part>();
+	private IdentifiableComparator<Part> comparator = new IdentifiableComparator<>();
 	
 	public PartsComboBoxModel() {
 		addAllElements();
@@ -41,7 +41,7 @@ public class PartsComboBoxModel extends DefaultComboBoxModel implements Property
 	}
 	
 	private void addAllElements() {
-		ArrayList<Part> parts = new ArrayList<Part>(Configuration.get().getParts());
+		ArrayList<Part> parts = new ArrayList<>(Configuration.get().getParts());
 		Collections.sort(parts, comparator);
 		for (Part part : parts) {
 			addElement(part);

--- a/src/main/java/org/openpnp/gui/tablemodel/CamerasTableModel.java
+++ b/src/main/java/org/openpnp/gui/tablemodel/CamerasTableModel.java
@@ -67,7 +67,7 @@ public class CamerasTableModel extends AbstractTableModel {
 	}
 	
 	public void refresh() {
-		cameras = new ArrayList<Camera>(Configuration.get().getMachine().getCameras());
+		cameras = new ArrayList<>(Configuration.get().getMachine().getCameras());
 		for (Head head : Configuration.get().getMachine().getHeads()) {
 	        cameras.addAll(head.getCameras());
 		}

--- a/src/main/java/org/openpnp/gui/tablemodel/FeedersTableModel.java
+++ b/src/main/java/org/openpnp/gui/tablemodel/FeedersTableModel.java
@@ -47,7 +47,7 @@ public class FeedersTableModel extends AbstractTableModel {
 	}
 
 	public void refresh() {
-		feeders = new ArrayList<Feeder>(configuration.getMachine().getFeeders());
+		feeders = new ArrayList<>(configuration.getMachine().getFeeders());
 		fireTableDataChanged();
 	}
 

--- a/src/main/java/org/openpnp/gui/tablemodel/HeadsTableModel.java
+++ b/src/main/java/org/openpnp/gui/tablemodel/HeadsTableModel.java
@@ -40,7 +40,7 @@ public class HeadsTableModel extends AbstractTableModel {
 		this.configuration = configuration;
         Configuration.get().addListener(new ConfigurationListener.Adapter() {
             public void configurationComplete(Configuration configuration) throws Exception {
-                heads = new ArrayList<Head>(configuration.getMachine().getHeads());
+                heads = new ArrayList<>(configuration.getMachine().getHeads());
                 fireTableDataChanged();
             }
         });

--- a/src/main/java/org/openpnp/gui/tablemodel/PackagesTableModel.java
+++ b/src/main/java/org/openpnp/gui/tablemodel/PackagesTableModel.java
@@ -49,7 +49,7 @@ public class PackagesTableModel extends AbstractTableModel implements PropertyCh
 	public PackagesTableModel(Configuration configuration) {
 		this.configuration = configuration;
 		configuration.addPropertyChangeListener("packages", this);
-		packages = new ArrayList<Package>(configuration.getPackages());
+		packages = new ArrayList<>(configuration.getPackages());
 		
 	}
 
@@ -107,7 +107,7 @@ public class PackagesTableModel extends AbstractTableModel implements PropertyCh
 
 	@Override
 	public void propertyChange(PropertyChangeEvent arg0) {
-		packages = new ArrayList<Package>(configuration.getPackages());
+		packages = new ArrayList<>(configuration.getPackages());
 		fireTableDataChanged();
 	}
 }

--- a/src/main/java/org/openpnp/gui/tablemodel/PartsTableModel.java
+++ b/src/main/java/org/openpnp/gui/tablemodel/PartsTableModel.java
@@ -55,7 +55,7 @@ public class PartsTableModel extends AbstractTableModel implements PropertyChang
 
 	public PartsTableModel() {
 		Configuration.get().addPropertyChangeListener("parts", this);
-		parts = new ArrayList<Part>(Configuration.get().getParts());
+		parts = new ArrayList<>(Configuration.get().getParts());
 	}
 
 	@Override
@@ -142,7 +142,7 @@ public class PartsTableModel extends AbstractTableModel implements PropertyChang
 
 	@Override
 	public void propertyChange(PropertyChangeEvent arg0) {
-		parts = new ArrayList<Part>(Configuration.get().getParts());
+		parts = new ArrayList<>(Configuration.get().getParts());
 		fireTableDataChanged();
 	}
 }

--- a/src/main/java/org/openpnp/machine/openbuilds/OpenBuildsDriver.java
+++ b/src/main/java/org/openpnp/machine/openbuilds/OpenBuildsDriver.java
@@ -47,7 +47,7 @@ public class OpenBuildsDriver extends AbstractSerialPortDriver implements Runnab
     private boolean disconnectRequested;
     private Object commandLock = new Object();
     private boolean connected;
-    private Queue<String> responseQueue = new ConcurrentLinkedQueue<String>();
+    private Queue<String> responseQueue = new ConcurrentLinkedQueue<>();
     private boolean n1Picked, n2Picked;
     
     @Override
@@ -431,7 +431,7 @@ public class OpenBuildsDriver extends AbstractSerialPortDriver implements Runnab
     }
 
     private List<String> drainResponseQueue() {
-        List<String> responses = new ArrayList<String>();
+        List<String> responses = new ArrayList<>();
         String response;
         while ((response = responseQueue.poll()) != null) {
             responses.add(response);

--- a/src/main/java/org/openpnp/machine/reference/ReferenceHead.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceHead.java
@@ -75,7 +75,7 @@ public class ReferenceHead extends AbstractHead {
 
     @Override
     public PropertySheetHolder[] getChildPropertySheetHolders() {
-        ArrayList<PropertySheetHolder> children = new ArrayList<PropertySheetHolder>();
+        ArrayList<PropertySheetHolder> children = new ArrayList<>();
         children.add(new SimplePropertySheetHolder("Nozzles", getNozzles()));
         children.add(new SimplePropertySheetHolder("Cameras", getCameras()));
         children.add(new SimplePropertySheetHolder("Actuators", getActuators()));

--- a/src/main/java/org/openpnp/machine/reference/ReferenceMachine.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceMachine.java
@@ -59,7 +59,7 @@ public class ReferenceMachine extends AbstractMachine {
 	
 	private boolean enabled;
 	
-	private List<Class<? extends Feeder>> registeredFeederClasses = new ArrayList<Class<? extends Feeder>>();
+	private List<Class<? extends Feeder>> registeredFeederClasses = new ArrayList<>();
 	
 	public ReferenceDriver getDriver() {
 		return driver;
@@ -117,12 +117,12 @@ public class ReferenceMachine extends AbstractMachine {
 
     @Override
     public PropertySheetHolder[] getChildPropertySheetHolders() {
-        ArrayList<PropertySheetHolder> children = new ArrayList<PropertySheetHolder>();
+        ArrayList<PropertySheetHolder> children = new ArrayList<>();
         children.add(new SimplePropertySheetHolder("Feeders", getFeeders()));
         children.add(new SimplePropertySheetHolder("Heads", getHeads()));
         children.add(new SimplePropertySheetHolder("Cameras", getCameras()));
         children.add(new SimplePropertySheetHolder("Driver", Collections.singletonList(getDriver())));
-        children.add(new SimplePropertySheetHolder("Job Processors", new ArrayList<JobProcessor>(jobProcessors.values())));
+        children.add(new SimplePropertySheetHolder("Job Processors", new ArrayList<>(jobProcessors.values())));
         return children.toArray(new PropertySheetHolder[]{});
     }
     
@@ -145,7 +145,7 @@ public class ReferenceMachine extends AbstractMachine {
 
     @Override
 	public List<Class<? extends Feeder>> getCompatibleFeederClasses() {
-		List<Class<? extends Feeder>> l = new ArrayList<Class<? extends Feeder>>();
+		List<Class<? extends Feeder>> l = new ArrayList<>();
         l.add(ReferenceStripFeeder.class);
         l.add(ReferenceTrayFeeder.class);
 		l.add(ReferenceDragFeeder.class);
@@ -156,7 +156,7 @@ public class ReferenceMachine extends AbstractMachine {
 
 	@Override
 	public List<Class<? extends Camera>>  getCompatibleCameraClasses() {
-		List<Class<? extends Camera>> l = new ArrayList<Class<? extends Camera>>();
+		List<Class<? extends Camera>> l = new ArrayList<>();
 		l.add(LtiCivilCamera.class);
 		l.add(VfwCamera.class);
         l.add(OpenCvCamera.class);

--- a/src/main/java/org/openpnp/machine/reference/ReferenceNozzle.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceNozzle.java
@@ -230,7 +230,7 @@ public class ReferenceNozzle extends AbstractNozzle implements
 
     @Override
     public PropertySheetHolder[] getChildPropertySheetHolders() {
-        ArrayList<PropertySheetHolder> children = new ArrayList<PropertySheetHolder>();
+        ArrayList<PropertySheetHolder> children = new ArrayList<>();
         children.add(new SimplePropertySheetHolder("Nozzle Tips", getNozzleTips()));
         return children.toArray(new PropertySheetHolder[]{});
     }

--- a/src/main/java/org/openpnp/machine/reference/ReferenceNozzleTip.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceNozzleTip.java
@@ -37,7 +37,7 @@ public class ReferenceNozzleTip extends AbstractNozzleTip {
             .getLogger(ReferenceNozzleTip.class);
 
     @ElementList(required = false, entry = "id")
-    private Set<String> compatiblePackageIds = new HashSet<String>();
+    private Set<String> compatiblePackageIds = new HashSet<>();
     
     @Attribute(required = false)
     private boolean allowIncompatiblePackages;
@@ -49,7 +49,7 @@ public class ReferenceNozzleTip extends AbstractNozzleTip {
     @Element(required = false)
     private Location changerEndLocation = new Location(LengthUnit.Millimeters);
 
-    private Set<org.openpnp.model.Package> compatiblePackages = new HashSet<org.openpnp.model.Package>();
+    private Set<org.openpnp.model.Package> compatiblePackages = new HashSet<>();
     
     public ReferenceNozzleTip() {
         Configuration.get().addListener(new ConfigurationListener.Adapter() {
@@ -77,7 +77,7 @@ public class ReferenceNozzleTip extends AbstractNozzleTip {
 	}
     
 	public Set<org.openpnp.model.Package> getCompatiblePackages() {
-        return new HashSet<org.openpnp.model.Package>(compatiblePackages);
+        return new HashSet<>(compatiblePackages);
     }
 
     public void setCompatiblePackages(

--- a/src/main/java/org/openpnp/machine/reference/camera/LtiCivilCamera.java
+++ b/src/main/java/org/openpnp/machine/reference/camera/LtiCivilCamera.java
@@ -110,7 +110,7 @@ public class LtiCivilCamera extends ReferenceCamera implements CaptureObserver {
 	}
 
 	public List<String> getDeviceIds() throws Exception {
-		ArrayList<String> deviceIds = new ArrayList<String>();
+		ArrayList<String> deviceIds = new ArrayList<>();
 		for (CaptureDeviceInfo captureDeviceInfo : (List<CaptureDeviceInfo>) captureSystem.getCaptureDeviceInfoList()) {
 			deviceIds.add(captureDeviceInfo.getDeviceID());
 		}

--- a/src/main/java/org/openpnp/machine/reference/camera/VfwCamera.java
+++ b/src/main/java/org/openpnp/machine/reference/camera/VfwCamera.java
@@ -114,7 +114,7 @@ public class VfwCamera extends ReferenceCamera implements Runnable {
 	}
 	
 	public List<String> getDrivers() {
-		ArrayList<String> drivers = new ArrayList<String>();
+		ArrayList<String> drivers = new ArrayList<>();
 		try {
 			for (String s : CaptureDevice.getCaptureDrivers()) {
 				drivers.add(s);

--- a/src/main/java/org/openpnp/machine/reference/driver/GrblDriver.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/GrblDriver.java
@@ -64,7 +64,7 @@ public class GrblDriver extends AbstractSerialPortDriver implements Runnable {
 	private Object commandLock = new Object();
 	private boolean connected;
 	private long connectedBuildNumber;
-	private Queue<String> responseQueue = new ConcurrentLinkedQueue<String>();
+	private Queue<String> responseQueue = new ConcurrentLinkedQueue<>();
 	
 	public GrblDriver() {
 	}
@@ -314,7 +314,7 @@ public class GrblDriver extends AbstractSerialPortDriver implements Runnable {
 	}
 
 	private List<String> drainResponseQueue() {
-		List<String> responses = new ArrayList<String>();
+		List<String> responses = new ArrayList<>();
 		String response;
 		while ((response = responseQueue.poll()) != null) {
 			responses.add(response);

--- a/src/main/java/org/openpnp/machine/reference/driver/LinuxCNC.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/LinuxCNC.java
@@ -118,7 +118,7 @@ public class LinuxCNC implements ReferenceDriver, Runnable {
     private Object commandLock = new Object();
     private boolean connected;
     private double connectedVersion;
-    private Queue<String> responseQueue = new ConcurrentLinkedQueue<String>();
+    private Queue<String> responseQueue = new ConcurrentLinkedQueue<>();
     private final static int CONNECT_TIMOUT = 5; // 5 second time-out for
                                                  // connection
 
@@ -389,7 +389,7 @@ public class LinuxCNC implements ReferenceDriver, Runnable {
     }
 
     private List<String> drainResponseQueue() {
-        List<String> responses = new ArrayList<String>();
+        List<String> responses = new ArrayList<>();
         String response;
         while ((response = responseQueue.poll()) != null) {
             responses.add(response);

--- a/src/main/java/org/openpnp/machine/reference/driver/MarlinDriver.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/MarlinDriver.java
@@ -80,7 +80,7 @@ public class MarlinDriver extends AbstractSerialPortDriver implements Runnable {
 	private Object commandLock = new Object();
 	private boolean connected;
 	private long connectedBuildNumber;
-	private Queue<String> responseQueue = new ConcurrentLinkedQueue<String>();
+	private Queue<String> responseQueue = new ConcurrentLinkedQueue<>();
 	
 	public MarlinDriver() {
 	}
@@ -343,7 +343,7 @@ public class MarlinDriver extends AbstractSerialPortDriver implements Runnable {
 	}
 
 	private List<String> drainResponseQueue() {
-		List<String> responses = new ArrayList<String>();
+		List<String> responses = new ArrayList<>();
 		String response;
 		while ((response = responseQueue.poll()) != null) {
 			responses.add(response);

--- a/src/main/java/org/openpnp/machine/reference/driver/NullDriver.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/NullDriver.java
@@ -57,7 +57,7 @@ public class NullDriver implements ReferenceDriver {
     @Attribute(required = false)
     private double feedRateMmPerMinute = 5000;
     
-    private HashMap<Head, Location> headLocations = new HashMap<Head, Location>();
+    private HashMap<Head, Location> headLocations = new HashMap<>();
     
     private boolean enabled;
 

--- a/src/main/java/org/openpnp/machine/reference/driver/SimulatorDriver.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/SimulatorDriver.java
@@ -54,7 +54,7 @@ public class SimulatorDriver implements ReferenceDriver {
     @Attribute(required = false)
     private double feedRateMmPerMinute;
     
-    private HashMap<Head, Location> headLocations = new HashMap<Head, Location>();
+    private HashMap<Head, Location> headLocations = new HashMap<>();
     
     private boolean enabled;
     

--- a/src/main/java/org/openpnp/machine/reference/driver/SprinterDriver.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/SprinterDriver.java
@@ -165,7 +165,7 @@ public class SprinterDriver extends AbstractSerialPortDriver implements Runnable
 	private Object commandLock = new Object();
 	private boolean connected;
 //	private double connectedVersion;
-	private Queue<String> responseQueue = new ConcurrentLinkedQueue<String>();
+	private Queue<String> responseQueue = new ConcurrentLinkedQueue<>();
 	
 	public SprinterDriver() {
 	}
@@ -424,7 +424,7 @@ public class SprinterDriver extends AbstractSerialPortDriver implements Runnable
 	}
 
 	private List<String> drainResponseQueue() {
-		List<String> responses = new ArrayList<String>();
+		List<String> responses = new ArrayList<>();
 		String response;
 		while ((response = responseQueue.poll()) != null) {
 			responses.add(response);

--- a/src/main/java/org/openpnp/machine/reference/vision/OpenCvVisionProvider.java
+++ b/src/main/java/org/openpnp/machine/reference/vision/OpenCvVisionProvider.java
@@ -127,7 +127,7 @@ public class OpenCvVisionProvider implements VisionProvider {
         double rangeMin = Math.max(threshold, corr * maxVal);
         double rangeMax = maxVal;
         
-        List<TemplateMatch> matches = new ArrayList<TemplateMatch>();
+        List<TemplateMatch> matches = new ArrayList<>();
         for (Point point : matMaxima(resultMat, rangeMin, rangeMax)) {
             TemplateMatch match = new TemplateMatch();
             int x = point.x;
@@ -281,7 +281,7 @@ public class OpenCvVisionProvider implements VisionProvider {
     
     static List<Point> matMaxima(Mat mat, double rangeMin,
             double rangeMax) {
-        List<Point> locations = new ArrayList<Point>();
+        List<Point> locations = new ArrayList<>();
 
         int rEnd = mat.rows() - 1;
         int cEnd = mat.cols() - 1;

--- a/src/main/java/org/openpnp/machine/reference/wizards/ReferenceHeadConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/wizards/ReferenceHeadConfigurationWizard.java
@@ -108,7 +108,7 @@ public class ReferenceHeadConfigurationWizard extends JPanel implements Wizard {
 	private JScrollPane scrollPane;
 	private JPanel panelMain;
 	
-	private List<WrappedBinding> wrappedBindings = new ArrayList<WrappedBinding>();
+	private List<WrappedBinding> wrappedBindings = new ArrayList<>();
 	
 	// TODO: Most of what this class did is deprecated and has been moved into
 	// Nozzles, Actuators and Cameras. We may still want to do softlimits, but

--- a/src/main/java/org/openpnp/machine/reference/wizards/ReferenceNozzleTipConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/wizards/ReferenceNozzleTipConfigurationWizard.java
@@ -79,7 +79,7 @@ public class ReferenceNozzleTipConfigurationWizard extends
     private JTable table;
     private PackagesTableModel tableModel;
     
-    private Set<org.openpnp.model.Package> compatiblePackages = new HashSet<org.openpnp.model.Package>();
+    private Set<org.openpnp.model.Package> compatiblePackages = new HashSet<>();
     
     public ReferenceNozzleTipConfigurationWizard(ReferenceNozzleTip nozzleTip) {
         this.nozzleTip = nozzleTip;
@@ -279,7 +279,7 @@ public class ReferenceNozzleTipConfigurationWizard extends
         }
 
         public void refresh() {
-            packages = new ArrayList<org.openpnp.model.Package>(Configuration.get().getPackages());
+            packages = new ArrayList<>(Configuration.get().getPackages());
             fireTableDataChanged();
         }
 

--- a/src/main/java/org/openpnp/model/Board.java
+++ b/src/main/java/org/openpnp/model/Board.java
@@ -104,14 +104,14 @@ public class Board extends AbstractModelObject implements PropertyChangeListener
 	
 	public void addFiducial(Fiducial fiducial) {
 		ArrayList<Fiducial> oldValue = fiducials;
-		fiducials = new ArrayList<Fiducial>(fiducials);
+		fiducials = new ArrayList<>(fiducials);
 		fiducials.add(fiducial);
 		firePropertyChange("fiducials", oldValue, fiducials);
 	}
 	
 	public void removeFiducial(Fiducial fiducial) {
 		ArrayList<Fiducial> oldValue = fiducials;
-		fiducials = new ArrayList<Fiducial>(fiducials);
+		fiducials = new ArrayList<>(fiducials);
 		fiducials.remove(fiducial);
 		firePropertyChange("fiducials", oldValue, fiducials);
 	}
@@ -122,7 +122,7 @@ public class Board extends AbstractModelObject implements PropertyChangeListener
 	
 	public void addPlacement(Placement placement) {
 		Object oldValue = placements;
-		placements = new ArrayList<Placement>(placements);
+		placements = new ArrayList<>(placements);
 		placements.add(placement);
 		firePropertyChange("placements", oldValue, placements);
 		if (placement != null) {
@@ -132,7 +132,7 @@ public class Board extends AbstractModelObject implements PropertyChangeListener
 	
 	public void removePlacement(Placement placement) {
 		Object oldValue = placements;
-		placements = new ArrayList<Placement>(placements);
+		placements = new ArrayList<>(placements);
 		placements.remove(placement);
 		firePropertyChange("placements", oldValue, placements);
 		if (placement != null) {
@@ -146,7 +146,7 @@ public class Board extends AbstractModelObject implements PropertyChangeListener
     
     public void addSolderPastePad(BoardPad pad) {
         Object oldValue = solderPastePads;
-        solderPastePads = new ArrayList<BoardPad>(solderPastePads);
+        solderPastePads = new ArrayList<>(solderPastePads);
         solderPastePads.add(pad);
         firePropertyChange("solderPastePads", oldValue, solderPastePads);
         if (pad != null) {
@@ -156,7 +156,7 @@ public class Board extends AbstractModelObject implements PropertyChangeListener
     
     public void removeSolderPastePad(BoardPad pad) {
         Object oldValue = solderPastePads;
-        solderPastePads = new ArrayList<BoardPad>(solderPastePads);
+        solderPastePads = new ArrayList<>(solderPastePads);
         solderPastePads.remove(pad);
         firePropertyChange("solderPastePads", oldValue, solderPastePads);
         if (pad != null) {

--- a/src/main/java/org/openpnp/model/Configuration.java
+++ b/src/main/java/org/openpnp/model/Configuration.java
@@ -69,12 +69,12 @@ public class Configuration extends AbstractModelObject {
 	private static final String PREF_VERTICAL_SCROLL_UNIT_INCREMENT = "Configuration.verticalScrollUnitIncrement";
 	private static final int PREF_VERTICAL_SCROLL_UNIT_INCREMENT_DEF = 16;
 	
-	private LinkedHashMap<String, Package> packages = new LinkedHashMap<String, Package>();
-	private LinkedHashMap<String, Part> parts = new LinkedHashMap<String, Part>();
+	private LinkedHashMap<String, Package> packages = new LinkedHashMap<>();
+	private LinkedHashMap<String, Part> parts = new LinkedHashMap<>();
 	private Machine machine;
-	private LinkedHashMap<File, Board> boards = new LinkedHashMap<File, Board>();
+	private LinkedHashMap<File, Board> boards = new LinkedHashMap<>();
 	private boolean loaded;
-	private Set<ConfigurationListener> listeners = Collections.synchronizedSet(new HashSet<ConfigurationListener>());
+	private Set<ConfigurationListener> listeners = Collections.synchronizedSet(new HashSet<>());
 	private File configurationDirectory;
 	private Preferences prefs;
 	
@@ -305,7 +305,7 @@ public class Configuration extends AbstractModelObject {
 	}
 	
 	public List<Package> getPackages() {
-		return Collections.unmodifiableList(new ArrayList<Package>(packages.values()));
+		return Collections.unmodifiableList(new ArrayList<>(packages.values()));
 	}
 	
 	public void addPackage(Package pkg) {
@@ -329,7 +329,7 @@ public class Configuration extends AbstractModelObject {
 	}
 	
 	public List<Part> getParts() {
-		return Collections.unmodifiableList(new ArrayList<Part>(parts.values()));
+		return Collections.unmodifiableList(new ArrayList<>(parts.values()));
 	}
 	
 	public void addPart(Part part) {
@@ -346,7 +346,7 @@ public class Configuration extends AbstractModelObject {
 	}
 	
 	public List<Board> getBoards() {
-		return Collections.unmodifiableList(new ArrayList<Board>(boards.values()));
+		return Collections.unmodifiableList(new ArrayList<>(boards.values()));
 	}
 	
 	public Machine getMachine() {
@@ -395,7 +395,7 @@ public class Configuration extends AbstractModelObject {
 	private void savePackages(File file) throws Exception {
 		Serializer serializer = createSerializer();
 		PackagesConfigurationHolder holder = new PackagesConfigurationHolder();
-		holder.packages = new ArrayList<Package>(packages.values());
+		holder.packages = new ArrayList<>(packages.values());
 		serializer.write(holder, new ByteArrayOutputStream());
 		serializer.write(holder, file);
 	}
@@ -411,7 +411,7 @@ public class Configuration extends AbstractModelObject {
 	private void saveParts(File file) throws Exception {
 		Serializer serializer = createSerializer();
 		PartsConfigurationHolder holder = new PartsConfigurationHolder();
-		holder.parts = new ArrayList<Part>(parts.values());
+		holder.parts = new ArrayList<>(parts.values());
 		serializer.write(holder, new ByteArrayOutputStream());
 		serializer.write(holder, file);
 	}
@@ -448,7 +448,7 @@ public class Configuration extends AbstractModelObject {
 	
 	public void saveJob(Job job, File file) throws Exception {
 		Serializer serializer = createSerializer();
-		Set<Board> boards = new HashSet<Board>();
+		Set<Board> boards = new HashSet<>();
 		// Fix the paths to any boards in the Job
 		for (BoardLocation boardLocation : job.getBoardLocations()) {
 			Board board = boardLocation.getBoard();
@@ -517,7 +517,7 @@ public class Configuration extends AbstractModelObject {
 	@Root(name="openpnp-packages")
 	public static class PackagesConfigurationHolder {
 		@ElementList(inline=true, entry="package", required=false)
-		private ArrayList<Package> packages = new ArrayList<Package>();
+		private ArrayList<Package> packages = new ArrayList<>();
 	}
 	
 	/**
@@ -526,6 +526,6 @@ public class Configuration extends AbstractModelObject {
 	@Root(name="openpnp-parts")
 	public static class PartsConfigurationHolder {
 		@ElementList(inline=true, entry="part", required=false)
-		private ArrayList<Part> parts = new ArrayList<Part>();
+		private ArrayList<Part> parts = new ArrayList<>();
 	}
 }

--- a/src/main/java/org/openpnp/model/Footprint.java
+++ b/src/main/java/org/openpnp/model/Footprint.java
@@ -40,7 +40,7 @@ public class Footprint {
     private LengthUnit units = LengthUnit.Millimeters;
     
     @ElementList(inline=true, required=false)
-    private ArrayList<Pad> pads = new ArrayList<Pad>();
+    private ArrayList<Pad> pads = new ArrayList<>();
     
     @Attribute(required=false)
     private double bodyWidth;

--- a/src/main/java/org/openpnp/model/Job.java
+++ b/src/main/java/org/openpnp/model/Job.java
@@ -38,7 +38,7 @@ import org.simpleframework.xml.core.Commit;
 @Root(name="openpnp-job")
 public class Job extends AbstractModelObject implements PropertyChangeListener {
 	@ElementList
-	private ArrayList<BoardLocation> boardLocations = new ArrayList<BoardLocation>();
+	private ArrayList<BoardLocation> boardLocations = new ArrayList<>();
 	
 	private transient File file;
 	private transient boolean dirty;
@@ -61,7 +61,7 @@ public class Job extends AbstractModelObject implements PropertyChangeListener {
 
 	public void addBoardLocation(BoardLocation boardLocation) {
 		Object oldValue = boardLocations;
-		boardLocations = new ArrayList<BoardLocation>(boardLocations);
+		boardLocations = new ArrayList<>(boardLocations);
 		boardLocations.add(boardLocation);
 		firePropertyChange("boardLocations", oldValue, boardLocations);
 		boardLocation.addPropertyChangeListener(this);
@@ -69,7 +69,7 @@ public class Job extends AbstractModelObject implements PropertyChangeListener {
 	
 	public void removeBoardLocation(BoardLocation boardLocation) {
 		Object oldValue = boardLocations;
-		boardLocations = new ArrayList<BoardLocation>(boardLocations);
+		boardLocations = new ArrayList<>(boardLocations);
 		boardLocations.remove(boardLocation);
 		firePropertyChange("boardLocations", oldValue, boardLocations);
 		boardLocation.removePropertyChangeListener(this);

--- a/src/main/java/org/openpnp/model/Outline.java
+++ b/src/main/java/org/openpnp/model/Outline.java
@@ -16,7 +16,7 @@ public class Outline {
         @ElementList(entry="line", inline=true, required=false, type=Outline.Line.class),
         @ElementList(entry="circle", inline=true, required=false, type=Outline.Circle.class)
     })
-    private ArrayList<Outline.OutlineElement> elements = new ArrayList<Outline.OutlineElement>();
+    private ArrayList<Outline.OutlineElement> elements = new ArrayList<>();
     
     @Attribute
     private LengthUnit units = LengthUnit.Millimeters;

--- a/src/main/java/org/openpnp/model/eagle/xml/Attributes.java
+++ b/src/main/java/org/openpnp/model/eagle/xml/Attributes.java
@@ -52,7 +52,7 @@ public class Attributes {
      */
     public List<Attribute> getAttribute() {
         if (attribute == null) {
-            attribute = new ArrayList<Attribute>();
+            attribute = new ArrayList<>();
         }
         return this.attribute;
     }

--- a/src/main/java/org/openpnp/model/eagle/xml/Autorouter.java
+++ b/src/main/java/org/openpnp/model/eagle/xml/Autorouter.java
@@ -52,7 +52,7 @@ public class Autorouter {
      */
     public List<Pass> getPass() {
         if (pass == null) {
-            pass = new ArrayList<Pass>();
+            pass = new ArrayList<>();
         }
         return this.pass;
     }

--- a/src/main/java/org/openpnp/model/eagle/xml/Bus.java
+++ b/src/main/java/org/openpnp/model/eagle/xml/Bus.java
@@ -82,7 +82,7 @@ public class Bus {
      */
     public List<Segment> getSegment() {
         if (segment == null) {
-            segment = new ArrayList<Segment>();
+            segment = new ArrayList<>();
         }
         return this.segment;
     }

--- a/src/main/java/org/openpnp/model/eagle/xml/Busses.java
+++ b/src/main/java/org/openpnp/model/eagle/xml/Busses.java
@@ -52,7 +52,7 @@ public class Busses {
      */
     public List<Bus> getBus() {
         if (bus == null) {
-            bus = new ArrayList<Bus>();
+            bus = new ArrayList<>();
         }
         return this.bus;
     }

--- a/src/main/java/org/openpnp/model/eagle/xml/Class.java
+++ b/src/main/java/org/openpnp/model/eagle/xml/Class.java
@@ -171,7 +171,7 @@ public class Class {
      */
     public List<Clearance> getClearance() {
         if (clearance == null) {
-            clearance = new ArrayList<Clearance>();
+            clearance = new ArrayList<>();
         }
         return this.clearance;
     }

--- a/src/main/java/org/openpnp/model/eagle/xml/Classes.java
+++ b/src/main/java/org/openpnp/model/eagle/xml/Classes.java
@@ -54,7 +54,7 @@ public class Classes {
      */
     public List<Class> getClazz() {
         if (clazz == null) {
-            clazz = new ArrayList<Class>();
+            clazz = new ArrayList<>();
         }
         return this.clazz;
     }

--- a/src/main/java/org/openpnp/model/eagle/xml/Compatibility.java
+++ b/src/main/java/org/openpnp/model/eagle/xml/Compatibility.java
@@ -52,7 +52,7 @@ public class Compatibility {
      */
     public List<Note> getNote() {
         if (note == null) {
-            note = new ArrayList<Note>();
+            note = new ArrayList<>();
         }
         return this.note;
     }

--- a/src/main/java/org/openpnp/model/eagle/xml/Connects.java
+++ b/src/main/java/org/openpnp/model/eagle/xml/Connects.java
@@ -52,7 +52,7 @@ public class Connects {
      */
     public List<Connect> getConnect() {
         if (connect == null) {
-            connect = new ArrayList<Connect>();
+            connect = new ArrayList<>();
         }
         return this.connect;
     }

--- a/src/main/java/org/openpnp/model/eagle/xml/Designrules.java
+++ b/src/main/java/org/openpnp/model/eagle/xml/Designrules.java
@@ -84,7 +84,7 @@ public class Designrules {
      */
     public List<Description> getDescription() {
         if (description == null) {
-            description = new ArrayList<Description>();
+            description = new ArrayList<>();
         }
         return this.description;
     }
@@ -113,7 +113,7 @@ public class Designrules {
      */
     public List<Param> getParam() {
         if (param == null) {
-            param = new ArrayList<Param>();
+            param = new ArrayList<>();
         }
         return this.param;
     }

--- a/src/main/java/org/openpnp/model/eagle/xml/Devices.java
+++ b/src/main/java/org/openpnp/model/eagle/xml/Devices.java
@@ -52,7 +52,7 @@ public class Devices {
      */
     public List<Device> getDevice() {
         if (device == null) {
-            device = new ArrayList<Device>();
+            device = new ArrayList<>();
         }
         return this.device;
     }

--- a/src/main/java/org/openpnp/model/eagle/xml/Devicesets.java
+++ b/src/main/java/org/openpnp/model/eagle/xml/Devicesets.java
@@ -52,7 +52,7 @@ public class Devicesets {
      */
     public List<Deviceset> getDeviceset() {
         if (deviceset == null) {
-            deviceset = new ArrayList<Deviceset>();
+            deviceset = new ArrayList<>();
         }
         return this.deviceset;
     }

--- a/src/main/java/org/openpnp/model/eagle/xml/Drawing.java
+++ b/src/main/java/org/openpnp/model/eagle/xml/Drawing.java
@@ -140,7 +140,7 @@ public class Drawing {
      */
     public List<Object> getLibraryOrSchematicOrBoard() {
         if (libraryOrSchematicOrBoard == null) {
-            libraryOrSchematicOrBoard = new ArrayList<Object>();
+            libraryOrSchematicOrBoard = new ArrayList<>();
         }
         return this.libraryOrSchematicOrBoard;
     }

--- a/src/main/java/org/openpnp/model/eagle/xml/Eagle.java
+++ b/src/main/java/org/openpnp/model/eagle/xml/Eagle.java
@@ -89,7 +89,7 @@ public class Eagle {
      */
     public List<Object> getCompatibilityOrDrawing() {
         if (compatibilityOrDrawing == null) {
-            compatibilityOrDrawing = new ArrayList<Object>();
+            compatibilityOrDrawing = new ArrayList<>();
         }
         return this.compatibilityOrDrawing;
     }

--- a/src/main/java/org/openpnp/model/eagle/xml/Element.java
+++ b/src/main/java/org/openpnp/model/eagle/xml/Element.java
@@ -344,7 +344,7 @@ public class Element {
      */
     public List<Attribute> getAttribute() {
         if (attribute == null) {
-            attribute = new ArrayList<Attribute>();
+            attribute = new ArrayList<>();
         }
         return this.attribute;
     }
@@ -373,7 +373,7 @@ public class Element {
      */
     public List<Variant> getVariant() {
         if (variant == null) {
-            variant = new ArrayList<Variant>();
+            variant = new ArrayList<>();
         }
         return this.variant;
     }

--- a/src/main/java/org/openpnp/model/eagle/xml/Elements.java
+++ b/src/main/java/org/openpnp/model/eagle/xml/Elements.java
@@ -52,7 +52,7 @@ public class Elements {
      */
     public List<Element> getElement() {
         if (element == null) {
-            element = new ArrayList<Element>();
+            element = new ArrayList<>();
         }
         return this.element;
     }

--- a/src/main/java/org/openpnp/model/eagle/xml/Errors.java
+++ b/src/main/java/org/openpnp/model/eagle/xml/Errors.java
@@ -52,7 +52,7 @@ public class Errors {
      */
     public List<Approved> getApproved() {
         if (approved == null) {
-            approved = new ArrayList<Approved>();
+            approved = new ArrayList<>();
         }
         return this.approved;
     }

--- a/src/main/java/org/openpnp/model/eagle/xml/Gates.java
+++ b/src/main/java/org/openpnp/model/eagle/xml/Gates.java
@@ -52,7 +52,7 @@ public class Gates {
      */
     public List<Gate> getGate() {
         if (gate == null) {
-            gate = new ArrayList<Gate>();
+            gate = new ArrayList<>();
         }
         return this.gate;
     }

--- a/src/main/java/org/openpnp/model/eagle/xml/Instance.java
+++ b/src/main/java/org/openpnp/model/eagle/xml/Instance.java
@@ -226,7 +226,7 @@ public class Instance {
      */
     public List<Attribute> getAttribute() {
         if (attribute == null) {
-            attribute = new ArrayList<Attribute>();
+            attribute = new ArrayList<>();
         }
         return this.attribute;
     }

--- a/src/main/java/org/openpnp/model/eagle/xml/Instances.java
+++ b/src/main/java/org/openpnp/model/eagle/xml/Instances.java
@@ -52,7 +52,7 @@ public class Instances {
      */
     public List<Instance> getInstance() {
         if (instance == null) {
-            instance = new ArrayList<Instance>();
+            instance = new ArrayList<>();
         }
         return this.instance;
     }

--- a/src/main/java/org/openpnp/model/eagle/xml/Layers.java
+++ b/src/main/java/org/openpnp/model/eagle/xml/Layers.java
@@ -52,7 +52,7 @@ public class Layers {
      */
     public List<Layer> getLayer() {
         if (layer == null) {
-            layer = new ArrayList<Layer>();
+            layer = new ArrayList<>();
         }
         return this.layer;
     }

--- a/src/main/java/org/openpnp/model/eagle/xml/Libraries.java
+++ b/src/main/java/org/openpnp/model/eagle/xml/Libraries.java
@@ -52,7 +52,7 @@ public class Libraries {
      */
     public List<Library> getLibrary() {
         if (library == null) {
-            library = new ArrayList<Library>();
+            library = new ArrayList<>();
         }
         return this.library;
     }

--- a/src/main/java/org/openpnp/model/eagle/xml/Moduleinst.java
+++ b/src/main/java/org/openpnp/model/eagle/xml/Moduleinst.java
@@ -288,7 +288,7 @@ public class Moduleinst {
      */
     public List<Attribute> getAttribute() {
         if (attribute == null) {
-            attribute = new ArrayList<Attribute>();
+            attribute = new ArrayList<>();
         }
         return this.attribute;
     }

--- a/src/main/java/org/openpnp/model/eagle/xml/Moduleinsts.java
+++ b/src/main/java/org/openpnp/model/eagle/xml/Moduleinsts.java
@@ -52,7 +52,7 @@ public class Moduleinsts {
      */
     public List<Moduleinst> getModuleinst() {
         if (moduleinst == null) {
-            moduleinst = new ArrayList<Moduleinst>();
+            moduleinst = new ArrayList<>();
         }
         return this.moduleinst;
     }

--- a/src/main/java/org/openpnp/model/eagle/xml/Modules.java
+++ b/src/main/java/org/openpnp/model/eagle/xml/Modules.java
@@ -52,7 +52,7 @@ public class Modules {
      */
     public List<Module> getModule() {
         if (module == null) {
-            module = new ArrayList<Module>();
+            module = new ArrayList<>();
         }
         return this.module;
     }

--- a/src/main/java/org/openpnp/model/eagle/xml/Net.java
+++ b/src/main/java/org/openpnp/model/eagle/xml/Net.java
@@ -113,7 +113,7 @@ public class Net {
      */
     public List<Segment> getSegment() {
         if (segment == null) {
-            segment = new ArrayList<Segment>();
+            segment = new ArrayList<>();
         }
         return this.segment;
     }

--- a/src/main/java/org/openpnp/model/eagle/xml/Nets.java
+++ b/src/main/java/org/openpnp/model/eagle/xml/Nets.java
@@ -52,7 +52,7 @@ public class Nets {
      */
     public List<Net> getNet() {
         if (net == null) {
-            net = new ArrayList<Net>();
+            net = new ArrayList<>();
         }
         return this.net;
     }

--- a/src/main/java/org/openpnp/model/eagle/xml/Package.java
+++ b/src/main/java/org/openpnp/model/eagle/xml/Package.java
@@ -131,7 +131,7 @@ public class Package {
      */
     public List<Object> getPolygonOrWireOrTextOrDimensionOrCircleOrRectangleOrFrameOrHoleOrPadOrSmd() {
         if (polygonOrWireOrTextOrDimensionOrCircleOrRectangleOrFrameOrHoleOrPadOrSmd == null) {
-            polygonOrWireOrTextOrDimensionOrCircleOrRectangleOrFrameOrHoleOrPadOrSmd = new ArrayList<Object>();
+            polygonOrWireOrTextOrDimensionOrCircleOrRectangleOrFrameOrHoleOrPadOrSmd = new ArrayList<>();
         }
         return this.polygonOrWireOrTextOrDimensionOrCircleOrRectangleOrFrameOrHoleOrPadOrSmd;
     }

--- a/src/main/java/org/openpnp/model/eagle/xml/Packages.java
+++ b/src/main/java/org/openpnp/model/eagle/xml/Packages.java
@@ -54,7 +54,7 @@ public class Packages {
      */
     public List<Package> getPackage() {
         if (_package == null) {
-            _package = new ArrayList<Package>();
+            _package = new ArrayList<>();
         }
         return this._package;
     }

--- a/src/main/java/org/openpnp/model/eagle/xml/Part.java
+++ b/src/main/java/org/openpnp/model/eagle/xml/Part.java
@@ -223,7 +223,7 @@ public class Part {
      */
     public List<Attribute> getAttribute() {
         if (attribute == null) {
-            attribute = new ArrayList<Attribute>();
+            attribute = new ArrayList<>();
         }
         return this.attribute;
     }
@@ -252,7 +252,7 @@ public class Part {
      */
     public List<Variant> getVariant() {
         if (variant == null) {
-            variant = new ArrayList<Variant>();
+            variant = new ArrayList<>();
         }
         return this.variant;
     }

--- a/src/main/java/org/openpnp/model/eagle/xml/Parts.java
+++ b/src/main/java/org/openpnp/model/eagle/xml/Parts.java
@@ -52,7 +52,7 @@ public class Parts {
      */
     public List<Part> getPart() {
         if (part == null) {
-            part = new ArrayList<Part>();
+            part = new ArrayList<>();
         }
         return this.part;
     }

--- a/src/main/java/org/openpnp/model/eagle/xml/Pass.java
+++ b/src/main/java/org/openpnp/model/eagle/xml/Pass.java
@@ -141,7 +141,7 @@ public class Pass {
      */
     public List<Param> getParam() {
         if (param == null) {
-            param = new ArrayList<Param>();
+            param = new ArrayList<>();
         }
         return this.param;
     }

--- a/src/main/java/org/openpnp/model/eagle/xml/Plain.java
+++ b/src/main/java/org/openpnp/model/eagle/xml/Plain.java
@@ -71,7 +71,7 @@ public class Plain {
      */
     public List<Object> getPolygonOrWireOrTextOrDimensionOrCircleOrRectangleOrFrameOrHole() {
         if (polygonOrWireOrTextOrDimensionOrCircleOrRectangleOrFrameOrHole == null) {
-            polygonOrWireOrTextOrDimensionOrCircleOrRectangleOrFrameOrHole = new ArrayList<Object>();
+            polygonOrWireOrTextOrDimensionOrCircleOrRectangleOrFrameOrHole = new ArrayList<>();
         }
         return this.polygonOrWireOrTextOrDimensionOrCircleOrRectangleOrFrameOrHole;
     }

--- a/src/main/java/org/openpnp/model/eagle/xml/Polygon.java
+++ b/src/main/java/org/openpnp/model/eagle/xml/Polygon.java
@@ -288,7 +288,7 @@ public class Polygon {
      */
     public List<Vertex> getVertex() {
         if (vertex == null) {
-            vertex = new ArrayList<Vertex>();
+            vertex = new ArrayList<>();
         }
         return this.vertex;
     }

--- a/src/main/java/org/openpnp/model/eagle/xml/Ports.java
+++ b/src/main/java/org/openpnp/model/eagle/xml/Ports.java
@@ -52,7 +52,7 @@ public class Ports {
      */
     public List<Port> getPort() {
         if (port == null) {
-            port = new ArrayList<Port>();
+            port = new ArrayList<>();
         }
         return this.port;
     }

--- a/src/main/java/org/openpnp/model/eagle/xml/Segment.java
+++ b/src/main/java/org/openpnp/model/eagle/xml/Segment.java
@@ -65,7 +65,7 @@ public class Segment {
      */
     public List<Object> getPinrefOrPortrefOrWireOrJunctionOrLabel() {
         if (pinrefOrPortrefOrWireOrJunctionOrLabel == null) {
-            pinrefOrPortrefOrWireOrJunctionOrLabel = new ArrayList<Object>();
+            pinrefOrPortrefOrWireOrJunctionOrLabel = new ArrayList<>();
         }
         return this.pinrefOrPortrefOrWireOrJunctionOrLabel;
     }

--- a/src/main/java/org/openpnp/model/eagle/xml/Settings.java
+++ b/src/main/java/org/openpnp/model/eagle/xml/Settings.java
@@ -52,7 +52,7 @@ public class Settings {
      */
     public List<Setting> getSetting() {
         if (setting == null) {
-            setting = new ArrayList<Setting>();
+            setting = new ArrayList<>();
         }
         return this.setting;
     }

--- a/src/main/java/org/openpnp/model/eagle/xml/Sheets.java
+++ b/src/main/java/org/openpnp/model/eagle/xml/Sheets.java
@@ -52,7 +52,7 @@ public class Sheets {
      */
     public List<Sheet> getSheet() {
         if (sheet == null) {
-            sheet = new ArrayList<Sheet>();
+            sheet = new ArrayList<>();
         }
         return this.sheet;
     }

--- a/src/main/java/org/openpnp/model/eagle/xml/Signal.java
+++ b/src/main/java/org/openpnp/model/eagle/xml/Signal.java
@@ -156,7 +156,7 @@ public class Signal {
      */
     public List<Object> getContactrefOrPolygonOrWireOrVia() {
         if (contactrefOrPolygonOrWireOrVia == null) {
-            contactrefOrPolygonOrWireOrVia = new ArrayList<Object>();
+            contactrefOrPolygonOrWireOrVia = new ArrayList<>();
         }
         return this.contactrefOrPolygonOrWireOrVia;
     }

--- a/src/main/java/org/openpnp/model/eagle/xml/Signals.java
+++ b/src/main/java/org/openpnp/model/eagle/xml/Signals.java
@@ -52,7 +52,7 @@ public class Signals {
      */
     public List<Signal> getSignal() {
         if (signal == null) {
-            signal = new ArrayList<Signal>();
+            signal = new ArrayList<>();
         }
         return this.signal;
     }

--- a/src/main/java/org/openpnp/model/eagle/xml/Symbol.java
+++ b/src/main/java/org/openpnp/model/eagle/xml/Symbol.java
@@ -127,7 +127,7 @@ public class Symbol {
      */
     public List<Object> getPolygonOrWireOrTextOrDimensionOrPinOrCircleOrRectangleOrFrame() {
         if (polygonOrWireOrTextOrDimensionOrPinOrCircleOrRectangleOrFrame == null) {
-            polygonOrWireOrTextOrDimensionOrPinOrCircleOrRectangleOrFrame = new ArrayList<Object>();
+            polygonOrWireOrTextOrDimensionOrPinOrCircleOrRectangleOrFrame = new ArrayList<>();
         }
         return this.polygonOrWireOrTextOrDimensionOrPinOrCircleOrRectangleOrFrame;
     }

--- a/src/main/java/org/openpnp/model/eagle/xml/Symbols.java
+++ b/src/main/java/org/openpnp/model/eagle/xml/Symbols.java
@@ -52,7 +52,7 @@ public class Symbols {
      */
     public List<Symbol> getSymbol() {
         if (symbol == null) {
-            symbol = new ArrayList<Symbol>();
+            symbol = new ArrayList<>();
         }
         return this.symbol;
     }

--- a/src/main/java/org/openpnp/model/eagle/xml/Technologies.java
+++ b/src/main/java/org/openpnp/model/eagle/xml/Technologies.java
@@ -52,7 +52,7 @@ public class Technologies {
      */
     public List<Technology> getTechnology() {
         if (technology == null) {
-            technology = new ArrayList<Technology>();
+            technology = new ArrayList<>();
         }
         return this.technology;
     }

--- a/src/main/java/org/openpnp/model/eagle/xml/Technology.java
+++ b/src/main/java/org/openpnp/model/eagle/xml/Technology.java
@@ -82,7 +82,7 @@ public class Technology {
      */
     public List<Attribute> getAttribute() {
         if (attribute == null) {
-            attribute = new ArrayList<Attribute>();
+            attribute = new ArrayList<>();
         }
         return this.attribute;
     }

--- a/src/main/java/org/openpnp/model/eagle/xml/Variantdefs.java
+++ b/src/main/java/org/openpnp/model/eagle/xml/Variantdefs.java
@@ -52,7 +52,7 @@ public class Variantdefs {
      */
     public List<Variantdef> getVariantdef() {
         if (variantdef == null) {
-            variantdef = new ArrayList<Variantdef>();
+            variantdef = new ArrayList<>();
         }
         return this.variantdef;
     }

--- a/src/main/java/org/openpnp/planner/SimpleJobPlanner.java
+++ b/src/main/java/org/openpnp/planner/SimpleJobPlanner.java
@@ -30,7 +30,7 @@ public class SimpleJobPlanner extends AbstractJobPlanner {
     @Attribute(required = false)
     private String placeHolder;
     
-    protected Set<PlacementSolution> solutions = new LinkedHashSet<PlacementSolution>();
+    protected Set<PlacementSolution> solutions = new LinkedHashSet<>();
     
     @Override
     public void setJob(Job job) {
@@ -71,7 +71,7 @@ public class SimpleJobPlanner extends AbstractJobPlanner {
      */
     @Override
     public synchronized Set<PlacementSolution> getNextPlacementSolutions(Head head) {
-        Set<PlacementSolution> results = new LinkedHashSet<PlacementSolution>();
+        Set<PlacementSolution> results = new LinkedHashSet<>();
         Machine machine = Configuration.get().getMachine();
         for (Nozzle nozzle : head.getNozzles()) {
             for (WeightedPlacementSolution solution : getWeightedSolutions(machine, nozzle)) {
@@ -96,7 +96,7 @@ public class SimpleJobPlanner extends AbstractJobPlanner {
     }
     
     protected List<WeightedPlacementSolution> getWeightedSolutions(Machine machine, Nozzle nozzle) {
-        List<WeightedPlacementSolution> weightedSolutions = new ArrayList<WeightedPlacementSolution>();
+        List<WeightedPlacementSolution> weightedSolutions = new ArrayList<>();
         for (PlacementSolution solution : solutions) {
             Part part = solution.placement.getPart();
             if (part == null) {
@@ -127,7 +127,7 @@ public class SimpleJobPlanner extends AbstractJobPlanner {
     }
     
     private static Set<NozzleTip> getCompatibleNozzleTips(Nozzle nozzle, Part part) {
-        Set<NozzleTip> nozzleTips = new HashSet<NozzleTip>();
+        Set<NozzleTip> nozzleTips = new HashSet<>();
         for (NozzleTip nozzleTip : nozzle.getNozzleTips()) {
             if (nozzleTip.canHandle(part)) {
                 nozzleTips.add(nozzleTip);
@@ -137,7 +137,7 @@ public class SimpleJobPlanner extends AbstractJobPlanner {
     }
     
     private static Set<Feeder> getCompatibleFeeders(Machine machine, Nozzle nozzle, Part part) {
-        Set<Feeder> feeders = new HashSet<Feeder>();
+        Set<Feeder> feeders = new HashSet<>();
         for (Feeder feeder : machine.getFeeders()) {
             if (feeder.getPart() == part && feeder.isEnabled()) {
                 feeders.add(feeder);

--- a/src/main/java/org/openpnp/spi/base/AbstractCamera.java
+++ b/src/main/java/org/openpnp/spi/base/AbstractCamera.java
@@ -39,7 +39,7 @@ public abstract class AbstractCamera implements Camera {
     @Attribute(required=false)
     protected long settleTimeMs = 250;
     
-    protected Set<ListenerEntry> listeners = Collections.synchronizedSet(new HashSet<ListenerEntry>());
+    protected Set<ListenerEntry> listeners = Collections.synchronizedSet(new HashSet<>());
     
     protected Head head;
     
@@ -138,7 +138,7 @@ public abstract class AbstractCamera implements Camera {
     }
     
     protected void broadcastCapture(BufferedImage img) {
-        for (ListenerEntry listener : new ArrayList<ListenerEntry>(listeners)) {
+        for (ListenerEntry listener : new ArrayList<>(listeners)) {
             if (listener.lastFrameSent < (System.currentTimeMillis() - (1000 / listener.maximumFps))) {
                 listener.listener.frameReceived(img);
                 listener.lastFrameSent = System.currentTimeMillis();

--- a/src/main/java/org/openpnp/spi/base/AbstractHead.java
+++ b/src/main/java/org/openpnp/spi/base/AbstractHead.java
@@ -27,16 +27,16 @@ public abstract class AbstractHead implements Head {
     protected String name;
     
     @ElementList(required=false)
-    protected IdentifiableList<Nozzle> nozzles = new IdentifiableList<Nozzle>();
+    protected IdentifiableList<Nozzle> nozzles = new IdentifiableList<>();
     
     @ElementList(required=false)
-    protected IdentifiableList<Actuator> actuators = new IdentifiableList<Actuator>();
+    protected IdentifiableList<Actuator> actuators = new IdentifiableList<>();
     
     @ElementList(required=false)
-    protected IdentifiableList<Camera> cameras = new IdentifiableList<Camera>();
+    protected IdentifiableList<Camera> cameras = new IdentifiableList<>();
     
     @ElementList(required=false)
-    protected IdentifiableList<PasteDispenser> pasteDispensers = new IdentifiableList<PasteDispenser>();
+    protected IdentifiableList<PasteDispenser> pasteDispensers = new IdentifiableList<>();
     
     public AbstractHead() {
         this.id = Configuration.createId();

--- a/src/main/java/org/openpnp/spi/base/AbstractJobProcessor.java
+++ b/src/main/java/org/openpnp/spi/base/AbstractJobProcessor.java
@@ -23,7 +23,7 @@ public abstract class AbstractJobProcessor implements JobProcessor, Runnable {
     private static final Logger logger = LoggerFactory.getLogger(AbstractJobProcessor.class);
 
     protected Job job;
-    protected Set<JobProcessorListener> listeners = new HashSet<JobProcessorListener>();
+    protected Set<JobProcessorListener> listeners = new HashSet<>();
     protected JobProcessorDelegate delegate = new DefaultJobProcessorDelegate();
     protected JobState state;
     protected Thread thread;

--- a/src/main/java/org/openpnp/spi/base/AbstractMachine.java
+++ b/src/main/java/org/openpnp/spi/base/AbstractMachine.java
@@ -44,13 +44,13 @@ public abstract class AbstractMachine implements Machine {
      */
 
     @ElementList
-    protected IdentifiableList<Head> heads = new IdentifiableList<Head>();
+    protected IdentifiableList<Head> heads = new IdentifiableList<>();
     
     @ElementList(required=false)
-    protected IdentifiableList<Feeder> feeders = new IdentifiableList<Feeder>();
+    protected IdentifiableList<Feeder> feeders = new IdentifiableList<>();
     
     @ElementList(required=false)
-    protected IdentifiableList<Camera> cameras = new IdentifiableList<Camera>();
+    protected IdentifiableList<Camera> cameras = new IdentifiableList<>();
     
     @Deprecated
     @Element(required=false)
@@ -63,7 +63,7 @@ public abstract class AbstractMachine implements Machine {
     @ElementMap(entry="jobProcessor", key="type", attribute=true, inline=false, required=false)
     protected Map<JobProcessor.Type, JobProcessor> jobProcessors = new HashMap<>();
     
-    protected Set<MachineListener> listeners = Collections.synchronizedSet(new HashSet<MachineListener>());
+    protected Set<MachineListener> listeners = Collections.synchronizedSet(new HashSet<>());
     
     protected ThreadPoolExecutor executor;
     
@@ -218,7 +218,7 @@ public abstract class AbstractMachine implements Machine {
                         1, 
                         1,
                         TimeUnit.SECONDS,
-                        new LinkedBlockingQueue<Runnable>());
+                        new LinkedBlockingQueue<>());
             }
         }
         

--- a/src/main/java/org/openpnp/spi/base/AbstractNozzle.java
+++ b/src/main/java/org/openpnp/spi/base/AbstractNozzle.java
@@ -16,7 +16,7 @@ import org.simpleframework.xml.ElementList;
 
 public abstract class AbstractNozzle implements Nozzle {
     @ElementList(required=false)
-    	protected IdentifiableList<NozzleTip> nozzleTips = new IdentifiableList<NozzleTip>();
+    	protected IdentifiableList<NozzleTip> nozzleTips = new IdentifiableList<>();
 
     @Attribute
     protected String id;

--- a/src/main/java/org/openpnp/vision/FiducialLocator.java
+++ b/src/main/java/org/openpnp/vision/FiducialLocator.java
@@ -281,7 +281,7 @@ public class FiducialLocator {
                 }
             }
         }
-        ArrayList<Placement> results = new ArrayList<Placement>();
+        ArrayList<Placement> results = new ArrayList<>();
         results.add(maxA);
         results.add(maxB);
         return results;
@@ -289,7 +289,7 @@ public class FiducialLocator {
     
     private static IdentifiableList<Placement> getFiducials(BoardLocation boardLocation) {
         Board board = boardLocation.getBoard();
-        IdentifiableList<Placement> fiducials = new IdentifiableList<Placement>();
+        IdentifiableList<Placement> fiducials = new IdentifiableList<>();
         for (Placement placement : board.getPlacements()) {
             if (placement.getType() == Type.Fiducial
                     && placement.getSide() == boardLocation.getSide()) {

--- a/src/main/java/org/openpnp/vision/FluentCv.java
+++ b/src/main/java/org/openpnp/vision/FluentCv.java
@@ -355,7 +355,7 @@ public class FluentCv {
 	}
 	
 	public List<String> getStoredTags() {
-		return new ArrayList<String>(stored.keySet());
+		return new ArrayList<>(stored.keySet());
 	}
 	
 	public FluentCv write(File file) throws Exception {
@@ -431,7 +431,7 @@ public class FluentCv {
 			double maxDistance,
 			String...tag
 			) {
-		List<float[]> results = new ArrayList<float[]>();
+		List<float[]> results = new ArrayList<>();
     	for (int i = 0; i < this.mat.cols(); i++) {
     		float[] circle = new float[3];
     		this.mat.get(0, i, circle);
@@ -468,7 +468,7 @@ public class FluentCv {
 			return store(this.mat, tag);
 		}
 		
-    	List<Point> points = new ArrayList<Point>();
+    	List<Point> points = new ArrayList<>();
     	// collect the circles into a list of points
     	for (int i = 0; i < this.mat.cols(); i++) {
     		float[] circle = new float[3];
@@ -483,7 +483,7 @@ public class FluentCv {
     	Point b = line[1];
 		
     	// filter the points by distance from the resulting line
-		List<float[]> results = new ArrayList<float[]>();
+		List<float[]> results = new ArrayList<>();
 		for (int i = 0; i < this.mat.cols(); i++) {
     		float[] circle = new float[3];
     		this.mat.get(0, i, circle);
@@ -633,7 +633,7 @@ public class FluentCv {
 	public FluentCv getContourMaxRects(List<MatOfPoint> contours, List<RotatedRect> rect) {
 		List<Point> contoursCombined = new ArrayList<>();
 		for (MatOfPoint mp : contours) {
-			List<Point> points = new ArrayList<Point>();
+			List<Point> points = new ArrayList<>();
 			Converters.Mat_to_vector_Point(mp, points);
 			for (Point point : points) {
 				contoursCombined.add(point);

--- a/src/test/java/BasicJobTest.java
+++ b/src/test/java/BasicJobTest.java
@@ -216,7 +216,7 @@ public class BasicJobTest {
      * field.
      */
     public static class BasicJobTestDriverDelegate extends TestDriverDelegate {
-        private Queue<ExpectedOp> expectedOps = new LinkedList<ExpectedOp>();
+        private Queue<ExpectedOp> expectedOps = new LinkedList<>();
 
         public void expectMove(String description, HeadMountable hm, Location location, double speed) {
             ExpectedMove o = new ExpectedMove(description, hm, location, speed);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2293 - “ The diamond operator ("<>") should be used ”. You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S2293
Please let me know if you have any questions.
Ayman Abdelghany.