### PR TITLE
Added paste dispense function to gcode driver with pre/post commands

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/driver/GcodeDriver.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/GcodeDriver.java
@@ -28,6 +28,7 @@ import org.openpnp.machine.reference.ReferenceHeadMountable;
 import org.openpnp.machine.reference.ReferenceMachine;
 import org.openpnp.machine.reference.ReferenceNozzle;
 import org.openpnp.machine.reference.ReferenceNozzleTip;
+import org.openpnp.machine.reference.ReferencePasteDispenser;
 import org.openpnp.machine.reference.driver.wizards.GcodeDriverConsole;
 import org.openpnp.machine.reference.driver.wizards.GcodeDriverGcodes;
 import org.openpnp.machine.reference.driver.wizards.GcodeDriverSettings;
@@ -72,7 +73,10 @@ public class GcodeDriver extends AbstractSerialPortDriver implements Runnable {
         VACUUM_REQUEST_COMMAND(true, "VacuumLevelPartOn", "VacuumLevelPartOff"),
         VACUUM_REPORT_REGEX(true),
         ACTUATOR_READ_COMMAND(true, "Id", "Name", "Index"),
-        ACTUATOR_READ_REGEX(true);
+        ACTUATOR_READ_REGEX(true),
+        PRE_DISPENSE_COMMAND(false, "DispenseTime"),
+        DISPENSE_COMMAND(false, "DispenseTime"),
+        POST_DISPENSE_COMMAND(false, "DispenseTime");
 
         final boolean headMountable;
         final String[] variableNames;
@@ -245,6 +249,29 @@ public class GcodeDriver extends AbstractSerialPortDriver implements Runnable {
         for (ReferenceDriver driver : subDrivers) {
             driver.setEnabled(enabled);
         }
+    }
+
+    @Override
+    public void dispense(ReferencePasteDispenser dispenser,Location startLocation,Location endLocation,long dispenseTimeMilliseconds) throws Exception {
+        Logger.debug("dispense({}, {}, {}, {})", new Object[] {dispenser, startLocation, endLocation, dispenseTimeMilliseconds});
+
+        String command = getCommand(null, CommandType.PRE_DISPENSE_COMMAND);
+        command = substituteVariable(command, "DispenseTime", dispenseTimeMilliseconds);
+
+        sendGcode(command);
+
+        for (ReferenceDriver driver: subDrivers )
+        {
+            driver.dispense(dispenser,startLocation,endLocation,dispenseTimeMilliseconds);
+        }
+
+        command = getCommand(null, CommandType.DISPENSE_COMMAND);
+        command = substituteVariable(command, "DispenseTime", dispenseTimeMilliseconds);
+        sendGcode(command);
+
+        command = getCommand(null, CommandType.POST_DISPENSE_COMMAND);
+        command = substituteVariable(command, "DispenseTime", dispenseTimeMilliseconds);
+        sendGcode(command);
     }
 
     @Override


### PR DESCRIPTION
# Read This First
To submit a Pull Request for OpenPnP you must use this template or it will be deleted. 

Be sure to review the [[Developers Guide]] and the [Contributing Guidelines](https://github.com/openpnp/openpnp/blob/develop/CONTRIBUTING.md).

Make your Pull Request as small as possible. Only include one bug or feature.
Large pull requests that change dozens of files or add multiple features are unlikely to be accepted.

Fill out all the details below.

-----------------------------------------------------------------------

# Description
Describe the change in detail. Explain how it works. The better you describe the change the more likely it is to be accepted.

Added an overridden dispense() function to the gcode driver, along with pre-dispense, dispense and post-dispense commands which can take the dispense-time as a variable and pass it down to the driver. Sub drivers also receive the dispense command.

# Justification
Why should this change be included in OpenPnP? Does it benefit a majority of users or is it specific to one type of user or machine?

Should make it easy for none-programmers to use the Dispense functionality of the gcode driver

# Instructions for Use
How does someone use the feature? Be descriptive. Include step by step instructions. If this is a new feature then these instructions will become the Wiki documentation for the feature, so explain here the same way you would explain to someone who had never used the feature.

This is documentation for a user, not for a developer.

# Implementation Details
1. How did you test the change?
2. Did you add automated tests?
3. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)?
4. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing.