### PR TITLE
DRO multistate pr

### DIFF
--- a/src/main/java/org/openpnp/gui/MachineControlsPanel.java
+++ b/src/main/java/org/openpnp/gui/MachineControlsPanel.java
@@ -173,7 +173,7 @@ public class MachineControlsPanel extends JPanel {
 
     public void updateDros() {
         Location l = getCurrentLocation();
-        if (l == null) {
+        if (l == null) { 
             return;
         }
 

--- a/src/main/java/org/openpnp/gui/MachineControlsPanel.java
+++ b/src/main/java/org/openpnp/gui/MachineControlsPanel.java
@@ -73,10 +73,20 @@ public class MachineControlsPanel extends JPanel {
 
     private JogControlsPanel jogControlsPanel;
 
-    private Location markLocation = null;
+    private enum DroDisplayEnum {NOZZLE, SAVED, DEFAULTCAM;
+    		private static DroDisplayEnum[] vals = values();
+    		public DroDisplayEnum next(){
+    			return vals[(this.ordinal()+1) % values().length];
+    		}
+    }
+    
+    private DroDisplayEnum droDisplayState = DroDisplayEnum.NOZZLE;
+    private Location markLocation;
 
     private Color droNormalColor = new Color(0xBDFFBE);
     private Color droSavedColor = new Color(0x90cce0);
+    private Color droHeadColor = new Color(0xe1f24c);
+    
 
     /**
      * Create the panel.
@@ -140,7 +150,22 @@ public class MachineControlsPanel extends JPanel {
             return null;
         }
 
-        Location l = selectedNozzle.getLocation();
+        Location l = null;
+        
+        switch (droDisplayState){
+        case NOZZLE:
+        case SAVED:
+        	l = selectedNozzle.getLocation();
+        	break;
+        case DEFAULTCAM:
+        	try {
+				l = selectedNozzle.getHead().getDefaultCamera().getLocation();
+			} catch (Exception e) {
+				return null;
+			}
+        	break;
+        }
+        
         l = l.convertToUnits(configuration.getSystemUnits());
 
         return l;
@@ -152,8 +177,17 @@ public class MachineControlsPanel extends JPanel {
             return;
         }
 
-        if (markLocation != null) {
-            l = l.subtract(markLocation);
+        switch (droDisplayState){
+        case NOZZLE:
+        	MainFrame.get().getDroLabel().setToolTipText("Selected Nozzle");
+        	break;
+        case SAVED:
+        	l = l.subtract(markLocation);
+        	MainFrame.get().getDroLabel().setToolTipText("Relative");
+        	break;
+        case DEFAULTCAM:
+        	MainFrame.get().getDroLabel().setToolTipText("Default Camera");
+        	break;
         }
 
         double x, y, z, c;
@@ -325,14 +359,25 @@ public class MachineControlsPanel extends JPanel {
                 @Override
                 public void mouseClicked(MouseEvent e) {
                     SwingUtilities.invokeLater(() -> {
-                        if (markLocation == null) {
-                            markLocation = getCurrentLocation();
-                            MainFrame.get().getDroLabel().setBackground(droSavedColor);
-                        }
-                        else {
-                            markLocation = null;
-                            MainFrame.get().getDroLabel().setBackground(droNormalColor);
-                        }
+                    	
+                    	droDisplayState = droDisplayState.next();
+                    	
+                    	switch (droDisplayState){
+                    	case NOZZLE:
+                    		MainFrame.get().getDroLabel().setBackground(droNormalColor);
+                    		break;
+                    		
+                    	case SAVED:
+                    		markLocation = getCurrentLocation();
+                    		MainFrame.get().getDroLabel().setBackground(droSavedColor);
+                    		break;
+                    		
+                    	case DEFAULTCAM:
+                    		MainFrame.get().getDroLabel().setBackground(droHeadColor);
+                    		break;
+                    		
+                    	}
+                    	
                         updateDros();
                     });
                 }


### PR DESCRIPTION
The DRO today can be cycled from current nozzle -> relative with a mouse click. This adds a 3rd option, allowing you to cycle from currentnozzle -> relative -> defaultcamera. Tools tips were added so a hover over the DRO will remind you what you are looking at. 

I haven't found a good way to locate features on my machine. For example, if I navigate the over a hardware fiducial used for homing the machine, there is no way to read off the camera location. Yes, I can read the nozzle location and then go in and calculate the offset, but that needs paper and pencil.

Also, let's say you want to make a 100 mm move that might bring you close to a limit. Currently, it's not easy to know if a move of 100mm will hit an end stop or not by looking at the DRO.  And if you have several nozzles, it gets even more confusing as you need to understand which nozzle might be selected.

For me, it makes a lot of sense to think in camera/head locations instead of 1-of-4 nozzle locations. 

This uses the defaultcamera on the head. I double checked things still work if there's not a default camera. Ideally, without a default camera, it'd revert to the two swaps as before. 

Changes were to a single file. If approved, I'll also look through the docs when the time is right and update the text.