### PR TITLE
Add FilterRects stage to OpenCV pipeline to filter rects based on width and height

### DIFF
--- a/TEST.md
+++ b/TEST.md
@@ -1,2 +1,3 @@
 Ignore this file. It is a dummy file so I can push commits and test auto update
 functionality. It will be removed when the auto update issues are fixed.
+Test 2.

--- a/src/main/java/org/openpnp/vision/pipeline/stages/FilterRects.java
+++ b/src/main/java/org/openpnp/vision/pipeline/stages/FilterRects.java
@@ -107,13 +107,13 @@ public class FilterRects extends CvStage {
             // cannot calculate absolute dimensions
             throw new Exception(dimErr);
             
-          } else if (!tolerance.matches("[\\+\\-0-9]*\\.?[0-9]+%")) {
+          } else if (!tolerance.matches("[\\+\\-0-9]*\\.?[0-9]+%*")) {
             // bad input
             throw new Exception("If only aspect is specified, tolerance should be expressed as a percentage, e.g. 5%");
           }
         }
         // parse tolerance
-        if (tolerance.matches("[0-9]*\\.?[0-9]+%*")) {
+        if (tolerance.matches("[\\+\\-0-9]*\\.?[0-9]+%*")) {
           tol = Double.parseDouble(tolerance.replaceAll("%","")) / 100.0;
           tolIsPerc = true;
         } else {

--- a/src/main/java/org/openpnp/vision/pipeline/stages/FilterRects.java
+++ b/src/main/java/org/openpnp/vision/pipeline/stages/FilterRects.java
@@ -49,7 +49,7 @@ public class FilterRects extends CvStage {
     }
     
     @Attribute
-    @Property(description="Aspect ratio of filtered rects, used if one or both of width and height are 0. If both width and height are 0, then any rect satisfying the aspect ratio specified will be selected.")
+    @Property(description="Aspect ratio of filtered rects, used if one or both of width and height are 0. If both width and height are 0, then any rect size satisfying the aspect ratio specified will be selected.")
     private double aspect = 0.0;
     
     public double getAspect() {

--- a/src/main/java/org/openpnp/vision/pipeline/stages/FilterRects.java
+++ b/src/main/java/org/openpnp/vision/pipeline/stages/FilterRects.java
@@ -2,6 +2,7 @@ package org.openpnp.vision.pipeline.stages;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Collections;
 
 import org.opencv.core.MatOfPoint;
 import org.opencv.core.RotatedRect;
@@ -10,40 +11,52 @@ import org.openpnp.vision.pipeline.CvStage;
 import org.simpleframework.xml.Attribute;
 import org.openpnp.vision.pipeline.Stage;
 import org.openpnp.vision.pipeline.Property;
+import org.pmw.tinylog.Logger;
 
 @Stage(category="Image Processing", description="Filters rotated rects based on given size and tolerance. Orientation of width and height does not matter.")
 public class FilterRects extends CvStage {
     @Attribute
     @Property(description="Width of filtered rects. Filtering takes tolerance into consideration.")
-    private int width = 50;
+    private double width = 50.0;
     
-    public int getWidth() {
+    public double getWidth() {
       return width;
     }
-    public void setWidth(int width) {
-      this.width = width;
+    public void setWidth(double width) {
+      this.width = Math.abs(width);
     }
     
     @Attribute
     @Property(description="Height of filtered rects. Filtering takes tolerance into consideration.")
-    private int height = 50;
+    private double height = 50.0;
 
-    public int getHeight() {
+    public double getHeight() {
       return height;
     }
-    public void setHeight(int height) {
-      this.height = height;
+    public void setHeight(double height) {
+      this.height = Math.abs(height);
     }
     
     @Attribute
-    @Property(description="Tolerance of desired rect size.")
-    private int tolerance = 5;
+    @Property(description="Tolerance of specified sizes. Can be expressed as a percentage, e.g. 5%. If negative, sizes are maximum values.")
+    private String tolerance = "5%";
     
-    public int getTolerance() {
+    public String getTolerance() {
       return tolerance;
     }
-    public void setTolerance(int tolerance) {
+    public void setTolerance(String tolerance) {
       this.tolerance = tolerance;
+    }
+    
+    @Attribute
+    @Property(description="Aspect ratio of filtered rects, used if one or both of width and height are 0. If both width and height are 0, then any rect satisfying the aspect ratio specified will be selected.")
+    private double aspect = 0.0;
+    
+    public double getAspect() {
+      return aspect;
+    }
+    public void setAspect(double aspect) {
+      this.aspect = Math.abs(aspect);
     }
     
 
@@ -64,23 +77,86 @@ public class FilterRects extends CvStage {
         if (rectStageName == null) {
             return null;
         }
+        String dimErr = "Width, height, or width and aspect, or aspect, must be non zero.";
+        
         Result result = pipeline.getResult(rectStageName);
         if (result == null || result.model == null) {
             return null;
         }
-        List<RotatedRect> rects = (List<RotatedRect>) result.model;
+        
+        List<RotatedRect> rects; 
+        if (result.model instanceof RotatedRect) {
+            rects = Collections.singletonList((RotatedRect)result.model);
+        }
+        else {
+            rects = (List<RotatedRect>)result.model;
+        }
+
         List<RotatedRect> results = new ArrayList<RotatedRect>();
-        // we need to sort sizes to do comparisons
-        double w = Math.max(width,height);
-        double h = Math.min(width, height);
-        double rw, rh;
+                
+        // we need to sort sizes to do comparisons. The following assures w is always greater than h
+        double w = Math.max(width,height), ww, upper_w;
+        double h = Math.min(width, height), hh, upper_h;
+        double rw, rh, tol, extUpper;
+        boolean tolIsPerc;
+        
+        // check the validity of input
+        if (w == 0.0) {
+          // this means h is also 0
+          if (aspect == 0.0) {
+            // cannot calculate absolute dimensions
+            throw new Exception(dimErr);
+            
+          } else if (!tolerance.matches("[\\+\\-0-9]*\\.?[0-9]+%")) {
+            // bad input
+            throw new Exception("If only aspect is specified, tolerance should be expressed as a percentage, e.g. 5%");
+          }
+        }
+        // parse tolerance
+        if (tolerance.matches("[0-9]*\\.?[0-9]+%*")) {
+          tol = Double.parseDouble(tolerance.replaceAll("%","")) / 100.0;
+          tolIsPerc = true;
+        } else {
+          tol = Double.parseDouble(tolerance);
+          tolIsPerc = false;
+        }
+        if (tol >= 0) {
+          // range will be dimension +- tolerance/2
+          extUpper = 1;
+          tol = tol / 2.0;
+        } else {
+          // range will be dimension 0- tolerance
+          extUpper = 0;
+          tol = Math.abs(tol);
+        }
+        
+        if (h == 0.0 && aspect != 0.0) {
+          // derive height from aspect
+          h = w / aspect;
+        }
         for (RotatedRect rect : rects) {
+        
           rw = Math.max(rect.size.width,rect.size.height);
           rh = Math.min(rect.size.width,rect.size.height);
-            if (rw >= w - tolerance && rw <= w + tolerance && rh >= h - tolerance && rh <= h + tolerance) {
-              // passes criteria
-              results.add(rect);
-            }
+          
+          if (width == 0.0 && height == 0.0) {
+            // Any size:
+            // Select rects based only on the aspect ratio of each input rectangle
+            w = rw;
+            h = rw / aspect;
+          }
+          
+          // trick to avoid lengthy checking of tolerance criteria bellow
+          ww = tolIsPerc ? w : 1;
+          hh = tolIsPerc ? h : 1;
+          upper_w = tol * ww * extUpper;
+          upper_h = tol * hh * extUpper;
+
+          // check criteria
+          if (rw >= w - tol * ww && rw <= w + upper_w && rh >= h - tol * hh && rh <= h + upper_h) {
+            // rect passes criteria
+            results.add(rect);
+          }
         }
         return new Result(null, results);
     }

--- a/src/main/java/org/openpnp/vision/pipeline/stages/FilterRects.java
+++ b/src/main/java/org/openpnp/vision/pipeline/stages/FilterRects.java
@@ -109,26 +109,25 @@ public class FilterRects extends CvStage {
        Logger.info(s);
       }
     }
-    // assign values here to minimize storage allocation costs in time, and use pointers to these values.\u25A0
     private static String[] verdict = {" ","+"};
     
     @Override
     public Result process(CvPipeline pipeline) throws Exception {
         if (rotatedRectsStageName == null) {
-            return null;
+          return null;
         }
         
         Result result = pipeline.getResult(rotatedRectsStageName);
         if (result == null || result.model == null) {
-            return null;
+          return null;
         }
         
         List<RotatedRect> rects; 
         if (result.model instanceof RotatedRect) {
-            rects = Collections.singletonList((RotatedRect)result.model);
+          rects = Collections.singletonList((RotatedRect)result.model);
         }
         else {
-            rects = (List<RotatedRect>)result.model;
+          rects = (List<RotatedRect>)result.model;
         }
 
         List<RotatedRect> results = new ArrayList<RotatedRect>();
@@ -147,23 +146,19 @@ public class FilterRects extends CvStage {
         armin = Math.min(aspectRatioMax, aspectRatioMin);
         
         // check input parameters
-        if (armin == 0 && (wmax == 0 || lmax == 0))
-        {
+        if (armin == 0 && (wmax == 0 || lmax == 0)) {
           // cannot accept this as there will be divisions by 0 
           throw new Exception("If width or length limits are 0, then both aspectRatioMax and aspepctRatioMin must be non zero.");            
         }
-        if (armax != 0 && (wmax == 0 && lmax == 0))
-        {
+        if (armax != 0 && (wmax == 0 && lmax == 0)) {
           sizeType = 2;
         }
-        else if (lmax == 0) 
-        {
+        else if (lmax == 0) {
           // derive length from aspect ratio
           lmax = wmax / armin; lmin = wmin / armax;
           sizeType = 1;
         } 
-        else if (wmax == 0)
-        {
+        else if (wmax == 0) {
           wmax = lmax * armax; wmin = lmin * armin;
           sizeType = 1;
         }
@@ -171,10 +166,12 @@ public class FilterRects extends CvStage {
           sizeType = 3;
         }
         if (enableLogging) {
-          if (sizeType == 1)
+          if (sizeType == 1) {
             Logger.info("Deriving "+(wmax == 0? "width":"length")+ " limits based on aspect ratio limits.");
-          else if (sizeType == 2)
+          }
+          else if (sizeType == 2) {
             Logger.info("Pass any size rect within aspect ratio limits.");
+          }
         }
         
         // iterate over input rects
@@ -184,8 +181,9 @@ public class FilterRects extends CvStage {
           rl = Math.min(rect.size.width,rect.size.height);
           // ignore aspect ratio = NaN or infinity
           rar= rw / rl;
-          if (Double.isNaN(rar) || Double.isInfinite(rar))
+          if (Double.isNaN(rar) || Double.isInfinite(rar)) {
             continue;
+          }
           
           if (sizeType == 2) {
             // Any size:
@@ -197,19 +195,27 @@ public class FilterRects extends CvStage {
           }
 
           // check criteria
-          if (rw >= wmin && rw <= wmax) wok = true;
-          else                          wok = false;
-            
-          if (rl >= lmin && rl <= lmax) lok = true;
-          else                          lok = false;
-            
-          if (rar >= armin && rar <= armax) arok = true;
-          else                              arok = false;
-
+          if (rw >= wmin && rw <= wmax) {
+            wok = true;
+          }
+          else {
+            wok = false;
+          }
+          if (rl >= lmin && rl <= lmax) {
+            lok = true;
+          }
+          else {
+           lok = false;
+          }
+          if (rar >= armin && rar <= armax) {
+            arok = true;
+          }
+          else {
+            arok = false;
+          }
           // if sizeTYpe == 3 we don't care about aspect ratio
           // because specified width and length limits take precedence over aspect ratio limits
-          if (wok && lok && (sizeType == 3 || arok))
-          {
+          if (wok && lok && (sizeType == 3 || arok)) {
             // rect passes criteria
             results.add(rect);
             pass = verdict[1];

--- a/src/main/java/org/openpnp/vision/pipeline/stages/FilterRects.java
+++ b/src/main/java/org/openpnp/vision/pipeline/stages/FilterRects.java
@@ -1,0 +1,87 @@
+package org.openpnp.vision.pipeline.stages;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.opencv.core.MatOfPoint;
+import org.opencv.core.RotatedRect;
+import org.openpnp.vision.pipeline.CvPipeline;
+import org.openpnp.vision.pipeline.CvStage;
+import org.simpleframework.xml.Attribute;
+import org.openpnp.vision.pipeline.Stage;
+import org.openpnp.vision.pipeline.Property;
+
+@Stage(category="Image Processing", description="Filters rotated rects based on given size and tolerance. Orientation of width and height does not matter.")
+public class FilterRects extends CvStage {
+    @Attribute
+    @Property(description="Width of filtered rects. Filtering takes tolerance into consideration.")
+    private int width = 50;
+    
+    public int getWidth() {
+      return width;
+    }
+    public void setWidth(int width) {
+      this.width = width;
+    }
+    
+    @Attribute
+    @Property(description="Height of filtered rects. Filtering takes tolerance into consideration.")
+    private int height = 50;
+
+    public int getHeight() {
+      return height;
+    }
+    public void setHeight(int height) {
+      this.height = height;
+    }
+    
+    @Attribute
+    @Property(description="Tolerance of desired rect size.")
+    private int tolerance = 5;
+    
+    public int getTolerance() {
+      return tolerance;
+    }
+    public void setTolerance(int tolerance) {
+      this.tolerance = tolerance;
+    }
+    
+
+    @Attribute
+    @Property(description="Pipeline stage that outputs rotated rects.")
+    private String rectStageName = "";
+    
+    public String getRectStageName() {
+        return rectStageName;
+    }
+
+    public void setRectStageName(String rectStageName) {
+        this.rectStageName = rectStageName;
+    }
+
+    @Override
+    public Result process(CvPipeline pipeline) throws Exception {
+        if (rectStageName == null) {
+            return null;
+        }
+        Result result = pipeline.getResult(rectStageName);
+        if (result == null || result.model == null) {
+            return null;
+        }
+        List<RotatedRect> rects = (List<RotatedRect>) result.model;
+        List<RotatedRect> results = new ArrayList<RotatedRect>();
+        // we need to sort sizes to do comparisons
+        double w = Math.max(width,height);
+        double h = Math.min(width, height);
+        double rw, rh;
+        for (RotatedRect rect : rects) {
+          rw = Math.max(rect.size.width,rect.size.height);
+          rh = Math.min(rect.size.width,rect.size.height);
+            if (rw >= w - tolerance && rw <= w + tolerance && rh >= h - tolerance && rh <= h + tolerance) {
+              // passes criteria
+              results.add(rect);
+            }
+        }
+        return new Result(null, results);
+    }
+}

--- a/src/main/java/org/openpnp/vision/pipeline/stages/ImageCapture.java
+++ b/src/main/java/org/openpnp/vision/pipeline/stages/ImageCapture.java
@@ -7,9 +7,16 @@ import org.openpnp.util.OpenCvUtils;
 import org.openpnp.vision.pipeline.CvPipeline;
 import org.openpnp.vision.pipeline.CvStage;
 import org.simpleframework.xml.Attribute;
+import org.openpnp.vision.pipeline.Stage;
+import org.openpnp.vision.pipeline.Property;
 
+@Stage(
+  category   ="Image Processing", 
+  description="Capture an image from the relevant to the pipeline camera.")
+  
 public class ImageCapture extends CvStage {
     @Attribute
+    @Property(description="Wait for the camera to settle before capturing an image.")
     private boolean settleFirst;
     
     public boolean isSettleFirst() {

--- a/src/main/java/org/openpnp/vision/pipeline/stages/ImageRead.java
+++ b/src/main/java/org/openpnp/vision/pipeline/stages/ImageRead.java
@@ -6,12 +6,16 @@ import org.opencv.highgui.Highgui;
 import org.openpnp.vision.pipeline.CvPipeline;
 import org.openpnp.vision.pipeline.CvStage;
 import org.simpleframework.xml.Attribute;
+import org.openpnp.vision.pipeline.Stage;
+import org.openpnp.vision.pipeline.Property;
 
-/**
- * Replace the working image with the image loaded from a given path.
- */
+@Stage(
+  category   ="Image Processing", 
+  description="Replace the working image with the image loaded from a given path.")
+  
 public class ImageRead extends CvStage {
     @Attribute
+    @Property(description="Absolute path of the image file to read.")
     private File file = new File("");
 
     public File getFile() {

--- a/src/main/java/org/openpnp/vision/pipeline/ui/CvPipelineEditor.java
+++ b/src/main/java/org/openpnp/vision/pipeline/ui/CvPipelineEditor.java
@@ -26,6 +26,7 @@ import org.openpnp.vision.pipeline.stages.DrawKeyPoints;
 import org.openpnp.vision.pipeline.stages.DrawRotatedRects;
 import org.openpnp.vision.pipeline.stages.DrawTemplateMatches;
 import org.openpnp.vision.pipeline.stages.FilterContours;
+import org.openpnp.vision.pipeline.stages.FilterRects;
 import org.openpnp.vision.pipeline.stages.FindContours;
 import org.openpnp.vision.pipeline.stages.GrabCut;
 import org.openpnp.vision.pipeline.stages.HistogramEqualize;
@@ -78,6 +79,7 @@ public class CvPipelineEditor extends JPanel {
         registerStageClass(DrawRotatedRects.class);
         registerStageClass(DrawTemplateMatches.class);
         registerStageClass(FilterContours.class);
+        registerStageClass(FilterRects.class);
         registerStageClass(FindContours.class);
         registerStageClass(GrabCut.class);
         registerStageClass(HistogramEqualize.class);


### PR DESCRIPTION
Original image:

![orig](https://cloud.githubusercontent.com/assets/1109829/24519447/dfc95bb0-158d-11e7-8f03-652892abe553.png)

`MinAreaRectContours` OpenCV pipeline stage selects rects based on contour area:

![contours-both](https://cloud.githubusercontent.com/assets/1109829/24464901/1197bc7a-14b4-11e7-99ca-d95acf04bfb5.png)

The contours above have approximately the same area, which makes it difficult to distinguish within a safe margin, although the have quite different dimensions.

It would be useful to be able to filter objects based on their expected dimensions, and not only on their contour area. The proposed OpenCV pipeline  stage adds this functionality.

With FilterRects and the example image above, specifying `width = 60, height = 50, tolerance = 5` yields the following rect:

![result_soic-8](https://cloud.githubusercontent.com/assets/1109829/24465162/c73598ae-14b4-11e7-9427-4255e2b3884b.png)

while specifying `width = 85, height = 80, tolerance = 5` yields the following rect:

![result_to-252](https://cloud.githubusercontent.com/assets/1109829/24465396/88786eba-14b5-11e7-8803-09981645be77.png)
