### PR TITLE
Adding a SystemLogger class for redirecting stdout and stderr to tinylog, related to #288

### DIFF
--- a/src/main/java/org/openpnp/Main.java
+++ b/src/main/java/org/openpnp/Main.java
@@ -25,8 +25,10 @@ import java.io.File;
 import javax.swing.UIManager;
 
 import org.openpnp.gui.MainFrame;
+import org.openpnp.logging.SystemLogger;
 import org.openpnp.model.Configuration;
 import org.pmw.tinylog.Configurator;
+import org.pmw.tinylog.Level;
 import org.pmw.tinylog.Logger;
 import org.pmw.tinylog.writers.RollingFileWriter;
 
@@ -50,11 +52,17 @@ public class Main {
         File logFile = new File(logDirectory, "OpenPnP.log");
         Configurator
             .currentConfig()
-            .addWriter(new RollingFileWriter(logFile.getAbsolutePath(), 100))
+            .writer(new RollingFileWriter(logFile.getAbsolutePath(), 100))
             .activate();
         Configurator.currentConfig()
             .formatPattern("{date:yyyy-MM-dd HH:mm:ss} {class_name} {level}: {message}")
             .activate();
+
+        // Redirect the stdout and stderr to the LogPanel
+        SystemLogger out = new SystemLogger(System.out, Level.INFO);
+        SystemLogger err = new SystemLogger(System.err, Level.ERROR);
+        System.setOut(out);
+        System.setErr(err);
     }
 
     public static void main(String[] args) {

--- a/src/main/java/org/openpnp/logging/SystemLogger.java
+++ b/src/main/java/org/openpnp/logging/SystemLogger.java
@@ -1,0 +1,48 @@
+package org.openpnp.logging;
+
+import java.io.OutputStream;
+import java.io.PrintStream;
+
+import org.pmw.tinylog.Level;
+import org.pmw.tinylog.Logger;
+
+/**
+ * A SystemLogger class that redirects another stream like e.g. stdout or stderr to the tinylog logger
+ */
+public class SystemLogger extends PrintStream {
+
+    private static final String lineSeparator = System.getProperty("line.separator");
+
+    private Level logLevel;
+
+    public SystemLogger(OutputStream out, Level logLevel) {
+        super(out);
+        this.logLevel = logLevel;
+    }
+
+    public SystemLogger(OutputStream out) {
+        super(out);
+        this.logLevel = Level.INFO;
+    }
+
+    @Override
+    public void write(byte[] buf, int off, int len) {
+        super.write(buf, off, len);
+
+        byte[] pb = new byte[len];
+        System.arraycopy(buf, off, pb, 0, len);
+        String str = new String(pb);
+
+        if(!str.equals(lineSeparator)) {
+            // There is no generic log function where one could pass the log level
+            switch (logLevel) {
+                case INFO:
+                    Logger.info(str);
+                    break;
+                case ERROR:
+                    Logger.error(str);
+                    break;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Hey there,

i managed to redirect the output, but there are some things to know about this:

1. No overwrite of the `System.out.write(int b)` primitive char printing as this does not make sense in the LogTab.
2. I had to change the addWriter to writer because the consoleWriter which is default attached by tinylog will create a circular dependency: System.out=> SystemLogger => Logger (Console Writer) => System.out
3. Initialization in Main class as the first logging is done there and i do not want config changes in between setup logging and setup of Log Panel.

Class was named SystemLogger because tinylog uses reflection and the class name will be used for tagging the LogEntry. I found no way to overwrite this in a simple way.

 Unfortunately there is no generic log function where one could pass a LogLevel, therefore it is used in the constructor of the SystemLogger to be evaluated on logging.

Best, Friedrich