### PR TITLE
Added currentStage, previousStage to CvPipeline. Added special stage …

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/vision/ReferenceBottomVision.java
+++ b/src/main/java/org/openpnp/machine/reference/vision/ReferenceBottomVision.java
@@ -129,7 +129,7 @@ public class ReferenceBottomVision implements PartAlignment {
                 1500);
 
 
-        return new PartAlignmentOffset(offsets.derive(0d, 0d, 0d, preRotateAngle), preRotate);
+        return new PartAlignmentOffset(offsets.derive(null, null, null, offsets.getRotation() + preRotateAngle),false);
     }
 
     @Override

--- a/src/main/java/org/openpnp/vision/pipeline/CvPipeline.java
+++ b/src/main/java/org/openpnp/vision/pipeline/CvPipeline.java
@@ -56,9 +56,6 @@ public class CvPipeline {
     private Mat workingImage;
     private Object workingModel;
     
-    private CvStage currentStage;
-    private CvStage previousStage;
-
     private Camera camera;
     private Nozzle nozzle;
     private Feeder feeder;
@@ -150,9 +147,6 @@ public class CvPipeline {
         if (name == null) {
             return null;
         }
-        if (name.trim().equals("..")) {
-          return getResult(getPreviousStage());
-        }
         return getResult(getStage(name));
     }
 
@@ -188,14 +182,6 @@ public class CvPipeline {
       return workingModel;
     }
 
-    public CvStage getCurrentStage() {
-      return this.currentStage;
-    }
-    
-    public CvStage getPreviousStage() {
-      return this.previousStage;
-    }
-    
     public void setCamera(Camera camera) {
         this.camera = camera;
     }
@@ -235,7 +221,6 @@ public class CvPipeline {
         for (CvStage stage : stages) {
             // Process and time the stage and get the result.
             long processingTimeNs = System.nanoTime();
-            currentStage = stage;
             Result result = null;
             try {
                 if (!stage.isEnabled()) {
@@ -248,7 +233,6 @@ public class CvPipeline {
             }
             processingTimeNs = System.nanoTime() - processingTimeNs;
             totalProcessingTimeNs += processingTimeNs;
-            previousStage = stage;
 
             Mat image = null;
             Object model = null;

--- a/src/main/java/org/openpnp/vision/pipeline/CvPipeline.java
+++ b/src/main/java/org/openpnp/vision/pipeline/CvPipeline.java
@@ -54,6 +54,7 @@ public class CvPipeline {
     private Map<CvStage, Result> results = new HashMap<CvStage, Result>();
 
     private Mat workingImage;
+    private Object workingModel;
     
     private CvStage currentStage;
     private CvStage previousStage;
@@ -183,6 +184,10 @@ public class CvPipeline {
         return workingImage;
     }
 
+    public Object getWorkingModel() {
+      return workingModel;
+    }
+
     public CvStage getCurrentStage() {
       return this.currentStage;
     }
@@ -251,7 +256,9 @@ public class CvPipeline {
                 image = result.image;
                 model = result.model;
             }
-
+            if(stage.isEnabled() && model != null) {
+              workingModel=model;
+            }
             // If the result image is null and there is a working image, replace the result image
             // replace the result image with a clone of the working image.
             if (image == null) {
@@ -289,6 +296,7 @@ public class CvPipeline {
                 result.image.release();
             }
         }
+        workingModel=null;
         results.clear();
     }
 

--- a/src/main/java/org/openpnp/vision/pipeline/CvPipeline.java
+++ b/src/main/java/org/openpnp/vision/pipeline/CvPipeline.java
@@ -54,6 +54,9 @@ public class CvPipeline {
     private Map<CvStage, Result> results = new HashMap<CvStage, Result>();
 
     private Mat workingImage;
+    
+    private CvStage currentStage;
+    private CvStage previousStage;
 
     private Camera camera;
     private Nozzle nozzle;
@@ -146,6 +149,9 @@ public class CvPipeline {
         if (name == null) {
             return null;
         }
+        if (name.trim().equals("..")) {
+          return getResult(getPreviousStage());
+        }
         return getResult(getStage(name));
     }
 
@@ -177,6 +183,14 @@ public class CvPipeline {
         return workingImage;
     }
 
+    public CvStage getCurrentStage() {
+      return this.currentStage;
+    }
+    
+    public CvStage getPreviousStage() {
+      return this.previousStage;
+    }
+    
     public void setCamera(Camera camera) {
         this.camera = camera;
     }
@@ -216,6 +230,7 @@ public class CvPipeline {
         for (CvStage stage : stages) {
             // Process and time the stage and get the result.
             long processingTimeNs = System.nanoTime();
+            currentStage = stage;
             Result result = null;
             try {
                 if (!stage.isEnabled()) {
@@ -228,6 +243,7 @@ public class CvPipeline {
             }
             processingTimeNs = System.nanoTime() - processingTimeNs;
             totalProcessingTimeNs += processingTimeNs;
+            previousStage = stage;
 
             Mat image = null;
             Object model = null;


### PR DESCRIPTION
…name `..` to mean `previousStage` for convenience.

# Description
This PR is a clean resubmission in place of #558 .

This PR adds the `previousStage` and `currentStage` properties to the CvPipeline class. The properties are read-only and return existing pipeline stages. No extra storage is required other than for the properties themselves and their getter methods.

This PR also adds the convenience stage name `..` to mean `previousStage` and return the contents of the `previousStage` property.

# Justification

Cascading of pipeline stages that operate on the working image is the default mode for the user of the opencv pipeline, and it is easy for the developer: method `getWorkingImage()` brings in the last image put in the pipeline by a previous stage.

The same is not true for a model produced by a previous stage. There is no method such as `getWorkingModel()` available to developers of pipeline stages, nor is there a way for a pipeline user to get the model output by the last stage, other than naming that stage explicitly. The pipeline is image-centric, but significant work is done too on models created by processing these images. These additions aim to make working with models similarly easy.

For pipeline users a convenience stage name, `..`,  is added as an alias to  `previousStage`. This makes it possible for users to cascade stages operating on models without the need to name these stages explicitly.

# Instructions for Use
The `previousStage` and `currentStage` are intended to be used by developers. `currentStage` can be used to get the name of a stage currently being processed, and will also help getting a stage's relative position in a pipeline, without resorting to looping through all stages of the pipeline and comparing. `previousStage` can help getting the results from the previous stage, both image and model, similarly without looping through all the pipeline stages.

Users will be able to use the name `..` for a stage to mean _previous stage_, which will allow them to cascade stages dealing with models.

# Implementation Details
1. The changes have been in continuous use for about 10 days in developing pipeline stages. No problems have been observed from such use. It should be noticed that contrary to the ill fated #558 PR, the pressent changes do not create or use new storage for images or models; the new class properties merely point to existing stage objects.
2. The coding style required by this project has been followed, and automatically verified.
3. No changes to `org.openpnp.spi` or `org.openpnp.model` packages were made.
4. The `mvn test` was run successfully before submitting the Pull Request.
