### PR TITLE
added feeder to pipeline

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/feeder/ReferenceLoosePartFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/ReferenceLoosePartFeeder.java
@@ -80,6 +80,7 @@ public class ReferenceLoosePartFeeder extends ReferenceFeeder {
     private Location getPickLocation(Camera camera) throws Exception {
         // Process the pipeline to extract RotatedRect results
         pipeline.setCamera(camera);
+        pipeline.setFeeder(this);
         pipeline.process();
         // Grab the results
         List<RotatedRect> results = (List<RotatedRect>) pipeline.getResult("results").model;

--- a/src/main/java/org/openpnp/machine/reference/feeder/wizards/ReferenceLoosePartFeederConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/wizards/ReferenceLoosePartFeederConfigurationWizard.java
@@ -94,6 +94,7 @@ public class ReferenceLoosePartFeederConfigurationWizard
     private void editPipeline() throws Exception {
         CvPipeline pipeline = feeder.getPipeline();
         pipeline.setCamera(Configuration.get().getMachine().getDefaultHead().getDefaultCamera());
+        pipeline.setFeeder(feeder);
         CvPipelineEditor editor = new CvPipelineEditor(pipeline);
         JDialog dialog = new JDialog(MainFrame.get(), feeder.getPart().getId() + " Pipeline");
         dialog.getContentPane().setLayout(new BorderLayout());

--- a/src/main/java/org/openpnp/vision/pipeline/CvPipeline.java
+++ b/src/main/java/org/openpnp/vision/pipeline/CvPipeline.java
@@ -15,6 +15,7 @@ import org.opencv.core.Point;
 import org.opencv.core.Scalar;
 import org.openpnp.model.Configuration;
 import org.openpnp.spi.Camera;
+import org.openpnp.spi.Feeder;
 import org.openpnp.vision.pipeline.CvStage.Result;
 import org.simpleframework.xml.ElementList;
 import org.simpleframework.xml.Root;
@@ -54,6 +55,7 @@ public class CvPipeline {
     private Mat workingImage;
 
     private Camera camera;
+    private Feeder feeder;
     
     private long totalProcessingTimeNs;
     
@@ -179,6 +181,14 @@ public class CvPipeline {
 
     public Camera getCamera() {
         return camera;
+    }
+
+    public void setFeeder(Feeder feeder) {
+        this.feeder = feeder;
+    }
+
+    public Feeder getFeeder() {
+        return feeder;
     }
 
     public long getTotalProcessingTimeNs() {


### PR DESCRIPTION
# Read This First
To submit a Pull Request for OpenPnP you must use this template or it will not be accepted. 

Be sure to review the [Developers Guide](https://github.com/openpnp/openpnp/wiki/Developers-Guide)
and the [Contributing Guidelines](https://github.com/openpnp/openpnp/blob/develop/CONTRIBUTING.md).

Make your Pull Request as small as possible. Only include one bug or feature.
Large pull requests that change dozens of files or add multiple features are unlikely to be accepted.

Fill out all the details below. All sections below are required. If they are not included your Pull Request
will not be accepted.

-----------------------------------------------------------------------

# Description
Add feeder into pipeline in order that (script) stages can access feeder 
# Justification
It is needed for looseFeeder to access Part and to avoid using temp files for reference images.

# Instructions for Use
example from script:
Footprint footprint = pipeline.getFeeder().getPart().getPackage().getFootprint();
If looseFeeder have: public Mat reference; 
one can use 
Mat reference = pipeline.getFeeder().reference;
Hovewer it shoudl be checked if reference is null or not, because reference can not be set or 
pipeline can be run from bottomvision or topvision outside the Feeder where getFeeder() return null.

This is documentation for a user, not for a developer.

# Implementation Details
added "Feeder feeder" to CvPipeline.java including getter/setter. and updated
ReferenceLooseFeeder for setting the variable.