### PR TITLE
Change hard-coded for loop to timeout after 50ms instead

### DIFF
--- a/src/main/java/org/openpnp/gui/importer/NamedCSVImporter.java
+++ b/src/main/java/org/openpnp/gui/importer/NamedCSVImporter.java
@@ -267,28 +267,18 @@ public class NamedCSVImporter implements BoardImporter {
         ArrayList<Placement> placements = new ArrayList<>();
         String line;
 
-        // Set the timeout limit, currently it will timeout after 50 milliseconds.
-        // 50ms seems like it should be more than enough.
-        long timeoutLimit = System.currentTimeMillis() + 50;
         while((line = reader.readLine()) != null) {
             line = line.trim();
             if (line.length() == 0)
-                continue;
-            if (checkLine(line) || System.currentTimeMillis() > timeoutLimit)
+            	continue;
+            
+            if (checkLine(line))
                 break;
         }
-           
+                   
         if (Len == 0) {
-            reader.close();
-            
-            String errorMessage = "Unable to parse CSV File Names";
-            if (System.currentTimeMillis() > timeoutLimit) {
-                // Is this message clear enough?
-                // It throws this when the lineReadThread fails to find the CSV proper headers.
-                errorMessage = "Timout while parsing CSV file. File may contain too much overhead.";
-            }
-            
-            throw new Exception(errorMessage);
+            reader.close();            
+            throw new Exception("Unable to parse CSV File Names");
         }
 
         // CSVParser csvParser = new CSVParser(new FileInputStream(file));

--- a/src/main/java/org/openpnp/gui/importer/NamedCSVImporter.java
+++ b/src/main/java/org/openpnp/gui/importer/NamedCSVImporter.java
@@ -267,19 +267,28 @@ public class NamedCSVImporter implements BoardImporter {
         ArrayList<Placement> placements = new ArrayList<>();
         String line;
 
-        //TODO why only check first 50 lines? If it is a time out would time based time out be better? 
-        for (int i = 0; i++ <50 && (line = reader.readLine()) != null;) {
+        // Set the timeout limit, currently it will timeout after 50 milliseconds.
+        // 50ms seems like it should be more than enough.
+        long timeoutLimit = System.currentTimeMillis() + 50;
+        while((line = reader.readLine()) != null) {
             line = line.trim();
             if (line.length() == 0)
                 continue;
-            if (checkLine(line))
+            if (checkLine(line) || System.currentTimeMillis() > timeoutLimit)
                 break;
         }
-
-
+           
         if (Len == 0) {
             reader.close();
-            throw new Exception("Unable to parse CSV File Names");
+            
+            String errorMessage = "Unable to parse CSV File Names";
+            if (System.currentTimeMillis() > timeoutLimit) {
+                // Is this message clear enough?
+                // It throws this when the lineReadThread fails to find the CSV proper headers.
+                errorMessage = "Timout while parsing CSV file. File may contain too much overhead.";
+            }
+            
+            throw new Exception(errorMessage);
         }
 
         // CSVParser csvParser = new CSVParser(new FileInputStream(file));


### PR DESCRIPTION
Hello!

I made a small change to CSV Importer. Instead of the for loop which only checks the first 50 lines, I added in a while loop and made it timeout after 50ms. Also added a custom timeout message, not sure tho if it's clear enough and easy to understand. 

**A little bit of good to know info:** 
We are a 6 interns divided into 2 groups at a company in Sweden called Pluspole.  The first group of 4 people is going to work on the documentation part, which in the beginning will mostly consist of creating class-diagrams and alike, while the other group (which i'm in) of 2 will be further developing the OpenPNP software. You might have already received a message or email about this from the group working on documentation. 

We are all currently studying for software development, so any and all feedback is greatly appreciated 😄 