### PR TITLE
Add Camera to Nav Combobox and then show selected item coords in DRO

### DIFF
--- a/src/main/java/org/openpnp/gui/MachineControlsPanel.java
+++ b/src/main/java/org/openpnp/gui/MachineControlsPanel.java
@@ -45,6 +45,7 @@ import org.openpnp.gui.support.HeadMountableItem;
 import org.openpnp.gui.support.Icons;
 import org.openpnp.gui.support.MessageBoxes;
 import org.openpnp.gui.support.NozzleItem;
+import org.openpnp.machine.reference.ReferenceCamera;
 import org.openpnp.model.Configuration;
 import org.openpnp.model.Location;
 import org.openpnp.spi.Camera;
@@ -361,11 +362,9 @@ public class MachineControlsPanel extends JPanel {
                     comboBoxHeadMountable.addItem(new NozzleItem(nozzle));
                 }
                 
-                try {
-					comboBoxHeadMountable.addItem(new CameraItem(head.getDefaultCamera()));
-				} catch (Exception e1) {
-					
-				}
+                for (Camera camera : head.getCameras()){
+                	comboBoxHeadMountable.addItem(new CameraItem(camera));
+                }
             }
                         
             setSelectedTool( ((HeadMountableItem)comboBoxHeadMountable.getItemAt(0)).getItem() );
@@ -378,7 +377,6 @@ public class MachineControlsPanel extends JPanel {
 
             for (Head head : machine.getHeads()) {
             	
-            	// Jason, what is going on down here????
                 BeanUtils.addPropertyChangeListener(head, "nozzles", (e) -> {
                     if (e.getOldValue() == null && e.getNewValue() != null) {
                         Nozzle nozzle = (Nozzle) e.getNewValue();
@@ -393,6 +391,21 @@ public class MachineControlsPanel extends JPanel {
                         }
                     }
                 });
+                
+                BeanUtils.addPropertyChangeListener(head, "cameras", (e) -> {
+                    if (e.getOldValue() == null && e.getNewValue() != null) {
+                    	Camera camera = (Camera) e.getNewValue();
+                        comboBoxHeadMountable.addItem(new CameraItem(camera));
+                    }
+                    else if (e.getOldValue() != null && e.getNewValue() == null) {
+                        for (int i = 0; i < comboBoxHeadMountable.getItemCount(); i++) {
+	                        	HeadMountableItem item = (HeadMountableItem) comboBoxHeadMountable.getItemAt(i);
+	                            if (item.getItem() == e.getOldValue()) {
+	                                comboBoxHeadMountable.removeItemAt(i);
+	                            }
+                        	}
+                    }
+                });                
             }
 
         }

--- a/src/main/java/org/openpnp/gui/MachineControlsPanel.java
+++ b/src/main/java/org/openpnp/gui/MachineControlsPanel.java
@@ -45,7 +45,6 @@ import org.openpnp.gui.support.HeadMountableItem;
 import org.openpnp.gui.support.Icons;
 import org.openpnp.gui.support.MessageBoxes;
 import org.openpnp.gui.support.NozzleItem;
-import org.openpnp.machine.reference.ReferenceCamera;
 import org.openpnp.model.Configuration;
 import org.openpnp.model.Location;
 import org.openpnp.spi.Camera;

--- a/src/main/java/org/openpnp/gui/MachineControlsPanel.java
+++ b/src/main/java/org/openpnp/gui/MachineControlsPanel.java
@@ -40,6 +40,8 @@ import javax.swing.border.TitledBorder;
 
 import org.jdesktop.swingx.JXCollapsiblePane;
 import org.openpnp.ConfigurationListener;
+import org.openpnp.gui.support.CameraItem;
+import org.openpnp.gui.support.HeadMountableItem;
 import org.openpnp.gui.support.Icons;
 import org.openpnp.gui.support.MessageBoxes;
 import org.openpnp.gui.support.NozzleItem;
@@ -68,8 +70,9 @@ public class MachineControlsPanel extends JPanel {
     private static final boolean PREF_JOG_CONTROLS_EXPANDED_DEF = true;
     private Preferences prefs = Preferences.userNodeForPackage(MachineControlsPanel.class);    
     
-    private Nozzle selectedNozzle;
-    private JComboBox comboBoxNozzles;
+    private HeadMountable selectedTool;
+    
+    private JComboBox comboBoxHeadMountable;
 
     private JogControlsPanel jogControlsPanel;
 
@@ -91,15 +94,18 @@ public class MachineControlsPanel extends JPanel {
         configuration.addListener(configurationListener);
     }
 
-    public void setSelectedNozzle(Nozzle nozzle) {
-        selectedNozzle = nozzle;
-        comboBoxNozzles.setSelectedItem(selectedNozzle);
-        updateDros();
-    }
-
     public Nozzle getSelectedNozzle() {
-        return selectedNozzle;
+    	if (selectedTool instanceof NozzleItem){
+    		return ((NozzleItem)(selectedTool)).getNozzle();
+    	}
+    				
+        try {
+			return configuration.getMachine().getDefaultHead().getDefaultNozzle();
+		} catch (Exception e) {
+			return null;
+		}
     }
+    
 
     public PasteDispenser getSelectedPasteDispenser() {
         try {
@@ -119,7 +125,13 @@ public class MachineControlsPanel extends JPanel {
      * @return
      */
     public HeadMountable getSelectedTool() {
-        return getSelectedNozzle();
+        return selectedTool;
+    }
+    
+    public void setSelectedTool(HeadMountable hm) {
+    	selectedTool= hm;
+    	comboBoxHeadMountable.setSelectedItem(selectedTool);
+    	updateDros();
     }
 
     public JogControlsPanel getJogControlsPanel() {
@@ -136,11 +148,11 @@ public class MachineControlsPanel extends JPanel {
     }
 
     public Location getCurrentLocation() {
-        if (selectedNozzle == null) {
+        if (selectedTool == null) {
             return null;
         }
 
-        Location l = selectedNozzle.getLocation();
+        Location l = selectedTool.getLocation();
         l = l.convertToUnits(configuration.getSystemUnits());
 
         return l;
@@ -199,16 +211,17 @@ public class MachineControlsPanel extends JPanel {
                         FormSpecs.RELATED_GAP_COLSPEC, ColumnSpec.decode("default:grow"),},
                 new RowSpec[] {FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,}));
 
-        comboBoxNozzles = new JComboBox();
-        comboBoxNozzles.addActionListener(new ActionListener() {
+        comboBoxHeadMountable = new JComboBox();
+        comboBoxHeadMountable.addActionListener(new ActionListener() {
             @Override
             public void actionPerformed(ActionEvent e) {
-                setSelectedNozzle(((NozzleItem) comboBoxNozzles.getSelectedItem()).getNozzle());
+            	HeadMountableItem selectedItem = (HeadMountableItem)comboBoxHeadMountable.getSelectedItem();
+            	setSelectedTool(selectedItem.getItem());
             }
         });
 
         panel.add(collapseButton, "2, 2");
-        panel.add(comboBoxNozzles, "4, 2, fill, default");
+        panel.add(comboBoxHeadMountable, "4, 2, fill, default");
         collapsePane.add(jogControlsPanel);
         add(collapsePane);
 
@@ -249,7 +262,7 @@ public class MachineControlsPanel extends JPanel {
         @Override
         public void actionPerformed(ActionEvent arg0) {
             UiUtils.submitUiMachineTask(() -> {
-                selectedNozzle.getHead().home();
+            	selectedTool.getHead().home();
             });
         }
     };
@@ -288,7 +301,7 @@ public class MachineControlsPanel extends JPanel {
         @Override
         public void machineHeadActivity(Machine machine, Head head) {
             EventQueue.invokeLater(() -> updateDros());
-            EventQueue.invokeLater(() -> comboBoxNozzles.repaint());
+            EventQueue.invokeLater(() -> comboBoxHeadMountable.repaint());
         }
 
         @Override
@@ -342,13 +355,20 @@ public class MachineControlsPanel extends JPanel {
             if (machine != null) {
                 machine.removeListener(machineListener);
             }
-
+            
             for (Head head : machine.getHeads()) {
                 for (Nozzle nozzle : head.getNozzles()) {
-                    comboBoxNozzles.addItem(new NozzleItem(nozzle));
+                    comboBoxHeadMountable.addItem(new NozzleItem(nozzle));
                 }
+                
+                try {
+					comboBoxHeadMountable.addItem(new CameraItem(head.getDefaultCamera()));
+				} catch (Exception e1) {
+					
+				}
             }
-            setSelectedNozzle(((NozzleItem) comboBoxNozzles.getItemAt(0)).getNozzle());
+                        
+            setSelectedTool( ((HeadMountableItem)comboBoxHeadMountable.getItemAt(0)).getItem() );
 
             machine.addListener(machineListener);
 
@@ -357,16 +377,18 @@ public class MachineControlsPanel extends JPanel {
             setEnabled(machine.isEnabled());
 
             for (Head head : machine.getHeads()) {
+            	
+            	// Jason, what is going on down here????
                 BeanUtils.addPropertyChangeListener(head, "nozzles", (e) -> {
                     if (e.getOldValue() == null && e.getNewValue() != null) {
                         Nozzle nozzle = (Nozzle) e.getNewValue();
-                        comboBoxNozzles.addItem(new NozzleItem(nozzle));
+                        comboBoxHeadMountable.addItem(new NozzleItem(nozzle));
                     }
                     else if (e.getOldValue() != null && e.getNewValue() == null) {
-                        for (int i = 0; i < comboBoxNozzles.getItemCount(); i++) {
-                            NozzleItem item = (NozzleItem) comboBoxNozzles.getItemAt(i);
+                        for (int i = 0; i < comboBoxHeadMountable.getItemCount(); i++) {
+                            NozzleItem item = (NozzleItem) comboBoxHeadMountable.getItemAt(i);
                             if (item.getNozzle() == e.getOldValue()) {
-                                comboBoxNozzles.removeItemAt(i);
+                                comboBoxHeadMountable.removeItemAt(i);
                             }
                         }
                     }

--- a/src/main/java/org/openpnp/gui/support/CameraItem.java
+++ b/src/main/java/org/openpnp/gui/support/CameraItem.java
@@ -21,20 +21,19 @@ package org.openpnp.gui.support;
 
 import org.openpnp.spi.Camera;
 
-public class CameraItem {
-    private Camera camera;
+public class CameraItem extends HeadMountableItem {
 
     public CameraItem(Camera camera) {
-        this.camera = camera;
+    	super(camera);
     }
 
     public Camera getCamera() {
-        return camera;
+        return (Camera)hm;
     }
 
     @Override
     public String toString() {
-        return String.format("Camera: %s %s", camera.getName(), camera.getHead() != null
-                ? String.format("(Head: %s)", camera.getHead().getName()) : "");
+        return String.format("Camera: %s %s", hm.getName(), hm.getHead() != null
+                ? String.format("(Head: %s)", hm.getHead().getName()) : "");
     }
 }

--- a/src/main/java/org/openpnp/gui/support/HeadMountableItem.java
+++ b/src/main/java/org/openpnp/gui/support/HeadMountableItem.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2011 Jason von Nieda <jason@vonnieda.org>
+ * 
+ * This file is part of OpenPnP.
+ * 
+ * OpenPnP is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * OpenPnP is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License along with OpenPnP. If not, see
+ * <http://www.gnu.org/licenses/>.
+ * 
+ * For more information about OpenPnP visit http://openpnp.org
+ */
+
+package org.openpnp.gui.support;
+
+import org.openpnp.spi.HeadMountable;
+import org.openpnp.spi.Nozzle;
+
+public class HeadMountableItem {
+    protected HeadMountable hm;
+    
+    public HeadMountableItem(HeadMountable hm){
+    	this.hm = hm;
+    }
+
+    public HeadMountable getItem() {
+        return this.hm;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("HeadMountable: %s - %s %s", hm.getName(),
+        		hm.getHead() != null ? String.format("(Head: %s)", hm.getHead().getName()) : "");
+    }
+}

--- a/src/main/java/org/openpnp/gui/support/HeadMountableItem.java
+++ b/src/main/java/org/openpnp/gui/support/HeadMountableItem.java
@@ -35,7 +35,7 @@ public class HeadMountableItem {
 
     @Override
     public String toString() {
-        return String.format("HeadMountable: %s - %s %s", hm.getName(),
+        return String.format("HeadMountable: %s - %s", hm.getName(),
         		hm.getHead() != null ? String.format("(Head: %s)", hm.getHead().getName()) : "");
     }
 }

--- a/src/main/java/org/openpnp/gui/support/NozzleItem.java
+++ b/src/main/java/org/openpnp/gui/support/NozzleItem.java
@@ -21,19 +21,20 @@ package org.openpnp.gui.support;
 
 import org.openpnp.spi.Nozzle;
 
-public class NozzleItem {
-    private Nozzle nozzle;
+public class NozzleItem extends HeadMountableItem {
 
     public NozzleItem(Nozzle nozzle) {
-        this.nozzle = nozzle;
+    	super(nozzle);
     }
 
     public Nozzle getNozzle() {
-        return nozzle;
+        return (Nozzle)hm;
     }
 
     @Override
     public String toString() {
+    	Nozzle nozzle = (Nozzle)hm;
+    	
         return String.format("Nozzle: %s - %s %s", nozzle.getName(),
         		nozzle.getNozzleTip() != null ? nozzle.getNozzleTip().getName() : "No Nozzle Tip", 
         		nozzle.getHead() != null ? String.format("(Head: %s)", nozzle.getHead().getName()) : "");


### PR DESCRIPTION
This is continuation of #504....This is to check if on the right path (not a lot of changes were needed). There was CameraItem and NozzleItem already. Looks like these are used to give a nice output string. I created a headmountableitem and derived cameraitem and nozzleitem from that, and then used the headmountable item in the combo box. Combobox populates as expected (with nozzle and head camera) and DRO reads as expected based on which is selected in the listbox. 

One bug I might have found that is unrelated to these changes: If you have two nozzles, one offset of -10,-10 and another of -5, -5, and you XY park, your absolute park location seems to depend on which nozzle was selected when you parked. That seems not right to me as the docs say park should park the head at its park location. If you confirm that is incorrect, I'll fix that in this pr. 

