### PR TITLE
Improve Gcode driver (see #376)

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/driver/GcodeDriver.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/GcodeDriver.java
@@ -469,8 +469,10 @@ public class GcodeDriver extends AbstractSerialPortDriver implements Runnable {
     @Override
     public void moveTo(ReferenceHeadMountable hm, Location location, double speed)
             throws Exception {
+        //keep copy for calling subdrivers as to not add offset on offset
+        Location locationOriginal = location;
+        
         location = location.convertToUnits(units);
-
         location = location.subtract(hm.getHeadOffsets());
 
         double x = location.getX();
@@ -496,124 +498,127 @@ public class GcodeDriver extends AbstractSerialPortDriver implements Runnable {
         }
         if (Double.isNaN(rotation)) {
             rotationAxis = null;
+        }
+
+        // Only do something if there at least one axis included in the move
+        if (xAxis != null || yAxis != null || zAxis != null || rotationAxis != null) {
+
+	        // For each included axis, if the axis has a transform, transform the target coordinate to
+	        // it's raw value.
+	        if (xAxis != null && xAxis.getTransform() != null) {
+	            x = xAxis.getTransform().toRaw(xAxis, hm, x);
+	        }
+	        if (yAxis != null && yAxis.getTransform() != null) {
+	            y = yAxis.getTransform().toRaw(yAxis, hm, y);
+	        }
+	        if (zAxis != null && zAxis.getTransform() != null) {
+	            z = zAxis.getTransform().toRaw(zAxis, hm, z);
+	        }
+	        if (rotationAxis != null && rotationAxis.getTransform() != null) {
+	            rotation = rotationAxis.getTransform().toRaw(rotationAxis, hm, rotation);
+	        }
+	
+	        boolean haveToMove = false;
+	
+	        String command = getCommand(hm, CommandType.MOVE_TO_COMMAND);
+	        command = substituteVariable(command, "Id", hm.getId());
+	        command = substituteVariable(command, "Name", hm.getName());
+	        command = substituteVariable(command, "FeedRate", maxFeedRate * speed);
+	
+	        if (xAxis == null || xAxis.getCoordinate() == x) {
+	            command = substituteVariable(command, "X", null);
+	        }
+	        else {
+	            command = substituteVariable(command, "X", x);
+	            haveToMove = true;
+	            if (xAxis.getPreMoveCommand() != null) {
+	                sendGcode(xAxis.getPreMoveCommand());
+	            }
+	            xAxis.setCoordinate(x);
+	        }
+	
+	        if (yAxis == null || yAxis.getCoordinate() == y) {
+	            command = substituteVariable(command, "Y", null);
+	        }
+	        else {
+	            command = substituteVariable(command, "Y", y);
+	            haveToMove = true;
+	            if (yAxis.getPreMoveCommand() != null) {
+	                sendGcode(yAxis.getPreMoveCommand());
+	            }
+	        }
+	
+	        if (zAxis == null || zAxis.getCoordinate() == z) {
+	            command = substituteVariable(command, "Z", null);
+	        }
+	        else {
+	            command = substituteVariable(command, "Z", z);
+	            haveToMove = true;
+	            if (zAxis.getPreMoveCommand() != null) {
+	                sendGcode(zAxis.getPreMoveCommand());
+	            }
+	        }
+	
+	        if (rotationAxis == null || rotationAxis.getCoordinate() == rotation) {
+	            command = substituteVariable(command, "Rotation", null);
+	        }
+	        else {
+	            command = substituteVariable(command, "Rotation", rotation);
+	            haveToMove = true;
+	            if (rotationAxis.getPreMoveCommand() != null) {
+	                sendGcode(rotationAxis.getPreMoveCommand());
+	            }
+	        }
+	
+	        // Only give a command when move is necessary
+	        if (haveToMove) {
+		
+		        List<String> responses = sendGcode(command);
+		
+		        /*
+		         * If moveToCompleteRegex is specified we need to wait until we match the regex in a
+		         * response before continuing. We first search the initial responses from the command for
+		         * the regex. If it's not found we then collect responses for up to timeoutMillis while
+		         * searching the responses for the regex. As soon as it is matched we continue. If it's not
+		         * matched within the timeout we throw an Exception.
+		         */
+		        String moveToCompleteRegex = getCommand(hm, CommandType.MOVE_TO_COMPLETE_REGEX);
+		        if (moveToCompleteRegex != null) {
+		            if (!containsMatch(responses, moveToCompleteRegex)) {
+		                long t = System.currentTimeMillis();
+		                boolean done = false;
+		                while (!done && System.currentTimeMillis() - t < timeoutMilliseconds) {
+		                    done = containsMatch(sendCommand(null, 250), moveToCompleteRegex);
+		                }
+		                if (!done) {
+		                    throw new Exception("Timed out waiting for move to complete.");
+		                }
+		            }
+		        }
+		        
+		        // And save the final values on the axes.
+		        if (xAxis != null) {
+		            xAxis.setCoordinate(x);
+		        }
+		        if (yAxis != null) {
+		            yAxis.setCoordinate(y);
+		        }
+		        if (zAxis != null) {
+		            zAxis.setCoordinate(z);
+		        }
+		        if (rotationAxis != null) {
+		            rotationAxis.setCoordinate(rotation);
+		        }
+	
+	        }//there is a move
+	        
+	    }//there were axes involved
+        
+    	//regardless of any action above the subdriver needs its actions based on original input
+        for (ReferenceDriver driver : subDrivers) {
+            driver.moveTo(hm, locationOriginal, speed);
         } 
 
-        // If no axes are included in the move, there's nothing to do, so just return.
-        if (xAxis == null && yAxis == null && zAxis == null && rotationAxis == null) {
-            return;
-        }
-
-        // For each included axis, if the axis has a transform, transform the target coordinate to
-        // it's raw value.
-        if (xAxis != null && xAxis.getTransform() != null) {
-            x = xAxis.getTransform().toRaw(xAxis, hm, x);
-        }
-        if (yAxis != null && yAxis.getTransform() != null) {
-            y = yAxis.getTransform().toRaw(yAxis, hm, y);
-        }
-        if (zAxis != null && zAxis.getTransform() != null) {
-            z = zAxis.getTransform().toRaw(zAxis, hm, z);
-        }
-        if (rotationAxis != null && rotationAxis.getTransform() != null) {
-            rotation = rotationAxis.getTransform().toRaw(rotationAxis, hm, rotation);
-        }
-
-        boolean emptyMove = true;
-
-        String command = getCommand(hm, CommandType.MOVE_TO_COMMAND);
-        command = substituteVariable(command, "Id", hm.getId());
-        command = substituteVariable(command, "Name", hm.getName());
-        command = substituteVariable(command, "FeedRate", maxFeedRate * speed);
-
-        if (xAxis == null || xAxis.getCoordinate() == x) {
-            command = substituteVariable(command, "X", null);
-        }
-        else {
-            command = substituteVariable(command, "X", x);
-            emptyMove = false;
-            if (xAxis.getPreMoveCommand() != null) {
-                sendGcode(xAxis.getPreMoveCommand());
-            }
-        }
-
-        if (yAxis == null || yAxis.getCoordinate() == y) {
-            command = substituteVariable(command, "Y", null);
-        }
-        else {
-            command = substituteVariable(command, "Y", y);
-            emptyMove = false;
-            if (yAxis.getPreMoveCommand() != null) {
-                sendGcode(yAxis.getPreMoveCommand());
-            }
-        }
-
-        if (zAxis == null || zAxis.getCoordinate() == z) {
-            command = substituteVariable(command, "Z", null);
-        }
-        else {
-            command = substituteVariable(command, "Z", z);
-            emptyMove = false;
-            if (zAxis.getPreMoveCommand() != null) {
-                sendGcode(zAxis.getPreMoveCommand());
-            }
-        }
-
-        if (rotationAxis == null || rotationAxis.getCoordinate() == rotation) {
-            command = substituteVariable(command, "Rotation", null);
-        }
-        else {
-            command = substituteVariable(command, "Rotation", rotation);
-            emptyMove = false;
-            if (rotationAxis.getPreMoveCommand() != null) {
-                sendGcode(rotationAxis.getPreMoveCommand());
-            }
-        }
-
-        // No axes were included in the move, so there is nothing to do.
-        if (emptyMove) {
-            return;
-        }
-
-        List<String> responses = sendGcode(command);
-
-        /*
-         * If moveToCompleteRegex is specified we need to wait until we match the regex in a
-         * response before continuing. We first search the initial responses from the command for
-         * the regex. If it's not found we then collect responses for up to timeoutMillis while
-         * searching the responses for the regex. As soon as it is matched we continue. If it's not
-         * matched within the timeout we throw an Exception.
-         */
-        String moveToCompleteRegex = getCommand(hm, CommandType.MOVE_TO_COMPLETE_REGEX);
-        if (moveToCompleteRegex != null) {
-            if (!containsMatch(responses, moveToCompleteRegex)) {
-                long t = System.currentTimeMillis();
-                boolean done = false;
-                while (!done && System.currentTimeMillis() - t < timeoutMilliseconds) {
-                    done = containsMatch(sendCommand(null, 250), moveToCompleteRegex);
-                }
-                if (!done) {
-                    throw new Exception("Timed out waiting for move to complete.");
-                }
-            }
-        }
-
-        // And save the final values on the axes.
-        if (xAxis != null) {
-            xAxis.setCoordinate(x);
-        }
-        if (yAxis != null) {
-            yAxis.setCoordinate(y);
-        }
-        if (zAxis != null) {
-            zAxis.setCoordinate(z);
-        }
-        if (rotationAxis != null) {
-            rotationAxis.setCoordinate(rotation);
-        }
-
-        for (ReferenceDriver driver : subDrivers) {
-            driver.moveTo(hm, location, speed);
-        }
     }
 
     private boolean containsMatch(List<String> responses, String regex) {

--- a/src/main/java/org/openpnp/machine/reference/driver/GcodeDriver.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/GcodeDriver.java
@@ -496,7 +496,7 @@ public class GcodeDriver extends AbstractSerialPortDriver implements Runnable {
         }
         if (Double.isNaN(rotation)) {
             rotationAxis = null;
-        }
+        } 
 
         // If no axes are included in the move, there's nothing to do, so just return.
         if (xAxis == null && yAxis == null && zAxis == null && rotationAxis == null) {


### PR DESCRIPTION
Gcode driver used to:
1) add headmovable offset to target location on every entry --> giving twice or more the physical move
2) stop processing when there is no action thus preventing subdrivers to take control --> unnecessary tweaks in machine.xml 

This PR:
1) keeps original target location aside for every next iterative call --> offsets are used correctly
2) just skips part of the code to always reach the point where subdrivers take control --> no tweaks necessary in machine.xml for this bug HOWEVER same tweaks still necessary for other bug (see text in #376)