### PR TITLE
DRO update works on Gcodedriver, even when axis info is on subdrivers

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/driver/GcodeDriver.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/GcodeDriver.java
@@ -458,6 +458,7 @@ public class GcodeDriver extends AbstractSerialPortDriver implements Runnable {
         Axis zAxis = getAxis(hm, Axis.Type.Z);
         Axis rotationAxis = getAxis(hm, Axis.Type.Rotation);
         
+        //additional info might be on subdrivers (note that subdrivers can only be one level deep)
         for (ReferenceDriver driver : subDrivers) {
         	GcodeDriver d = (GcodeDriver) driver;
             if (d.getAxis(hm, Axis.Type.X) != null){

--- a/src/main/java/org/openpnp/machine/reference/driver/GcodeDriver.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/GcodeDriver.java
@@ -452,10 +452,27 @@ public class GcodeDriver extends AbstractSerialPortDriver implements Runnable {
 
     @Override
     public Location getLocation(ReferenceHeadMountable hm) {
+    	//according main driver
         Axis xAxis = getAxis(hm, Axis.Type.X);
         Axis yAxis = getAxis(hm, Axis.Type.Y);
         Axis zAxis = getAxis(hm, Axis.Type.Z);
         Axis rotationAxis = getAxis(hm, Axis.Type.Rotation);
+        
+        for (ReferenceDriver driver : subDrivers) {
+        	GcodeDriver d = (GcodeDriver) driver;
+            if (d.getAxis(hm, Axis.Type.X) != null){
+            	xAxis = d.getAxis(hm, Axis.Type.X);
+            }
+            if (d.getAxis(hm, Axis.Type.Y) != null){
+            	yAxis = d.getAxis(hm, Axis.Type.Y);
+            }
+            if (d.getAxis(hm, Axis.Type.Z) != null){
+            	zAxis = d.getAxis(hm, Axis.Type.Z);
+            }
+            if (d.getAxis(hm, Axis.Type.Rotation) != null){
+            	rotationAxis = d.getAxis(hm, Axis.Type.Rotation);
+            }
+        } 
 
         Location location =
                 new Location(units, xAxis == null ? 0 : xAxis.getTransformedCoordinate(hm),


### PR DESCRIPTION
getLocation() was only reporting axes found on the main Gcodedriver.
Axes defined on subdrivers where thus lost and not in DRO and also not available for next relative move.
A tweak was to define the missing axes on the main driver as well but this has other implications and is not ideal.
First solution thought of was to have GcodeDriver.getAxis() look on all subdrivers but that gave problems in GcodeDriver.moveTo(). So this solution is based getLocation() looking on subdrivers.
@vonnieda I had to use a typecast (ReferenceDriver to GcodeDriver). Maybe you know a better way.
In the meantime I tested this solution on my machine (Z2 on maindriver, XYZ1C on subdriver) and found no problems whatsoever.
This concludes the bugs found in #376 so that issue maybe closed