### PR TITLE
CvPipelineEditor issue #597

### DIFF
--- a/src/main/java/org/openpnp/vision/pipeline/ui/PipelinePanel.java
+++ b/src/main/java/org/openpnp/vision/pipeline/ui/PipelinePanel.java
@@ -40,8 +40,7 @@ import org.openpnp.gui.support.Icons;
 import org.openpnp.gui.support.MessageBoxes;
 import org.openpnp.vision.pipeline.CvStage;
 
-import com.l2fprod.common.propertysheet.Property;
-import com.l2fprod.common.propertysheet.PropertySheetPanel;
+import com.l2fprod.common.propertysheet.*;
 
 public class PipelinePanel extends JPanel {
     private final CvPipelineEditor editor;

--- a/src/main/java/org/openpnp/vision/pipeline/ui/PipelinePanel.java
+++ b/src/main/java/org/openpnp/vision/pipeline/ui/PipelinePanel.java
@@ -49,11 +49,13 @@ public class PipelinePanel extends JPanel {
     private JTable stagesTable;
     private StagesTableModel stagesTableModel;
     private PropertySheetPanel propertySheetPanel;
+    private PipelinePropertySheetTable pipelinePropertySheetTable;
 
     public PipelinePanel(CvPipelineEditor editor) {
         this.editor = editor;
 
-        propertySheetPanel = new PropertySheetPanel();
+        pipelinePropertySheetTable = new PipelinePropertySheetTable(this);
+        propertySheetPanel = new PropertySheetPanel(pipelinePropertySheetTable);
         propertySheetPanel.setDescriptionVisible(true);
 
         setLayout(new BorderLayout(0, 0));
@@ -153,24 +155,20 @@ public class PipelinePanel extends JPanel {
         
         splitPaneMain.setResizeWeight(0.5);
         splitPaneStages.setResizeWeight(0.80);
+    }
 
-        // Listen for editing events in the properties and process the pipeline to update the
-        // results.
-        propertySheetPanel.getTable().addPropertyChangeListener(new PropertyChangeListener() {
-            @Override
-            public void propertyChange(PropertyChangeEvent e) {
-                if ("tableCellEditor".equals(e.getPropertyName())) {
-                    if (!propertySheetPanel.getTable().isEditing()) {
-                        // editing has ended for a cell, save the values
+    public void onStagePropertySheetValueChanged(Object aValue, int row, int column) {
+        // editing has ended for a cell, save the values
+        refreshDescription();
 
-                        refreshDescription();
-                        
-                        propertySheetPanel.writeToObject(getSelectedStage());
-                        editor.process();
-                    }
-                }
-            }
-        });
+        // Don't use propertySheetPanel.writeToObject(stage) as it will cause infinitely recursive setValueAt() calls
+        // due to it calling getTable().commitEditing() (which is what called this function originally)
+        PropertySheetTableModel propertySheetTableModel = propertySheetPanel.getTable().getSheetModel();
+        PropertySheetTableModel.Item propertySheetElement = propertySheetTableModel.getPropertySheetElement(row);
+        Property property = propertySheetElement.getProperty();
+        property.writeToObject(getSelectedStage());
+
+        editor.process();
     }
     
     private void refreshProperties() {

--- a/src/main/java/org/openpnp/vision/pipeline/ui/PipelinePropertySheetTable.java
+++ b/src/main/java/org/openpnp/vision/pipeline/ui/PipelinePropertySheetTable.java
@@ -1,0 +1,18 @@
+package org.openpnp.vision.pipeline.ui;
+
+import com.l2fprod.common.propertysheet.PropertySheetTable;
+
+public class PipelinePropertySheetTable extends PropertySheetTable {
+    private PipelinePanel pipelinePanel;
+
+    public PipelinePropertySheetTable(PipelinePanel pipelinePanel) {
+        this.pipelinePanel = pipelinePanel;
+    }
+
+    @Override
+    public void setValueAt(Object aValue, int row, int column) {
+        super.setValueAt(aValue, row, column);
+
+        pipelinePanel.onStagePropertySheetValueChanged(aValue, row, column);
+    }
+}


### PR DESCRIPTION
# Description
PropertyChangeListener is fired asynchronously, so when it is received the PropertySheetPanel may no longer reflect the items the change was fired for (as is the case when the user is editing a cell of a stage’s properties and clicks to another stage, cancelling the edit while the properties change to reflect the newly selected stage).

# Justification
Addresses #597.

# Instructions for Use
No change in existing behaviours.

# Implementation Details
1. How did you test the change? Tested the pipeline editor according to the repro steps described in the issue.
2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)? I believe so.
3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing.
No changes.
4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted.
Done.
