### PR TITLE
Feature - Reset Feed Count

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/ReferenceNozzle.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceNozzle.java
@@ -212,16 +212,20 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
         unloadNozzleTip();
         logger.debug("{}.loadNozzleTip({}): Start", getName(), nozzleTip.getName());
         ReferenceNozzleTip nt = (ReferenceNozzleTip) nozzleTip;
+        
         logger.debug("{}.loadNozzleTip({}): moveTo Start Location",
                 new Object[] {getName(), nozzleTip.getName()});
         MovableUtils.moveToLocationAtSafeZ(this, nt.getChangerStartLocation());
+        
         logger.debug("{}.loadNozzleTip({}): moveTo Mid Location",
                 new Object[] {getName(), nozzleTip.getName()});
-        moveTo(nt.getChangerMidLocation(), 0.25);
+        moveTo(nt.getChangerMidLocation(), getHead().getMachine().getSpeed() * 0.25);
+        
         logger.debug("{}.loadNozzleTip({}): moveTo End Location",
                 new Object[] {getName(), nozzleTip.getName()});
-        moveTo(nt.getChangerEndLocation(), 1.0);
-        moveToSafeZ(1.0);
+        moveTo(nt.getChangerEndLocation(), getHead().getMachine().getSpeed());
+        moveToSafeZ(getHead().getMachine().getSpeed());
+        
         logger.debug("{}.loadNozzleTip({}): Finished",
                 new Object[] {getName(), nozzleTip.getName()});
         this.nozzleTip = (ReferenceNozzleTip) nozzleTip;
@@ -239,13 +243,17 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
         }
         logger.debug("{}.unloadNozzleTip(): Start", getName());
         ReferenceNozzleTip nt = (ReferenceNozzleTip) nozzleTip;
+        
         logger.debug("{}.unloadNozzleTip(): moveTo End Location", getName());
         MovableUtils.moveToLocationAtSafeZ(this, nt.getChangerEndLocation());
+        
         logger.debug("{}.unloadNozzleTip(): moveTo Mid Location", getName());
-        moveTo(nt.getChangerMidLocation(), 1.0);
+        moveTo(nt.getChangerMidLocation(), getHead().getMachine().getSpeed());
+        
         logger.debug("{}.unloadNozzleTip(): moveTo Start Location", getName());
-        moveTo(nt.getChangerStartLocation(), 0.25);
-        moveToSafeZ(1.0);
+        moveTo(nt.getChangerStartLocation(), getHead().getMachine().getSpeed() * 0.25);
+        moveToSafeZ(getHead().getMachine().getSpeed());
+        
         logger.debug("{}.unloadNozzleTip(): Finished", getName());
         nozzleTip = null;
         currentNozzleTipId = null;

--- a/src/main/java/org/openpnp/machine/reference/feeder/wizards/ReferenceTrayFeederConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/wizards/ReferenceTrayFeederConfigurationWizard.java
@@ -37,6 +37,12 @@ import com.jgoodies.forms.layout.FormLayout;
 import com.jgoodies.forms.layout.FormSpecs;
 import com.jgoodies.forms.layout.RowSpec;
 
+import javax.swing.AbstractAction;
+import javax.swing.JButton;
+import java.awt.event.ActionEvent;
+import javax.swing.SwingConstants;
+
+@SuppressWarnings("serial")
 public class ReferenceTrayFeederConfigurationWizard
         extends AbstractReferenceFeederConfigurationWizard {
     private final ReferenceTrayFeeder feeder;
@@ -56,7 +62,7 @@ public class ReferenceTrayFeederConfigurationWizard
         panelFields.setLayout(new FormLayout(
                 new ColumnSpec[] {FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,
                         FormSpecs.RELATED_GAP_COLSPEC, ColumnSpec.decode("default:grow"),
-                        FormSpecs.RELATED_GAP_COLSPEC, ColumnSpec.decode("default:grow"),
+                        FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC, ColumnSpec.decode("default:grow"),
                         FormSpecs.RELATED_GAP_COLSPEC, ColumnSpec.decode("default:grow"),
                         FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,},
                 new RowSpec[] {FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
@@ -88,7 +94,7 @@ public class ReferenceTrayFeederConfigurationWizard
         textFieldOffsetsX.setColumns(10);
 
         textFieldOffsetsY = new JTextField();
-        panelFields.add(textFieldOffsetsY, "6, 4, fill, default");
+        panelFields.add(textFieldOffsetsY, "6, 4, 2, 1, fill, default");
         textFieldOffsetsY.setColumns(10);
 
         JLabel lblTrayCount = new JLabel("Tray Count");
@@ -99,11 +105,11 @@ public class ReferenceTrayFeederConfigurationWizard
         textFieldTrayCountX.setColumns(10);
 
         textFieldTrayCountY = new JTextField();
-        panelFields.add(textFieldTrayCountY, "6, 6, fill, default");
+        panelFields.add(textFieldTrayCountY, "6, 6, 2, 1, fill, default");
         textFieldTrayCountY.setColumns(10);
 
         JSeparator separator = new JSeparator();
-        panelFields.add(separator, "4, 8, 3, 1");
+        panelFields.add(separator, "4, 8, 4, 1");
 
         JLabel lblFeedCount = new JLabel("Feed Count");
         panelFields.add(lblFeedCount, "2, 10, right, default");
@@ -113,6 +119,16 @@ public class ReferenceTrayFeederConfigurationWizard
         textFieldFeedCount.setColumns(10);
 
         contentPanel.add(panelFields);
+        
+        JButton btnResetFeedCount = new JButton(new AbstractAction("Reset") {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                textFieldFeedCount.setText("0");
+                applyAction.actionPerformed(e);
+            }
+        });
+        btnResetFeedCount.setHorizontalAlignment(SwingConstants.LEFT);
+        panelFields.add(btnResetFeedCount, "6, 10, left, default");
     }
 
     @Override

--- a/src/main/java/org/openpnp/machine/reference/feeder/wizards/ReferenceTrayFeederConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/wizards/ReferenceTrayFeederConfigurationWizard.java
@@ -23,6 +23,10 @@ import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JSeparator;
 import javax.swing.JTextField;
+import javax.swing.AbstractAction;
+import javax.swing.JButton;
+import java.awt.event.ActionEvent;
+import javax.swing.SwingConstants;
 
 import org.jdesktop.beansbinding.AutoBinding.UpdateStrategy;
 import org.openpnp.gui.components.ComponentDecorators;
@@ -36,11 +40,6 @@ import com.jgoodies.forms.layout.ColumnSpec;
 import com.jgoodies.forms.layout.FormLayout;
 import com.jgoodies.forms.layout.FormSpecs;
 import com.jgoodies.forms.layout.RowSpec;
-
-import javax.swing.AbstractAction;
-import javax.swing.JButton;
-import java.awt.event.ActionEvent;
-import javax.swing.SwingConstants;
 
 @SuppressWarnings("serial")
 public class ReferenceTrayFeederConfigurationWizard


### PR DESCRIPTION
This feature adds a "Reset" button to the Tray Feed count as requested by issue 276: [https://github.com/openpnp/openpnp/issues/276](url) 

The biggest change is from lines 121 - 130. This adds the buttons functionality and sets its design to be a simple button. Once the user selects the "Reset" button, it will then set the Feed Count to be 0 and then update the value.

Other lines had properties added to them to make their Grid width 2. This allows for the button to maintain a small size, while the other elements in the column are able to resize with the rest of the window.