### PR TITLE
Added keyboard hotkeys for some more common functions.

### DIFF
--- a/src/main/java/org/openpnp/gui/JogControlsPanel.java
+++ b/src/main/java/org/openpnp/gui/JogControlsPanel.java
@@ -543,6 +543,40 @@ public class JogControlsPanel extends JPanel {
                     Math.max(sliderIncrements.getMinimum(), sliderIncrements.getValue() - 1));
         }
     };
+	
+    @SuppressWarnings("serial")
+    public Action setIncrementHundredthAction = new AbstractAction("0.01mm Jog Increment") {
+        @Override
+        public void actionPerformed(ActionEvent arg0) {
+            sliderIncrements.setValue(1);
+		}
+    };
+    @SuppressWarnings("serial")
+    public Action setIncrementTenthAction = new AbstractAction("0.1mm Jog Increment") {
+        @Override
+        public void actionPerformed(ActionEvent arg0) {
+            sliderIncrements.setValue(2);
+		}
+    };
+    public Action setIncrementOnesAction = new AbstractAction("1mm Jog Increment") {
+        @Override
+        public void actionPerformed(ActionEvent arg0) {
+            sliderIncrements.setValue(3);
+		}
+    };
+    public Action setIncrementTensAction = new AbstractAction("10mm Jog Increment") {
+        @Override
+        public void actionPerformed(ActionEvent arg0) {
+            sliderIncrements.setValue(4);
+		}
+    };
+    public Action setIncrementHundredsAction = new AbstractAction("100mm Jog Increment") {
+        @Override
+        public void actionPerformed(ActionEvent arg0) {
+            sliderIncrements.setValue(5);
+		}
+    };
+
 
     private void addActuator(Actuator actuator) {
         String name = actuator.getHead() == null ? actuator.getName()

--- a/src/main/java/org/openpnp/gui/MainFrame.java
+++ b/src/main/java/org/openpnp/gui/MainFrame.java
@@ -454,7 +454,29 @@ public class MainFrame extends JFrame {
                 machineControlsPanel.getJogControlsPanel().lowerIncrementAction);
         hotkeyActionMap.put(KeyStroke.getKeyStroke(KeyEvent.VK_EQUALS, mask),
                 machineControlsPanel.getJogControlsPanel().raiseIncrementAction);
-
+        hotkeyActionMap.put(KeyStroke.getKeyStroke(KeyEvent.VK_R, KeyEvent.CTRL_DOWN_MASK | KeyEvent.SHIFT_DOWN_MASK),
+                jobPanel.startPauseResumeJobAction); // Ctrl-Shift-R for Start
+        hotkeyActionMap.put(KeyStroke.getKeyStroke(KeyEvent.VK_S, KeyEvent.CTRL_DOWN_MASK | KeyEvent.SHIFT_DOWN_MASK),
+                jobPanel.stepJobAction); // Ctrl-Shift-S for Step
+        hotkeyActionMap.put(KeyStroke.getKeyStroke(KeyEvent.VK_A, KeyEvent.CTRL_DOWN_MASK | KeyEvent.SHIFT_DOWN_MASK),
+                jobPanel.stopJobAction); // Ctrl-Shift-A for Stop
+        hotkeyActionMap.put(KeyStroke.getKeyStroke(KeyEvent.VK_P, KeyEvent.CTRL_DOWN_MASK | KeyEvent.SHIFT_DOWN_MASK),
+                machineControlsPanel.getJogControlsPanel().xyParkAction); // Ctrl-Shift-P for xyPark
+        hotkeyActionMap.put(KeyStroke.getKeyStroke(KeyEvent.VK_Z, KeyEvent.CTRL_DOWN_MASK | KeyEvent.SHIFT_DOWN_MASK),
+                machineControlsPanel.getJogControlsPanel().safezAction); // Ctrl-Shift-Z for safezAction
+        hotkeyActionMap.put(KeyStroke.getKeyStroke(KeyEvent.VK_D, KeyEvent.CTRL_DOWN_MASK | KeyEvent.SHIFT_DOWN_MASK),
+                machineControlsPanel.getJogControlsPanel().discardAction); // Ctrl-Shift-D for discard
+        hotkeyActionMap.put(KeyStroke.getKeyStroke(KeyEvent.VK_F1, KeyEvent.CTRL_DOWN_MASK | KeyEvent.SHIFT_DOWN_MASK),
+                machineControlsPanel.getJogControlsPanel().setIncrementHundredthAction);
+        hotkeyActionMap.put(KeyStroke.getKeyStroke(KeyEvent.VK_F2, KeyEvent.CTRL_DOWN_MASK | KeyEvent.SHIFT_DOWN_MASK),
+                machineControlsPanel.getJogControlsPanel().setIncrementTenthAction);
+        hotkeyActionMap.put(KeyStroke.getKeyStroke(KeyEvent.VK_F3, KeyEvent.CTRL_DOWN_MASK | KeyEvent.SHIFT_DOWN_MASK),
+                machineControlsPanel.getJogControlsPanel().setIncrementOnesAction);
+        hotkeyActionMap.put(KeyStroke.getKeyStroke(KeyEvent.VK_F4, KeyEvent.CTRL_DOWN_MASK | KeyEvent.SHIFT_DOWN_MASK),
+                machineControlsPanel.getJogControlsPanel().setIncrementTensAction);
+        hotkeyActionMap.put(KeyStroke.getKeyStroke(KeyEvent.VK_F5, KeyEvent.CTRL_DOWN_MASK | KeyEvent.SHIFT_DOWN_MASK),
+                machineControlsPanel.getJogControlsPanel().setIncrementHundredsAction);
+				
         tabs = new JTabbedPane(JTabbedPane.TOP);
         splitPaneMachineAndTabs.setRightComponent(tabs);
 


### PR DESCRIPTION

# Description
I am building a control panel for my system with jog wheels and buttons (using a teensy which will use a virtual HID keyboard interface.)

I added a few more hotkeys based on info from Jason and Cri S from https://groups.google.com/forum/#!topic/openpnp/knlnB8PrGw0 and https://github.com/openpnp/openpnp/issues/509

Hotkeys were added to MainFrame.java and some actions were added to JogControlsPanel.java to directly set a jog increment (as opposed to incrementing up / down). 

The coding style seems to favor separate actions vs a using parameters so I copied that.

# Justification
IMHO It is always useful to have hotkeys available, and this makes a great low-impact workaround for supporting hardware buttons / joysticks, etc.

# Instructions for Use

Ctrl-Shift-R: Starts a job
Ctrl-Shift-S: Steps through the job
Ctrl-Shift-A: Stops the job
Ctrl-Shift-P: Parks head (Z retract then XY park)
Ctrl-Shift-Z: Moves head to safe Z
Ctrl-Shift-D: Discard component
Ctrl-Shift-F1: 0.01mm jog increment
Ctrl-Shift-F2: 0.1mm jog increment
Ctrl-Shift-F3: 1mm jog increment
Ctrl-Shift-F4: 10mm jog increment
Ctrl-Shift-F5: 100mm jog increment

# Implementation Details
1. How did you test the change? Be descriptive. Untested code will not be accepted.

Developed on live hardware (liteplacer conversion to openpnp)

There are some "well don't do that then" type of bugs which this update does not address (clicking on the buttons in the UI will exhibit the same behavior)

2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)?

yes

3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing.

N/A

4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted.

done