### PR TITLE
Feeder panel layout in line with other panels

### DIFF
--- a/src/main/java/org/openpnp/gui/FeedersPanel.java
+++ b/src/main/java/org/openpnp/gui/FeedersPanel.java
@@ -34,6 +34,7 @@ import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.JSplitPane;
+import javax.swing.JTabbedPane;
 import javax.swing.JTable;
 import javax.swing.JTextField;
 import javax.swing.JToolBar;
@@ -138,6 +139,8 @@ public class FeedersPanel extends JPanel implements WizardContainer {
         });
         panel_1.add(searchTextField);
         searchTextField.setColumns(15);
+        
+        
         table = new AutoSelectTextTable(tableModel);
         tableSorter = new TableRowSorter<>(tableModel);
 
@@ -151,18 +154,23 @@ public class FeedersPanel extends JPanel implements WizardContainer {
                 prefs.putInt(PREF_DIVIDER_POSITION, splitPane.getDividerLocation());
             }
         });
+        
         add(splitPane, BorderLayout.CENTER);
-
+        splitPane.setLeftComponent(new JScrollPane(table));
         table.setRowSorter(tableSorter);
         table.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
 
+        JTabbedPane tabbedPane = new JTabbedPane(JTabbedPane.TOP);
+        splitPane.setRightComponent(tabbedPane);
+
         configurationPanel = new JPanel();
-        configurationPanel.setBorder(new TitledBorder(null, "Configuration", TitledBorder.LEADING,
-                TitledBorder.TOP, null, null));
+        tabbedPane.addTab("Configuration", null, configurationPanel, null);
+        configurationPanel.setLayout(new BorderLayout(0, 0));
 
         feederSelectedActionGroup = new ActionGroup(deleteFeederAction, feedFeederAction,
                 pickFeederAction, moveCameraToPickLocation, moveToolToPickLocation);
-
+        feederSelectedActionGroup.setEnabled(false);
+        
         table.getSelectionModel().addListSelectionListener(new ListSelectionListener() {
             @Override
             public void valueChanged(ListSelectionEvent e) {
@@ -188,11 +196,7 @@ public class FeedersPanel extends JPanel implements WizardContainer {
             }
         });
 
-        feederSelectedActionGroup.setEnabled(false);
 
-        splitPane.setLeftComponent(new JScrollPane(table));
-        splitPane.setRightComponent(configurationPanel);
-        configurationPanel.setLayout(new BorderLayout(0, 0));
     }
 
     /**


### PR DESCRIPTION
Changed "Configuration" border into a tab like other panels.
Before: 
![feeder panel before](https://cloud.githubusercontent.com/assets/15858032/20031781/63e17a28-a37d-11e6-8e03-ec90b44b3af7.JPG)
After: 
![feeder panel after](https://cloud.githubusercontent.com/assets/15858032/20031783/6b347d52-a37d-11e6-9ca5-531cc2957133.JPG)

