### PR TITLE
Add arguments to ScriptRun OpenCV pipeline stage

### DIFF
--- a/src/main/java/org/openpnp/vision/pipeline/stages/ScriptRun.java
+++ b/src/main/java/org/openpnp/vision/pipeline/stages/ScriptRun.java
@@ -28,6 +28,17 @@ public class ScriptRun extends CvStage {
         this.file = file;
     }
 
+    @Attribute
+    private String args = new String("");
+
+    public String getArgs() {
+        return args;
+    }
+
+    public void setArgs(String args) {
+        this.args = args;
+    }
+
     @Override
     public Result process(CvPipeline pipeline) throws Exception {
         if (!file.exists()) {
@@ -43,6 +54,7 @@ public class ScriptRun extends CvStage {
 
         engine.put("pipeline", pipeline);
         engine.put("stage", this);
+        engine.put("args",args);
 
         try (FileReader reader = new FileReader(file)) {
             Object result = engine.eval(reader);
@@ -51,7 +63,5 @@ public class ScriptRun extends CvStage {
             }
             return null;
         }
-
-
     }
 }


### PR DESCRIPTION
It is useful to have arguments passed to the ScriptRun OpenCV pipeline stage. This PR adds a string parameter `args` to the stage, which can then be parsed from inside the script.

Example parsing, from inside a ScriptRun stage with `args=size:[45,60],tol:5` 
```
eval("var args={" + args + "}");
for (var i in args)
  print(i,args[i]);
```
LOG window shows:
```
2017-03-29 01:33:01 SystemLogger INFO: size 45,60
2017-03-29 01:33:01 SystemLogger INFO: tol 5

```
