### PR TITLE
Math operands should be cast before assignment

### DIFF
--- a/src/main/java/org/openpnp/gui/components/CameraView.java
+++ b/src/main/java/org/openpnp/gui/components/CameraView.java
@@ -1095,8 +1095,8 @@ public class CameraView extends JComponent implements CameraListener {
 
         // Find the difference in X and Y from the center of the image
         // to the mouse click.
-        double offsetX = (scaledWidth / 2) - (x - imageX);
-        double offsetY = (scaledHeight / 2) - (y - imageY);
+        double offsetX = (scaledWidth / 2.0D) - (x - imageX);
+        double offsetY = (scaledHeight / 2.0D) - (y - imageY);
 
         // Invert the X so that the offsets represent a bottom left to
         // top right coordinate system.
@@ -1133,8 +1133,8 @@ public class CameraView extends JComponent implements CameraListener {
 
         // Find the difference in X and Y from the center of the image
         // to the mouse click.
-        double offsetX = (scaledWidth / 2) - (x - imageX);
-        double offsetY = (scaledHeight / 2) - (y - imageY) + 1;
+        double offsetX = (scaledWidth / 2.0D) - (x - imageX);
+        double offsetY = (scaledHeight / 2.0D) - (y - imageY) + 1;
 
         // Invert the X so that the offsets represent a bottom left to
         // top right coordinate system.

--- a/src/main/java/org/openpnp/machine/reference/ReferenceCamera.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceCamera.java
@@ -166,7 +166,7 @@ public abstract class ReferenceCamera extends AbstractCamera implements Referenc
         }
         
         if (rotation != 0) {
-            xform.rotate(Math.toRadians(-rotation), image.getWidth() / 2, image.getHeight() / 2);
+            xform.rotate(Math.toRadians(-rotation), image.getWidth() / 2.0D, image.getHeight() / 2.0D);
         }
         
         g2d.drawImage(image, xform, null);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2184 - “ Math operands should be cast before assignment”. You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S2184
Please let me know if you have any questions.
Ayman Abdelghany.