### PR TITLE
added Part to HeadMountable

### DIFF
--- a/src/main/java/org/openpnp/spi/HeadMountable.java
+++ b/src/main/java/org/openpnp/spi/HeadMountable.java
@@ -17,4 +17,14 @@ public interface HeadMountable extends Movable, Identifiable, Named {
      * HeadMountable is added to it.
      */
     void setHead(Head head);
+
+    /**
+     * Get the Part that this HeadMountable is attached to.
+     */
+    void getPart(Part part);
+    
+    /**
+     * Set the Part that this HeadMountable is attached to. 
+     */
+    void setPart(Part part);
 }

--- a/src/main/java/org/openpnp/spi/base/AbstractCamera.java
+++ b/src/main/java/org/openpnp/spi/base/AbstractCamera.java
@@ -15,6 +15,7 @@ import org.openpnp.model.AbstractModelObject;
 import org.openpnp.model.Configuration;
 import org.openpnp.model.LengthUnit;
 import org.openpnp.model.Location;
+import org.openpnp.model.Part;
 import org.openpnp.spi.Camera;
 import org.openpnp.spi.Head;
 import org.openpnp.spi.VisionProvider;
@@ -43,6 +44,9 @@ public abstract class AbstractCamera extends AbstractModelObject implements Came
     protected Set<ListenerEntry> listeners = Collections.synchronizedSet(new HashSet<>());
 
     protected Head head;
+    
+    protected Part part;
+
 
     protected Integer width;
 
@@ -92,6 +96,19 @@ public abstract class AbstractCamera extends AbstractModelObject implements Came
         this.head = head;
         this.headSet = true;
     }
+
+         
+    @Override
+    public void setPart(Part part) {
+        this.part = part;
+    }
+
+    
+    @Override
+    public Part getPart() {
+        return part;
+    }
+	
 
     @Override
     public Location getUnitsPerPixel() {

--- a/src/main/java/org/openpnp/spi/base/AbstractNozzle.java
+++ b/src/main/java/org/openpnp/spi/base/AbstractNozzle.java
@@ -71,6 +71,12 @@ public abstract class AbstractNozzle extends AbstractModelObject implements Nozz
         return part;
     }
 
+        
+    @Override
+    public void setPart(Part part) {
+        this.part = part;
+    }
+
     @Override
     public Icon getPropertySheetHolderIcon() {
         return Icons.captureTool;


### PR DESCRIPTION
This is  for the visionOffsets(HeadMountable hm)  that are callable with nozzle for bottom vision and with
camera for top vision. The reason for prefer this over 
Location visionOffsets(Nozzle nozzle, Part part) 
where in case of topvision nozzle is given as null is that adding part to camera gives vision pipeline the
access to part data and preserve the possibility to have more then one downlooking camera for the case
of multiple heads or for two distinct cameras with different fields of view.
