### PR TITLE
added nozzle variable to pipeline

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/ReferenceNozzleTip.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceNozzleTip.java
@@ -193,7 +193,7 @@ public class ReferenceNozzleTip extends AbstractNozzleTip {
     private Nozzle getParentNozzle() {
         for (Head head : Configuration.get().getMachine().getHeads()) {
             for (Nozzle nozzle : head.getNozzles()) {
-                for (NozzleTip nozzleTip : nozzle.getNozzleTips()) {
+                for (NozzleTip nozzleTip : nozzle.Tips()) {
                     if (nozzleTip == this) {
                         return nozzle;
                     }
@@ -473,6 +473,7 @@ public class ReferenceNozzleTip extends AbstractNozzleTip {
 
         public CvPipeline getPipeline() throws Exception {
             pipeline.setCamera(VisionUtils.getBottomVisionCamera());
+			pipeline.setNozzle(getParentNozzle());
             return pipeline;
         }
 

--- a/src/main/java/org/openpnp/machine/reference/ReferenceNozzleTip.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceNozzleTip.java
@@ -193,7 +193,7 @@ public class ReferenceNozzleTip extends AbstractNozzleTip {
     private Nozzle getParentNozzle() {
         for (Head head : Configuration.get().getMachine().getHeads()) {
             for (Nozzle nozzle : head.getNozzles()) {
-                for (NozzleTip nozzleTip : nozzle.Tips()) {
+                for (NozzleTip nozzleTip : nozzle.getNozzleTips()) {
                     if (nozzleTip == this) {
                         return nozzle;
                     }

--- a/src/main/java/org/openpnp/machine/reference/ReferenceNozzleTip.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceNozzleTip.java
@@ -202,7 +202,7 @@ public class ReferenceNozzleTip extends AbstractNozzleTip {
         }
         return null;
     }
-
+	
     public double getVacuumLevelPartOn() {
         return vacuumLevelPartOn;
     }
@@ -473,7 +473,6 @@ public class ReferenceNozzleTip extends AbstractNozzleTip {
 
         public CvPipeline getPipeline() throws Exception {
             pipeline.setCamera(VisionUtils.getBottomVisionCamera());
-			pipeline.setNozzle(getParentNozzle());
             return pipeline;
         }
 

--- a/src/main/java/org/openpnp/machine/reference/feeder/ReferenceLoosePartFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/ReferenceLoosePartFeeder.java
@@ -60,6 +60,7 @@ public class ReferenceLoosePartFeeder extends ReferenceFeeder {
     private CvPipeline pipeline = createDefaultPipeline();
 
     private Location pickLocation;
+	Nozzle nozzle;
 
     @Override
     public Location getPickLocation() throws Exception {
@@ -69,6 +70,7 @@ public class ReferenceLoosePartFeeder extends ReferenceFeeder {
     @Override
     public void feed(Nozzle nozzle) throws Exception {
         Camera camera = nozzle.getHead().getDefaultCamera();
+		this.nozzle=nozzle;
         // Move to the feeder pick location
         MovableUtils.moveToLocationAtSafeZ(camera, location);
         for (int i = 0; i < 3; i++) {
@@ -80,6 +82,7 @@ public class ReferenceLoosePartFeeder extends ReferenceFeeder {
     private Location getPickLocation(Camera camera) throws Exception {
         // Process the pipeline to extract RotatedRect results
         pipeline.setCamera(camera);
+        pipeline.setNozzle(nozzle);
         pipeline.process();
         // Grab the results
         List<RotatedRect> results = (List<RotatedRect>) pipeline.getResult("results").model;

--- a/src/main/java/org/openpnp/machine/reference/vision/ReferenceBottomVision.java
+++ b/src/main/java/org/openpnp/machine/reference/vision/ReferenceBottomVision.java
@@ -76,6 +76,7 @@ public class ReferenceBottomVision implements PartAlignment {
         CvPipeline pipeline = partSettings.getPipeline();
 
         pipeline.setCamera(camera);
+		pipeline.setNozzle(nozzle);
         pipeline.process();
 
         Result result = pipeline.getResult("result");

--- a/src/main/java/org/openpnp/machine/reference/vision/wizards/ReferenceBottomVisionConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/vision/wizards/ReferenceBottomVisionConfigurationWizard.java
@@ -101,6 +101,7 @@ public class ReferenceBottomVisionConfigurationWizard extends AbstractConfigurat
     private void editPipeline() throws Exception {
         CvPipeline pipeline = bottomVision.getPipeline();
         pipeline.setCamera(VisionUtils.getBottomVisionCamera());
+		pipeline.setNozzle(MainFrame.get().getMachineControls().getSelectedNozzle());
         CvPipelineEditor editor = new CvPipelineEditor(pipeline);
         JDialog dialog = new JDialog(MainFrame.get(), "Bottom Vision Pipeline");
         dialog.getContentPane().setLayout(new BorderLayout());

--- a/src/main/java/org/openpnp/machine/reference/vision/wizards/ReferenceBottomVisionPartConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/vision/wizards/ReferenceBottomVisionPartConfigurationWizard.java
@@ -1,4 +1,4 @@
-package org.openpnp.machine.reference.vision.wizards;
+jjjpackage org.openpnp.machine.reference.vision.wizards;
 
 import java.awt.BorderLayout;
 import java.awt.event.ActionEvent;
@@ -162,6 +162,8 @@ public class ReferenceBottomVisionPartConfigurationWizard extends AbstractConfig
     private void editPipeline() throws Exception {
         CvPipeline pipeline = partSettings.getPipeline();
         pipeline.setCamera(VisionUtils.getBottomVisionCamera());
+		pipeline.setNozzle(MainFrame.get().getMachineControls().getSelectedNozzle());
+
         CvPipelineEditor editor = new CvPipelineEditor(pipeline);
         JDialog dialog = new JDialog(MainFrame.get(), "Bottom Vision Pipeline");
         dialog.getContentPane().setLayout(new BorderLayout());

--- a/src/main/java/org/openpnp/machine/reference/vision/wizards/ReferenceBottomVisionPartConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/vision/wizards/ReferenceBottomVisionPartConfigurationWizard.java
@@ -1,4 +1,4 @@
-jjjpackage org.openpnp.machine.reference.vision.wizards;
+package org.openpnp.machine.reference.vision.wizards;
 
 import java.awt.BorderLayout;
 import java.awt.event.ActionEvent;

--- a/src/main/java/org/openpnp/vision/pipeline/CvPipeline.java
+++ b/src/main/java/org/openpnp/vision/pipeline/CvPipeline.java
@@ -15,6 +15,7 @@ import org.opencv.core.Point;
 import org.opencv.core.Scalar;
 import org.openpnp.model.Configuration;
 import org.openpnp.spi.Camera;
+import org.openpnp.spi.Nozzle;
 import org.openpnp.vision.pipeline.CvStage.Result;
 import org.simpleframework.xml.ElementList;
 import org.simpleframework.xml.Root;
@@ -54,6 +55,7 @@ public class CvPipeline {
     private Mat workingImage;
 
     private Camera camera;
+    private Nozzle nozzle;
     
     private long totalProcessingTimeNs;
     
@@ -179,6 +181,14 @@ public class CvPipeline {
 
     public Camera getCamera() {
         return camera;
+    }
+
+    public void setNozzle(Nozzle nozzle) {
+        this.nozzle = nozzle;
+    }
+
+    public Nozzle getNozzle() {
+        return nozzle;
     }
 
     public long getTotalProcessingTimeNs() {


### PR DESCRIPTION

# Description
Added Nozzle variable to pipeline including getter/setter 

# Justification
This allows accessing the nozzle, from scripts.
This is useful for stages that need to stitch images in order to get a wider field of view,
access to all classes behind nozzle, as part, nozzleTip, and differentiate to bottom or top vision.
If nozzle.getPart() is not null, the pipeline is uplooking because nozzle have part loaded.
Otherwise it is downlooking for the normal usage.
Special pipelines like NozzleTip Calibration pipeline are exceptions to this rules and as special
pipeline that rule don't need to be respected.

# Instructions for Use
moveTo(pipeline.getNozzle().getLocation().add(new Location(LengthUnit.Millimeters,10,10,0,0)):
As note, inside StandaloneEditor, getNozzle return always null.
For Wizards that don't have access to the nozzle parameter, selected Nozzle from gui selector is used.

# Implementation Details
added variable to pipeline and updated code that use pipeline to include nozzle settings.