### PR TITLE
ReferenceStripFeeder converted to use CvPipeline

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/camera/BufferedImageCamera.java
+++ b/src/main/java/org/openpnp/machine/reference/camera/BufferedImageCamera.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2011 Jason von Nieda <jason@vonnieda.org>
+ *
+ * This file is part of OpenPnP.
+ *
+ * OpenPnP is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * OpenPnP is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with OpenPnP. If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * For more information about OpenPnP visit http://openpnp.org
+ */
+
+package org.openpnp.machine.reference.camera;
+
+import java.awt.image.BufferedImage;
+import java.beans.PropertyChangeSupport;
+
+import org.openpnp.gui.support.Wizard;
+import org.openpnp.machine.reference.ReferenceCamera;
+import org.openpnp.spi.Camera;
+import org.openpnp.spi.PropertySheetHolder;
+
+public class BufferedImageCamera extends ReferenceCamera {
+    private PropertyChangeSupport pcs = new PropertyChangeSupport(this);
+
+    private Camera originalCamera;
+    private BufferedImage source;
+
+    public BufferedImageCamera(Camera _originalCamera, BufferedImage _source) {
+        originalCamera = _originalCamera;
+        source = _source;
+
+        setUnitsPerPixel(originalCamera.getUnitsPerPixel());
+    }
+
+    @Override
+    public synchronized BufferedImage internalCapture() {
+        // Don't do transformImage() like regular cameras - expect the image in this camera to have already
+        // been transformed by the original camera.
+        return source;
+    }
+
+    @Override
+    public Wizard getConfigurationWizard() {
+        return null;
+    }
+
+    @Override
+    public String getPropertySheetHolderTitle() {
+        return getClass().getSimpleName() + " " + getName();
+    }
+
+    @Override
+    public PropertySheetHolder[] getChildPropertySheetHolders() {
+        return null;
+    }
+}

--- a/src/main/java/org/openpnp/vision/pipeline/ui/PipelinePanel.java
+++ b/src/main/java/org/openpnp/vision/pipeline/ui/PipelinePanel.java
@@ -52,6 +52,7 @@ public class PipelinePanel extends JPanel {
     private JTable stagesTable;
     private StagesTableModel stagesTableModel;
     private PropertySheetPanel propertySheetPanel;
+    private PipelinePropertySheetTable pipelinePropertySheetTable;
     private LengthPropertySheetConverter lengthPropertySheetConverter = new LengthPropertySheetConverter();
 
     public PipelinePanel(CvPipelineEditor editor) {
@@ -64,7 +65,8 @@ public class PipelinePanel extends JPanel {
         PropertyEditorRegistry propertyEditorRegistry = PropertyEditorRegistry.Instance;
         propertyEditorRegistry.registerEditor(Length.class, LengthEditor.class);
 
-        propertySheetPanel = new PropertySheetPanel();
+        pipelinePropertySheetTable = new PipelinePropertySheetTable(this);
+        propertySheetPanel = new PropertySheetPanel(pipelinePropertySheetTable);
         propertySheetPanel.setDescriptionVisible(true);
 
         setLayout(new BorderLayout(0, 0));
@@ -164,24 +166,20 @@ public class PipelinePanel extends JPanel {
         
         splitPaneMain.setResizeWeight(0.5);
         splitPaneStages.setResizeWeight(0.80);
+    }
 
-        // Listen for editing events in the properties and process the pipeline to update the
-        // results.
-        propertySheetPanel.getTable().addPropertyChangeListener(new PropertyChangeListener() {
-            @Override
-            public void propertyChange(PropertyChangeEvent e) {
-                if ("tableCellEditor".equals(e.getPropertyName())) {
-                    if (!propertySheetPanel.getTable().isEditing()) {
-                        // editing has ended for a cell, save the values
+    public void onStagePropertySheetValueChanged(Object aValue, int row, int column) {
+        // editing has ended for a cell, save the values
+        refreshDescription();
 
-                        refreshDescription();
-                        
-                        propertySheetPanel.writeToObject(getSelectedStage());
-                        editor.process();
-                    }
-                }
-            }
-        });
+        // Don't use propertySheetPanel.writeToObject(stage) as it will cause infinitely recursive setValueAt() calls
+        // due to it calling getTable().commitEditing() (which is what called this function originally)
+        PropertySheetTableModel propertySheetTableModel = propertySheetPanel.getTable().getSheetModel();
+        PropertySheetTableModel.Item propertySheetElement = propertySheetTableModel.getPropertySheetElement(row);
+        Property property = propertySheetElement.getProperty();
+        property.writeToObject(getSelectedStage());
+
+        editor.process();
     }
     
     private void refreshProperties() {

--- a/src/main/java/org/openpnp/vision/pipeline/ui/PipelinePanel.java
+++ b/src/main/java/org/openpnp/vision/pipeline/ui/PipelinePanel.java
@@ -38,10 +38,13 @@ import org.openpnp.gui.components.ClassSelectionDialog;
 import org.openpnp.gui.support.Helpers;
 import org.openpnp.gui.support.Icons;
 import org.openpnp.gui.support.MessageBoxes;
+import org.openpnp.model.Length;
 import org.openpnp.vision.pipeline.CvStage;
+import org.openpnp.vision.pipeline.ui.converters.LengthPropertySheetConverter;
+import org.openpnp.vision.pipeline.ui.editors.LengthEditor;
 
-import com.l2fprod.common.propertysheet.Property;
-import com.l2fprod.common.propertysheet.PropertySheetPanel;
+import com.l2fprod.common.propertysheet.*;
+import com.l2fprod.common.util.converter.ConverterRegistry;
 
 public class PipelinePanel extends JPanel {
     private final CvPipelineEditor editor;
@@ -49,9 +52,17 @@ public class PipelinePanel extends JPanel {
     private JTable stagesTable;
     private StagesTableModel stagesTableModel;
     private PropertySheetPanel propertySheetPanel;
+    private LengthPropertySheetConverter lengthPropertySheetConverter = new LengthPropertySheetConverter();
 
     public PipelinePanel(CvPipelineEditor editor) {
         this.editor = editor;
+
+        // Converters for using custom types in the property sheet editor
+        lengthPropertySheetConverter.register(ConverterRegistry.instance());
+
+        // Editors for custom types in the property sheet editor
+        PropertyEditorRegistry propertyEditorRegistry = PropertyEditorRegistry.Instance;
+        propertyEditorRegistry.registerEditor(Length.class, LengthEditor.class);
 
         propertySheetPanel = new PropertySheetPanel();
         propertySheetPanel.setDescriptionVisible(true);

--- a/src/main/java/org/openpnp/vision/pipeline/ui/PipelinePropertySheetTable.java
+++ b/src/main/java/org/openpnp/vision/pipeline/ui/PipelinePropertySheetTable.java
@@ -1,0 +1,18 @@
+package org.openpnp.vision.pipeline.ui;
+
+import com.l2fprod.common.propertysheet.PropertySheetTable;
+
+public class PipelinePropertySheetTable extends PropertySheetTable {
+    private PipelinePanel pipelinePanel;
+
+    public PipelinePropertySheetTable(PipelinePanel pipelinePanel) {
+        this.pipelinePanel = pipelinePanel;
+    }
+
+    @Override
+    public void setValueAt(Object aValue, int row, int column) {
+        super.setValueAt(aValue, row, column);
+
+        pipelinePanel.onStagePropertySheetValueChanged(aValue, row, column);
+    }
+}

--- a/src/main/java/org/openpnp/vision/pipeline/ui/converters/LengthPropertySheetConverter.java
+++ b/src/main/java/org/openpnp/vision/pipeline/ui/converters/LengthPropertySheetConverter.java
@@ -1,0 +1,40 @@
+package org.openpnp.vision.pipeline.ui.converters;
+
+import com.l2fprod.common.util.converter.Converter;
+import com.l2fprod.common.util.converter.Registry;
+
+import org.openpnp.gui.support.LengthConverter;
+import org.openpnp.model.Length;
+
+public class LengthPropertySheetConverter implements Converter {
+    private LengthConverter lengthConverter = new LengthConverter();
+
+    @Override
+    public Object convert(Class aClass, Object o) {
+        if (aClass == Length.class) {
+            String string = (String)o;
+            return toObject(string);
+        } else if (aClass == String.class) {
+            Length length = (Length)o;
+            return toString(length);
+        }
+        return null;
+    }
+
+    @Override
+    public void register(Registry registry) {
+        registry.addConverter(Length.class, String.class, this);
+        registry.addConverter(String.class, Length.class, this);
+    }
+
+    public Length toObject(String text) {
+        return lengthConverter.convertReverse(text);
+    }
+
+    public String toString(Length length) {
+        // lengthConverter.convertForward(length) will convert the units to the systems units, and not display the
+        // units used in the final string. We don't want this, as the user is entering the units they want to be using.
+        return length.toString();
+    }
+
+}

--- a/src/main/java/org/openpnp/vision/pipeline/ui/editors/LengthEditor.java
+++ b/src/main/java/org/openpnp/vision/pipeline/ui/editors/LengthEditor.java
@@ -1,0 +1,20 @@
+package org.openpnp.vision.pipeline.ui.editors;
+
+import com.l2fprod.common.annotations.EditorRegistry;
+import com.l2fprod.common.beans.editor.StringConverterPropertyEditor;
+import org.openpnp.gui.support.LengthConverter;
+import org.openpnp.model.Length;
+
+@EditorRegistry(
+        type = {Length.class}
+)
+public class LengthEditor extends StringConverterPropertyEditor {
+    private LengthConverter lengthConverter = new LengthConverter();
+
+    public LengthEditor() {
+    }
+
+    protected Object convertFromString(String text) {
+        return lengthConverter.convertReverse(text);
+    }
+}

--- a/src/main/resources/org/openpnp/machine/reference/feeder/ReferenceStripFeeder-DefaultPipeline.xml
+++ b/src/main/resources/org/openpnp/machine/reference/feeder/ReferenceStripFeeder-DefaultPipeline.xml
@@ -1,7 +1,16 @@
 <cv-pipeline>
    <stages>
-      <cv-stage class="org.openpnp.vision.pipeline.stages.ImageCapture" name="9" enabled="true" settle-first="true"/>
+      <cv-stage class="org.openpnp.vision.pipeline.stages.ImageCapture" name="1" enabled="true" settle-first="true"/>
       <cv-stage class="org.openpnp.vision.pipeline.stages.ConvertColor" name="2" enabled="true" conversion="Bgr2Gray"/>
-      <cv-stage class="org.openpnp.vision.pipeline.stages.BlurGaussian" name="results" enabled="true" kernel-size="9"/>
+      <cv-stage class="org.openpnp.vision.pipeline.stages.BlurGaussian" name="predetect" enabled="true" kernel-size="9"/>
+      <cv-stage class="org.openpnp.vision.pipeline.stages.DetectCirclesHough" name="results" enabled="true">
+         <min-diameter value="1.35" units="Millimeters"/>
+         <max-diameter value="1.65" units="Millimeters"/>
+         <min-distance value="3.6" units="Millimeters"/>
+      </cv-stage>
+      <cv-stage class="org.openpnp.vision.pipeline.stages.ConvertColor" name="5" enabled="true" conversion="Gray2Bgr"/>
+      <cv-stage class="org.openpnp.vision.pipeline.stages.DrawCircles" name="6" enabled="true" circles-stage-name="results" thickness="1">
+         <color r="255" g="0" b="0" a="255"/>
+      </cv-stage>
    </stages>
 </cv-pipeline>

--- a/src/main/resources/org/openpnp/machine/reference/feeder/ReferenceStripFeeder-DefaultPipeline.xml
+++ b/src/main/resources/org/openpnp/machine/reference/feeder/ReferenceStripFeeder-DefaultPipeline.xml
@@ -1,0 +1,7 @@
+<cv-pipeline>
+   <stages>
+      <cv-stage class="org.openpnp.vision.pipeline.stages.ImageCapture" name="9" enabled="true" settle-first="true"/>
+      <cv-stage class="org.openpnp.vision.pipeline.stages.ConvertColor" name="2" enabled="true" conversion="Bgr2Gray"/>
+      <cv-stage class="org.openpnp.vision.pipeline.stages.BlurGaussian" name="results" enabled="true" kernel-size="9"/>
+   </stages>
+</cv-pipeline>


### PR DESCRIPTION
# Description
Stage 1 of adding CvPipeline to ReferenceStripFeeder, as per #330: Add pipeline for pre-processing the image, allowing it to be cleaned up for improved recognition by the current algorithm. Stage 1 would allow the user to configure steps to clean up the image in their Machine.xml file, but still use the current recognition code on the cleaned up image.
Stage 2 of adding CvPipeline to ReferenceStripFeeder, as per #330: Completely convert the vision system to use the CvPipeline. Stage 2 would be a complete conversion to using the CvPipeline for recognition.

Compiles and runs, however I cannot test the functionality on real hardware at this time so further work may be required.

# Justification
Addresses bug report.

# Instructions for Use
A CvPipeline can be customized to clean up the cameras' image for improved recognition. The pipeline can be configured by clicking Edit Pipeline in the feeders configuration. The final pipeline stage (with detected circles) should have the name 'results'.

During the feeder setup wizard, the strip feeder hole debug colors are as follows:
  * Red are any holes that are found.
  * Orange are holes that passed the distance check but failed the line check. **
  * Blue are holes that passed the line check but are considered superfluous. **
  * Green passed all checks and are considered good.

** - only displayed when Alt/Option is held down when the setup wizard is started.

# Implementation Details
1. How did you test the change?
  Has only been tested with a webcam at this stage, which is not configured properly. If proper testing can be done to confirm the functionality it would be appreciated. Unfortunately I have no access to working hardware at this point.
  pnp-test.job.xml runs successfully (in addition to using -DoverrideUserConfig=true), and appears to use vision with its ReferenceStripFeeders, so I'm hopeful that everything is working correctly. The strip feeder setup wizard runs successfully with the test job loaded, and all circles are displayed as expected in the debug camera image.
2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)?
  I believe so.
3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing.
  No
4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted.
  Done.

One possibly dubious change has been the addition of a BufferedImageCamera, which is only to be used internally (not as a selectable camera type by the user). It is used to use a BufferedImage as the source for CvPipeline rather than an actual Camera (used in ReferenceStripFeederConfigurationWizard.showHoles()).

A second change that potentially impacts some users is changing the DetectCirclesHough CvStage to have unit-based (Length) for its sizes and distances, rather than using pixels. This change was made because:
1. It matches the old behaviour from FluentCv
2. It allows the stage to be used across different hardware configurations (no longer tied to the camera resolution, distance, etc)
3. It matches what a user expects (detect a 1mm fid, 1.5mm tape hole, etc)
4. I don't expect that DetectCirclesHough is actually being used by any users presently due to all parameters being marked as required, despite most being undocumented and unintuitive. These parameters are now marked as not-required.