### PR TITLE
Pre rotate test

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/ReferencePnpJobProcessor.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferencePnpJobProcessor.java
@@ -671,15 +671,8 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
                         - this is useful for say an external rotating stage that the component is
                         placed on, rotated to correct placement angle, and then picked up again.
                  */
-                if(plannedPlacement.alignmentOffsets.getPreRotated())
-                {
-                    Location location = placementLocation;
-                    location = location.derive(null, null, null,
-                            plannedPlacement.alignmentOffsets.getLocation().getRotation());
-                    placementLocation = location;
-                }
-                else
-                {
+                if(plannedPlacement.alignmentOffsets.getPreRotated()) {	placementLocation = placementLocation.subtractWithRotation(plannedPlacement.alignmentOffsets.getLocation()); }
+                else {
                     Location alignmentOffsets = plannedPlacement.alignmentOffsets.getLocation();
                     // Rotate the point 0,0 using the alignment offsets as a center point by the angle
                     // that is

--- a/src/main/java/org/openpnp/machine/reference/vision/wizards/ReferenceBottomVisionPartConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/vision/wizards/ReferenceBottomVisionPartConfigurationWizard.java
@@ -121,10 +121,8 @@ public class ReferenceBottomVisionPartConfigurationWizard extends AbstractConfig
         Nozzle nozzle = MainFrame.get().getMachineControls().getSelectedNozzle();
 
         // perform the alignment
-
-
         PartAlignment.PartAlignmentOffset alignmentOffset =
-                VisionUtils.findPartAlignmentOffsets(bottomVision, part, null, null, nozzle);
+                VisionUtils.findPartAlignmentOffsets(bottomVision, part, null, new Location(LengthUnit.Millimeters), nozzle);
         Location offsets = alignmentOffset.getLocation();
 
         if (!chckbxCenterAfterTest.isSelected()) {
@@ -133,6 +131,14 @@ public class ReferenceBottomVisionPartConfigurationWizard extends AbstractConfig
 
         // position the part over camera center
         Location cameraLocation = VisionUtils.getBottomVisionCamera().getLocation();
+		
+		if(alignmentOffset.getPreRotated()) {
+			if(Math.abs(alignmentOffset.getLocation().convertToUnits(LengthUnit.Millimeters).getLinearDistanceTo(0.,0.))>19.999) {
+				throw new Exception("Offset too big");
+			}
+			nozzle.moveTo(nozzle.getLocation().subtract(alignmentOffset.getLocation()),nozzle.getPart().getSpeed());
+			return;
+		}
 
         // Rotate the point 0,0 using the bottom offsets as a center point by the angle
         // that is


### PR DESCRIPTION
Test prerotate feature with ClosedLoop Stage removed as wanted by  @vonnieda  comments.
It now work globally without the possibility to have it per part or to do better alignment using closed loop
vision process.

Superset of this feature was tested, it should work and just one picture was tested on this branch.
If first stage is ImageRead and second stage is Rotate it works on stored images.
I have leaved this feature for testing purposes.