### PR TITLE
Removing default values in Actuator Signaler

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/signaler/ActuatorSignaler.java
+++ b/src/main/java/org/openpnp/machine/reference/signaler/ActuatorSignaler.java
@@ -24,10 +24,10 @@ public class ActuatorSignaler extends AbstractSignaler {
     protected String actuatorId;
 
     @Attribute(required = false)
-    protected AbstractJobProcessor.State jobState = AbstractJobProcessor.State.ERROR;
+    protected AbstractJobProcessor.State jobState;
 
     @Attribute(required = false)
-    protected AbstractMachine.State machineState = AbstractMachine.State.ERROR;
+    protected AbstractMachine.State machineState;
 
     public ActuatorSignaler() {
         Configuration.get().addListener(new ConfigurationListener.Adapter() {


### PR DESCRIPTION
This is what i acutally ment since if they are present the signaler will go off in a machineError even if that was not configured in the XML. I will also edit the Wiki to show the different options