### PR TITLE
Configuration tabs within "Machine Setup" panel now with titles (partly #172)

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/ReferenceCamera.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceCamera.java
@@ -30,10 +30,13 @@ import org.opencv.core.Rect;
 import org.opencv.core.RotatedRect;
 import org.opencv.imgproc.Imgproc;
 import org.openpnp.ConfigurationListener;
+import org.openpnp.gui.support.PropertySheetWizardAdapter;
+import org.openpnp.gui.wizards.CameraConfigurationWizard;
 import org.openpnp.model.Configuration;
 import org.openpnp.model.Length;
 import org.openpnp.model.LengthUnit;
 import org.openpnp.model.Location;
+import org.openpnp.spi.PropertySheetHolder.PropertySheet;
 import org.openpnp.spi.base.AbstractCamera;
 import org.openpnp.util.OpenCvUtils;
 import org.openpnp.vision.LensCalibration;
@@ -384,6 +387,13 @@ public abstract class ReferenceCamera extends AbstractCamera implements Referenc
 
     @Override
     public void close() throws IOException {}
+
+    @Override
+    public PropertySheet[] getPropertySheets() {
+        return new PropertySheet[] {
+                new PropertySheetWizardAdapter(new CameraConfigurationWizard(this), "General Configuration"),
+                new PropertySheetWizardAdapter(getConfigurationWizard(), "Camera Specific")};
+    }
 
     public interface CalibrationCallback {
         public void callback(int progressCurrent, int progressMax, boolean complete);

--- a/src/main/java/org/openpnp/machine/reference/camera/ImageCamera.java
+++ b/src/main/java/org/openpnp/machine/reference/camera/ImageCamera.java
@@ -190,8 +190,8 @@ public class ImageCamera extends ReferenceCamera implements Runnable {
     @Override
     public PropertySheet[] getPropertySheets() {
         return new PropertySheet[] {
-                new PropertySheetWizardAdapter(new CameraConfigurationWizard(this)),
-                new PropertySheetWizardAdapter(getConfigurationWizard())};
+                new PropertySheetWizardAdapter(new CameraConfigurationWizard(this), "General Configuration"),
+                new PropertySheetWizardAdapter(getConfigurationWizard(), "Camera Specific")};
     }
 
     @Override

--- a/src/main/java/org/openpnp/machine/reference/camera/ImageCamera.java
+++ b/src/main/java/org/openpnp/machine/reference/camera/ImageCamera.java
@@ -188,13 +188,6 @@ public class ImageCamera extends ReferenceCamera implements Runnable {
     }
 
     @Override
-    public PropertySheet[] getPropertySheets() {
-        return new PropertySheet[] {
-                new PropertySheetWizardAdapter(new CameraConfigurationWizard(this), "General Configuration"),
-                new PropertySheetWizardAdapter(getConfigurationWizard(), "Camera Specific")};
-    }
-
-    @Override
     public Action[] getPropertySheetHolderActions() {
         // TODO Auto-generated method stub
         return null;

--- a/src/main/java/org/openpnp/machine/reference/camera/LtiCivilCamera.java
+++ b/src/main/java/org/openpnp/machine/reference/camera/LtiCivilCamera.java
@@ -178,7 +178,7 @@ public class LtiCivilCamera extends ReferenceCamera implements CaptureObserver {
     @Override
     public PropertySheet[] getPropertySheets() {
         return new PropertySheet[] {
-                new PropertySheetWizardAdapter(new CameraConfigurationWizard(this)),
-                new PropertySheetWizardAdapter(getConfigurationWizard())};
+                new PropertySheetWizardAdapter(new CameraConfigurationWizard(this),"General Configuration"),
+                new PropertySheetWizardAdapter(getConfigurationWizard(), "Camera Specific")};
     }
 }

--- a/src/main/java/org/openpnp/machine/reference/camera/LtiCivilCamera.java
+++ b/src/main/java/org/openpnp/machine/reference/camera/LtiCivilCamera.java
@@ -175,6 +175,7 @@ public class LtiCivilCamera extends ReferenceCamera implements CaptureObserver {
         return null;
     }
 
+    //TODO: remove this in favour of base class method after researching reason for crossed out getConfigurationWizard
     @Override
     public PropertySheet[] getPropertySheets() {
         return new PropertySheet[] {

--- a/src/main/java/org/openpnp/machine/reference/camera/OnvifIPCamera.java
+++ b/src/main/java/org/openpnp/machine/reference/camera/OnvifIPCamera.java
@@ -426,13 +426,6 @@ public class OnvifIPCamera extends ReferenceCamera implements Runnable {
     }
 
     @Override
-    public PropertySheet[] getPropertySheets() {
-        return new PropertySheet[] {
-        		new PropertySheetWizardAdapter(new CameraConfigurationWizard(this),"General Configuration"),
-                new PropertySheetWizardAdapter(getConfigurationWizard(), "Camera Specific")};
-    }
-
-    @Override
     public Action[] getPropertySheetHolderActions() {
         // TODO Auto-generated method stub
         return null;

--- a/src/main/java/org/openpnp/machine/reference/camera/OnvifIPCamera.java
+++ b/src/main/java/org/openpnp/machine/reference/camera/OnvifIPCamera.java
@@ -427,8 +427,9 @@ public class OnvifIPCamera extends ReferenceCamera implements Runnable {
 
     @Override
     public PropertySheet[] getPropertySheets() {
-        return new PropertySheet[] {new PropertySheetWizardAdapter(new CameraConfigurationWizard(this)),
-                new PropertySheetWizardAdapter(getConfigurationWizard())};
+        return new PropertySheet[] {
+        		new PropertySheetWizardAdapter(new CameraConfigurationWizard(this),"General Configuration"),
+                new PropertySheetWizardAdapter(getConfigurationWizard(), "Camera Specific")};
     }
 
     @Override

--- a/src/main/java/org/openpnp/machine/reference/camera/OpenCvCamera.java
+++ b/src/main/java/org/openpnp/machine/reference/camera/OpenCvCamera.java
@@ -221,13 +221,6 @@ public class OpenCvCamera extends ReferenceCamera implements Runnable {
     }
 
     @Override
-    public PropertySheet[] getPropertySheets() {
-        return new PropertySheet[] {
-                new PropertySheetWizardAdapter(new CameraConfigurationWizard(this),"General Configuration"),
-                new PropertySheetWizardAdapter(getConfigurationWizard(), "Camera Specific")};
-    }
-
-    @Override
     public Action[] getPropertySheetHolderActions() {
         // TODO Auto-generated method stub
         return null;

--- a/src/main/java/org/openpnp/machine/reference/camera/OpenCvCamera.java
+++ b/src/main/java/org/openpnp/machine/reference/camera/OpenCvCamera.java
@@ -223,8 +223,8 @@ public class OpenCvCamera extends ReferenceCamera implements Runnable {
     @Override
     public PropertySheet[] getPropertySheets() {
         return new PropertySheet[] {
-                new PropertySheetWizardAdapter(new CameraConfigurationWizard(this)),
-                new PropertySheetWizardAdapter(getConfigurationWizard())};
+                new PropertySheetWizardAdapter(new CameraConfigurationWizard(this),"General Configuration"),
+                new PropertySheetWizardAdapter(getConfigurationWizard(), "Camera Specific")};
     }
 
     @Override

--- a/src/main/java/org/openpnp/machine/reference/camera/SimulatedUpCamera.java
+++ b/src/main/java/org/openpnp/machine/reference/camera/SimulatedUpCamera.java
@@ -222,8 +222,8 @@ public class SimulatedUpCamera extends ReferenceCamera implements Runnable {
     @Override
     public PropertySheet[] getPropertySheets() {
         return new PropertySheet[] {
-                new PropertySheetWizardAdapter(new CameraConfigurationWizard(this)),
-                new PropertySheetWizardAdapter(getConfigurationWizard())};
+                new PropertySheetWizardAdapter(new CameraConfigurationWizard(this), "General Configuration"),
+                new PropertySheetWizardAdapter(getConfigurationWizard(), "Camera Specific")};
     }
 
     @Override

--- a/src/main/java/org/openpnp/machine/reference/camera/SimulatedUpCamera.java
+++ b/src/main/java/org/openpnp/machine/reference/camera/SimulatedUpCamera.java
@@ -220,13 +220,6 @@ public class SimulatedUpCamera extends ReferenceCamera implements Runnable {
     }
 
     @Override
-    public PropertySheet[] getPropertySheets() {
-        return new PropertySheet[] {
-                new PropertySheetWizardAdapter(new CameraConfigurationWizard(this), "General Configuration"),
-                new PropertySheetWizardAdapter(getConfigurationWizard(), "Camera Specific")};
-    }
-
-    @Override
     public Action[] getPropertySheetHolderActions() {
         // TODO Auto-generated method stub
         return null;

--- a/src/main/java/org/openpnp/machine/reference/camera/VfwCamera.java
+++ b/src/main/java/org/openpnp/machine/reference/camera/VfwCamera.java
@@ -200,11 +200,4 @@ public class VfwCamera extends ReferenceCamera implements Runnable {
         // TODO Auto-generated method stub
         return null;
     }
-
-    @Override
-    public PropertySheet[] getPropertySheets() {
-        return new PropertySheet[] {
-                new PropertySheetWizardAdapter(new CameraConfigurationWizard(this), "General Configuration"),
-                new PropertySheetWizardAdapter(getConfigurationWizard(), "Camera Specific")};
-    }
 }

--- a/src/main/java/org/openpnp/machine/reference/camera/VfwCamera.java
+++ b/src/main/java/org/openpnp/machine/reference/camera/VfwCamera.java
@@ -204,7 +204,7 @@ public class VfwCamera extends ReferenceCamera implements Runnable {
     @Override
     public PropertySheet[] getPropertySheets() {
         return new PropertySheet[] {
-                new PropertySheetWizardAdapter(new CameraConfigurationWizard(this)),
-                new PropertySheetWizardAdapter(getConfigurationWizard())};
+                new PropertySheetWizardAdapter(new CameraConfigurationWizard(this), "General Configuration"),
+                new PropertySheetWizardAdapter(getConfigurationWizard(), "Camera Specific")};
     }
 }

--- a/src/main/java/org/openpnp/machine/reference/camera/Webcams.java
+++ b/src/main/java/org/openpnp/machine/reference/camera/Webcams.java
@@ -209,8 +209,8 @@ public class Webcams extends ReferenceCamera implements Runnable, WebcamImageTra
     @Override
     public PropertySheet[] getPropertySheets() {
         return new PropertySheet[] {
-                new PropertySheetWizardAdapter(new CameraConfigurationWizard(this)),
-                new PropertySheetWizardAdapter(getConfigurationWizard())};
+                new PropertySheetWizardAdapter(new CameraConfigurationWizard(this), "General Configuration"),
+                new PropertySheetWizardAdapter(getConfigurationWizard(), "Camera Specific")};
     }
 
 

--- a/src/main/java/org/openpnp/machine/reference/camera/Webcams.java
+++ b/src/main/java/org/openpnp/machine/reference/camera/Webcams.java
@@ -206,13 +206,6 @@ public class Webcams extends ReferenceCamera implements Runnable, WebcamImageTra
         return null;
     }
 
-    @Override
-    public PropertySheet[] getPropertySheets() {
-        return new PropertySheet[] {
-                new PropertySheetWizardAdapter(new CameraConfigurationWizard(this), "General Configuration"),
-                new PropertySheetWizardAdapter(getConfigurationWizard(), "Camera Specific")};
-    }
-
 
     public List<String> getDeviceIds() throws Exception {
         ArrayList<String> deviceIds = new ArrayList<>();

--- a/src/main/java/org/openpnp/machine/reference/feeder/ReferenceAutoFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/ReferenceAutoFeeder.java
@@ -102,11 +102,6 @@ public class ReferenceAutoFeeder extends ReferenceFeeder {
     }
 
     @Override
-    public PropertySheet[] getPropertySheets() {
-        return new PropertySheet[] {new PropertySheetWizardAdapter(getConfigurationWizard(), "Configuration")};
-    }
-
-    @Override
     public Action[] getPropertySheetHolderActions() {
         // TODO Auto-generated method stub
         return null;

--- a/src/main/java/org/openpnp/machine/reference/feeder/ReferenceAutoFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/ReferenceAutoFeeder.java
@@ -103,7 +103,7 @@ public class ReferenceAutoFeeder extends ReferenceFeeder {
 
     @Override
     public PropertySheet[] getPropertySheets() {
-        return new PropertySheet[] {new PropertySheetWizardAdapter(getConfigurationWizard())};
+        return new PropertySheet[] {new PropertySheetWizardAdapter(getConfigurationWizard(), "Configuration")};
     }
 
     @Override

--- a/src/main/java/org/openpnp/machine/reference/feeder/ReferenceDragFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/ReferenceDragFeeder.java
@@ -344,11 +344,6 @@ public class ReferenceDragFeeder extends ReferenceFeeder {
     }
 
     @Override
-    public PropertySheet[] getPropertySheets() {
-        return new PropertySheet[] {new PropertySheetWizardAdapter(getConfigurationWizard(), "Configuration")};
-    }
-
-    @Override
     public Action[] getPropertySheetHolderActions() {
         // TODO Auto-generated method stub
         return null;

--- a/src/main/java/org/openpnp/machine/reference/feeder/ReferenceDragFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/ReferenceDragFeeder.java
@@ -345,7 +345,7 @@ public class ReferenceDragFeeder extends ReferenceFeeder {
 
     @Override
     public PropertySheet[] getPropertySheets() {
-        return new PropertySheet[] {new PropertySheetWizardAdapter(getConfigurationWizard())};
+        return new PropertySheet[] {new PropertySheetWizardAdapter(getConfigurationWizard(), "Configuration")};
     }
 
     @Override

--- a/src/main/java/org/openpnp/machine/reference/feeder/ReferenceStripFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/ReferenceStripFeeder.java
@@ -411,11 +411,6 @@ public class ReferenceStripFeeder extends ReferenceFeeder {
     }
 
     @Override
-    public PropertySheet[] getPropertySheets() {
-        return new PropertySheet[] {new PropertySheetWizardAdapter(getConfigurationWizard(), "Configuration")};
-    }
-
-    @Override
     public Action[] getPropertySheetHolderActions() {
         // TODO Auto-generated method stub
         return null;

--- a/src/main/java/org/openpnp/machine/reference/feeder/ReferenceStripFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/ReferenceStripFeeder.java
@@ -412,7 +412,7 @@ public class ReferenceStripFeeder extends ReferenceFeeder {
 
     @Override
     public PropertySheet[] getPropertySheets() {
-        return new PropertySheet[] {new PropertySheetWizardAdapter(getConfigurationWizard())};
+        return new PropertySheet[] {new PropertySheetWizardAdapter(getConfigurationWizard(), "Configuration")};
     }
 
     @Override

--- a/src/main/java/org/openpnp/machine/reference/feeder/ReferenceTrayFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/ReferenceTrayFeeder.java
@@ -150,11 +150,6 @@ public class ReferenceTrayFeeder extends ReferenceFeeder {
     }
 
     @Override
-    public PropertySheet[] getPropertySheets() {
-        return new PropertySheet[] {new PropertySheetWizardAdapter(getConfigurationWizard(), "Configuration")};
-    }
-
-    @Override
     public Action[] getPropertySheetHolderActions() {
         // TODO Auto-generated method stub
         return null;

--- a/src/main/java/org/openpnp/machine/reference/feeder/ReferenceTrayFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/ReferenceTrayFeeder.java
@@ -151,7 +151,7 @@ public class ReferenceTrayFeeder extends ReferenceFeeder {
 
     @Override
     public PropertySheet[] getPropertySheets() {
-        return new PropertySheet[] {new PropertySheetWizardAdapter(getConfigurationWizard())};
+        return new PropertySheet[] {new PropertySheetWizardAdapter(getConfigurationWizard(), "Configuration")};
     }
 
     @Override

--- a/src/main/java/org/openpnp/machine/reference/feeder/ReferenceTubeFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/ReferenceTubeFeeder.java
@@ -62,7 +62,7 @@ public class ReferenceTubeFeeder extends ReferenceFeeder {
 
     @Override
     public PropertySheet[] getPropertySheets() {
-        return new PropertySheet[] {new PropertySheetWizardAdapter(getConfigurationWizard())};
+        return new PropertySheet[] {new PropertySheetWizardAdapter(getConfigurationWizard(), "Configuration")};
     }
 
     @Override

--- a/src/main/java/org/openpnp/machine/reference/feeder/ReferenceTubeFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/ReferenceTubeFeeder.java
@@ -59,12 +59,6 @@ public class ReferenceTubeFeeder extends ReferenceFeeder {
         // TODO Auto-generated method stub
         return null;
     }
-
-    @Override
-    public PropertySheet[] getPropertySheets() {
-        return new PropertySheet[] {new PropertySheetWizardAdapter(getConfigurationWizard(), "Configuration")};
-    }
-
     @Override
     public Action[] getPropertySheetHolderActions() {
         // TODO Auto-generated method stub

--- a/src/main/java/org/openpnp/spi/base/AbstractFeeder.java
+++ b/src/main/java/org/openpnp/spi/base/AbstractFeeder.java
@@ -4,10 +4,12 @@ import javax.swing.Icon;
 
 import org.openpnp.ConfigurationListener;
 import org.openpnp.gui.support.Icons;
+import org.openpnp.gui.support.PropertySheetWizardAdapter;
 import org.openpnp.model.AbstractModelObject;
 import org.openpnp.model.Configuration;
 import org.openpnp.model.Part;
 import org.openpnp.spi.Feeder;
+import org.openpnp.spi.PropertySheetHolder.PropertySheet;
 import org.simpleframework.xml.Attribute;
 
 public abstract class AbstractFeeder extends AbstractModelObject implements Feeder {
@@ -86,5 +88,10 @@ public abstract class AbstractFeeder extends AbstractModelObject implements Feed
 
     public void setRetryCount(int retryCount) {
         this.retryCount = retryCount;
+    }
+
+    @Override
+    public PropertySheet[] getPropertySheets() {
+        return new PropertySheet[] {new PropertySheetWizardAdapter(getConfigurationWizard(), "Configuration")};
     }
 }


### PR DESCRIPTION
Changed for available camera objects but with some remarks:

- ImageCamera, IPCamera, OpenCVCamera, SimulatedUpCamera and Webcams
work fine

- Webcams give however a warning in the log file
  log4j:WARN No appenders could be found for logger
  (com.github.sarxos.webcam.Webcam).
   log4j:WARN Please initialize the log4j system properly.
   log4j:WARN See http://logging.apache.org/log4j/1.2/faq.html#noconfig for
   more info.

- Lticivil cam give, when trying to add on the cameras panel:
Caused by: com.lti.civil.CaptureException:
java.lang.UnsatisfiedLinkError: no civil in java.library.path

- Vfw cam gives, when selecting in the machine setup tree and also after
returning to Cameras panel and selecting it:
The vonnieda.org Java video capture kit is unable to load it's native
layer.
Please make sure you have org_vonnieda_vfw_CaptureDevice.dll in
yourPATH, Windows directory or current directory.
If you do not have this file, you should be able to find the latest
version at http://www.vonnieda.org/software.html.
Load failed due to:
java.lang.UnsatisfiedLinkError: no org_vonnieda_vfw_CaptureDevice in
java.library.path
camera’s are not updated to the machine setup tree, you have to reload
and crashes the app.

The remarks however, I cannot relate to the changes made. Hence still a
commit and PR.

A second commit covers the feeders. I found no problems there.