### PR TITLE
Center camera and move to next part

### DIFF
--- a/src/main/java/org/openpnp/gui/FeedersPanel.java
+++ b/src/main/java/org/openpnp/gui/FeedersPanel.java
@@ -283,9 +283,6 @@ public class FeedersPanel extends JPanel implements WizardContainer {
         }
         tableSorter.setRowFilter(rf);
     }
-    public void refresh() {
-        tableModel.refresh();
-    }
 
     @Override
     public void wizardCompleted(Wizard wizard) {

--- a/src/main/java/org/openpnp/gui/FeedersPanel.java
+++ b/src/main/java/org/openpnp/gui/FeedersPanel.java
@@ -283,6 +283,9 @@ public class FeedersPanel extends JPanel implements WizardContainer {
         }
         tableSorter.setRowFilter(rf);
     }
+    public void refresh() {
+        tableModel.refresh();
+    }
 
     @Override
     public void wizardCompleted(Wizard wizard) {

--- a/src/main/java/org/openpnp/gui/JobPanel.java
+++ b/src/main/java/org/openpnp/gui/JobPanel.java
@@ -283,7 +283,7 @@ public class JobPanel extends JPanel {
         pnlRight.add(tabbedPane, BorderLayout.CENTER);
 
         jobPastePanel = new JobPastePanel(this);
-        jobPlacementsPanel = new JobPlacementsPanel(frame, this);
+        jobPlacementsPanel = new JobPlacementsPanel(this);
 
         add(splitPane);
 
@@ -1040,15 +1040,16 @@ public class JobPanel extends JPanel {
 				// Need to keep current focus owner so that the space bar can be
 				// used after the initial click. Otherwise, button focus is lost
 				// when table is updated
-				Component comp = frame.getFocusOwner();
+				Component comp = MainFrame.get().getFocusOwner();
 				HeadMountable tool = MainFrame.get().getMachineControls().getSelectedTool();
 				Camera camera = tool.getHead().getDefaultCamera();
 				MainFrame.get().getCameraViews().ensureCameraVisible(camera);
 				Location location = getSelectedBoardLocation().getLocation();
 				MovableUtils.moveToLocationAtSafeZ(camera, location);	
 				Helpers.selectNextTableRow(boardLocationsTable);
-				if (comp!=null)
+				if (comp!=null){
 					comp.requestFocus();
+				}
 			});
 		}
 	};

--- a/src/main/java/org/openpnp/gui/JobPanel.java
+++ b/src/main/java/org/openpnp/gui/JobPanel.java
@@ -21,6 +21,7 @@ package org.openpnp.gui;
 
 import java.awt.BorderLayout;
 import java.awt.Color;
+import java.awt.Component;
 import java.awt.FileDialog;
 import java.awt.Frame;
 import java.awt.Rectangle;
@@ -282,7 +283,7 @@ public class JobPanel extends JPanel {
         pnlRight.add(tabbedPane, BorderLayout.CENTER);
 
         jobPastePanel = new JobPastePanel(this);
-        jobPlacementsPanel = new JobPlacementsPanel(this);
+        jobPlacementsPanel = new JobPlacementsPanel(frame, this);
 
         add(splitPane);
 
@@ -1036,12 +1037,19 @@ public class JobPanel extends JPanel {
 		@Override
 		public void actionPerformed(ActionEvent arg0) {
 			UiUtils.submitUiMachineTask(() -> {
+				// Need to keep current focus owner so that the space bar can be
+				// used after the initial click. Otherwise, button focus is lost
+				// when table is updated
+				Component comp = frame.getFocusOwner();
+				
 				HeadMountable tool = MainFrame.get().getMachineControls().getSelectedTool();
 				Camera camera = tool.getHead().getDefaultCamera();
 				MainFrame.get().getCameraViews().ensureCameraVisible(camera);
 				Location location = getSelectedBoardLocation().getLocation();
-				MovableUtils.moveToLocationAtSafeZ(camera, location);
-				Helpers.selectNextTableRow(boardLocationsTable); 
+				MovableUtils.moveToLocationAtSafeZ(camera, location);	
+				Helpers.selectNextTableRow(boardLocationsTable);
+				if (comp!=null)
+					comp.requestFocus();
 			});
 		}
 	};

--- a/src/main/java/org/openpnp/gui/JobPanel.java
+++ b/src/main/java/org/openpnp/gui/JobPanel.java
@@ -163,8 +163,8 @@ public class JobPanel extends JPanel {
 
         boardLocationSelectionActionGroup = new ActionGroup(removeBoardAction,
                 captureCameraBoardLocationAction, captureToolBoardLocationAction,
-                moveCameraToBoardLocationAction, moveToolToBoardLocationAction,
-                twoPointLocateBoardLocationAction, fiducialCheckAction);
+                moveCameraToBoardLocationAction, moveCameraToBoardLocationNextAction,
+                moveToolToBoardLocationAction, twoPointLocateBoardLocationAction, fiducialCheckAction);
         boardLocationSelectionActionGroup.setEnabled(false);
 
         boardLocationsTableModel = new BoardLocationsTableModel(configuration);
@@ -255,6 +255,9 @@ public class JobPanel extends JPanel {
         btnPositionCameraBoardLocation.setHideActionText(true);
         toolBarBoards.add(btnPositionCameraBoardLocation);
 
+        JButton btnPositionCameraBoardLocationNext = new JButton(moveCameraToBoardLocationNextAction);
+        btnPositionCameraBoardLocationNext.setHideActionText(true);
+        toolBarBoards.add(btnPositionCameraBoardLocationNext);
         JButton btnPositionToolBoardLocation = new JButton(moveToolToBoardLocationAction);
         btnPositionToolBoardLocation.setHideActionText(true);
         toolBarBoards.add(btnPositionToolBoardLocation);
@@ -1024,6 +1027,24 @@ public class JobPanel extends JPanel {
                     });
                 }
             };
+	public final Action moveCameraToBoardLocationNextAction = new AbstractAction("Move Camera To Board Location") {
+		{
+			putValue(SMALL_ICON, Icons.centerCameraMoveNext);
+			putValue(NAME, "Move Camera To Board Location and Move to the Next Board");
+			putValue(SHORT_DESCRIPTION, "Position the camera at the board's location and move to the next board.");
+		}
+		@Override
+		public void actionPerformed(ActionEvent arg0) {
+			UiUtils.submitUiMachineTask(() -> {
+				HeadMountable tool = MainFrame.get().getMachineControls().getSelectedTool();
+				Camera camera = tool.getHead().getDefaultCamera();
+				MainFrame.get().getCameraViews().ensureCameraVisible(camera);
+				Location location = getSelectedBoardLocation().getLocation();
+				MovableUtils.moveToLocationAtSafeZ(camera, location);
+				Helpers.selectNextTableRow(boardLocationsTable); 
+			});
+		}
+	};
 
     public final Action moveToolToBoardLocationAction = new AbstractAction() {
         {

--- a/src/main/java/org/openpnp/gui/JobPanel.java
+++ b/src/main/java/org/openpnp/gui/JobPanel.java
@@ -1041,7 +1041,6 @@ public class JobPanel extends JPanel {
 				// used after the initial click. Otherwise, button focus is lost
 				// when table is updated
 				Component comp = frame.getFocusOwner();
-				
 				HeadMountable tool = MainFrame.get().getMachineControls().getSelectedTool();
 				Camera camera = tool.getHead().getDefaultCamera();
 				MainFrame.get().getCameraViews().ensureCameraVisible(camera);

--- a/src/main/java/org/openpnp/gui/JobPlacementsPanel.java
+++ b/src/main/java/org/openpnp/gui/JobPlacementsPanel.java
@@ -341,6 +341,9 @@ public class JobPlacementsPanel extends JPanel {
         @Override
         public void actionPerformed(ActionEvent arg0) {
         	UiUtils.submitUiMachineTask(() -> {
+				// Need to keep current focus owner so that the space bar can be
+				// used after the initial click. Otherwise, button focus is lost
+				// when table is updated
         		Component comp = frame.getFocusOwner();
                 Location location = Utils2D.calculateBoardPlacementLocation(boardLocation,
                         getSelection().getLocation());

--- a/src/main/java/org/openpnp/gui/JobPlacementsPanel.java
+++ b/src/main/java/org/openpnp/gui/JobPlacementsPanel.java
@@ -87,7 +87,7 @@ public class JobPlacementsPanel extends JPanel {
 
         captureAndPositionActionGroup =
                 new ActionGroup(captureCameraPlacementLocation, captureToolPlacementLocation,
-                        moveCameraToPlacementLocation, moveToolToPlacementLocation);
+                        moveCameraToPlacementLocation, moveCameraToPlacementLocationNext, moveToolToPlacementLocation);
         captureAndPositionActionGroup.setEnabled(false);
 
         JComboBox<PartsComboBoxModel> partsComboBox = new JComboBox(new PartsComboBoxModel());
@@ -118,6 +118,9 @@ public class JobPlacementsPanel extends JPanel {
         JButton btnPositionCameraPositionLocation = new JButton(moveCameraToPlacementLocation);
         btnPositionCameraPositionLocation.setHideActionText(true);
         toolBarPlacements.add(btnPositionCameraPositionLocation);
+        JButton btnPositionCameraPositionNextLocation = new JButton(moveCameraToPlacementLocationNext);
+        btnPositionCameraPositionNextLocation.setHideActionText(true);
+        toolBarPlacements.add(btnPositionCameraPositionNextLocation);
 
         JButton btnPositionToolPositionLocation = new JButton(moveToolToPlacementLocation);
         btnPositionToolPositionLocation.setHideActionText(true);
@@ -324,6 +327,24 @@ public class JobPlacementsPanel extends JPanel {
                 MovableUtils.moveToLocationAtSafeZ(camera, location);
             });
         }
+    };
+    public final Action moveCameraToPlacementLocationNext = new AbstractAction() {
+        {
+            putValue(SMALL_ICON, Icons.centerCameraMoveNext);
+            putValue(NAME, "Move Camera To Placement Location and Move to Next Part");
+            putValue(SHORT_DESCRIPTION, "Position the camera at the placement's location and move to next part.");
+        }
+        @Override
+        public void actionPerformed(ActionEvent arg0) {
+        	UiUtils.submitUiMachineTask(() -> {
+                Location location = Utils2D.calculateBoardPlacementLocation(boardLocation,
+                        getSelection().getLocation());
+                Camera camera = MainFrame.get().getMachineControls().getSelectedTool().getHead()
+                        .getDefaultCamera();
+                MovableUtils.moveToLocationAtSafeZ(camera, location); 
+                Helpers.selectNextTableRow(table);   
+            });          
+        };
     };
 
     public final Action moveToolToPlacementLocation = new AbstractAction() {

--- a/src/main/java/org/openpnp/gui/JobPlacementsPanel.java
+++ b/src/main/java/org/openpnp/gui/JobPlacementsPanel.java
@@ -2,6 +2,7 @@ package org.openpnp.gui;
 
 import java.awt.BorderLayout;
 import java.awt.Color;
+import java.awt.Component;
 import java.awt.Point;
 import java.awt.Rectangle;
 import java.awt.event.ActionEvent;
@@ -17,6 +18,7 @@ import javax.swing.Action;
 import javax.swing.DefaultCellEditor;
 import javax.swing.JButton;
 import javax.swing.JComboBox;
+import javax.swing.JFrame;
 import javax.swing.JMenu;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
@@ -57,6 +59,7 @@ import org.openpnp.util.UiUtils;
 import org.openpnp.util.Utils2D;
 
 public class JobPlacementsPanel extends JPanel {
+	private JFrame frame;
     private JTable table;
     private PlacementsTableModel tableModel;
     private ActionGroup boardLocationSelectionActionGroup;
@@ -72,7 +75,8 @@ public class JobPlacementsPanel extends JPanel {
     private static Color statusColorReady = new Color(157, 255, 168);
     private static Color statusColorError = new Color(255, 157, 157);
 
-    public JobPlacementsPanel(JobPanel jobPanel) {
+    public JobPlacementsPanel(JFrame frame, JobPanel jobPanel) {
+    	this.frame = frame;
         Configuration configuration = Configuration.get();
 
         boardLocationSelectionActionGroup = new ActionGroup(newAction);
@@ -337,13 +341,16 @@ public class JobPlacementsPanel extends JPanel {
         @Override
         public void actionPerformed(ActionEvent arg0) {
         	UiUtils.submitUiMachineTask(() -> {
+        		Component comp = frame.getFocusOwner();
                 Location location = Utils2D.calculateBoardPlacementLocation(boardLocation,
                         getSelection().getLocation());
                 Camera camera = MainFrame.get().getMachineControls().getSelectedTool().getHead()
                         .getDefaultCamera();
                 MovableUtils.moveToLocationAtSafeZ(camera, location); 
-                Helpers.selectNextTableRow(table);   
-            });          
+                Helpers.selectNextTableRow(table);
+                if (comp!=null)
+					comp.requestFocus();
+            }); 
         };
     };
 

--- a/src/main/java/org/openpnp/gui/JobPlacementsPanel.java
+++ b/src/main/java/org/openpnp/gui/JobPlacementsPanel.java
@@ -59,7 +59,6 @@ import org.openpnp.util.UiUtils;
 import org.openpnp.util.Utils2D;
 
 public class JobPlacementsPanel extends JPanel {
-	private JFrame frame;
     private JTable table;
     private PlacementsTableModel tableModel;
     private ActionGroup boardLocationSelectionActionGroup;
@@ -75,8 +74,7 @@ public class JobPlacementsPanel extends JPanel {
     private static Color statusColorReady = new Color(157, 255, 168);
     private static Color statusColorError = new Color(255, 157, 157);
 
-    public JobPlacementsPanel(JFrame frame, JobPanel jobPanel) {
-    	this.frame = frame;
+    public JobPlacementsPanel(JobPanel jobPanel) {
         Configuration configuration = Configuration.get();
 
         boardLocationSelectionActionGroup = new ActionGroup(newAction);
@@ -344,15 +342,16 @@ public class JobPlacementsPanel extends JPanel {
 				// Need to keep current focus owner so that the space bar can be
 				// used after the initial click. Otherwise, button focus is lost
 				// when table is updated
-        		Component comp = frame.getFocusOwner();
+        		Component comp = MainFrame.get().getFocusOwner();
                 Location location = Utils2D.calculateBoardPlacementLocation(boardLocation,
                         getSelection().getLocation());
                 Camera camera = MainFrame.get().getMachineControls().getSelectedTool().getHead()
                         .getDefaultCamera();
                 MovableUtils.moveToLocationAtSafeZ(camera, location); 
                 Helpers.selectNextTableRow(table);
-                if (comp!=null)
+                if (comp!=null){
 					comp.requestFocus();
+                }
             }); 
         };
     };

--- a/src/main/java/org/openpnp/gui/support/Helpers.java
+++ b/src/main/java/org/openpnp/gui/support/Helpers.java
@@ -68,6 +68,21 @@ public class Helpers {
         index = table.convertRowIndexToView(index);
         table.addRowSelectionInterval(index, index);
     }
+    
+    public static void selectNextTableRow(JTable table){
+    	 int index = table.getSelectedRow();
+    	 
+    	 if (index == -1)
+    		 index = 0;
+    	 
+         table.clearSelection();
+         if (++index > table.getRowCount()-1)
+         	index = 0;
+         index = table.convertRowIndexToView(index);
+         table.addRowSelectionInterval(index, index);   
+    }
+    
+    
 
     /**
      * Create a unique name consisting of the prefix and an integer. The name is guaranteed to be

--- a/src/main/java/org/openpnp/gui/support/Helpers.java
+++ b/src/main/java/org/openpnp/gui/support/Helpers.java
@@ -72,12 +72,15 @@ public class Helpers {
     public static void selectNextTableRow(JTable table){
     	 int index = table.getSelectedRow();
     	 
-    	 if (index == -1)
+    	 if (index == -1){
     		 index = 0;
+    	 }
     	 
          table.clearSelection();
-         if (++index > table.getRowCount()-1)
+         if (++index > table.getRowCount()-1){
          	index = 0;
+         }
+         
          index = table.convertRowIndexToView(index);
          table.addRowSelectionInterval(index, index);   
     }

--- a/src/main/java/org/openpnp/gui/support/Icons.java
+++ b/src/main/java/org/openpnp/gui/support/Icons.java
@@ -24,6 +24,7 @@ public class Icons {
     public static Icon capturePin = getIcon("/icons/capture-actuator.svg");
 
     public static Icon centerCamera = getIcon("/icons/position-camera.svg");
+    public static Icon centerCameraMoveNext = getIcon("/icons/position-camera-move-next.svg");
     public static Icon centerTool = getIcon("/icons/position-nozzle.svg");
     public static Icon centerToolNoSafeZ = getIcon("/icons/position-nozzle-no-safe-z.svg");
     public static Icon centerPin = getIcon("/icons/position-actuator.svg");

--- a/src/main/resources/icons/position-camera-move-next.svg
+++ b/src/main/resources/icons/position-camera-move-next.svg
@@ -1,0 +1,130 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:sketch="http://www.bohemiancoding.com/sketch/ns"
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24px"
+   height="24px"
+   viewBox="0 0 24 24"
+   version="1.1"
+   id="svg2"
+   inkscape:version="0.92.1 r15371"
+   sodipodi:docname="position-camera-move-next.svg">
+  <metadata
+     id="metadata15">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>position-camera-move-next</dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1600"
+     inkscape:window-height="837"
+     id="namedview13"
+     showgrid="true"
+     inkscape:zoom="22.627417"
+     inkscape:cx="12.480456"
+     inkscape:cy="11.286748"
+     inkscape:window-x="1672"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="g4942"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-midpoints="true"
+     inkscape:snap-smooth-nodes="true"
+     inkscape:object-nodes="true"
+     inkscape:snap-intersection-paths="true"
+     inkscape:object-paths="true"
+     inkscape:snap-text-baseline="true"
+     inkscape:snap-page="true"
+     inkscape:snap-center="true"
+     inkscape:snap-object-midpoints="true"
+     inkscape:snap-bbox="true"
+     showborder="false">
+    <sodipodi:guide
+       position="12,11.956522"
+       orientation="1,0"
+       id="guide4741"
+       inkscape:label=""
+       inkscape:color="rgb(0,0,255)"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="17.282609,12"
+       orientation="0,1"
+       id="guide4743"
+       inkscape:label=""
+       inkscape:color="rgb(0,0,255)"
+       inkscape:locked="false" />
+    <inkscape:grid
+       type="xygrid"
+       id="grid4141" />
+  </sodipodi:namedview>
+  <!-- Generator: Sketch 3.2.2 (9983) - http://www.bohemiancoding.com/sketch -->
+  <title
+     id="title4">position-camera-move-next</title>
+  <g
+     sketch:type="MSPage"
+     id="g4942"
+     style="fill:none;fill-rule:evenodd;stroke:none;stroke-width:1"
+     transform="translate(-0.13498791,0.13498791)">
+    <path
+       inkscape:connector-curvature="0"
+       d="m 5.1349878,14.865012 -2,0 0,4 c 0,1.1 0.9,2 2,2 l 4,0 0,-2 -4,0 0,-4 z m 0,-9.9999999 4,0 0,-2 -4,0 c -1.1,0 -2,0.9 -2,2 l 0,4 2,0 0,-4 z m 14.0000002,-2 -4,0 0,2 4,0 0,4 2,0 0,-4 c 0,-1.1 -0.9,-2 -2,-2 l 0,0 z m 0,15.9999999 -4,0 0,2 4,0 c 1.1,0 2,-0.9 2,-2 l 0,-4 -2,0 0,4 z"
+       id="path4946"
+       sketch:type="MSShapeGroup"
+       sodipodi:nodetypes="ccssccccccccssccccccccccsccccccsscccc"
+       style="fill:#bd0404;fill-opacity:1" />
+    <g
+       style="fill:none;fill-rule:evenodd;stroke:none;stroke-width:1"
+       id="g4148"
+       transform="matrix(1.109493,0,0,1.1094922,-1.07981,-1.4840876)">
+      <ellipse
+         style="fill:none;fill-opacity:0.99215686;fill-rule:evenodd;stroke:#005bdb;stroke-width:1.35196924;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.99215686"
+         id="path4948"
+         cx="11.910664"
+         cy="12.03172"
+         rx="4.2812347"
+         ry="4.2812381" />
+      <path
+         sodipodi:open="true"
+         d="m 13.713289,12.03172 a 1.8026252,1.8026206 0 0 1 -1.793814,1.802599 1.8026252,1.8026206 0 0 1 -1.81135,-1.784977 1.8026252,1.8026206 0 0 1 1.776106,-1.820049 1.8026252,1.8026206 0 0 1 1.828713,1.767185"
+         sodipodi:end="6.2636335"
+         sodipodi:start="0"
+         sodipodi:ry="1.8026206"
+         sodipodi:rx="1.8026252"
+         sodipodi:cy="12.03172"
+         sodipodi:cx="11.910664"
+         sodipodi:type="arc"
+         id="path4950"
+         style="fill:#005bdb;fill-opacity:0.99215686;fill-rule:evenodd;stroke:none;stroke-width:1.99999976;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.99215686" />
+    </g>
+    <path
+       style="opacity:1;fill:#000000;fill-rule:evenodd;stroke:#000000;stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 13.972197,4.3953424 V 19.218564 l 6.325581,-7.411612 z"
+       id="path4143"
+       inkscape:connector-curvature="0" />
+  </g>
+  <desc
+     id="desc6">Created with Sketch.</desc>
+  <defs
+     id="defs8" />
+</svg>


### PR DESCRIPTION
This was sketched out here with a picture: https://groups.google.com/forum/#!topic/openpnp/SpG09TKEVWg. The goal is to augment the "move camera to board" and "move camera to part" buttons with similar buttons with an arrow that performs the same action BUT then it advances the board or part table to the next line. The buttons also keep focus, allowing you to quickly move the camera through the PCB origins or part origins using the space bar so that you can verify the board origins in a panel, for example, are correct. And in part mode, this allows you to quickly zip from part to part and using the rotating gratical you can quickly see if part rotations are as expected.

Without this feature, you had to bounce between "move camera" button and then go click the next line in the table, and then back to "move camera" button. Very tedious. 

Changes needed were minor. One challenge was in order to ensure focus isn't lost on table row change, the focus had to first be captured, then the table changed, then the focus restored. Otherwise the focus bounced to seemingly random controls and the spacebar advance couldn't work. In the JobPanel this was straightforward to fix. In the JobPlacement panel, there wasn't a way to get to the frame, and so I added the frame arg to the constructor of the JobPlacementPanel. 