### PR TITLE
prerotate patch

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/ReferencePnpJobProcessor.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferencePnpJobProcessor.java
@@ -673,8 +673,9 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
                  */
                 if(plannedPlacement.alignmentOffsets.getPreRotated())
                 {
-                    Location location = plannedPlacement.alignmentOffsets.getLocation().multiply(-1.,-1.,0.,1);
-                    placementLocation = location.add(placementLocation);
+               
+                    placementLocation = placementLocation.subtract(plannedPlacement.alignmentOffsets.getLocation())
+                                        .derive(null,null,null,nozzle.getLocation().getRotation());
                 }
                 else
                 {

--- a/src/main/java/org/openpnp/machine/reference/ReferencePnpJobProcessor.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferencePnpJobProcessor.java
@@ -673,10 +673,8 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
                  */
                 if(plannedPlacement.alignmentOffsets.getPreRotated())
                 {
-                    Location location = placementLocation;
-                    location = location.derive(null, null, null,
-                            plannedPlacement.alignmentOffsets.getLocation().getRotation());
-                    placementLocation = location;
+                    Location location = plannedPlacement.alignmentOffsets.getLocation().multiply(-1.,-1.,0.,1);
+                    placementLocation = location.add(placementLocation);
                 }
                 else
                 {

--- a/src/main/java/org/openpnp/machine/reference/ReferencePnpJobProcessor.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferencePnpJobProcessor.java
@@ -672,8 +672,9 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
                         placed on, rotated to correct placement angle, and then picked up again.
                  */
                 if(plannedPlacement.alignmentOffsets.getPreRotated())
-                {
-               
+               {
+                    // part is preRotated and offset are related to XY orientatio n. 
+                    // small rotation can be applied (usually below 1/10 degree) 
                     placementLocation = placementLocation.subtractWithRotation(plannedPlacement.alignmentOffsets.getLocation());
                 }
                 else

--- a/src/main/java/org/openpnp/machine/reference/ReferencePnpJobProcessor.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferencePnpJobProcessor.java
@@ -674,8 +674,7 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
                 if(plannedPlacement.alignmentOffsets.getPreRotated())
                 {
                
-                    placementLocation = placementLocation.subtract(plannedPlacement.alignmentOffsets.getLocation())
-                                        .derive(null,null,null,nozzle.getLocation().getRotation());
+                    placementLocation = placementLocation.subtractWithRotation(plannedPlacement.alignmentOffsets.getLocation());
                 }
                 else
                 {

--- a/src/main/java/org/openpnp/machine/reference/vision/ReferenceBottomVision.java
+++ b/src/main/java/org/openpnp/machine/reference/vision/ReferenceBottomVision.java
@@ -107,7 +107,16 @@ public class ReferenceBottomVision implements PartAlignment {
         // so if OpenCV tells us it's rotated more than 45º we correct
         // it. This seems to happen quite a bit when the angle of rotation
         // is close to 0.
-        double angle = rect.angle;
+        while (Math.abs(preRotateAngle) > 45) {
+            if (preRotateAngle < 0) {
+                preRotateAngle += 90;
+            }
+            else {
+                preRotateAngle -= 90;
+            }
+        }
+
+        double angle = rect.angle + preRotateAngle;    // angle is CW, preRotateAngle is CCW
         while (Math.abs(angle) > 45) {
             if (angle < 0) {
                 angle += 90;
@@ -132,7 +141,7 @@ public class ReferenceBottomVision implements PartAlignment {
                 1500);
 
 
-        return new PartAlignmentOffset(offsets.derive(null, null, null, offsets.getRotation() + preRotateAngle),preRotate);
+        return new PartAlignmentOffset(offsets,false);
     }
 
     @Override

--- a/src/main/java/org/openpnp/machine/reference/vision/ReferenceBottomVision.java
+++ b/src/main/java/org/openpnp/machine/reference/vision/ReferenceBottomVision.java
@@ -132,7 +132,7 @@ public class ReferenceBottomVision implements PartAlignment {
                 1500);
 
 
-        return new PartAlignmentOffset(offsets.derive(null, null, 0., offsets.getRotation() + preRotateAngle),preRotate);
+        return new PartAlignmentOffset(offsets.derive(null, null, null, offsets.getRotation() + preRotateAngle),preRotate);
     }
 
     @Override

--- a/src/main/java/org/openpnp/machine/reference/vision/ReferenceBottomVision.java
+++ b/src/main/java/org/openpnp/machine/reference/vision/ReferenceBottomVision.java
@@ -132,7 +132,7 @@ public class ReferenceBottomVision implements PartAlignment {
                 1500);
 
 
-        return new PartAlignmentOffset(offsets.derive(null, null, null, offsets.getRotation() + preRotateAngle),preRotate);
+        return new PartAlignmentOffset(offsets.derive(null, null, 0., offsets.getRotation() + preRotateAngle),preRotate);
     }
 
     @Override

--- a/src/main/java/org/openpnp/machine/reference/vision/ReferenceBottomVision.java
+++ b/src/main/java/org/openpnp/machine/reference/vision/ReferenceBottomVision.java
@@ -129,11 +129,9 @@ public class ReferenceBottomVision implements PartAlignment {
         // Set the angle on the offsets.
         offsets = offsets.derive(null, null, null, -angle);
         if(preRotate||postRotate) {
-            Location placementLocation = new Location (LengthUnit.Millimeters);
-            Location location =
-                    new Location(LengthUnit.Millimeters).rotateXyCenterPoint(offsets,angle);
-            location = location.derive(null, null, null, nozzle.getLocation().getRotation()-angle);
-            offsets = location.subtract(offsets);
+           Location location = new Location(LengthUnit.Millimeters).rotateXyCenterPoint(offsets,angle);
+                    location = location.derive(null, null, null, nozzle.getLocation().getRotation()-angle);
+                    offsets  = location.subtract(offsets);
         }
 
 

--- a/src/main/java/org/openpnp/machine/reference/vision/ReferenceBottomVision.java
+++ b/src/main/java/org/openpnp/machine/reference/vision/ReferenceBottomVision.java
@@ -65,7 +65,7 @@ public class ReferenceBottomVision implements PartAlignment {
 
         // Pre-rotate to minimize runout
         double preRotateAngle = 0;
-        if (preRotate && boardLocation != null && placementLocation != null) {
+        if ( boardLocation != null && placementLocation != null) {
             preRotateAngle =
                     Utils2D.calculateBoardPlacementLocation(boardLocation, placementLocation)
                            .getRotation();
@@ -78,7 +78,7 @@ public class ReferenceBottomVision implements PartAlignment {
         Location partHeightLocation =
                 new Location(partHeight.getUnits(), 0, 0, partHeight.getValue(), 0);
         startLocation = startLocation.add(partHeightLocation)
-                                     .derive(null, null, null, preRotateAngle);
+                                     .derive(null, null, null, preRotate?preRotateAngle:null);
 
         MovableUtils.moveToLocationAtSafeZ(nozzle, startLocation);
 
@@ -86,8 +86,11 @@ public class ReferenceBottomVision implements PartAlignment {
 
         pipeline.setCamera(camera);
         pipeline.setNozzle(nozzle);
+        pipeline.setValue(preRotateAngle);     
         pipeline.process();
-
+        preRotate=preRotate||Double.isNaN(pipeline.getValue());
+        preRotateAngle = preRotate ? preRotateAngle : 0.;
+        
         Result result = pipeline.getResult("result");
         if (!(result.model instanceof RotatedRect)) {
             throw new Exception("Bottom vision alignment failed for part " + part.getId()
@@ -129,7 +132,7 @@ public class ReferenceBottomVision implements PartAlignment {
                 1500);
 
 
-        return new PartAlignmentOffset(offsets.derive(null, null, null, offsets.getRotation() + preRotateAngle),false);
+        return new PartAlignmentOffset(offsets.derive(null, null, null, offsets.getRotation() + preRotateAngle),preRotate);
     }
 
     @Override

--- a/src/main/java/org/openpnp/vision/pipeline/CvPipeline.java
+++ b/src/main/java/org/openpnp/vision/pipeline/CvPipeline.java
@@ -74,6 +74,7 @@ public class CvPipeline {
         }
     }
 
+    private double value;
     /**
      * Set double value for pipeline
      *

--- a/src/main/java/org/openpnp/vision/pipeline/CvPipeline.java
+++ b/src/main/java/org/openpnp/vision/pipeline/CvPipeline.java
@@ -87,6 +87,21 @@ public class CvPipeline {
         return value;
     }
 
+     /**
+     * Add the given CvStage to the end of the pipeline using the given name. If name is null a
+     * unique one will be generated and set on the stage.
+     * 
+     * @param name
+     * @param stage
+     */
+    public void add(String name, CvStage stage) {
+        if (name == null) {
+            name = generateUniqueName();
+        }
+        stage.setName(name);
+        stages.add(stage);
+     }
+ 
     /**
      * Add the given CvStage to the end of the pipeline. If the stage does not have a name a unique
      * one will be generated and set on the stage.

--- a/src/main/java/org/openpnp/vision/pipeline/CvPipeline.java
+++ b/src/main/java/org/openpnp/vision/pipeline/CvPipeline.java
@@ -75,18 +75,15 @@ public class CvPipeline {
     }
 
     /**
-     * Add the given CvStage to the end of the pipeline using the given name. If name is null a
-     * unique one will be generated and set on the stage.
-     * 
-     * @param name
-     * @param stage
+     * Set double value for pipeline
+     *
      */
-    public void add(String name, CvStage stage) {
-        if (name == null) {
-            name = generateUniqueName();
-        }
-        stage.setName(name);
-        stages.add(stage);
+    public void setValue(double val) {
+        value=val;
+    }
+
+    public double getValue() {
+        return value;
     }
 
     /**


### PR DESCRIPTION
# Justification
correct xy offset handling for prerotate and adding preliminary suport for per part prerotate.
What was previously wrong.
XY offsets:
Using preRotate boolean returned from partAligner there was not considered.
Returning false, there was calculated wrong.
As example if part is prerotated to 266 degree and part is wrong -16 degree, the X/Y offsets need to be
rotated only 16 degree instead of 272 degree as the previous code does.
The reason is that the rotation difference from reference picture to target position is only 16 degree and
not 272 degree because part was pictured with nozzle at 266 degree.
Further offset calc was presumibly wrong as the vision was checked for +-45 degree from horizontal 
and not related to final part rotation.

# Instructions for Use
same as before, 

This is documentation for a user, not for a developer.

# Implementation Detail
added generic double value support for pipeline, setValue and getValue 
that can be used to pass a double between pipeline and calling code.
On Bottomvision it passes down the final rotation angle, and if pipeline set it to NaN
bottomvision return the final offset preRotated.
corrected some offsets calcs, but all unproben as i actually cannot test it on real machine.
It should be verified before merging, user smdude ???