### PR TITLE
Untitled machine setup tabs filled

### DIFF
--- a/src/main/java/org/openpnp/gui/MachineSetupPanel.java
+++ b/src/main/java/org/openpnp/gui/MachineSetupPanel.java
@@ -158,7 +158,7 @@ public class MachineSetupPanel extends JPanel implements WizardContainer {
                             String title = propertySheet.getPropertySheetTitle();
                             JPanel panel = propertySheet.getPropertySheetPanel();
                             if (title == null) {
-                                title = "Untitled";
+                                title = "Configuration";
                             }
                             if (panel != null) {
                                 tabbedPane.add(title, panel);

--- a/src/main/java/org/openpnp/machine/reference/camera/LtiCivilCamera.java
+++ b/src/main/java/org/openpnp/machine/reference/camera/LtiCivilCamera.java
@@ -174,12 +174,4 @@ public class LtiCivilCamera extends ReferenceCamera implements CaptureObserver {
         // TODO Auto-generated method stub
         return null;
     }
-
-    //TODO: remove this in favour of base class method after researching reason for crossed out getConfigurationWizard
-    @Override
-    public PropertySheet[] getPropertySheets() {
-        return new PropertySheet[] {
-                new PropertySheetWizardAdapter(new CameraConfigurationWizard(this),"General Configuration"),
-                new PropertySheetWizardAdapter(getConfigurationWizard(), "Camera Specific")};
-    }
 }


### PR DESCRIPTION
Apart from feeders, cameras and Gcode driver all objects wizards return
no title. For those cases "Untitled"  is replaced by "Configuration"
which is much neater to see.
LtiCivilCamera override code has been removed so base class supplies the
getPropertySheets method with titles for the two panels.
These two should be the finishing touch on issue #172 