### PR TITLE
Added missing return statement

### DIFF
--- a/src/main/java/org/openpnp/vision/pipeline/stages/DilateModel.java
+++ b/src/main/java/org/openpnp/vision/pipeline/stages/DilateModel.java
@@ -73,7 +73,8 @@ public class DilateModel extends CvStage {
         if (inStage.model instanceof RotatedRect) {
           // just one RotatedRect
           RotatedRect model = dilateRotatedRect((RotatedRect) inStage.model);
-          
+          return new Result(pipeline.getWorkingImage(),model);
+         
         } else if (inStage.model instanceof Result.Circle) {
           // just one circle
           Result.Circle circle = (Result.Circle) inStage.model;


### PR DESCRIPTION
Return statement for single RotatedRect in DilateModel was missing.  The stage returned the result unchanged, no matter what the `delate` parameter was.