### PR TITLE
Protect board against nozzle

### DIFF
--- a/src/main/java/org/openpnp/gui/JobPanel.java
+++ b/src/main/java/org/openpnp/gui/JobPanel.java
@@ -147,8 +147,7 @@ public class JobPanel extends JPanel {
 
     private FiniteStateMachine<State, Message> fsm = new FiniteStateMachine<>(State.Stopped);
 
-    public JobPanel(Configuration configuration, MainFrame frame,
-            MachineControlsPanel machineControlsPanel) {
+    public JobPanel(Configuration configuration, MainFrame frame) {
         this.configuration = configuration;
         this.frame = frame;
 

--- a/src/main/java/org/openpnp/gui/JogControlsPanel.java
+++ b/src/main/java/org/openpnp/gui/JogControlsPanel.java
@@ -221,7 +221,8 @@ public class JogControlsPanel extends JPanel {
                             targetLocation, new Length(1.0, l.getUnits()));
                     if (!safe) {
                         throw new Exception(
-                                "Z Axis would move against " + boardLocation.toString());
+                                "Nozzle would crash into board: " + boardLocation.toString() + "\n" +
+                                "To disable the board protection go to the \"Safety\" tab in the \"Machine Controls\" panel.");
                     }
                 }
             }
@@ -325,9 +326,6 @@ public class JogControlsPanel extends JPanel {
         homeButton.setIcon(Icons.home);
         homeButton.setHideActionText(true);
         panelControls.add(homeButton, "2, 2");
-
-        boardProtectionOverrideCheck = new JCheckBox("Override Board Protection");
-        panelControls.add(boardProtectionOverrideCheck, "24, 2");
 
         JLabel lblXy = new JLabel("X/Y");
         lblXy.setFont(new Font("Lucida Grande", Font.PLAIN, 22));
@@ -458,6 +456,14 @@ public class JogControlsPanel extends JPanel {
         tabbedPane_1.addTab("Dispense", null, panelDispensers, null);
         FlowLayout flowLayout = (FlowLayout) panelDispensers.getLayout();
         flowLayout.setAlignment(FlowLayout.LEFT);
+        
+        JPanel panelSafety = new JPanel();
+        tabbedPane_1.addTab("Safety", null, panelSafety, null);
+        panelSafety.setLayout(new FlowLayout(FlowLayout.LEFT, 5, 5));
+
+        boardProtectionOverrideCheck = new JCheckBox("Override Board Protection");
+        boardProtectionOverrideCheck.setToolTipText("Disable protection of the nozzle jogging closer than 1mm to any loaded board.");
+        panelSafety.add(boardProtectionOverrideCheck, "1, 1");
     }
 
     private FocusTraversalPolicy focusPolicy = new FocusTraversalPolicy() {

--- a/src/main/java/org/openpnp/gui/JogControlsPanel.java
+++ b/src/main/java/org/openpnp/gui/JogControlsPanel.java
@@ -29,12 +29,14 @@ import java.awt.event.ActionEvent;
 import java.beans.PropertyChangeListener;
 import java.util.HashMap;
 import java.util.Hashtable;
+import java.util.List;
 import java.util.Map;
 
 import javax.swing.AbstractAction;
 import javax.swing.Action;
 import javax.swing.BoxLayout;
 import javax.swing.JButton;
+import javax.swing.JCheckBox;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JSlider;
@@ -45,10 +47,14 @@ import javax.swing.event.ChangeListener;
 
 import org.openpnp.ConfigurationListener;
 import org.openpnp.gui.support.Icons;
+import org.openpnp.model.Board;
+import org.openpnp.model.BoardLocation;
 import org.openpnp.model.Configuration;
+import org.openpnp.model.Job;
 import org.openpnp.model.Length;
 import org.openpnp.model.LengthUnit;
 import org.openpnp.model.Location;
+import org.openpnp.model.Point;
 import org.openpnp.spi.Actuator;
 import org.openpnp.spi.Head;
 import org.openpnp.spi.HeadMountable;
@@ -76,6 +82,7 @@ public class JogControlsPanel extends JPanel {
     private JPanel panelActuators;
     private JPanel panelDispensers;
     private JSlider sliderIncrements;
+    private JCheckBox boardProtectionOverrideCheck;
 
     /**
      * Create the panel.
@@ -152,10 +159,16 @@ public class JogControlsPanel extends JPanel {
         }
     }
 
+    public boolean getBoardProtectionOverrideEnabled() {
+        return boardProtectionOverrideCheck.isSelected();
+    }
+
     private void jog(final int x, final int y, final int z, final int c) {
         UiUtils.submitUiMachineTask(() -> {
             HeadMountable tool = machineControlsPanel.getSelectedTool();
-            Location l = tool.getLocation().convertToUnits(Configuration.get().getSystemUnits());
+            Location l = tool.getLocation()
+                             .convertToUnits(Configuration.get()
+                                                          .getSystemUnits());
             double xPos = l.getX();
             double yPos = l.getY();
             double zPos = l.getZ();
@@ -192,15 +205,80 @@ public class JogControlsPanel extends JPanel {
                 cPos -= jogIncrement;
             }
 
-            tool.moveTo(new Location(l.getUnits(), xPos, yPos, zPos, cPos));
+            Location targetLocation = new Location(l.getUnits(), xPos, yPos, zPos, cPos);
+            if (!this.getBoardProtectionOverrideEnabled()) {
+                /* check board location before movement */
+                List<BoardLocation> boardLocations = machineControlsPanel.getJobPanel()
+                                                                         .getJob()
+                                                                         .getBoardLocations();
+                for (BoardLocation boardLocation : boardLocations) {
+                    if (!boardLocation.isEnabled()) {
+                        continue;
+                    }
+                    boolean safe = nozzleLocationIsSafe(boardLocation.getLocation(),
+                            boardLocation.getBoard()
+                                         .getDimensions(),
+                            targetLocation, new Length(1.0, l.getUnits()));
+                    if (!safe) {
+                        throw new Exception(
+                                "Z Axis would move against " + boardLocation.toString());
+                    }
+                }
+            }
+
+            tool.moveTo(targetLocation);
         });
+    }
+
+    private boolean nozzleLocationIsSafe(Location origin, Location dimension, Location nozzle,
+            Length safeDistance) {
+        double distance = safeDistance.convertToUnits(nozzle.getUnits())
+                                      .getValue();
+        Location originConverted = origin.convertToUnits(nozzle.getUnits());
+        Location dimensionConverted = dimension.convertToUnits(dimension.getUnits());
+        double boardUpperZ = originConverted.getZ();
+        boolean containsXY = pointWithinRectangle(originConverted, dimensionConverted, nozzle);
+        boolean containsZ = nozzle.getZ() <= (boardUpperZ + distance);
+        return !(containsXY && containsZ);
+    }
+
+    private boolean pointWithinRectangle(Location origin, Location dimension, Location point) {
+        double rotation = Math.toRadians(origin.getRotation());
+        double ay = origin.getY() + Math.sin(rotation) * dimension.getX();
+        double ax = origin.getX() + Math.cos(rotation) * dimension.getX();
+        Location a = new Location(dimension.getUnits(), ax, ay, 0.0, 0.0);
+
+        double cx = origin.getX() - Math.cos(Math.PI / 2 - rotation) * dimension.getY();
+        double cy = origin.getY() + Math.sin(Math.PI / 2 - rotation) * dimension.getY();
+        Location c = new Location(dimension.getUnits(), cx, cy, 0.0, 0.0);
+
+        double bx = ax + cx - origin.getX();
+        double by = ay + cy - origin.getY();
+        Location b = new Location(dimension.getUnits(), bx, by, 0.0, 0.0);
+
+        return pointWithinTriangle(origin, b, a, point) || pointWithinTriangle(origin, c, b, point);
+    }
+
+    private boolean pointWithinTriangle(Location p1, Location p2, Location p3, Location p) {
+        double alpha = ((p2.getY() - p3.getY()) * (p.getX() - p3.getX())
+                + (p3.getX() - p2.getX()) * (p.getY() - p3.getY()))
+                / ((p2.getY() - p3.getY()) * (p1.getX() - p3.getX())
+                        + (p3.getX() - p2.getX()) * (p1.getY() - p3.getY()));
+        double beta = ((p3.getY() - p1.getY()) * (p.getX() - p3.getX())
+                + (p1.getX() - p3.getX()) * (p.getY() - p3.getY()))
+                / ((p2.getY() - p3.getY()) * (p1.getX() - p3.getX())
+                        + (p3.getX() - p2.getX()) * (p1.getY() - p3.getY()));
+        double gamma = 1.0 - alpha - beta;
+
+        return (alpha > 0.0) && (beta > 0.0) && (gamma > 0.0);
     }
 
     private void park(boolean xy, boolean z, boolean c) {
         UiUtils.submitUiMachineTask(() -> {
             HeadMountable tool = machineControlsPanel.getSelectedTool();
             Location location = tool.getLocation();
-            Location parkLocation = tool.getHead().getParkLocation();
+            Location parkLocation = tool.getHead()
+                                        .getParkLocation();
             parkLocation = parkLocation.convertToUnits(location.getUnits());
             location = location.derive(xy ? parkLocation.getX() : null,
                     xy ? parkLocation.getY() : null, z ? parkLocation.getZ() : null,
@@ -231,6 +309,7 @@ public class JogControlsPanel extends JPanel {
                         FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,
                         FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,
                         FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,
+                        FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,
                         FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,},
                 new RowSpec[] {FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
                         FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
@@ -246,6 +325,9 @@ public class JogControlsPanel extends JPanel {
         homeButton.setIcon(Icons.home);
         homeButton.setHideActionText(true);
         panelControls.add(homeButton, "2, 2");
+
+        boardProtectionOverrideCheck = new JCheckBox("Override Board Protection");
+        panelControls.add(boardProtectionOverrideCheck, "24, 2");
 
         JLabel lblXy = new JLabel("X/Y");
         lblXy.setFont(new Font("Lucida Grande", Font.PLAIN, 22));
@@ -295,7 +377,9 @@ public class JogControlsPanel extends JPanel {
         speedSlider.addChangeListener(new ChangeListener() {
             @Override
             public void stateChanged(ChangeEvent e) {
-                Configuration.get().getMachine().setSpeed(speedSlider.getValue() * 0.01);
+                Configuration.get()
+                             .getMachine()
+                             .setSpeed(speedSlider.getValue() * 0.01);
             }
         });
 
@@ -505,7 +589,10 @@ public class JogControlsPanel extends JPanel {
         @Override
         public void actionPerformed(ActionEvent arg0) {
             UiUtils.submitUiMachineTask(() -> {
-                Configuration.get().getMachine().getDefaultHead().moveToSafeZ();
+                Configuration.get()
+                             .getMachine()
+                             .getDefaultHead()
+                             .moveToSafeZ();
             });
         }
     };
@@ -517,8 +604,9 @@ public class JogControlsPanel extends JPanel {
             UiUtils.submitUiMachineTask(() -> {
                 Nozzle nozzle = machineControlsPanel.getSelectedNozzle();
                 // move to the discard location
-                MovableUtils.moveToLocationAtSafeZ(nozzle,
-                        Configuration.get().getMachine().getDiscardLocation());
+                MovableUtils.moveToLocationAtSafeZ(nozzle, Configuration.get()
+                                                                        .getMachine()
+                                                                        .getDiscardLocation());
                 // discard the part
                 nozzle.place();
                 nozzle.moveToSafeZ();
@@ -545,8 +633,9 @@ public class JogControlsPanel extends JPanel {
     };
 
     private void addActuator(Actuator actuator) {
-        String name = actuator.getHead() == null ? actuator.getName()
-                : actuator.getHead().getName() + ":" + actuator.getName();
+        String name = actuator.getHead() == null ? actuator.getName() : actuator.getHead()
+                                                                                .getName()
+                + ":" + actuator.getName();
         JButton actuatorButton = new JButton(name);
         actuatorButton.addActionListener((e) -> {
             ActuatorControlDialog dlg = new ActuatorControlDialog(actuator);
@@ -556,8 +645,10 @@ public class JogControlsPanel extends JPanel {
             dlg.setVisible(true);
         });
         BeanUtils.addPropertyChangeListener(actuator, "name", e -> {
-            actuatorButton.setText(actuator.getHead() == null ? actuator.getName()
-                    : actuator.getHead().getName() + ":" + actuator.getName());
+            actuatorButton.setText(
+                    actuator.getHead() == null ? actuator.getName() : actuator.getHead()
+                                                                              .getName()
+                            + ":" + actuator.getName());
         });
         panelActuators.add(actuatorButton);
         actuatorButtons.put(actuator, actuatorButton);
@@ -571,11 +662,14 @@ public class JogControlsPanel extends JPanel {
         @Override
         public void configurationComplete(Configuration configuration) throws Exception {
             setUnits(configuration.getSystemUnits());
-            speedSlider.setValue((int) (configuration.getMachine().getSpeed() * 100));
+            speedSlider.setValue((int) (configuration.getMachine()
+                                                     .getSpeed()
+                    * 100));
 
             panelActuators.removeAll();
 
-            Machine machine = Configuration.get().getMachine();
+            Machine machine = Configuration.get()
+                                           .getMachine();
 
             for (Actuator actuator : machine.getActuators()) {
                 addActuator(actuator);

--- a/src/main/java/org/openpnp/gui/MachineControlsPanel.java
+++ b/src/main/java/org/openpnp/gui/MachineControlsPanel.java
@@ -69,6 +69,7 @@ import com.jgoodies.forms.layout.RowSpec;
 
 public class MachineControlsPanel extends JPanel {
     private final Configuration configuration;
+    private final JobPanel jobPanel;
 
     private static final String PREF_JOG_CONTROLS_EXPANDED =
             "MachineControlsPanel.jogControlsExpanded";
@@ -85,14 +86,15 @@ public class MachineControlsPanel extends JPanel {
 
     private Color droNormalColor = new Color(0xBDFFBE);
     private Color droSavedColor = new Color(0x90cce0);
-
+    
     /**
      * Create the panel.
      */
-    public MachineControlsPanel(Configuration configuration) {
+    public MachineControlsPanel(Configuration configuration, JobPanel jobPanel) {
         setBorder(new TitledBorder(null, "Machine Controls", TitledBorder.LEADING, TitledBorder.TOP,
                 null, null));
         this.configuration = configuration;
+        this.jobPanel = jobPanel;
 
         createUi();
 
@@ -148,6 +150,10 @@ public class MachineControlsPanel extends JPanel {
 
     public JogControlsPanel getJogControlsPanel() {
         return jogControlsPanel;
+    }
+    
+    public JobPanel getJobPanel() {
+    	return jobPanel;
     }
 
     @Override

--- a/src/main/java/org/openpnp/gui/MainFrame.java
+++ b/src/main/java/org/openpnp/gui/MainFrame.java
@@ -209,7 +209,7 @@ public class MainFrame extends JFrame {
                 prefs.getInt(PREF_WINDOW_Y, PREF_WINDOW_Y_DEF),
                 prefs.getInt(PREF_WINDOW_WIDTH, PREF_WINDOW_WIDTH_DEF),
                 prefs.getInt(PREF_WINDOW_HEIGHT, PREF_WINDOW_HEIGHT_DEF));
-        jobPanel = new JobPanel(configuration, this, machineControlsPanel);
+        jobPanel = new JobPanel(configuration, this);
         partsPanel = new PartsPanel(configuration, this);
         packagesPanel = new PackagesPanel(configuration, this);
         feedersPanel = new FeedersPanel(configuration, this);
@@ -428,7 +428,7 @@ public class MainFrame extends JFrame {
         lblInstructions.setEditable(false);
         panel_1.add(lblInstructions);
 
-        machineControlsPanel = new MachineControlsPanel(configuration);
+        machineControlsPanel = new MachineControlsPanel(configuration, jobPanel);
         panelMachine.add(machineControlsPanel, BorderLayout.SOUTH);
 
         mnCommands.add(new JMenuItem(machineControlsPanel.homeAction));

--- a/src/main/java/org/openpnp/model/Location.java
+++ b/src/main/java/org/openpnp/model/Location.java
@@ -282,6 +282,22 @@ public class Location {
     public Point getXyPoint() {
         return new Point(getX(), getY());
     }
+    
+    /**
+     * Checks if targetLocation is contained in current location given the current location represents a rectangular item with the origin in originLocation.
+     */
+    public boolean containsLocation(Location originLocation, Location targetLocation) {
+    	Location target = targetLocation.convertToUnits(this.units);
+    	double x = target.getX();
+    	double y = target.getY();
+    	Location origin = originLocation.convertToUnits(this.units);
+    	double x1 = origin.getX();
+    	double y1 = origin.getY();
+    	double x2 = x1 + getX();
+    	double y2 = y1 + getY();
+    	
+    	return (x >= x1) && (x <= x2) && (y > y1) && (y < y2);
+    }
 
     /**
      * Performs a unit agnostic equality check. If the Object being tested is a Location in a


### PR DESCRIPTION
# Description
This patch adds a feature that checks the nozzle position against the board position and Z distance. If the nozzle would move into the board either from the side or from the top it throws an exception.

# Justification
Crashing the nozzle into board can damage the board as well as the nozzle. Therefore, it makes sense to prevent jog moves from accidentally crashing into the board. The code is generic and not machine specific.

# Instructions for Use
1. Load a board and set the Z position.
2. Move your head above the board e.g. by using the camera.
3. Move the nozzle to the head position.
4. Try to move the nozzle into the board (be careful!).
5. When reaching the Z tolerance position an exception message will pop up.
6. To override the Z limit you can use the button in the jog panel.

![image](https://user-images.githubusercontent.com/1467368/28033887-e8b84a98-65af-11e7-9ccf-96b600f59e81.png)

# Implementation Details
The code has been tested on a real machine with the board rotated in different angles. Changes only affect the JogControlPanel.