### PR TITLE
Update Scripting.java

### DIFF
--- a/src/main/java/org/openpnp/Scripting.java
+++ b/src/main/java/org/openpnp/Scripting.java
@@ -67,28 +67,28 @@ public class Scripting {
         // over.
         if (!getScriptsDirectory().exists()) {
             getScriptsDirectory().mkdirs();
-        }
 
-        // TODO: It would be better if we just copied all the files from the Examples
-        // directory in the jar, but this is relatively difficult to do.
-        // There is some information on how to do it in:
-        // http://stackoverflow.com/questions/1386809/copy-directory-from-a-jar-file
-        File examplesDir = new File(getScriptsDirectory(), "Examples");
-        examplesDir.mkdirs();
-        String[] exampleScripts =
-                new String[] {"Call_Java.js", "Hello_World.js", "Print_Scripting_Info.js",
-                        "Reset_Strip_Feeders.js", "Move_Machine.js", "Utility.js", "QrCodeXout.js"};
-        for (String name : exampleScripts) {
-            try {
-                File file = new File(examplesDir, name);
-                if (file.exists()) {
-                    continue;
+            // TODO: It would be better if we just copied all the files from the Examples
+            // directory in the jar, but this is relatively difficult to do.
+            // There is some information on how to do it in:
+            // http://stackoverflow.com/questions/1386809/copy-directory-from-a-jar-file
+            File examplesDir = new File(getScriptsDirectory(), "Examples");
+            examplesDir.mkdirs();
+            String[] exampleScripts =
+                    new String[] {"Call_Java.js", "Hello_World.js", "Print_Scripting_Info.js",
+                            "Reset_Strip_Feeders.js", "Move_Machine.js", "Utility.js", "QrCodeXout.js"};
+            for (String name : exampleScripts) {
+                try {
+                    File file = new File(examplesDir, name);
+                    if (file.exists()) {
+                        continue;
+                    }
+                    FileUtils.copyURLToFile(ClassLoader.getSystemResource("scripts/Examples/" + name),
+                            file);
                 }
-                FileUtils.copyURLToFile(ClassLoader.getSystemResource("scripts/Examples/" + name),
-                        file);
-            }
-            catch (Exception e) {
-                e.printStackTrace();
+                catch (Exception e) {
+                    e.printStackTrace();
+                }
             }
         }
 


### PR DESCRIPTION
changed Scripting to create Examples directory only when it need to create scripts directory.
This is for real usage, where one want remove the example directory because scripts are already setup better to check for examples.


# Description
Actually scripts Examples get copied from jar file every time if Examples file is not present.
For final installation, this behavior is not always wanted.
With this change, Examples get copied if the scripts directory is missing.

# Justification
One want to delete the example directory once scripts are personalized and many of the examples
are customized or are copied elsewhere.

# Instructions for Use
What changes to users, in case it upgrades the examples are not automatically expanded because scripts directory exists. In that case it must lauch openpnp with different, inexistant configDir in order 
examples are extracted.

# Implementation Details
1. How did you test the change?
not tested
2. Did you add automated tests?
no
