### PR TITLE
New OpenCV pipeline stage: DilateModel

### DIFF
--- a/src/main/java/org/openpnp/vision/pipeline/stages/DilateModel.java
+++ b/src/main/java/org/openpnp/vision/pipeline/stages/DilateModel.java
@@ -1,0 +1,109 @@
+package org.openpnp.vision.pipeline.stages;
+
+import java.awt.Color;
+import java.util.List;
+import java.util.ArrayList;
+
+import org.opencv.core.Core;
+import org.opencv.core.Mat;
+import org.opencv.core.RotatedRect;
+import org.opencv.core.Point;
+import org.opencv.core.Size;
+import org.opencv.core.Scalar;
+
+import org.openpnp.vision.pipeline.CvPipeline;
+import org.openpnp.vision.pipeline.CvStage;
+import org.openpnp.vision.pipeline.stages.convert.ColorConverter;
+import org.openpnp.vision.pipeline.Stage;
+import org.openpnp.vision.pipeline.Property;
+import org.openpnp.vision.FluentCv;
+
+import org.simpleframework.xml.Attribute;
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.convert.Convert;
+import org.pmw.tinylog.Logger;
+
+@Stage(
+  category="Image Processing", 
+  description="Dilate or contract a model by a given number of pixels.")
+  
+public class DilateModel extends CvStage {
+
+    @Attribute(required = false)
+    @Property(description="Name of stage to input model data from.")
+    private String modelStageName = null;
+    
+    @Attribute(required = false)
+    @Property(description="Dilate the model by given pixels. Negative values contract the model.")
+    private int dilate = 0;
+    
+    public String getModelStageName() {
+        return modelStageName;
+    }
+
+    public void setModelStageName(String modelStageName) {
+        this.modelStageName = modelStageName;
+    }
+
+    public int getDilate() {
+        return dilate;
+    }
+    
+    public void setDilate(int dilate) {
+        this.dilate = dilate;
+    }
+
+    private RotatedRect dilateRotatedRect(RotatedRect r) {
+      RotatedRect rect = new RotatedRect();
+      rect.center = r.center;
+      rect.angle = r.angle;
+      rect.size.width = r.size.width + dilate * 2;
+      rect.size.height = r.size.height + dilate * 2;
+      return rect;
+    }
+    
+    @Override
+    public Result process(CvPipeline pipeline) throws Exception {
+        if (modelStageName == null) {
+            throw new Exception("Stage name for model must be specified.");
+        }
+        
+        Result inStage = pipeline.getResult(modelStageName);
+
+        if (inStage.model instanceof RotatedRect) {
+          // just one RotatedRect
+          RotatedRect model = dilateRotatedRect((RotatedRect) inStage.model);
+          
+        } else if (inStage.model instanceof Result.Circle) {
+          // just one circle
+          Result.Circle circle = (Result.Circle) inStage.model;
+          // do the expansion by increasing the diameter
+          Result.Circle model = new Result.Circle(circle.x, circle.y, circle.diameter + dilate * 2);
+          return new Result(pipeline.getWorkingImage(),model);
+          
+        } else if (inStage.model instanceof List<?>) {
+          // we've got multiple Circles or RotatedRects
+          ArrayList multi = (ArrayList) inStage.model;
+          if (multi.get(0) instanceof  Result.Circle) {
+            // a collection of circles 
+            ArrayList<Result.Circle> model = new ArrayList<Result.Circle>();
+            for (int i=0; i < multi.size(); i++) {
+              Result.Circle circle = (Result.Circle) multi.get(i);
+              // dilate each circle by altering its diameter
+              model.add(new Result.Circle(circle.x, circle.y, circle.diameter + dilate * 2));
+            }
+            return new Result(pipeline.getWorkingImage(),model);
+            
+          } else if (multi.get(0) instanceof RotatedRect) {
+            // a collection of Rotatedmulti
+            ArrayList<RotatedRect> model = new ArrayList<RotatedRect>();
+            for (int i=0; i < multi.size(); i++) {
+              // get the 4 points of each rotated rect
+              model.add(dilateRotatedRect((RotatedRect) multi.get(i)));
+            }
+            return new Result(pipeline.getWorkingImage(),model);
+          }
+        }
+        return new Result(pipeline.getWorkingImage(), inStage.model);
+    }
+}

--- a/src/main/java/org/openpnp/vision/pipeline/stages/DilateModel.java
+++ b/src/main/java/org/openpnp/vision/pipeline/stages/DilateModel.java
@@ -98,7 +98,7 @@ public class DilateModel extends CvStage {
             // a collection of Rotatedmulti
             ArrayList<RotatedRect> model = new ArrayList<RotatedRect>();
             for (int i=0; i < multi.size(); i++) {
-              // get the 4 points of each rotated rect
+              // dilate each rotated rect
               model.add(dilateRotatedRect((RotatedRect) multi.get(i)));
             }
             return new Result(pipeline.getWorkingImage(),model);

--- a/src/main/java/org/openpnp/vision/pipeline/ui/CvPipelineEditor.java
+++ b/src/main/java/org/openpnp/vision/pipeline/ui/CvPipelineEditor.java
@@ -20,6 +20,7 @@ import org.openpnp.vision.pipeline.stages.DetectCirclesHough;
 import org.openpnp.vision.pipeline.stages.DetectEdgesCanny;
 import org.openpnp.vision.pipeline.stages.DetectEdgesLaplacian;
 import org.openpnp.vision.pipeline.stages.DetectEdgesRobertsCross;
+import org.openpnp.vision.pipeline.stages.DilateModel;
 import org.openpnp.vision.pipeline.stages.DrawCircles;
 import org.openpnp.vision.pipeline.stages.DrawContours;
 import org.openpnp.vision.pipeline.stages.DrawImageCenter;
@@ -76,6 +77,7 @@ public class CvPipelineEditor extends JPanel {
         registerStageClass(DetectEdgesCanny.class);
         registerStageClass(DetectEdgesRobertsCross.class);
         registerStageClass(DetectEdgesLaplacian.class);
+        registerStageClass(DilateModel.class);
         registerStageClass(DrawCircles.class);
         registerStageClass(DrawContours.class);
         registerStageClass(DrawImageCenter.class);


### PR DESCRIPTION
# Description
When building an OpenCV pipeline, there are cases where the detected models of parts contain unwanted content, e.g. portions of pins, shadows etc, which may be difficult to remove without affecting other parts of the image. While processing the image content directly may be difficult in such cases, there exists an alternative  path to take: **process the geometry of the model** instead.

A new OpenCV pipeline stage is thus proposed, named `DilateModel`, that performs dilation or contraction on the shape of a model. At present, it operates on Circles and RotatedRect models. The following series of images show an example of a dilate operation.

Original image:

![screenshot-3](https://cloud.githubusercontent.com/assets/1109829/25844544/7bf46b44-34b3-11e7-867f-0b56b5df3d82.png)

Model masked (makes use of a `MaskModel` stage to isolate the original image content inside the model) :

![screenshot-4](https://cloud.githubusercontent.com/assets/1109829/25844824/69d951f8-34b4-11e7-8bc2-a9520c467138.png)

The result of applying the new `DilateModel` pipeline stage, with a dilation, or rather, in this case, a contraction width of -10px:

![screenshot-5](https://cloud.githubusercontent.com/assets/1109829/25844985/e3097eea-34b4-11e7-8c64-5fe5a4b5ae64.png)

_Before_ (red) and _after_ (Cyan) models, showing the result of applying a `DilateModel` stage with a contraction width of -10px:

![screenshot-7](https://cloud.githubusercontent.com/assets/1109829/25845026/08ed1f4a-34b5-11e7-8e02-b735225439dd.png)

# Justification
Users of OpenPnP vision system may benefit from the additional flexibility offered by the new pipeline stage by using it together with other stages, like MaskHsv, to improve the performance of a pipeline.

# Instructions for Use
![screenshot-6](https://cloud.githubusercontent.com/assets/1109829/25845680/7ab55046-34b7-11e7-8b72-86ebccd4eac5.png)

- Set the `modelStageName` parameter to the pipeline stage to use as an input for the model.
- Set the `dilate` parameter to the number of pixels to dilate (negative number to contract) the model.

# Implementation Details
1. How did you test the change?

Visually.

2. Did you add automated tests?

No.

3. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)?

If memory serves me right, yes.  
___________________________________________
**NOTE:** 
_4.2 Block indentation: +2 spaces_ of the Google document asks for 2 spaces of indentation. OpenPnP seems to prefer 4 spaces instead, and keeps correcting the code. **This creates conflicts** when merging back the code from OpenPnP github to the local repository, which need to be resolved **every time**.
___________________________________________

4. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing.

No such changes were made.