### PR TITLE
Fix the double line breaks from the script runners

### DIFF
--- a/src/main/java/org/openpnp/Main.java
+++ b/src/main/java/org/openpnp/Main.java
@@ -26,8 +26,10 @@ import javax.swing.UIManager;
 
 import org.openpnp.gui.MainFrame;
 import org.openpnp.logging.ConsoleWriter;
+import org.openpnp.logging.SystemLogger;
 import org.openpnp.model.Configuration;
 import org.pmw.tinylog.Configurator;
+import org.pmw.tinylog.Level;
 import org.pmw.tinylog.Logger;
 import org.pmw.tinylog.writers.RollingFileWriter;
 
@@ -65,13 +67,10 @@ public class Main {
             .activate();
 
         // Redirect the stdout and stderr to the LogPanel
-        // TODO: Temporarily commented out because of stack overflows on shutdown
-        // on Windows. See:
-        // https://github.com/openpnp/openpnp/issues/288
-//        SystemLogger out = new SystemLogger(System.out, Level.INFO);
-//        SystemLogger err = new SystemLogger(System.err, Level.ERROR);
-//        System.setOut(out);
-//        System.setErr(err);
+        SystemLogger out = new SystemLogger(System.out, Level.INFO);
+        SystemLogger err = new SystemLogger(System.err, Level.ERROR);
+        System.setOut(out);
+        System.setErr(err);
     }
     
     private static void monkeyPatchBeansBinding() {

--- a/src/main/java/org/openpnp/logging/SystemLogger.java
+++ b/src/main/java/org/openpnp/logging/SystemLogger.java
@@ -13,12 +13,10 @@ public class SystemLogger extends PrintStream {
     private StringBuilder logMessage = new StringBuilder();
 
     private Level logLevel;
-    private OutputStream out;
     private boolean logToLogger = true;
 
     public SystemLogger(OutputStream out, Level logLevel) {
         super(out);
-        this.out = out;
         this.logLevel = logLevel;
 
         // In order to stop logging on shutdown, we need to make sure that we do not call the Logger anymore

--- a/src/main/java/org/openpnp/logging/SystemLogger.java
+++ b/src/main/java/org/openpnp/logging/SystemLogger.java
@@ -48,21 +48,12 @@ public class SystemLogger extends PrintStream {
          * As tinylog will forward all logs to the console, we do not call the super method
          */
         if (logToLogger) {
-            byte[] pb = new byte[len];
-            System.arraycopy(buf, off, pb, 0, len);
-            String str = new String(pb);
-
-            // String builder cannot handle a byte array
-            for (int i = 0; i < len; i++) {
-                if (i == (len - 1)) {
-                    // The log message will appen a line break, so we remove the original one here
-                    if (pb[i] == '\n') {
-                        logMessage.append(str, 0, str.length() - 1);
-                        flushLogMessage();
-                    } else {
-                        logMessage.append(str, 0, str.length());
-                    }
-                }
+            String str = new String(buf, off, len);
+            if (str.endsWith("\n")) {
+                logMessage.append(str, 0, str.length() - 1);
+                flushLogMessage();
+            } else {
+                logMessage.append(str);
             }
         } else {
             super.write(buf, off, len);

--- a/src/main/java/org/openpnp/logging/SystemLogger.java
+++ b/src/main/java/org/openpnp/logging/SystemLogger.java
@@ -1,7 +1,6 @@
 package org.openpnp.logging;
 
-import java.io.OutputStream;
-import java.io.PrintStream;
+import java.io.*;
 
 import org.pmw.tinylog.Level;
 import org.pmw.tinylog.Logger;
@@ -11,27 +10,26 @@ import org.pmw.tinylog.Logger;
  */
 public class SystemLogger extends PrintStream {
 
-    private static final String lineSeparator = System.getProperty("line.separator");
+    private StringBuilder logMessage = new StringBuilder();
 
     private Level logLevel;
+    private OutputStream out;
+    private boolean logToLogger = true;
 
     public SystemLogger(OutputStream out, Level logLevel) {
         super(out);
+        this.out = out;
         this.logLevel = logLevel;
+
+        // In order to stop logging on shutdown, we need to make sure that we do not call the Logger anymore
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> logToLogger = false));
     }
 
-    public SystemLogger(OutputStream out) {
-        super(out);
-        this.logLevel = Level.INFO;
-    }
+    private void flushLogMessage() {
 
-    @Override
-    public void write(byte[] buf, int off, int len) {
-
-        byte[] pb = new byte[len];
-        System.arraycopy(buf, off, pb, 0, len);
-        String str = new String(pb);
-        str = str.replace(lineSeparator, "");
+        String str = logMessage.toString();
+        logMessage.setLength(0); // set length of buffer to 0
+        logMessage.trimToSize(); // trim the underlying buffer
 
         // There is no generic log function where one could pass the log level
         switch (logLevel) {
@@ -41,6 +39,35 @@ public class SystemLogger extends PrintStream {
             case ERROR:
                 Logger.error(str);
                 break;
+        }
+
+    }
+
+    @Override
+    public void write(byte[] buf, int off, int len) {
+        /*
+         * Log to tinylog as long as the Logger is available (before shutdown)
+         * As tinylog will forward all logs to the console, we do not call the super method
+         */
+        if (logToLogger) {
+            byte[] pb = new byte[len];
+            System.arraycopy(buf, off, pb, 0, len);
+            String str = new String(pb);
+
+            // String builder cannot handle a byte array
+            for (int i = 0; i < len; i++) {
+                if (i == (len - 1)) {
+                    // The log message will appen a line break, so we remove the original one here
+                    if (pb[i] == '\n') {
+                        logMessage.append(str, 0, str.length() - 1);
+                        flushLogMessage();
+                    } else {
+                        logMessage.append(str, 0, str.length());
+                    }
+                }
+            }
+        } else {
+            super.write(buf, off, len);
         }
     }
 }


### PR DESCRIPTION
# Description

As promised I took a look at this. Had not much time recently, but today I found some hours.

1. Fix the StackOverflow on shutdown where Logger gets called but is no longer available (exception loop) #288 
2. Fix the double new line issues with the Script Runners #515

The Logger will attach a listener to the VM Shutdown. Otherwise I cannot know if the tinylog logger is still available. This could be replaced by a teardown function, but right now this stuff is split up between the `Main` class and the `MainFrame`.

The code for fixing the newline issue is not the best, but using the `StringBuilder` was my favorite option altough maybe not the best in this case (some bytearray might be better or something similar).

Best, Friedrich

