### PR TITLE
Altered partAlignment interface

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/vision/ReferenceBottomVision.java
+++ b/src/main/java/org/openpnp/machine/reference/vision/ReferenceBottomVision.java
@@ -18,6 +18,7 @@ import org.openpnp.model.Length;
 import org.openpnp.model.LengthUnit;
 import org.openpnp.model.Location;
 import org.openpnp.model.Part;
+import org.openpnp.model.BoardLocation;
 import org.openpnp.spi.Camera;
 import org.openpnp.spi.Nozzle;
 import org.openpnp.spi.PartAlignment;
@@ -49,11 +50,11 @@ public class ReferenceBottomVision implements PartAlignment {
     protected Map<String, PartSettings> partSettingsByPartId = new HashMap<>();
 
     @Override
-    public Location findOffsets(Part part, Nozzle nozzle) throws Exception {
+    public PartAlignmentOffset findOffsets(Part part, BoardLocation boardLocation, Location placementLocation, Nozzle nozzle) throws Exception {
         PartSettings partSettings = getPartSettings(part);
 
         if (!isEnabled() || !partSettings.isEnabled()) {
-            return new Location(LengthUnit.Millimeters);
+            return new PartAlignmentOffset(new Location(LengthUnit.Millimeters),false);
         }
 
         Camera camera = VisionUtils.getBottomVisionCamera();
@@ -109,7 +110,7 @@ public class ReferenceBottomVision implements PartAlignment {
                 1500);
 
 
-        return offsets;
+        return new PartAlignmentOffset(offsets,false);
     }
 
     public static CvPipeline createDefaultPipeline() {

--- a/src/main/java/org/openpnp/machine/reference/vision/wizards/ReferenceBottomVisionPartConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/vision/wizards/ReferenceBottomVisionPartConfigurationWizard.java
@@ -20,6 +20,7 @@ import org.openpnp.model.LengthUnit;
 import org.openpnp.model.Location;
 import org.openpnp.model.Part;
 import org.openpnp.spi.Nozzle;
+import org.openpnp.spi.PartAlignment;
 import org.openpnp.util.UiUtils;
 import org.openpnp.util.VisionUtils;
 import org.openpnp.vision.pipeline.CvPipeline;
@@ -109,7 +110,10 @@ public class ReferenceBottomVisionPartConfigurationWizard extends AbstractConfig
         Nozzle nozzle = MainFrame.get().getMachineControls().getSelectedNozzle();
 
         // perform the alignment
-        Location offsets = bottomVision.findOffsets(part, nozzle);
+
+
+        PartAlignment.PartAlignmentOffset alignmentOffset = bottomVision.findOffsets(part, null, null, nozzle);
+        Location offsets = alignmentOffset.getLocation();
 
         if (!chckbxCenterAfterTest.isSelected()) {
             return;

--- a/src/main/java/org/openpnp/spi/PartAlignment.java
+++ b/src/main/java/org/openpnp/spi/PartAlignment.java
@@ -3,6 +3,7 @@ package org.openpnp.spi;
 import org.openpnp.gui.support.Wizard;
 import org.openpnp.model.Location;
 import org.openpnp.model.Part;
+import org.openpnp.model.BoardLocation;
 
 /**
  * A method to allow after-pick, pre-place alignment of parts on the nozzle. Bottom vision
@@ -10,6 +11,29 @@ import org.openpnp.model.Part;
  * alignment or pit alignment.  
  */
 public interface PartAlignment extends PropertySheetHolder {
+
+    public class PartAlignmentOffset
+    {
+        private Location location;
+        private Boolean preRotated;
+
+        public Location getLocation()
+        {
+            return location;
+        }
+
+        public Boolean getPreRotated()
+        {
+            return preRotated;
+        }
+
+        public PartAlignmentOffset(Location loc, Boolean PreRotated)
+        {
+            location=loc;
+            preRotated=PreRotated;
+        }
+    }
+
     /**
      * Perform the part alignment operation. The method must return a Location containing
      * the offsets on the nozzle of the aligned part and these offsets will be applied
@@ -21,7 +45,7 @@ public interface PartAlignment extends PropertySheetHolder {
      * @return
      * @throws Exception if the alignment fails for any reason. The caller may retry.
      */
-    Location findOffsets(Part part, Nozzle nozzle) throws Exception;
+    PartAlignmentOffset findOffsets(Part part, BoardLocation boardLocation, Location placementLocation, Nozzle nozzle) throws Exception;
     
     /**
      * Get a Wizard for configuring the PartAlignment instance properties for a specific


### PR DESCRIPTION
Altered partAlignment interface to allow the alignmentProcessor to signal if it has done all the necessary component rotations (such as a remote centering stage), it now gets passed all the information it needs to calculate the final rotation