### PR TITLE
equals(Object obj)" and "hashCode()" should be overridden in pairs

### DIFF
--- a/src/main/java/org/openpnp/gui/support/HeadCellValue.java
+++ b/src/main/java/org/openpnp/gui/support/HeadCellValue.java
@@ -64,4 +64,9 @@ public class HeadCellValue {
 		}
 		return ((HeadCellValue) obj).head == this.head;
 	}
+
+	@Override
+	public int hashCode() {
+		return this.head != null ? this.head.hashCode() : 0;
+	}
 }

--- a/src/main/java/org/openpnp/model/Location.java
+++ b/src/main/java/org/openpnp/model/Location.java
@@ -295,4 +295,20 @@ public class Location {
                 this.y == that.y && this.z == that.z && 
                 this.rotation == that.rotation; 
     }
+
+	@Override
+	public int hashCode() {
+		int result;
+		long temp;
+		result = this.units != null ? this.units.hashCode() : 0;
+		temp = Double.doubleToLongBits(this.x);
+		result = 31 * result + (int) (temp ^ temp >>> 32);
+		temp = Double.doubleToLongBits(this.y);
+		result = 31 * result + (int) (temp ^ temp >>> 32);
+		temp = Double.doubleToLongBits(this.z);
+		result = 31 * result + (int) (temp ^ temp >>> 32);
+		temp = Double.doubleToLongBits(this.rotation);
+		result = 31 * result + (int) (temp ^ temp >>> 32);
+		return result;
+	}
 }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1206 - “ equals(Object obj) and hashCode() should be overridden in pairs ”. You can find more information about the issue here: https://dev.eclipse.org/sonar/rules/show/squid:S1206
Please let me know if you have any questions.
Ayman Abdelghany.