### PR TITLE
Added getResult("..") to CvPipeline

### DIFF
--- a/src/main/java/org/openpnp/vision/pipeline/CvPipeline.java
+++ b/src/main/java/org/openpnp/vision/pipeline/CvPipeline.java
@@ -246,7 +246,11 @@ public class CvPipeline {
             results.put(stage, new Result(image, model, processingTimeNs));
             // if there is an error, then there is no point in storing the error condition, just skip it
             if (!err) {
-              previousResult = new Result(image, model, processingTimeNs);
+              Mat pmat = null;
+              if (image != null) {
+                pmat = image.clone();
+              }
+              previousResult = new Result(pmat, model, processingTimeNs);
             }
         }
     }

--- a/src/main/java/org/openpnp/vision/pipeline/CvPipeline.java
+++ b/src/main/java/org/openpnp/vision/pipeline/CvPipeline.java
@@ -134,8 +134,9 @@ public class CvPipeline {
     }
 
     /**
-     * Get the Result returned by the CvStage with the given name. May return null if the stage did
-     * not return a result.
+     * Get the Result returned by the CvStage with the given name. 
+     * If name is '..', then return the previous result. 
+     * May return null if the stage did not return a result.
      * 
      * @param name
      * @return
@@ -143,6 +144,8 @@ public class CvPipeline {
     public Result getResult(String name) {
         if (name == null) {
             return null;
+        } else if (name.matches("..")) {
+          return previousResult;
         }
         return getResult(getStage(name));
     }
@@ -159,19 +162,6 @@ public class CvPipeline {
             return null;
         }
         return results.get(stage);
-    }
-
-    /**
-     * Get the Result returned by the previous CvStage. May return null if the stage did not return a
-     * result.
-     * 
-     * @return
-     */
-    public Result getResult() {
-        if (previousResult == null) {
-            return null;
-        }
-        return previousResult;
     }
 
     /**

--- a/src/main/java/org/openpnp/vision/pipeline/CvPipeline.java
+++ b/src/main/java/org/openpnp/vision/pipeline/CvPipeline.java
@@ -203,6 +203,7 @@ public class CvPipeline {
             // Process and time the stage and get the result.
             long processingTimeNs = System.nanoTime();
             Result result = null;
+            boolean err = false;
             try {
                 if (!stage.isEnabled()) {
                     throw new Exception("Stage not enabled.");
@@ -211,6 +212,7 @@ public class CvPipeline {
             }
             catch (Exception e) {
                 result = new Result(null, e);
+                err = true;
             }
             processingTimeNs = System.nanoTime() - processingTimeNs;
             totalProcessingTimeNs += processingTimeNs;
@@ -242,7 +244,12 @@ public class CvPipeline {
             }
 
             results.put(stage, new Result(image, model, processingTimeNs));
-            previousResult = new Result(image, model, processingTimeNs);
+
+            if (model == null && previousResult != null && previousResult.model != null && !err) {
+              previousResult = new Result(image, previousResult.model, processingTimeNs);
+            } else {
+              previousResult = new Result(image, model, processingTimeNs);
+            }
         }
     }
 

--- a/src/main/java/org/openpnp/vision/pipeline/CvPipeline.java
+++ b/src/main/java/org/openpnp/vision/pipeline/CvPipeline.java
@@ -19,7 +19,7 @@ import org.openpnp.vision.pipeline.CvStage.Result;
 import org.simpleframework.xml.ElementList;
 import org.simpleframework.xml.Root;
 import org.simpleframework.xml.Serializer;
-
+import org.pmw.tinylog.Logger;
 /**
  * A CvPipeline performs computer vision operations on a working image by processing in series a
  * list of CvStage instances. Each CvStage instance can modify the working image and return a new
@@ -244,10 +244,8 @@ public class CvPipeline {
             }
 
             results.put(stage, new Result(image, model, processingTimeNs));
-
-            if (model == null && previousResult != null && previousResult.model != null && !err) {
-              previousResult = new Result(image, previousResult.model, processingTimeNs);
-            } else {
+            // if there is an error, then there is no point in storing the error condition, just skip it
+            if (!err) {
               previousResult = new Result(image, model, processingTimeNs);
             }
         }

--- a/src/main/java/org/openpnp/vision/pipeline/CvPipeline.java
+++ b/src/main/java/org/openpnp/vision/pipeline/CvPipeline.java
@@ -57,6 +57,8 @@ public class CvPipeline {
     
     private long totalProcessingTimeNs;
     
+    private Result previousResult;
+    
     public CvPipeline() {
         
     }
@@ -146,7 +148,7 @@ public class CvPipeline {
     }
 
     /**
-     * Get the Result returned by give CvStage. May return null if the stage did not return a
+     * Get the Result returned by given CvStage. May return null if the stage did not return a
      * result.
      * 
      * @param stage
@@ -157,6 +159,19 @@ public class CvPipeline {
             return null;
         }
         return results.get(stage);
+    }
+
+    /**
+     * Get the Result returned by the previous CvStage. May return null if the stage did not return a
+     * result.
+     * 
+     * @return
+     */
+    public Result getResult() {
+        if (previousResult == null) {
+            return null;
+        }
+        return previousResult;
     }
 
     /**
@@ -192,6 +207,7 @@ public class CvPipeline {
     public void process() {
 
         totalProcessingTimeNs = 0;
+        previousResult = null;
         release();
         for (CvStage stage : stages) {
             // Process and time the stage and get the result.
@@ -236,6 +252,7 @@ public class CvPipeline {
             }
 
             results.put(stage, new Result(image, model, processingTimeNs));
+            previousResult = new Result(image, model, processingTimeNs);
         }
     }
 


### PR DESCRIPTION
Cascading of pipeline stages that operate on the `working image` is the default mode for the user of the opencv pipeline, and it is easy for the developer: method `getWorkingImage()` brings in the last image put in the pipeline by a previous stage.

The same is not true for _a model_ produced by a previous stage. To get such model, the user/developer has to explicitly ask for it by naming the specific stage or by using `getResult(stage)` in code.

This PR adds code that stores the result produced by the previous stage and makes it available through the method `getResult()`, the same method used before to get the result from a specific stage, but now without arguments.

This change will make it easier to cascade stages that work on models, in the same way that they work for images: a stage can be moved around without the need to change its reference to a previous model, by using the input of the stage that precedes.
