### PR TITLE
Rotate before Align Option

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/ReferencePnpJobProcessor.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferencePnpJobProcessor.java
@@ -593,7 +593,7 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
             if (feeder != null) {
                 feeder.postPick(nozzle);
             }
-              
+
             plannedPlacement.stepComplete = true;
         }
 
@@ -607,8 +607,8 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
             }
             Nozzle nozzle = plannedPlacement.nozzle;
             JobPlacement jobPlacement = plannedPlacement.jobPlacement;
-            Placement placement = jobPlacement.placement;            
-            Part part = placement.getPart();          
+            Placement placement = jobPlacement.placement;
+            Part part = placement.getPart();
             fireTextStatus("Aligning %s for %s.", part.getId(), placement.getId());
             PartAlignment.PartAlignmentOffset alignmentOffset = machine.getPartAlignment().findOffsets(part, jobPlacement.boardLocation, placement.getLocation(), nozzle);
             plannedPlacement.alignmentOffsets = alignmentOffset;

--- a/src/main/java/org/openpnp/machine/reference/ReferencePnpJobProcessor.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferencePnpJobProcessor.java
@@ -593,7 +593,7 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
             if (feeder != null) {
                 feeder.postPick(nozzle);
             }
-
+              
             plannedPlacement.stepComplete = true;
         }
 
@@ -607,8 +607,8 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
             }
             Nozzle nozzle = plannedPlacement.nozzle;
             JobPlacement jobPlacement = plannedPlacement.jobPlacement;
-            Placement placement = jobPlacement.placement;
-            Part part = placement.getPart();
+            Placement placement = jobPlacement.placement;            
+            Part part = placement.getPart();          
             fireTextStatus("Aligning %s for %s.", part.getId(), placement.getId());
             PartAlignment.PartAlignmentOffset alignmentOffset = machine.getPartAlignment().findOffsets(part, jobPlacement.boardLocation, placement.getLocation(), nozzle);
             plannedPlacement.alignmentOffsets = alignmentOffset;

--- a/src/main/java/org/openpnp/machine/reference/vision/ReferenceBottomVision.java
+++ b/src/main/java/org/openpnp/machine/reference/vision/ReferenceBottomVision.java
@@ -36,8 +36,11 @@ import org.simpleframework.xml.ElementMap;
 import org.simpleframework.xml.Root;
 
 public class ReferenceBottomVision implements PartAlignment {
+
+
     @Element(required = false)
     protected CvPipeline pipeline = createDefaultPipeline();
+
 
     @Attribute(required = false)
     protected boolean enabled = false;

--- a/src/main/java/org/openpnp/machine/reference/vision/ReferenceBottomVision.java
+++ b/src/main/java/org/openpnp/machine/reference/vision/ReferenceBottomVision.java
@@ -44,7 +44,7 @@ public class ReferenceBottomVision implements PartAlignment {
 
     @Attribute(required = false)
     protected boolean enabled = false;
-    -
+    
     @Attribute(required = false)
     protected boolean preRotate = false;    
 

--- a/src/main/java/org/openpnp/machine/reference/vision/ReferenceBottomVision.java
+++ b/src/main/java/org/openpnp/machine/reference/vision/ReferenceBottomVision.java
@@ -36,17 +36,14 @@ import org.simpleframework.xml.ElementMap;
 import org.simpleframework.xml.Root;
 
 public class ReferenceBottomVision implements PartAlignment {
-
-
     @Element(required = false)
     protected CvPipeline pipeline = createDefaultPipeline();
-
 
     @Attribute(required = false)
     protected boolean enabled = false;
     
     @Attribute(required = false)
-    protected boolean preRot = false;    
+    protected boolean preRotate = false;    
 
     @ElementMap(required = false)
     protected Map<String, PartSettings> partSettingsByPartId = new HashMap<>();
@@ -62,8 +59,10 @@ public class ReferenceBottomVision implements PartAlignment {
         Camera camera = VisionUtils.getBottomVisionCamera();
         
         // Pre-rotate to minimize runout
-        if (preRot){
-        	MovableUtils.moveToLocationAtSafeZ(nozzle, 	camera.getLocation().derive(null,  null,  null,  Utils2D.calculateBoardPlacementLocation(boardLocation, placementLocation).getRotation()));
+        double preRotateAngle = 0;
+        if (preRotate){
+        	preRotateAngle = Utils2D.calculateBoardPlacementLocation(boardLocation, placementLocation).getRotation();
+        	MovableUtils.moveToLocationAtSafeZ(nozzle, 	camera.getLocation().derive(null,  null,  null,  preRotateAngle));
         }
 
         // Create a location that is the Camera's X, Y, it's Z + part height
@@ -72,7 +71,7 @@ public class ReferenceBottomVision implements PartAlignment {
         Length partHeight = part.getHeight();
         Location partHeightLocation =
                 new Location(partHeight.getUnits(), 0, 0, partHeight.getValue(), 0);
-        startLocation = startLocation.add(partHeightLocation).derive(null, null, null, 0d);
+        startLocation = startLocation.add(partHeightLocation).derive(null, null, null, preRotateAngle);
 
         MovableUtils.moveToLocationAtSafeZ(nozzle, startLocation);
 
@@ -119,7 +118,7 @@ public class ReferenceBottomVision implements PartAlignment {
                 1500);
 
 
-        return new PartAlignmentOffset(offsets, preRot);
+        return new PartAlignmentOffset(offsets.derive(0d,  0d,  0d,  preRotateAngle), preRotate);
     }
 
     public static CvPipeline createDefaultPipeline() {
@@ -150,11 +149,11 @@ public class ReferenceBottomVision implements PartAlignment {
     }
     
     public boolean isPreRot() {
-        return preRot;
+        return preRotate;
     }
 
     public void setPreRot(boolean preRot) {
-        this.preRot = preRot;
+        this.preRotate = preRot;
     }    
 
     @Override

--- a/src/main/java/org/openpnp/machine/reference/vision/ReferenceBottomVision.java
+++ b/src/main/java/org/openpnp/machine/reference/vision/ReferenceBottomVision.java
@@ -62,7 +62,6 @@ public class ReferenceBottomVision implements PartAlignment {
         double preRotateAngle = 0;
         if (preRotate){
         	preRotateAngle = Utils2D.calculateBoardPlacementLocation(boardLocation, placementLocation).getRotation();
-        	MovableUtils.moveToLocationAtSafeZ(nozzle, 	camera.getLocation().derive(null,  null,  null,  preRotateAngle));
         }
 
         // Create a location that is the Camera's X, Y, it's Z + part height

--- a/src/main/java/org/openpnp/machine/reference/vision/ReferenceBottomVision.java
+++ b/src/main/java/org/openpnp/machine/reference/vision/ReferenceBottomVision.java
@@ -41,6 +41,7 @@ public class ReferenceBottomVision implements PartAlignment {
     @Element(required = false)
     protected CvPipeline pipeline = createDefaultPipeline();
 
+
     @Attribute(required = false)
     protected boolean enabled = false;
     

--- a/src/main/java/org/openpnp/machine/reference/vision/ReferenceBottomVision.java
+++ b/src/main/java/org/openpnp/machine/reference/vision/ReferenceBottomVision.java
@@ -44,7 +44,7 @@ public class ReferenceBottomVision implements PartAlignment {
 
     @Attribute(required = false)
     protected boolean enabled = false;
-    
+    -
     @Attribute(required = false)
     protected boolean preRotate = false;    
 
@@ -68,7 +68,7 @@ public class ReferenceBottomVision implements PartAlignment {
         }
 
         // Create a location that is the Camera's X, Y, it's Z + part height
-        // and a rotation of 0.
+        // and a rotation of 0, unless preRotate is enabled
         Location startLocation = camera.getLocation();
         Length partHeight = part.getHeight();
         Location partHeightLocation =

--- a/src/main/java/org/openpnp/machine/reference/vision/wizards/ReferenceBottomVisionConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/vision/wizards/ReferenceBottomVisionConfigurationWizard.java
@@ -30,6 +30,7 @@ import com.jgoodies.forms.layout.RowSpec;
 public class ReferenceBottomVisionConfigurationWizard extends AbstractConfigurationWizard {
     private final ReferenceBottomVision bottomVision;
     private JCheckBox enabledCheckbox;
+    private JCheckBox preRotCheckbox;
 
     public ReferenceBottomVisionConfigurationWizard(ReferenceBottomVision bottomVision) {
         this.bottomVision = bottomVision;
@@ -44,6 +45,7 @@ public class ReferenceBottomVisionConfigurationWizard extends AbstractConfigurat
                         FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,
                         FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,},
                 new RowSpec[] {FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
                         FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,}));
 
         JLabel lblEnabled = new JLabel("Enabled?");
@@ -96,6 +98,12 @@ public class ReferenceBottomVisionConfigurationWizard extends AbstractConfigurat
             }
         });
         panel.add(btnResetAllTo, "8, 4");
+        
+        JLabel lblPreRot = new JLabel("Rotate parts prior to vision?");
+        panel.add(lblPreRot, "2, 6");
+
+        preRotCheckbox = new JCheckBox("");
+        panel.add(preRotCheckbox, "4, 6");
     }
 
     private void editPipeline() throws Exception {
@@ -112,5 +120,6 @@ public class ReferenceBottomVisionConfigurationWizard extends AbstractConfigurat
     @Override
     public void createBindings() {
         addWrappedBinding(bottomVision, "enabled", enabledCheckbox, "selected");
+        addWrappedBinding(bottomVision, "preRot", preRotCheckbox, "selected");
     }
 }


### PR DESCRIPTION
This is to continue discussion of the topic [here](https://groups.google.com/forum/#!topic/openpnp/iFQVZyUgnlA). This has not been tested on my actual machine yet (which I will do this weekend), but it's just a few lines, seems to work in the emulator, and it'd be good to have a look from Jason before then. Since it defaults to disabled, and since the no existing code paths are disturbed if disabled, it seems low risk. 

This adds a "Rotate parts prior to vision?" checkbox to the Bottom Vision config page. If the user opts to do this, then in findsOffsets() the part will be pre-rotated (taking any PCB rotation into account) before vision alignment is performed.

Later in that same function when the PartAlignmentOffset() is instantiated and returned, the flag is set appropriately.


