### PR TITLE
Added histogram equalization and doing circle detection for fiducials

### DIFF
--- a/src/main/java/org/openpnp/vision/FluentCv.java
+++ b/src/main/java/org/openpnp/vision/FluentCv.java
@@ -206,6 +206,10 @@ public class FluentCv {
         return store(mat, tag);
     }
 
+    public FluentCv equalizeHist(String... tag) {
+        Imgproc.equalizeHist(mat, mat);
+        return store(mat, tag);
+    } 
     public FluentCv blurMedian(int kernelSize, String... tag) {
         Imgproc.medianBlur(mat, mat, kernelSize);
         return store(mat, tag);
@@ -222,6 +226,7 @@ public class FluentCv {
     public FluentCv findCirclesHough(int minDiameter, int maxDiameter, int minDistance,
             String... tag) {
         Mat circles = new Mat();
+        Imgproc.equalizeHist(mat, mat);
         Imgproc.HoughCircles(mat, circles, Imgproc.CV_HOUGH_GRADIENT, 1, minDistance, 80, 10,
                 minDiameter / 2, maxDiameter / 2);
         store(circles, tag);


### PR DESCRIPTION
The histogram equalization fixed problems with strip tape feeders not
being detcted by the image processing. 

The circle detection for the fiducials is done if the fiducial template
match fails and the fiducal is 100% round package. This works well for
using through hole parts as fiducials