### PR TITLE
Add Check Box "Use only Value as PartId", ...

### DIFF
--- a/src/main/java/org/openpnp/gui/importer/KicadPosImporter.java
+++ b/src/main/java/org/openpnp/gui/importer/KicadPosImporter.java
@@ -89,7 +89,8 @@ public class KicadPosImporter implements BoardImporter {
         return board;
     }
 
-    private static List<Placement> parseFile(File file, Side side, boolean createMissingParts)
+    private static List<Placement> parseFile(File file, Side side, boolean createMissingParts, 
+    		boolean useOnlyValueAsPartId)
             throws Exception {
         BufferedReader reader =
                 new BufferedReader(new InputStreamReader(new FileInputStream(file)));
@@ -134,7 +135,12 @@ public class KicadPosImporter implements BoardImporter {
                     placementRotation));
             Configuration cfg = Configuration.get();
             if (cfg != null && createMissingParts) {
-                String partId = pkgName + "-" + partValue;
+                String partId;
+                if(useOnlyValueAsPartId == true) {
+                	partId = partValue;
+                }else {
+                	partId = pkgName + "-" + partValue;
+                }
                 Part part = cfg.getPart(partId);
                 if (part == null) {
                     part = new Part(partId);
@@ -166,6 +172,7 @@ public class KicadPosImporter implements BoardImporter {
         private final Action importAction = new SwingAction_2();
         private final Action cancelAction = new SwingAction_3();
         private JCheckBox chckbxCreateMissingParts;
+        private JCheckBox chckbxUseValueOnlyAsPartId;
 
         public Dlg(Frame parent) {
             super(parent, DESCRIPTION, true);
@@ -213,8 +220,14 @@ public class KicadPosImporter implements BoardImporter {
                     new RowSpec[] {FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,}));
 
             chckbxCreateMissingParts = new JCheckBox("Create Missing Parts");
-            chckbxCreateMissingParts.setSelected(true);
-            panel_1.add(chckbxCreateMissingParts, "2, 2");
+            chckbxCreateMissingParts.setSelected(false);
+            chckbxCreateMissingParts.setToolTipText("PartId = 'Package'-'Value'");
+            panel_1.add(chckbxCreateMissingParts, "2, 1");
+
+            chckbxUseValueOnlyAsPartId = new JCheckBox("Use only Value as PartId");
+            chckbxUseValueOnlyAsPartId.setSelected(false);
+            chckbxUseValueOnlyAsPartId.setToolTipText("Check this, if Value is unique (e.g. company internal part number)");
+            panel_1.add(chckbxUseValueOnlyAsPartId, "2, 2");
 
             JSeparator separator = new JSeparator();
             getContentPane().add(separator);
@@ -302,11 +315,13 @@ public class KicadPosImporter implements BoardImporter {
                 try {
                     if (topFile.exists()) {
                         placements.addAll(parseFile(topFile, Side.Top,
-                                chckbxCreateMissingParts.isSelected()));
+                                chckbxCreateMissingParts.isSelected(), 
+                                chckbxUseValueOnlyAsPartId.isSelected()));
                     }
                     if (bottomFile.exists()) {
                         placements.addAll(parseFile(bottomFile, Side.Bottom,
-                                chckbxCreateMissingParts.isSelected()));
+                                chckbxCreateMissingParts.isSelected(), 
+                                chckbxUseValueOnlyAsPartId.isSelected()));
                     }
                 }
                 catch (Exception e1) {


### PR DESCRIPTION
TODO: fix GUI container row, see screenshot:
![2017-08-15_020](https://user-images.githubusercontent.com/2773445/29321325-5d95c03e-81da-11e7-8a88-596cf190ff1d.png)


# Read This First
To submit a Pull Request for OpenPnP you must use this template or it will not be accepted. 

Be sure to review the [Developers Guide](https://github.com/openpnp/openpnp/wiki/Developers-Guide)
and the [Contributing Guidelines](https://github.com/openpnp/openpnp/blob/develop/CONTRIBUTING.md).

Make your Pull Request as small as possible. Only include one bug or feature.
Large pull requests that change dozens of files or add multiple features are unlikely to be accepted.

Fill out all the details below. All sections below are required. If they are not included your Pull Request
will not be accepted.

-----------------------------------------------------------------------

# Description
1. Adds a Checkbox "Use only Value as PartId" to the board importd dialog for KiCad. 

2. Unchecked both checkboxes by default. 

3. Both checkboxes got a tooltip. 


# Justification
ad 1) PartId could be a primary key from a company internal data base.  
Therefore mixing up value and package isn't of any help and Value in the .pos file is exactly that primary key in this case. 

ad 2) The Parts.xml is a sensitive table, which should not be polluted by default. The user has to do it with care!

ad 3) Tooltips are always a good idea. 

# Instructions for Use
If you want to create parts on import, you can either give them an ID named 'Package'-'Value' or, if both check boxes are enabled, the ID is only the 'Value' from the .pos-file. Use this, if your Value is a unique value, e.g. from a database. 

# Implementation Details
1. How did you test the change? Be descriptive. Untested code will not be accepted.
I imported a .pos file, and the created parts had the PartId only from the value. 
2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)?  
Yes
3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing.
4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted.
```Tests run: 13, Failures: 0, Errors: 0, Skipped: 0```

