### PR TITLE
Created new pipeline stage: DrawImageCenter

### DIFF
--- a/src/main/java/org/openpnp/vision/pipeline/stages/DrawImageCenter.java
+++ b/src/main/java/org/openpnp/vision/pipeline/stages/DrawImageCenter.java
@@ -1,0 +1,88 @@
+package org.openpnp.vision.pipeline.stages;
+
+import java.io.File;
+import java.awt.Color;
+
+import org.opencv.core.Core;
+import org.opencv.core.Mat;
+import org.opencv.core.Scalar;
+import org.opencv.core.Point;
+import org.openpnp.vision.FluentCv;
+import org.openpnp.vision.pipeline.CvPipeline;
+import org.openpnp.vision.pipeline.CvStage;
+import org.openpnp.vision.pipeline.stages.convert.ColorConverter;
+
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Attribute;
+import org.simpleframework.xml.convert.Convert;
+import org.openpnp.vision.pipeline.Stage;
+import org.openpnp.vision.pipeline.Property;
+
+@Stage(
+  category   ="Image Processing", 
+  description="Draw a mark at the center of the image.")
+  
+public class DrawImageCenter extends CvStage {
+    @Attribute(required = false)
+    @Property(description="Show a mark at the center of the image.")
+    private boolean showImageCenter = true;
+    
+    @Element(required = false)
+    @Convert(ColorConverter.class)
+    @Property(description="Color for the center mark.")
+    private Color color = null;
+    
+    @Attribute(required = false)
+    @Property(description="Thickness of center mark.")
+    private int thickness = 2;
+    
+    @Attribute(required = false)
+    @Property(description="Size of center mark.")
+    private int size = 40;
+
+    public boolean isShowImageCenter() {
+        return showImageCenter;
+    }
+
+    public void setShowImageCenter(boolean showImageCenter) {
+        this.showImageCenter = showImageCenter;
+    }
+
+    public Color getColor() {
+        return color;
+    }
+
+    public void setColor(Color color) {
+        this.color = color;
+    }
+    
+    public int getThickness() {
+        return thickness;
+    }
+
+    public void setThickness(int thickness) {
+        this.thickness = thickness;
+    }
+    
+    public int getSize() {
+        return size;
+    }
+
+    public void setSize(int size) {
+        this.size = size;
+    }
+
+    
+    @Override
+    public Result process(CvPipeline pipeline) throws Exception {
+        Mat mat = pipeline.getWorkingImage();
+        if (showImageCenter) {
+            int cx = (int)mat.size().width/2;
+            int cy = (int)mat.size().height/2;
+            Scalar c = FluentCv.colorToScalar( color == null ? FluentCv.indexedColor(0) : color);
+            Core.line(mat,new Point(cx - size/2,cy), new Point(cx + size/2,cy), c, thickness);
+            Core.line(mat,new Point(cx,cy - size/2), new Point(cx,cy + size/2), c, thickness);
+        }
+        return new Result(mat);
+    }
+}

--- a/src/main/java/org/openpnp/vision/pipeline/ui/CvPipelineEditor.java
+++ b/src/main/java/org/openpnp/vision/pipeline/ui/CvPipelineEditor.java
@@ -22,6 +22,7 @@ import org.openpnp.vision.pipeline.stages.DetectEdgesLaplacian;
 import org.openpnp.vision.pipeline.stages.DetectEdgesRobertsCross;
 import org.openpnp.vision.pipeline.stages.DrawCircles;
 import org.openpnp.vision.pipeline.stages.DrawContours;
+import org.openpnp.vision.pipeline.stages.DrawImageCenter;
 import org.openpnp.vision.pipeline.stages.DrawKeyPoints;
 import org.openpnp.vision.pipeline.stages.DrawRotatedRects;
 import org.openpnp.vision.pipeline.stages.DrawTemplateMatches;
@@ -75,6 +76,7 @@ public class CvPipelineEditor extends JPanel {
         registerStageClass(DetectEdgesLaplacian.class);
         registerStageClass(DrawCircles.class);
         registerStageClass(DrawContours.class);
+        registerStageClass(DrawImageCenter.class);
         registerStageClass(DrawKeyPoints.class);
         registerStageClass(DrawRotatedRects.class);
         registerStageClass(DrawTemplateMatches.class);


### PR DESCRIPTION
# Description
New OpenCV pipeline stage `DrawImageCenter`. Draws a configurable mark at the center of the current image.

# Justification
This is complementary to #537: `Draw a mark at the center of each RotatedRect`, and aims to aid in camera alignment and visual comparisons of detected features. Here is what it does:

![drawimagecenter](https://cloud.githubusercontent.com/assets/1109829/25739117/21199d3e-3189-11e7-87ac-dbdda75f515c.png)

# Instructions for Use
The new stage is intended to be used mostly at the end of the pipeline, after image processing has finished. Setting of the center mark is straight forward, by tweaking the `color`, `showImageCenter`, `size` and/or `thickness` properties of the new stage:

![drawimagecenter1](https://cloud.githubusercontent.com/assets/1109829/25740604/e44a75f2-318f-11e7-8d00-3ea53f126da5.png)

In the image above, the bottom camera position needs to be better aligned with the optical center of the camera.

![drawimagecenter2](https://cloud.githubusercontent.com/assets/1109829/25740621/f4087444-318f-11e7-808d-e01dbea400a6.png)

In the image above, a comparison of the optical center with the center of a RoratedRect can help visualize successful alignment.

# Implementation Details
1. How did you test the change?

Manually, visually. 

2. Did you add automated tests?

No.

3. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)?

Yes, `mvn package` checks it automatically, and forces one to comply.

4. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing.

No changes there.

