### PR TITLE
Fixed an issue with the non-squareness factor

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/driver/GcodeDriver.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/GcodeDriver.java
@@ -453,8 +453,17 @@ public class GcodeDriver extends AbstractSerialPortDriver implements Runnable {
             command = substituteVariable(command, "BacklashFeedRate", maxFeedRate * speed * backlashFeedRateFactor);
 
             if (xAxis == null || xAxis.getCoordinate() == x) {
-                command = substituteVariable(command, "X", null);
-                command = substituteVariable(command, "BacklashOffsetX", null); // Backlash Compensation
+                if(yAxis != null && yAxis.getCoordinate() != y &&
+                   xAxis != null && nonSquarenessFactor != 0) {
+                    command = substituteVariable(command, "X", x + nonSquarenessFactor * y);
+                    command = substituteVariable(command, "BacklashOffsetX", x + nonSquarenessFactor * y);
+
+                    xAxis.setCoordinate(x);
+                }
+                else {
+                    command = substituteVariable(command, "X", null);
+                    command = substituteVariable(command, "BacklashOffsetX", null); // Backlash Compensation
+                }
             }
             else {
                 command = substituteVariable(command, "X", x + nonSquarenessFactor * y);


### PR DESCRIPTION
# Description
I used the non-squareness factor for my PNP machine. But when I moved the head only in Y-direction, I noticed that the X coordinate hasn't changed accordingly.  The original code doesn't change the x-coordinate when there is no x-movement. This is the reason why the non-squareness factor isn't used in this case.
My fix recalculates the X coordinate as soon as there is a change of the Y coordinate.

# Justification
Every user who is using the non-squareness factor will be effected by the problem. In some rare cases when the machine is only moving in the Y direction, the position will be wrong because of not using the non-squareness factor to correct the X coordinate.

# Implementation Details
1. How did you test the change?
- First test: I used some plotting paper and moved the head only in Y direction. With the help of the plotting paper, I can see that the camera position also changed in X.
- Second test: Inspected the debug output. If a movement in Y is started, I can see that also the X coordinate is corrected.

2. Did you add automated tests?
No

3. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)?
Yes, I think so.

