### PR TITLE
Changed Scripting.execute from private to public. Will now accept a S…

### DIFF
--- a/src/main/java/org/openpnp/Scripting.java
+++ b/src/main/java/org/openpnp/Scripting.java
@@ -247,11 +247,19 @@ public class Scripting {
         return items;
     }
 
-    private void execute(File script) throws Exception {
+    public void execute(String script) throws Exception {
+        execute(new File(script), null);
+    }
+    
+    public void execute(File script) throws Exception {
         execute(script, null);
     }
-
-    private void execute(File script, Map<String, Object> additionalGlobals) throws Exception {
+    
+    public void execute(String script, Map<String, Object> additionalGlobals) throws Exception {
+      execute(new File(script), additionalGlobals );
+    }
+    
+    public void execute(File script, Map<String, Object> additionalGlobals) throws Exception {
         ScriptEngine engine =
                 manager.getEngineByExtension(Files.getFileExtension(script.getName()));
 


### PR DESCRIPTION
…tring filepath, as well.

See #523 for details.

# Description
Allow scripts to execute other scripts, in any language accepted by openpnp, by using the `scripting.execute()` method. Method now accepts filepaths as either `String` or `File` types.

# Instructions for Use
The user will now be able to run:
```
scripting.execute(new File(scripting.getScriptsDirectory().getAbsolutePath()+"/tests/hi.js"));
```
or even
```
scripting.execute(scripting.getScriptsDirectory().getAbsolutePath()+"/tests/hi.js");
```
from another script and execute a javascript script, e.g. `scripts/tests/hi.js` from inside e.g. a BeanShell script.