### PR TITLE
Added center mark to rotatedRects in DrawRotatedRects

### DIFF
--- a/src/main/java/org/openpnp/vision/pipeline/stages/DrawImageCenter.java
+++ b/src/main/java/org/openpnp/vision/pipeline/stages/DrawImageCenter.java
@@ -1,0 +1,88 @@
+package org.openpnp.vision.pipeline.stages;
+
+import java.io.File;
+import java.awt.Color;
+
+import org.opencv.core.Core;
+import org.opencv.core.Mat;
+import org.opencv.core.Scalar;
+import org.opencv.core.Point;
+import org.openpnp.vision.FluentCv;
+import org.openpnp.vision.pipeline.CvPipeline;
+import org.openpnp.vision.pipeline.CvStage;
+import org.openpnp.vision.pipeline.stages.convert.ColorConverter;
+
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Attribute;
+import org.simpleframework.xml.convert.Convert;
+import org.openpnp.vision.pipeline.Stage;
+import org.openpnp.vision.pipeline.Property;
+
+@Stage(
+  category   ="Image Processing", 
+  description="Draw a mark at the center of the image.")
+  
+public class DrawImageCenter extends CvStage {
+    @Attribute(required = false)
+    @Property(description="Draw a mark at the center of the image.")
+    private boolean showImageCenter = true;
+    
+    @Element(required = false)
+    @Convert(ColorConverter.class)
+    @Property(description="Color for the image center mark.")
+    private Color color = null;
+    
+    @Attribute(required = false)
+    @Property(description="Thickness of center mark.")
+    private int thickness = 2;
+    
+    @Attribute(required = false)
+    @Property(description="Size of center mark.")
+    private int size = 40;
+
+    public boolean isShowImageCenter() {
+        return showImageCenter;
+    }
+
+    public void setShowImageCenter(boolean showImageCenter) {
+        this.showImageCenter = showImageCenter;
+    }
+
+    public Color getColor() {
+        return color;
+    }
+
+    public void setColor(Color color) {
+        this.color = color;
+    }
+    
+    public int getThickness() {
+        return thickness;
+    }
+
+    public void setThickness(int thickness) {
+        this.thickness = thickness;
+    }
+    
+    public int getSize() {
+        return size;
+    }
+
+    public void setSize(int size) {
+        this.size = size;
+    }
+
+    
+    @Override
+    public Result process(CvPipeline pipeline) throws Exception {
+        Mat mat = pipeline.getWorkingImage();
+        if (showImageCenter) {
+            int cx = (int)mat.size().width/2;
+            int cy = (int)mat.size().height/2;
+            Scalar c = FluentCv.colorToScalar( color == null ? FluentCv.indexedColor(0) : color);
+            Core.line(mat,new Point(cx - size/2,cy), new Point(cx + size/2,cy), c, thickness);
+            Core.line(mat,new Point(cx,cy - size/2), new Point(cx,cy + size/2), c, thickness);
+        }
+        return new Result(mat);
+    }
+}

--- a/src/main/java/org/openpnp/vision/pipeline/stages/DrawRotatedRects.java
+++ b/src/main/java/org/openpnp/vision/pipeline/stages/DrawRotatedRects.java
@@ -2,6 +2,8 @@ package org.openpnp.vision.pipeline.stages;
 
 import java.awt.Color;
 import java.util.List;
+import java.util.ArrayList;
+import org.opencv.core.Core;
 
 import org.opencv.core.Mat;
 import org.opencv.core.RotatedRect;
@@ -9,25 +11,37 @@ import org.openpnp.vision.FluentCv;
 import org.openpnp.vision.pipeline.CvPipeline;
 import org.openpnp.vision.pipeline.CvStage;
 import org.openpnp.vision.pipeline.stages.convert.ColorConverter;
+import org.openpnp.vision.pipeline.Stage;
 import org.simpleframework.xml.Attribute;
 import org.simpleframework.xml.Element;
+import org.openpnp.vision.pipeline.Property;
 import org.simpleframework.xml.convert.Convert;
 
-/**
- * Draws RotatedRects from a stage's model. Input can be either a single RotatedRect or
- * a List<RotatedRect> 
- */
+@Stage(
+  category="Image Processing", 
+  description="Draws RotatedRects from a stage's model. Input can be either a single RotatedRect or a List of RotatedRect")
+  
 public class DrawRotatedRects extends CvStage {
     @Element(required = false)
     @Convert(ColorConverter.class)
     private Color color = null;
 
     @Attribute(required = false)
+    @Property(description="Stage to input RotatedRect from.")
     private String rotatedRectsStageName = null;
     
-    @Attribute
+    @Attribute(required = true)
+    @Property(description="Thickness of RotatedRect outline.")
     private int thickness = 1;
-
+    
+    @Attribute(required = false)
+    @Property(description="Draw a circle at the center of each RotatedRect.")
+    private boolean drawRectCenter = false;
+    
+    @Attribute(required = false)
+    @Property(description="Radius of circle at center of RotatedRects.")
+    private int rectCenterRadius = 20;
+    
     public Color getColor() {
         return color;
     }
@@ -52,6 +66,22 @@ public class DrawRotatedRects extends CvStage {
         this.thickness = thickness;
     }
 
+    public boolean isDrawRectCenter() {
+        return drawRectCenter;
+    }
+
+    public void setDrawRectCenter(boolean drawRectCenter) {
+        this.drawRectCenter = drawRectCenter;
+    }
+
+    public int getrectCenterRadius() {
+        return rectCenterRadius;
+    }
+
+    public void setRectCenterRadius(int rectCenterRadius) {
+        this.rectCenterRadius = rectCenterRadius;
+    }
+
     @Override
     public Result process(CvPipeline pipeline) throws Exception {
         if (rotatedRectsStageName == null) {
@@ -61,15 +91,21 @@ public class DrawRotatedRects extends CvStage {
         if (result == null || result.model == null) {
             return null;
         }
+        
         Mat mat = pipeline.getWorkingImage();
+        List<RotatedRect> rects = new ArrayList();
+         
         if (result.model instanceof RotatedRect) {
-            FluentCv.drawRotatedRect(mat, ((RotatedRect) result.model), color == null ? FluentCv.indexedColor(0) : color, thickness);
+            rects.add((RotatedRect) result.model);
         }
         else if (result.model instanceof List<?>) {
-            List<RotatedRect> rects = (List<RotatedRect>) result.model;
-            for (int i = 0; i < rects.size(); i++) {
-                RotatedRect rect = rects.get(i);
-                FluentCv.drawRotatedRect(mat, rect, color == null ? FluentCv.indexedColor(i) : color, thickness);
+            rects = (List<RotatedRect>) result.model;
+        }
+        for (int i = 0; i < rects.size(); i++) {
+            RotatedRect rect = rects.get(i);
+            FluentCv.drawRotatedRect(mat, rect, color == null ? FluentCv.indexedColor(i) : color, thickness);
+            if (drawRectCenter) {
+                Core.circle(mat, rect.center, rectCenterRadius, FluentCv.colorToScalar(color == null ? FluentCv.indexedColor(i) : color), thickness);
             }
         }
         return null;

--- a/src/main/java/org/openpnp/vision/pipeline/ui/CvPipelineEditor.java
+++ b/src/main/java/org/openpnp/vision/pipeline/ui/CvPipelineEditor.java
@@ -22,6 +22,7 @@ import org.openpnp.vision.pipeline.stages.DetectEdgesLaplacian;
 import org.openpnp.vision.pipeline.stages.DetectEdgesRobertsCross;
 import org.openpnp.vision.pipeline.stages.DrawCircles;
 import org.openpnp.vision.pipeline.stages.DrawContours;
+import org.openpnp.vision.pipeline.stages.DrawImageCenter;
 import org.openpnp.vision.pipeline.stages.DrawKeyPoints;
 import org.openpnp.vision.pipeline.stages.DrawRotatedRects;
 import org.openpnp.vision.pipeline.stages.DrawTemplateMatches;
@@ -75,6 +76,7 @@ public class CvPipelineEditor extends JPanel {
         registerStageClass(DetectEdgesLaplacian.class);
         registerStageClass(DrawCircles.class);
         registerStageClass(DrawContours.class);
+        registerStageClass(DrawImageCenter.class);
         registerStageClass(DrawKeyPoints.class);
         registerStageClass(DrawRotatedRects.class);
         registerStageClass(DrawTemplateMatches.class);


### PR DESCRIPTION
# Description
Added code to DrawRoatedRects to (optionally) draw a circle at the center of each rect. Thickness and radius of the circle are configurable.

# Justification
Here is one case where a visual comparison of the center of a rotatedRect is useful:
![rectcenter](https://cloud.githubusercontent.com/assets/1109829/25730190/504f2dda-3143-11e7-988f-437917cbb7b1.png)
By using the new rotatedRectCenter and the image center one can directly compare alignment results while editing the pipeline or adjusting camera offsets.

# Instructions for Use
Same as before. There are two more settings available: a checkbox to chose to draw the center marks and a field for the radius of the circle mark.

![rectcenter_settings](https://cloud.githubusercontent.com/assets/1109829/25730510/ee67d04c-3145-11e7-8ae1-eada4e9cd279.png)

# Implementation Details
1. How did you test the change?

Manually, visually;

2. Did you add automated tests?

Nope.

3. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)?

Yes, `mvn package` checks it automatically

4. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing.

No changes there.
