### PR TITLE
Bug Fix - Tray Feeders feed count was not updating

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/feeder/ReferenceTrayFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/ReferenceTrayFeeder.java
@@ -92,7 +92,7 @@ public class ReferenceTrayFeeder extends ReferenceFeeder {
                 feedCount, partX, partY, pickLocation.getX(), pickLocation.getY(),
                 pickLocation.getRotation()));
 
-        feedCount++;
+        setFeedCount(getFeedCount() + 1);
     }
 
     public int getTrayCountX() {
@@ -124,7 +124,9 @@ public class ReferenceTrayFeeder extends ReferenceFeeder {
     }
 
     public void setFeedCount(int feedCount) {
+        int oldValue = this.feedCount;
         this.feedCount = feedCount;
+        firePropertyChange("feedCount", oldValue, feedCount);
     }
 
     @Override


### PR DESCRIPTION
This fix was in response to issue #321 

The major change is instead of the feeder increment on line 95, the code now uses the setFeedCount method to increase the number. The setFeedCount method takes in the new number given and then updates the screen accordingly.