### PR TITLE
Feature - Check Fiducials Before Individual Placement

### DIFF
--- a/src/main/java/org/openpnp/gui/tablemodel/PlacementsTableModel.java
+++ b/src/main/java/org/openpnp/gui/tablemodel/PlacementsTableModel.java
@@ -38,11 +38,11 @@ public class PlacementsTableModel extends AbstractTableModel {
     final Configuration configuration;
 
     private String[] columnNames =
-            new String[] {"Id", "Part", "Side", "X", "Y", "ø", "Type", "Status", "Glue"};
+            new String[] {"Id", "Part", "Side", "X", "Y", "ø", "Type", "Status", "Glue", "Check Fids"};
 
     private Class[] columnTypes = new Class[] {PartCellValue.class, Part.class, Side.class,
             LengthCellValue.class, LengthCellValue.class, RotationCellValue.class, Type.class,
-            Status.class, Boolean.class};
+            Status.class, Boolean.class, Boolean.class};
 
     public enum Status {
         Ready,
@@ -78,7 +78,7 @@ public class PlacementsTableModel extends AbstractTableModel {
     @Override
     public boolean isCellEditable(int rowIndex, int columnIndex) {
         return columnIndex == 1 || columnIndex == 2 || columnIndex == 3 || columnIndex == 4
-                || columnIndex == 5 || columnIndex == 6 || columnIndex == 8;
+                || columnIndex == 5 || columnIndex == 6 || columnIndex == 8 || columnIndex == 9;
     }
 
     @Override
@@ -123,6 +123,9 @@ public class PlacementsTableModel extends AbstractTableModel {
             }
             else if (columnIndex == 8) {
                 placement.setGlue((Boolean) aValue);
+            }
+            else if (columnIndex == 9) {
+                placement.setCheckFids((Boolean) aValue);
             }
         }
         catch (Exception e) {
@@ -179,6 +182,8 @@ public class PlacementsTableModel extends AbstractTableModel {
                 return getPlacementStatus(placement);
             case 8:
                 return placement.getGlue();
+            case 9:
+                return placement.getCheckFids();
             default:
                 return null;
         }

--- a/src/main/java/org/openpnp/machine/reference/ReferencePnpJobProcessor.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferencePnpJobProcessor.java
@@ -344,6 +344,16 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
             logger.debug("Fiducial check for {}", boardLocation);
         }
     }
+    
+    protected void doIndividualFiducialCheck(BoardLocation boardLocation) throws Exception {
+        fireTextStatus("Performing individual fiducial check.");
+
+        FiducialLocator locator = Configuration.get().getMachine().getFiducialLocator();
+        
+        Location location = locator.locateBoard(boardLocation);
+        boardLocationFiducialOverrides.put(boardLocation, location);
+        logger.debug("Fiducial check for {}", boardLocation);
+    }
 
     /**
      * Description of the planner:
@@ -573,6 +583,9 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
             Placement placement = jobPlacement.placement;
             Part part = placement.getPart();
             BoardLocation boardLocation = plannedPlacement.jobPlacement.boardLocation;
+            //Check if the individual piece has a fiducial check and check to see if the board is enabled
+            if(jobPlacement.placement.getCheckFids()&&jobPlacement.boardLocation.isEnabled())
+                doIndividualFiducialCheck(jobPlacement.boardLocation);
 
             // Check if there is a fiducial override for the board location and if so, use it.
             if (boardLocationFiducialOverrides.containsKey(boardLocation)) {

--- a/src/main/java/org/openpnp/model/Placement.java
+++ b/src/main/java/org/openpnp/model/Placement.java
@@ -65,6 +65,9 @@ public class Placement extends AbstractModelObject implements Identifiable {
 
     @Attribute
     private boolean glue;
+    
+    @Attribute
+    private boolean checkFids;
 
     @SuppressWarnings("unused")
     private Placement() {
@@ -150,6 +153,15 @@ public class Placement extends AbstractModelObject implements Identifiable {
         Object oldValue = this.glue;
         this.glue = glue;
         firePropertyChange("glue", oldValue, glue);
+    }
+    
+    public boolean getCheckFids() { return checkFids; }
+
+    public void setCheckFids(boolean checkFids)
+    {
+        Object oldValue = this.checkFids;
+        this.checkFids = checkFids;
+        firePropertyChange("check fids", oldValue, checkFids);
     }
 
 


### PR DESCRIPTION
This feature allows the user to do a Fiducial Check of an individual board prior to placing it. This is in regards to Issue #319.

In the PlacementTableModel.java there is an extra column added for the Check Fids which has a checkbox element within it.

In the Placement.java there is the Check Fids attribute. This will determine if the placement has requested a Check Fid for the board.

Lastly the ReferencePnpJobProcessor.java adds a method that will override the fiducial locations of the board being called. This method is then called in the doPlace() method just before a boardLocationFiducialOverrides check.
