### PR TITLE
Pre rotate fix

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/ReferencePnpJobProcessor.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferencePnpJobProcessor.java
@@ -671,15 +671,8 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
                         - this is useful for say an external rotating stage that the component is
                         placed on, rotated to correct placement angle, and then picked up again.
                  */
-                if(plannedPlacement.alignmentOffsets.getPreRotated())
-                {
-                    Location location = placementLocation;
-                    location = location.derive(null, null, null,
-                            plannedPlacement.alignmentOffsets.getLocation().getRotation());
-                    placementLocation = location;
-                }
-                else
-                {
+                if(plannedPlacement.alignmentOffsets.getPreRotated()) {	placementLocation = placementLocation.subtractWithRotation(plannedPlacement.alignmentOffsets.getLocation()); }
+                else {
                     Location alignmentOffsets = plannedPlacement.alignmentOffsets.getLocation();
                     // Rotate the point 0,0 using the alignment offsets as a center point by the angle
                     // that is

--- a/src/main/java/org/openpnp/machine/reference/vision/ReferenceBottomVision.java
+++ b/src/main/java/org/openpnp/machine/reference/vision/ReferenceBottomVision.java
@@ -69,6 +69,8 @@ public class ReferenceBottomVision implements PartAlignment {
         // Pre-rotate to minimize runout
         double preRotateAngle = 0;
         if (preRotate) {
+		// Prerotate just prerotate nozzle, take picture, adjust rotation and take second picture before getting xy offsets.
+		// is is complicated by the fact that it need some workaround for rotation angle that is not normalized.
 			if(part == null || nozzle.getPart() == null) { throw new Exception("no part on nozzle"); }			
 			if((!part.toString().equals(nozzle.getPart().toString()))) { throw new Exception("Part mismatch with part on nozzle"); }
 			part=nozzle.getPart();
@@ -88,6 +90,7 @@ public class ReferenceBottomVision implements PartAlignment {
 				throw new Exception("Bottom vision alignment failed for part " + part.getId()
 						+ " on nozzle " + nozzle.getName() + ". No result found.");
 			}
+		// first picture was ok, now calc error
 
 
 			RotatedRect rect = ((RotatedRect)(pipeline.getResult("result")).model);
@@ -96,13 +99,14 @@ public class ReferenceBottomVision implements PartAlignment {
 			while (Math.abs(rect.angle) > 45.0) { rect.angle += (rect.angle < 0)? 90 : -90; } 
 			angle += rect.angle;
 			while (Math.abs(angle) > 45.0) { angle += (angle < 0.)? 90 : -90; } 
-
+		// error is -angle
 			nozzle.moveTo(new Location(LengthUnit.Millimeters,Double.NaN, Double.NaN, Double.NaN, placementAngle+angle), part.getSpeed());
 			pipeline.process();
 			if (!((pipeline.getResult("result")).model instanceof RotatedRect)) {
 				throw new Exception("Bottom vision alignment failed for part " + part.getId()
-					 " on nozzle " + nozzle.getName() + ". No result found.");
+					+ " on nozzle " + nozzle.getName() + ". No result found.");
 			}
+		// second picture taken
 
 			rect = (RotatedRect) pipeline.getResult("result").model;
                         Logger.debug("Result rect {}", rect);

--- a/src/main/java/org/openpnp/machine/reference/vision/ReferenceBottomVision.java
+++ b/src/main/java/org/openpnp/machine/reference/vision/ReferenceBottomVision.java
@@ -100,6 +100,8 @@ public class ReferenceBottomVision implements PartAlignment {
 			angle += rect.angle;
 			while (Math.abs(angle) > 45.0) { angle += (angle < 0.)? 90 : -90; } 
 		// error is -angle
+			if(Math.abs(angle)>0.0765) { angle+=0.0567 * Math.signum(angle); } // rounding 
+		// error 
 			nozzle.moveTo(new Location(LengthUnit.Millimeters,Double.NaN, Double.NaN, Double.NaN, placementAngle+angle), part.getSpeed());
 			pipeline.process();
 			if (!((pipeline.getResult("result")).model instanceof RotatedRect)) {

--- a/src/main/java/org/openpnp/machine/reference/vision/ReferenceBottomVision.java
+++ b/src/main/java/org/openpnp/machine/reference/vision/ReferenceBottomVision.java
@@ -110,8 +110,8 @@ public class ReferenceBottomVision implements PartAlignment {
 
 			rect = (RotatedRect) pipeline.getResult("result").model;
                         Logger.debug("Result rect {}", rect);
-		        String s = "Align offset for "+part.getName()+": " + offsets.toString() + "     ";
 			Location offsets = VisionUtils.getPixelCenterOffsets(pipeline.getCamera(), rect.center.x, rect.center.y).derive(null,null,null,Double.NaN);
+		        String s = "Align offset for "+part.getName()+": " + offsets.toString() + "     ";
                         MainFrame.get().getCameraViews().getCameraView(pipeline.getCamera()).showFilteredImage(OpenCvUtils.toBufferedImage(pipeline.getWorkingImage()),  s , 1500);
 			return new PartAlignment.PartAlignmentOffset(offsets, true);
         }

--- a/src/main/java/org/openpnp/machine/reference/vision/ReferenceBottomVision.java
+++ b/src/main/java/org/openpnp/machine/reference/vision/ReferenceBottomVision.java
@@ -106,8 +106,9 @@ public class ReferenceBottomVision implements PartAlignment {
 
 			rect = (RotatedRect) pipeline.getResult("result").model;
                         Logger.debug("Result rect {}", rect);
+		        String s = "Align offset for "+part.getName()+": " + offsets.toString() + "     ";
 			Location offsets = VisionUtils.getPixelCenterOffsets(pipeline.getCamera(), rect.center.x, rect.center.y).derive(null,null,null,Double.NaN);
-                        MainFrame.get().getCameraViews().getCameraView(pipeline.getCamera()).showFilteredImage(OpenCvUtils.toBufferedImage(pipeline.getWorkingImage()),  "Align offset for "+part.getName()+": " + offsets.toString() + "     " , 1500);
+                        MainFrame.get().getCameraViews().getCameraView(pipeline.getCamera()).showFilteredImage(OpenCvUtils.toBufferedImage(pipeline.getWorkingImage()),  s , 1500);
 			return new PartAlignment.PartAlignmentOffset(offsets, true);
         }
 

--- a/src/main/java/org/openpnp/machine/reference/vision/ReferenceBottomVision.java
+++ b/src/main/java/org/openpnp/machine/reference/vision/ReferenceBottomVision.java
@@ -2,6 +2,7 @@ package org.openpnp.machine.reference.vision;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.List;
 
 import javax.swing.Action;
 import javax.swing.Icon;
@@ -68,21 +69,26 @@ public class ReferenceBottomVision implements PartAlignment {
         // Pre-rotate to minimize runout
         double preRotateAngle = 0;
         if (preRotate) {
-			if((!part.toString().equals(nozzle.getPart().toString()))) { throw new Exception("Part mismatch with part on nozzle"); }			
-			if((part = nozzle.getPart()) == null) 					   { throw new Exception("no part on nozzle"); }			
+			if(part == null || nozzle.getPart() == null) 					   { throw new Exception("no part on nozzle"); }			
+			if((!part.toString().equals(nozzle.getPart().toString()))) { throw new Exception("Part mismatch with part on nozzle"); }
+			part=nozzle.getPart();
 			double angle = placementLocation.getRotation();
 			if(boardLocation!=null) {
 				angle = Utils2D.calculateBoardPlacementLocation(boardLocation, placementLocation).getRotation();              
 			}
 			while (Math.abs(angle) > 180.0) { angle += (angle < 0.)? 360. : -360.; } 
-            MovableUtils.moveToLocationAtSafeZ(nozzle, VisionUtils.getBottomVisionCamera().getLocation().add(new Location(part.getHeight().getUnits(), 0.0, 0.0,part.getHeight().getValue(), 0.0)).derive(null, null, null, angle));
 			double nozzleAngle=angle;
+			double placementAngle=angle;
+            MovableUtils.moveToLocationAtSafeZ(nozzle, VisionUtils.getBottomVisionCamera().getLocation().add(new Location(part.getHeight().getUnits(), 0.0, 0.0,part.getHeight().getValue(), 0.0)).derive(null, null, null, angle));
             CvPipeline pipeline = partSettings.getPipeline();
             pipeline.setCamera(VisionUtils.getBottomVisionCamera());
             pipeline.setNozzle(nozzle);
+			pipeline.setValue(angle);
+				Logger.info("pipeline {} -- angle {} -- nozzleAngle {} ",pipeline.getValue(), angle, nozzleAngle);
+			if(Boolean.getBoolean("develop")) {
             if ("Rotate".equals(pipeline.getStages().get(1).getClass().getSimpleName())) {
                 ((Rotate)pipeline.getStages().get(1)).setDegrees( angle );
-            }
+            }}
 			pipeline.process();
 			if (!((pipeline.getResult("result")).model instanceof RotatedRect)) {
 				throw new Exception("Bottom vision alignment failed for part " + part.getId()
@@ -93,24 +99,44 @@ public class ReferenceBottomVision implements PartAlignment {
 			RotatedRect rect = ((RotatedRect)(pipeline.getResult("result")).model);
 			if (rect.size.width < rect.size.height) { rect.angle = 90 + rect.angle; }
             Logger.debug("Result rect {}", rect);
-			while (Math.abs(angle) > 45.0) { angle += (angle < 0.)? 90 : -90; } 
+			while (Math.abs(angle) > 45.0) { nozzleAngle= (angle += (angle < 0.)? 90 : -90); } 
 			while (Math.abs(rect.angle) > 45.0) { rect.angle += (rect.angle < 0)? 90 : -90; } 
 			angle += rect.angle;
 			while (Math.abs(angle) > 45.0) { angle += (angle < 0.)? 90 : -90; } 
-	
-			Location offsets = new Location(LengthUnit.Millimeters,Double.NaN, Double.NaN, Double.NaN, nozzleAngle+angle);
-		    nozzle.moveTo(offsets, part.getSpeed());
-			pipeline.process();
-			if (!((pipeline.getResult("result")).model instanceof RotatedRect)) {
-				throw new Exception("Bottom vision alignment failed for part " + part.getId()
-						+ " on nozzle " + nozzle.getName() + ". No result found.");
+
+			int cnt=1;
+			if (pipeline.getResult("contours")!=null&&pipeline.getResult("contours").model instanceof List<?>) {
+				cnt=((List<?>)(pipeline.getResult("contours")).model).size();
 			}
 
-			rect = (RotatedRect) pipeline.getResult("result").model;
-			offsets = VisionUtils.getPixelCenterOffsets(pipeline.getCamera(), rect.center.x, rect.center.y).derive(null,null,null,-angle);
-            String s = "Align offset for "+part.getName()+": " + offsets.toString() + "     " ;
-			MainFrame.get().setStatus(s);
-			offsets = offsets.derive(null,null,null,Double.NaN);
+			String s="";
+			Location offsets = null;
+			int old=999;
+			int rot=999; do {	
+				Logger.info("pipeline {} -- angle {} -- nozzleAngle {} ",pipeline.getValue(), angle, nozzleAngle);
+				offsets = new Location(LengthUnit.Millimeters,Double.NaN, Double.NaN, Double.NaN, placementAngle+angle);
+				nozzle.moveTo(offsets, part.getSpeed());
+				pipeline.process();
+				if (!((pipeline.getResult("result")).model instanceof RotatedRect)) {
+					throw new Exception("Bottom vision alignment failed for part " + part.getId()
+							+ " on nozzle " + nozzle.getName() + ". No result found.");
+				}
+
+				rect = (RotatedRect) pipeline.getResult("result").model;
+				offsets = VisionUtils.getPixelCenterOffsets(pipeline.getCamera(), rect.center.x, rect.center.y).derive(null,null,null,-angle);
+				s = "Align offset for "+part.getName()+": " + offsets.toString() + "     " ;
+				MainFrame.get().setStatus(s);
+				offsets = offsets.derive(null,null,null,Double.NaN);
+				if(cnt>Integer.getInt("contours",40)) {
+					if (rect.size.width < rect.size.height) { rect.angle = 90 + rect.angle; }
+					while (Math.abs(rect.angle) > 45.0) { rect.angle += (rect.angle < 0)? 90 : -90; } 
+					angle=nozzleAngle + rect.angle;
+					while (Math.abs(angle) > 45.0) { angle += (angle < 0.)? 90 : -90; }
+					double step=(360./200./16.);
+					old=rot;
+					rot=(int)((angle+step/2.)/step);
+					angle=rot*step+(step/2)*Math.signum(angle);
+			}} while(Math.abs(rot)!=0&&rot>old);
           
             MainFrame.get().getCameraViews().getCameraView(pipeline.getCamera()).showFilteredImage(OpenCvUtils.toBufferedImage(pipeline.getWorkingImage()), s, 1500);
 			return new PartAlignment.PartAlignmentOffset(offsets, true);

--- a/src/main/java/org/openpnp/machine/reference/vision/ReferenceBottomVision.java
+++ b/src/main/java/org/openpnp/machine/reference/vision/ReferenceBottomVision.java
@@ -84,7 +84,6 @@ public class ReferenceBottomVision implements PartAlignment {
             pipeline.setCamera(VisionUtils.getBottomVisionCamera());
             pipeline.setNozzle(nozzle);
 			pipeline.setValue(angle);
-				Logger.info("pipeline {} -- angle {} -- nozzleAngle {} ",pipeline.getValue(), angle, nozzleAngle);
 			if(Boolean.getBoolean("develop")) {
             if ("Rotate".equals(pipeline.getStages().get(1).getClass().getSimpleName())) {
                 ((Rotate)pipeline.getStages().get(1)).setDegrees( angle );
@@ -113,7 +112,6 @@ public class ReferenceBottomVision implements PartAlignment {
 			Location offsets = null;
 			int old=999;
 			int rot=999; do {	
-				Logger.info("pipeline {} -- angle {} -- nozzleAngle {} ",pipeline.getValue(), angle, nozzleAngle);
 				offsets = new Location(LengthUnit.Millimeters,Double.NaN, Double.NaN, Double.NaN, placementAngle+angle);
 				nozzle.moveTo(offsets, part.getSpeed());
 				pipeline.process();
@@ -123,6 +121,7 @@ public class ReferenceBottomVision implements PartAlignment {
 				}
 
 				rect = (RotatedRect) pipeline.getResult("result").model;
+		                Logger.debug("Result rect {} inside vision loop", rect);
 				offsets = VisionUtils.getPixelCenterOffsets(pipeline.getCamera(), rect.center.x, rect.center.y).derive(null,null,null,-angle);
 				s = "Align offset for "+part.getName()+": " + offsets.toString() + "     " ;
 				MainFrame.get().setStatus(s);

--- a/src/main/java/org/openpnp/machine/reference/vision/ReferenceBottomVision.java
+++ b/src/main/java/org/openpnp/machine/reference/vision/ReferenceBottomVision.java
@@ -126,7 +126,7 @@ public class ReferenceBottomVision implements PartAlignment {
 				s = "Align offset for "+part.getName()+": " + offsets.toString() + "     " ;
 				MainFrame.get().setStatus(s);
 				offsets = offsets.derive(null,null,null,Double.NaN);
-				if(cnt>Integer.getInteger("contours",40)) {
+				if(cnt>Integer.getInteger("contours",40)||Double.isNaN(pipeline.getValue())) {
 					if (rect.size.width < rect.size.height) { rect.angle = 90 + rect.angle; }
 					while (Math.abs(rect.angle) > 45.0) { rect.angle += (rect.angle < 0)? 90 : -90; } 
 					angle=nozzleAngle + rect.angle;

--- a/src/main/java/org/openpnp/machine/reference/vision/ReferenceBottomVision.java
+++ b/src/main/java/org/openpnp/machine/reference/vision/ReferenceBottomVision.java
@@ -126,7 +126,7 @@ public class ReferenceBottomVision implements PartAlignment {
 				s = "Align offset for "+part.getName()+": " + offsets.toString() + "     " ;
 				MainFrame.get().setStatus(s);
 				offsets = offsets.derive(null,null,null,Double.NaN);
-				if(cnt>Integer.getInt("contours",40)) {
+				if(cnt>Integer.getInteger("contours",40)) {
 					if (rect.size.width < rect.size.height) { rect.angle = 90 + rect.angle; }
 					while (Math.abs(rect.angle) > 45.0) { rect.angle += (rect.angle < 0)? 90 : -90; } 
 					angle=nozzleAngle + rect.angle;

--- a/src/main/java/org/openpnp/machine/reference/vision/ReferenceBottomVision.java
+++ b/src/main/java/org/openpnp/machine/reference/vision/ReferenceBottomVision.java
@@ -54,6 +54,12 @@ public class ReferenceBottomVision implements PartAlignment {
     @ElementMap(required = false)
     protected Map<String, PartSettings> partSettingsByPartId = new HashMap<>();
 
+	private double angleNorm(double val, double lim)  { double clip = lim*2;
+			while (Math.abs(val) > lim) { nozzleAngle= (val += (val < 0.)? clip : -clip); }
+            return val;
+    } 
+	private double angleNorm(double val)  { return angleNorm(val,45.); }
+	
 
     @Override
     public PartAlignmentOffset findOffsets(Part part, BoardLocation boardLocation,
@@ -69,8 +75,6 @@ public class ReferenceBottomVision implements PartAlignment {
         // Pre-rotate to minimize runout
         double preRotateAngle = 0;
         if (preRotate) {
-		// Prerotate just prerotate nozzle, take picture, adjust rotation and take second picture before getting xy offsets.
-		// is is complicated by the fact that it need some workaround for rotation angle that is not normalized.
 			if(part == null || nozzle.getPart() == null) { throw new Exception("no part on nozzle"); }			
 			if((!part.toString().equals(nozzle.getPart().toString()))) { throw new Exception("Part mismatch with part on nozzle"); }
 			part=nozzle.getPart();
@@ -78,7 +82,7 @@ public class ReferenceBottomVision implements PartAlignment {
 			if(boardLocation!=null) {
 				angle = Utils2D.calculateBoardPlacementLocation(boardLocation, placementLocation).getRotation();              
 			}
-			while (Math.abs(angle) > 180.0) { angle += (angle < 0.)? 360. : -360.; } 
+			angle=angleNorm(angle,180.);
 			double nozzleAngle=angle;
 			double placementAngle=angle;
                         MovableUtils.moveToLocationAtSafeZ(nozzle, VisionUtils.getBottomVisionCamera().getLocation().add(new Location(part.getHeight().getUnits(), 0.0, 0.0,part.getHeight().getValue(), 0.0)).derive(null, null, null, angle));
@@ -90,25 +94,17 @@ public class ReferenceBottomVision implements PartAlignment {
 				throw new Exception("Bottom vision alignment failed for part " + part.getId()
 						+ " on nozzle " + nozzle.getName() + ". No result found.");
 			}
-		// first picture was ok, now calc error
-
 
 			RotatedRect rect = ((RotatedRect)(pipeline.getResult("result")).model);
-			if (rect.size.width < rect.size.height) { rect.angle = 90 + rect.angle; }
-			while (Math.abs(angle) > 45.0) { nozzleAngle= (angle += (angle < 0.)? 90 : -90); } 
-			while (Math.abs(rect.angle) > 45.0) { rect.angle += (rect.angle < 0)? 90 : -90; } 
-			angle += rect.angle;
-			while (Math.abs(angle) > 45.0) { angle += (angle < 0.)? 90 : -90; } 
+			angle = angleNorm(angleNorm(angle) + angleNorm((rect.size.width < rect.size.height) ? 90 + rect.angle : rect.angle));
 		// error is -angle
 			if(Math.abs(angle)>0.0765) { angle+=0.0567 * Math.signum(angle); } // rounding 
-		// error 
 			nozzle.moveTo(new Location(LengthUnit.Millimeters,Double.NaN, Double.NaN, Double.NaN, placementAngle+angle), part.getSpeed());
 			pipeline.process();
 			if (!((pipeline.getResult("result")).model instanceof RotatedRect)) {
 				throw new Exception("Bottom vision alignment failed for part " + part.getId()
 					+ " on nozzle " + nozzle.getName() + ". No result found.");
 			}
-		// second picture taken
 
 			rect = (RotatedRect) pipeline.getResult("result").model;
                         Logger.debug("Result rect {}", rect);

--- a/src/main/java/org/openpnp/machine/reference/vision/wizards/ReferenceBottomVisionPartConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/vision/wizards/ReferenceBottomVisionPartConfigurationWizard.java
@@ -121,10 +121,8 @@ public class ReferenceBottomVisionPartConfigurationWizard extends AbstractConfig
         Nozzle nozzle = MainFrame.get().getMachineControls().getSelectedNozzle();
 
         // perform the alignment
-
-
         PartAlignment.PartAlignmentOffset alignmentOffset =
-                VisionUtils.findPartAlignmentOffsets(bottomVision, part, null, null, nozzle);
+                VisionUtils.findPartAlignmentOffsets(bottomVision, part, null, new Location(LengthUnit.Millimeters), nozzle);
         Location offsets = alignmentOffset.getLocation();
 
         if (!chckbxCenterAfterTest.isSelected()) {
@@ -133,6 +131,14 @@ public class ReferenceBottomVisionPartConfigurationWizard extends AbstractConfig
 
         // position the part over camera center
         Location cameraLocation = VisionUtils.getBottomVisionCamera().getLocation();
+		
+		if(alignmentOffset.getPreRotated()) {
+			if(Math.abs(alignmentOffset.getLocation().convertToUnits(LengthUnit.Millimeters).getLinearDistanceTo(0.,0.))>19.999) {
+				throw new Exception("Offset too big");
+			}
+			nozzle.moveTo(nozzle.getLocation().subtract(alignmentOffset.getLocation()),nozzle.getPart().getSpeed());
+			return;
+		}
 
         // Rotate the point 0,0 using the bottom offsets as a center point by the angle
         // that is

--- a/src/main/java/org/openpnp/vision/pipeline/CvPipeline.java
+++ b/src/main/java/org/openpnp/vision/pipeline/CvPipeline.java
@@ -59,7 +59,6 @@ public class CvPipeline {
     private Camera camera;
     private Nozzle nozzle;
     private Feeder feeder;
-	private double value;
     
     private long totalProcessingTimeNs;
     
@@ -199,14 +198,6 @@ public class CvPipeline {
         return nozzle;
     }
 	
-    public void setValue(double value) {
-        this.value = value;
-    }
-
-    public double getValue() {
-        return value;
-    }
-  
     public void setFeeder(Feeder feeder) {
         this.feeder = feeder;
     }

--- a/src/main/java/org/openpnp/vision/pipeline/CvPipeline.java
+++ b/src/main/java/org/openpnp/vision/pipeline/CvPipeline.java
@@ -59,6 +59,7 @@ public class CvPipeline {
     private Camera camera;
     private Nozzle nozzle;
     private Feeder feeder;
+	private double value;
     
     private long totalProcessingTimeNs;
     
@@ -196,6 +197,14 @@ public class CvPipeline {
 
     public Nozzle getNozzle() {
         return nozzle;
+    }
+	
+    public void setValue(double value) {
+        this.value = value;
+    }
+
+    public double getValue() {
+        return value;
     }
   
     public void setFeeder(Feeder feeder) {


### PR DESCRIPTION
# Description
It does prerote removing nozzle runout offset.

setValue/getValue is needed for several stages that need to know the intended rotation on bottom vision, one example is ImageCapture if it need takin 2 snapshoot and stitch the image because camera
FOV is too small.
It require the "Temporarily disable the Bottom Vision pre-rotate feature until ..." commit to be rolled back.

# Justification
#401 was mentioned , but was not the origin of this PR:

# Instructions for Use
Just set the checkbox and prerotation get enabled.

# Implementation Details
SMdude have done the tests , a big thank to him.
