### PR TITLE
New OpenCV pipeline stage: MaskPolygon

### DIFF
--- a/src/main/java/org/openpnp/vision/pipeline/stages/MaskPolygon.java
+++ b/src/main/java/org/openpnp/vision/pipeline/stages/MaskPolygon.java
@@ -1,0 +1,146 @@
+package org.openpnp.vision.pipeline.stages;
+
+import java.awt.Color;
+import java.util.List;
+import java.util.ArrayList;
+
+import org.opencv.core.Core;
+import org.opencv.core.Mat;
+import org.opencv.core.RotatedRect;
+import org.opencv.core.Point;
+import org.opencv.core.MatOfPoint;
+import org.opencv.core.Scalar;
+
+import org.openpnp.vision.pipeline.CvPipeline;
+import org.openpnp.vision.pipeline.CvStage;
+import org.openpnp.vision.pipeline.stages.convert.ColorConverter;
+import org.openpnp.vision.pipeline.Stage;
+import org.openpnp.vision.pipeline.Property;
+import org.openpnp.vision.FluentCv;
+
+import org.simpleframework.xml.Attribute;
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.convert.Convert;
+import org.pmw.tinylog.Logger;
+
+@Stage(
+  category="Image Processing", 
+  description="Mask an image with multiple shapes formed with numeric data provided by the user.")
+  
+public class MaskPolygon extends CvStage {
+
+    @Element(required = false)
+    @Convert(ColorConverter.class)
+    @Property(description="Color of mask.")
+    private Color color = Color.black;
+
+    @Attribute(required = false)
+    @Property(description="Coordinates forming shapes. X,Y coordinates or sizes are separated by commas, coordinate or size pairs are separated by colons ':'. Multiple shapes are separated by semicolons ';'")
+    private String shapes = null;
+    
+    @Attribute(required = false)
+    @Property(description="Invert the mask.")
+    private boolean inverted = false;
+    
+    public Color getColor() {
+        return color;
+    }
+
+    public void setColor(Color color) {
+        this.color = color;
+    }
+    
+    public String getShapes() {
+        return shapes;
+    }
+
+    public void setShapes(String shapes) {
+        this.shapes = shapes;
+    }
+
+    public boolean isInverted() {
+        return inverted;
+    }
+    
+    public void setInverted(boolean inverted) {
+        this.inverted = inverted;
+    }
+
+    @Override
+    public Result process(CvPipeline pipeline) throws Exception {
+        if (shapes == null) {
+            throw new Exception("Mask shape coordinates must be specified.");
+        }
+        /*
+         decide about the format of the input. Items are separated by semicolons. White space allowed
+         - X,Y : R = circle center + radius 
+         - X,Y : W,H = rectangle centered at X,Y
+         - X1,Y1 : X2,Y2 : X3,Y3 = triangle 
+         - etc
+        */
+        Mat mat = pipeline.getWorkingImage();
+        Mat mask = mat.clone();
+        mask.setTo(FluentCv.colorToScalar(color == null ? FluentCv.indexedColor(0) : color));
+        Mat masked = mask.clone();
+        
+        String[] items = shapes.split("\\s*;\\s*"), atoms, coords;
+        // we will be constructing an array of polygons
+        ArrayList<MatOfPoint> poly = new ArrayList<MatOfPoint>();
+        
+        for (String item : items) {
+        
+          atoms = item.split("\\s*:\\s*");
+          
+          if (atoms.length == 1) {
+              
+          } else if (atoms.length == 2) {
+              // this should be a circle or a rectangle. First atom is the center coordinates
+              coords = item.split("\\s*(,|:)\\s*");
+              try {
+                if (coords.length == 3) {
+                  // A circle: the second atom is the radius
+                  Core.circle(mask,
+                    new Point(Integer.parseInt(coords[0]),Integer.parseInt(coords[1])),
+                    Integer.parseInt(coords[2]), 
+                    new Scalar(255,255,255), -1
+                  );
+                } else {
+                  // A rectangle: the second atom is the width and height of the rectangle
+                  int[] coord = new int[4];
+                  for (int i=0; i<4; i++) {
+                    coord[i] = Integer.parseInt(coords[i]);
+                  }
+                  // calculate two opposite rectangle vertices
+                  Core.rectangle(mask, 
+                    new Point(coord[0]-(int)coord[2]/2,coord[1]+(int)coord[3]/2), 
+                    new Point(coord[0]+(int)coord[2]/2,coord[1]-(int)coord[3]/2),
+                    new Scalar(255,255,255), -1
+                  );
+                }
+              } catch (NumberFormatException e) {
+                Logger.error("Cannot parse number. "+e.getMessage());
+              }
+          } else {
+              // this should be a polygon
+              poly.clear();
+              Point[] points = new Point[(int)atoms.length];
+              try {
+                for (int i=0; i< atoms.length; i++) {
+                  coords = atoms[i].split("\\s*,\\s*");
+                  points[i] = new Point(Integer.parseInt(coords[0]),Integer.parseInt(coords[1]));
+                }
+                poly.add(new MatOfPoint(points));
+                Core.fillPoly(mask,poly,new Scalar(255,255,255));
+              } catch (NumberFormatException e) {
+                Logger.error("Cannot parse number. "+e.getMessage());
+              }
+          }
+        }
+        if (inverted) {
+          Core.bitwise_not(mask, mask);
+        }
+        mat.copyTo(masked, mask);
+        mask.release();
+        return new Result(masked,null);
+    }
+}

--- a/src/main/java/org/openpnp/vision/pipeline/ui/CvPipelineEditor.java
+++ b/src/main/java/org/openpnp/vision/pipeline/ui/CvPipelineEditor.java
@@ -39,6 +39,7 @@ import org.openpnp.vision.pipeline.stages.ImageWriteDebug;
 import org.openpnp.vision.pipeline.stages.MaskCircle;
 import org.openpnp.vision.pipeline.stages.MaskHsv;
 import org.openpnp.vision.pipeline.stages.MaskModel;
+import org.openpnp.vision.pipeline.stages.MaskPolygon;
 import org.openpnp.vision.pipeline.stages.MaskRectangle;
 import org.openpnp.vision.pipeline.stages.MatchTemplate;
 import org.openpnp.vision.pipeline.stages.MinAreaRect;
@@ -94,6 +95,7 @@ public class CvPipelineEditor extends JPanel {
         registerStageClass(MaskCircle.class);
         registerStageClass(MaskHsv.class);
         registerStageClass(MaskModel.class);
+        registerStageClass(MaskPolygon.class);
         registerStageClass(MaskRectangle.class);
         registerStageClass(MatchTemplate.class);
         registerStageClass(MinAreaRect.class);


### PR DESCRIPTION
# Description
A new OpenCV pileline stage is proposed, named `MaskPolygon`, which offers masking of multiple image areas based on shapes derived from user provided data.

There are three OpenCV pipeline stages that provide a masking operation, namely: `MaskCircle`, `MaskRect` and `MaskHsv`. The two former apply the mask as a geometric shape at the center of the image,

![screenshot-1](https://cloud.githubusercontent.com/assets/1109829/25779254/7cdfb83a-331c-11e7-9e1a-5f9ce64592dd.png)

![screenshot-3](https://cloud.githubusercontent.com/assets/1109829/25779257/877da806-331c-11e7-8ad8-62dc45bfc37a.png)

while the latter operates on the whole image based on the color of the features.

The new `MaskPolygon` stage can apply multiple mask shapes anywhere on the image:

![poly1](https://cloud.githubusercontent.com/assets/1109829/25830692/32343512-3467-11e7-8081-a73369b1a7fb.png)

The above image was produced by  defining shape coordinates in parameter `shapes`:
```
shapes: 640,400 : 50; 440,532 : 540,532 : 540,632; 700,532 : 800,532 : 800,632 : 700,632
```
### Using multiple mask shapes
Multiple shapes can be used to mask out unwanted features scattered in the image. For example, the following image contains bright spots that may interfere with the part detection process:

![poly2](https://cloud.githubusercontent.com/assets/1109829/25830695/3909e986-3467-11e7-817b-103237c5293a.png)

By applying a multiple shape mask, the unwanted features can be eliminated (here, a colored mask has been used just for demonstration):

![poly3](https://cloud.githubusercontent.com/assets/1109829/25830708/48047f78-3467-11e7-9991-98a991baf21d.png)

The result (mask is black):

![poly4](https://cloud.githubusercontent.com/assets/1109829/25830713/50d3bfc4-3467-11e7-9ae6-070aed6f8325.png)

# Justification
Blanking unwanted areas on an image can help reduce noise and improve part detection. Users of OpenPnP's vision system will be able to utilize the new `MaskPolygon` stage to add flexibility and advanced masking capabilities to their part detection OpenCV pipelines.

# Instructions for Use

- Define the shape by specifying shape coordinates:
1. Circle: X,Y:R, i.e. coordinates of center and radius, e.g.:
`shapes: 731,942 : 80`
2. Rectangle: X,Y:W,H, i.e. coordinates of center and size (width and height), e.g.
`shapes: 320,240 : 100,100`
2. Triangle: X1,Y1 : X2,Y2 : X3,Y3, i.e. the coordinates of the 3 vertices, e.g.
 `shapes: 440,532 : 540,532 : 540,632`
3. Polygon`shapes: X1,Y1 : X2,Y2 : ... as in triangle above, e.g.
`shapes:1090,370:985,475:985,635:1090,745:1280,680:1280,450`

- Define the shapes by combining some or all of the above, separated by semicolons, (`;`)
- Use the `inverted` parameter checkbox to change operation from masking to filtering.
- Use the `color` parameter to visualize the shape of the mask, or experiment with tinting the colors of the image. `Black` is the default color for masking.

# Implementation Details
1. How did you test the change?

Visually.

2. Did you add automated tests?

No.

3. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)?

I think so.

4. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing.

No such changes were made.