### PR TITLE
Don't crop rotated frames in ReferenceCamera

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/ReferenceCamera.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceCamera.java
@@ -82,6 +82,9 @@ public abstract class ReferenceCamera extends AbstractCamera implements Referenc
     private CalibrationCallback calibrationCallback;
     private int calibrationCountGoal = 25;
 
+    private Mat undistortionMap1;
+    private Mat undistortionMap2;
+
     protected ReferenceMachine machine;
     protected ReferenceDriver driver;
 
@@ -245,9 +248,16 @@ public abstract class ReferenceCamera extends AbstractCamera implements Referenc
         if (!calibration.isEnabled()) {
             return mat;
         }
+
+        if (undistortionMap1 == null || undistortionMap2 == null) {
+            undistortionMap1 = new Mat();
+            undistortionMap2 = new Mat();
+            Mat rectification = Mat.eye(3, 3, CvType.CV_32F);
+            Imgproc.initUndistortRectifyMap(calibration.getCameraMatrixMat(), calibration.getDistortionCoefficientsMat(), rectification, calibration.getCameraMatrixMat(), mat.size(), CvType.CV_32FC1, undistortionMap1, undistortionMap2);
+        }
+
         Mat dst = mat.clone();
-        Imgproc.undistort(mat, dst, calibration.getCameraMatrixMat(),
-                calibration.getDistortionCoefficientsMat());
+        Imgproc.remap(mat, dst, undistortionMap1, undistortionMap2, Imgproc.INTER_LINEAR);
         mat.release();
         return dst;
     }

--- a/src/main/java/org/openpnp/machine/reference/ReferenceCamera.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceCamera.java
@@ -288,6 +288,9 @@ public abstract class ReferenceCamera extends AbstractCamera implements Referenc
                 calibration
                         .setDistortionCoefficientsMat(lensCalibration.getDistortionCoefficients());
                 calibration.setEnabled(true);
+                
+                lensCalibration.close();
+                lensCalibration = null;
                 calibrating = false;
             }
             else {
@@ -308,6 +311,9 @@ public abstract class ReferenceCamera extends AbstractCamera implements Referenc
     }
 
     public void cancelCalibration() {
+    	if (calibrating) {
+    		lensCalibration.close();
+    	}
         calibrating = false;
     }
 
@@ -378,7 +384,7 @@ public abstract class ReferenceCamera extends AbstractCamera implements Referenc
         }
 
         public void setCameraMatrixMat(Mat cameraMatrix) {
-            this.cameraMatrix = cameraMatrix;
+            this.cameraMatrix = cameraMatrix.clone();
         }
 
         public Mat getDistortionCoefficientsMat() {
@@ -386,7 +392,7 @@ public abstract class ReferenceCamera extends AbstractCamera implements Referenc
         }
 
         public void setDistortionCoefficientsMat(Mat distortionCoefficients) {
-            this.distortionCoefficients = distortionCoefficients;
+            this.distortionCoefficients = distortionCoefficients.clone();
         }
     }
 }

--- a/src/main/java/org/openpnp/machine/reference/ReferenceCamera.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceCamera.java
@@ -26,6 +26,8 @@ import org.opencv.core.Core;
 import org.opencv.core.CvType;
 import org.opencv.core.Mat;
 import org.opencv.core.Point;
+import org.opencv.core.Rect;
+import org.opencv.core.RotatedRect;
 import org.opencv.imgproc.Imgproc;
 import org.openpnp.ConfigurationListener;
 import org.openpnp.model.Configuration;
@@ -171,25 +173,9 @@ public abstract class ReferenceCamera extends AbstractCamera implements Referenc
         mat = undistort(mat);
 
         // apply affine transformations
-        if (rotation != 0) {
-            // TODO: Fix cropping of rotated image:
-            // http://stackoverflow.com/questions/22041699/rotate-an-image-without-cropping-in-opencv-in-c
-            Point center = new Point(mat.width() / 2D, mat.height() / 2D);
-            Mat mapMatrix = Imgproc.getRotationMatrix2D(center, rotation, 1.0);
-            Imgproc.warpAffine(mat, mat, mapMatrix, mat.size(), Imgproc.INTER_LINEAR);
-            mapMatrix.release();
-        }
+        mat = rotate(mat, rotation);
 
-        if (offsetX != 0 || offsetY != 0) {
-            Mat mapMatrix = new Mat(2, 3, CvType.CV_32F) {
-                {
-                    put(0, 0, 1, 0, offsetX);
-                    put(1, 0, 0, 1, offsetY);
-                }
-            };
-            Imgproc.warpAffine(mat, mat, mapMatrix, mat.size(), Imgproc.INTER_LINEAR);
-            mapMatrix.release();
-        }
+        mat = offset(mat, offsetX, offsetY);
 
         if (flipX || flipY) {
             int flipCode;
@@ -205,6 +191,54 @@ public abstract class ReferenceCamera extends AbstractCamera implements Referenc
         image = OpenCvUtils.toBufferedImage(mat);
         mat.release();
         return image;
+    }
+    
+    private Mat rotate(Mat mat, double rotation) {
+        if (rotation == 0D) {
+        	return mat;
+        }
+
+        // See: http://stackoverflow.com/questions/22041699/rotate-an-image-without-cropping-in-opencv-in-c
+        Point center = new Point(mat.width() / 2D, mat.height() / 2D);
+        Mat mapMatrix = Imgproc.getRotationMatrix2D(center, rotation, 1.0);
+        
+        // determine bounding rectangle
+        Rect bbox = new RotatedRect(center, mat.size(), rotation).boundingRect();
+        // adjust transformation matrix
+        double[] cx = mapMatrix.get(0, 2);
+        double[] cy = mapMatrix.get(1, 2);
+        cx[0] += bbox.width / 2D - center.x;
+        cy[0] += bbox.height / 2D - center.y;
+        mapMatrix.put(0, 2, cx);
+        mapMatrix.put(1, 2, cy);
+
+        Mat dst = new Mat(bbox.width, bbox.height, mat.type());
+        Imgproc.warpAffine(mat, dst, mapMatrix, bbox.size(), Imgproc.INTER_LINEAR);
+        mat.release();
+
+        mapMatrix.release();
+        
+        return dst;
+    }
+    
+    private Mat offset(Mat mat, int offsetX, int offsetY) {
+        if (offsetX == 0D && offsetY == 0D) {
+        	return mat;
+        }
+
+    	Mat mapMatrix = new Mat(2, 3, CvType.CV_32F) {
+            {
+                put(0, 0, 1, 0, offsetX);
+                put(1, 0, 0, 1, offsetY);
+            }
+        };
+        
+        Mat dst = mat.clone();
+        Imgproc.warpAffine(mat, dst, mapMatrix, mat.size(), Imgproc.INTER_LINEAR);
+
+        mapMatrix.release();
+        
+        return dst;
     }
 
     private Mat undistort(Mat mat) {

--- a/src/main/java/org/openpnp/machine/reference/ReferenceCamera.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceCamera.java
@@ -238,6 +238,7 @@ public abstract class ReferenceCamera extends AbstractCamera implements Referenc
         
         Mat dst = mat.clone();
         Imgproc.warpAffine(mat, dst, mapMatrix, mat.size(), Imgproc.INTER_LINEAR);
+        mat.release();
 
         mapMatrix.release();
         
@@ -254,11 +255,13 @@ public abstract class ReferenceCamera extends AbstractCamera implements Referenc
             undistortionMap2 = new Mat();
             Mat rectification = Mat.eye(3, 3, CvType.CV_32F);
             Imgproc.initUndistortRectifyMap(calibration.getCameraMatrixMat(), calibration.getDistortionCoefficientsMat(), rectification, calibration.getCameraMatrixMat(), mat.size(), CvType.CV_32FC1, undistortionMap1, undistortionMap2);
+            rectification.release();
         }
 
         Mat dst = mat.clone();
         Imgproc.remap(mat, dst, undistortionMap1, undistortionMap2, Imgproc.INTER_LINEAR);
         mat.release();
+        
         return dst;
     }
 

--- a/src/main/java/org/openpnp/vision/LensCalibration.java
+++ b/src/main/java/org/openpnp/vision/LensCalibration.java
@@ -70,6 +70,20 @@ public class LensCalibration {
         // and then add it to the list with each processed image.
         objectPoints = calculateObjectPoints();
     }
+    
+    public void close() {
+    	if (cameraMatrix != null) {
+    		cameraMatrix.release();
+    	}
+    	if (distortionCoefficients != null) {
+    		distortionCoefficients.release();
+    	}
+    	
+    	objectPoints.release();
+    	for (Mat imagePoints : imagePointsList) {
+    		imagePoints.release();
+    	}
+    }
 
     public Mat apply(Mat mat) {
         if (imageSize == null) {
@@ -130,6 +144,15 @@ public class LensCalibration {
                     cameraMatrix, distortionCoefficients, rvecs, tvecs);
         }
 
+        for (Mat rvec : rvecs) {
+        	rvec.release();
+        }
+        rvecs.clear();
+        for (Mat tvec : tvecs) {
+        	tvec.release();
+        }
+        tvecs.clear();
+        
         boolean ok = Core.checkRange(cameraMatrix) && Core.checkRange(distortionCoefficients);
 
         logger.info("calibrate() ok {}, rms {}", ok, rms);
@@ -137,6 +160,9 @@ public class LensCalibration {
         if (ok) {
             this.cameraMatrix = cameraMatrix;
             this.distortionCoefficients = distortionCoefficients;
+        } else {
+        	cameraMatrix.release();
+        	distortionCoefficients.release();
         }
 
         return ok;
@@ -188,7 +214,12 @@ public class LensCalibration {
                         Calib3d.CALIB_CB_ASYMMETRIC_GRID);
                 break;
         }
-        return found ? imagePoints : null;
+        if (found) {
+        	return imagePoints;
+        } else {
+        	imagePoints.release();
+        	return null;
+        }
     }
 
     private MatOfPoint3f calculateObjectPoints() {


### PR DESCRIPTION
In ReferenceCamera#transformImage, adjust the size of the image before rotating so that the full rotated image will fit in the new frame. Fixes #228