### PR TITLE
Update ReferenceNozzleTip.java

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/ReferenceNozzleTip.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceNozzleTip.java
@@ -102,7 +102,7 @@ public class ReferenceNozzleTip extends AbstractNozzleTip {
     public boolean canHandle(Part part) {
         boolean result =
                 allowIncompatiblePackages || compatiblePackages.contains(part.getPackage());
-        Logger.debug("{}.canHandle({}) => {}", getName(), part.getId(), result);
+        // Logger.debug("{}.canHandle({}) => {}", getName(), part.getId(), result);
         return result;
     }
 


### PR DESCRIPTION
Speed issue because of logging calling.
If call it present, on 400 components and 2 nozzles, it pauses over 7 seconds after having placed
the parts from nozzle, removing the call resolved the issue.