### PR TITLE
Added alternative HOME hotkey Ctrl-H (Modifier-H to be P.C.)

### DIFF
--- a/src/main/java/org/openpnp/gui/MainFrame.java
+++ b/src/main/java/org/openpnp/gui/MainFrame.java
@@ -454,6 +454,8 @@ public class MainFrame extends JFrame {
                 machineControlsPanel.getJogControlsPanel().lowerIncrementAction);
         hotkeyActionMap.put(KeyStroke.getKeyStroke(KeyEvent.VK_EQUALS, mask),
                 machineControlsPanel.getJogControlsPanel().raiseIncrementAction);
+        hotkeyActionMap.put(KeyStroke.getKeyStroke(KeyEvent.VK_H, mask),
+                machineControlsPanel.homeAction);
         hotkeyActionMap.put(KeyStroke.getKeyStroke(KeyEvent.VK_R, KeyEvent.CTRL_DOWN_MASK | KeyEvent.SHIFT_DOWN_MASK),
                 jobPanel.startPauseResumeJobAction); // Ctrl-Shift-R for Start
         hotkeyActionMap.put(KeyStroke.getKeyStroke(KeyEvent.VK_S, KeyEvent.CTRL_DOWN_MASK | KeyEvent.SHIFT_DOWN_MASK),


### PR DESCRIPTION
# Description
Some users reported Ctrl-\<backtick\> does not work in windows.
https://groups.google.com/forum/#!topic/openpnp/knlnB8PrGw0

Added hotkey Ctrl-H as an alternative choice for HOME. 

# Justification
While Ctrl-\<backtick\> works for me on my system, at best it is a confusing character to describe. 
Some users also report it as not working on their version of windows.

Ctrl-H acts as a mnemonic (second only to using the actual home key) 

I added Ctrl-H as an alternative leaving the original hotkey alone

# Instructions for Use

Press Modifier-H to "Home" the pick and place head

# Implementation Details
1. How did you test the change? Be descriptive. Untested code will not be accepted.

Tested on live machine (Liteplacer conversion to openpnp) under Windows 7

2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)?

Yes

3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing.

N/A

4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted.

done