### PR TITLE
Added "placed" checkbox in pick and place job panel

### DIFF
--- a/src/main/java/org/openpnp/gui/JobPlacementsPanel.java
+++ b/src/main/java/org/openpnp/gui/JobPlacementsPanel.java
@@ -301,6 +301,7 @@ public class JobPlacementsPanel extends JPanel {
 
             boardLocation.getBoard().addPlacement(placement);
             tableModel.fireTableDataChanged();
+            placement.setPlaced(false);
             Helpers.selectLastTableRow(table);
         }
     };

--- a/src/main/java/org/openpnp/gui/JobPlacementsPanel.java
+++ b/src/main/java/org/openpnp/gui/JobPlacementsPanel.java
@@ -222,6 +222,11 @@ public class JobPlacementsPanel extends JPanel {
             setSideMenu.add(new SetSideAction(side));
         }
         popupMenu.add(setSideMenu);
+        
+        JMenu setPlacedMenu = new JMenu(setPlacedAction);
+        setPlacedMenu.add(new SetPlacedAction(true));
+        setPlacedMenu.add(new SetPlacedAction(false));
+        popupMenu.add(setPlacedMenu);
 
         table.setComponentPopupMenu(popupMenu);
 
@@ -464,6 +469,7 @@ public class JobPlacementsPanel extends JPanel {
         public void actionPerformed(ActionEvent arg0) {
             for (Placement placement : getSelections()) {
                 placement.setType(type);
+                tableModel.fireTableDataChanged();
             }
         }
     };
@@ -491,6 +497,35 @@ public class JobPlacementsPanel extends JPanel {
         public void actionPerformed(ActionEvent arg0) {
             for (Placement placement : getSelections()) {
                 placement.setSide(side);
+                tableModel.fireTableDataChanged();
+            }
+        }
+    };
+    
+    public final Action setPlacedAction = new AbstractAction() {
+        {
+            putValue(NAME, "Set Placed");
+            putValue(SHORT_DESCRIPTION, "Set placement status to...");
+        }
+
+        @Override
+        public void actionPerformed(ActionEvent arg0) {}
+    };
+
+    class SetPlacedAction extends AbstractAction {
+        final Boolean placed;
+
+        public SetPlacedAction(Boolean placed) {
+            this.placed = placed;
+            putValue(NAME, placed.toString());
+            putValue(SHORT_DESCRIPTION, "Set placement status to " + placed.toString());
+        }
+
+        @Override
+        public void actionPerformed(ActionEvent arg0) {
+            for (Placement placement : getSelections()) {
+                placement.setPlaced(placed);
+                tableModel.fireTableDataChanged();   
             }
         }
     };

--- a/src/main/java/org/openpnp/gui/tablemodel/PlacementsTableModel.java
+++ b/src/main/java/org/openpnp/gui/tablemodel/PlacementsTableModel.java
@@ -38,11 +38,11 @@ public class PlacementsTableModel extends AbstractTableModel {
     final Configuration configuration;
 
     private String[] columnNames =
-            new String[] {"Id", "Part", "Side", "X", "Y", "Rot.", "Type", "Status", "Check Fids"};
+            new String[] {"Id", "Part", "Side", "X", "Y", "Rot.", "Type", "Placed", "Status", "Check Fids"};
 
     private Class[] columnTypes = new Class[] {PartCellValue.class, Part.class, Side.class,
             LengthCellValue.class, LengthCellValue.class, RotationCellValue.class, Type.class,
-            Status.class, Boolean.class, Boolean.class};
+            Boolean.class, Status.class, Boolean.class};
 
     public enum Status {
         Ready,
@@ -82,7 +82,7 @@ public class PlacementsTableModel extends AbstractTableModel {
     @Override
     public boolean isCellEditable(int rowIndex, int columnIndex) {
         return columnIndex == 1 || columnIndex == 2 || columnIndex == 3 || columnIndex == 4
-                || columnIndex == 5 || columnIndex == 6 || columnIndex == 8;
+                || columnIndex == 5 || columnIndex == 6 || columnIndex == 7 || columnIndex == 9;
     }
 
     @Override
@@ -125,7 +125,10 @@ public class PlacementsTableModel extends AbstractTableModel {
             else if (columnIndex == 6) {
                 placement.setType((Type) aValue);
             }
-            else if (columnIndex == 8) {
+            else if (columnIndex == 7) {
+                placement.setPlaced((Boolean) aValue);
+            }
+            else if (columnIndex == 9) {
                 placement.setCheckFids((Boolean) aValue);
             }
         }
@@ -180,8 +183,10 @@ public class PlacementsTableModel extends AbstractTableModel {
             case 6:
                 return placement.getType();
             case 7:
-                return getPlacementStatus(placement);
+            	return placement.getPlaced();
             case 8:
+                return getPlacementStatus(placement);
+            case 9:
                 return placement.getCheckFids();
             default:
                 return null;

--- a/src/main/java/org/openpnp/machine/reference/ReferencePnpJobProcessor.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferencePnpJobProcessor.java
@@ -283,6 +283,11 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
                 if (placement.getType() != Placement.Type.Place) {
                     continue;
                 }
+                
+                // Ignore placements that are placed already
+                if (placement.getPlaced()) {
+                    continue;
+                }
 
                 // Ignore placements that aren't on the side of the board we're processing.
                 if (placement.getSide() != boardLocation.getSide()) {
@@ -721,6 +726,9 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
 
             // Mark the placement as finished
             jobPlacement.status = Status.Complete;
+            
+            // Mark the placement as "placed"
+            jobPlacement.placement.setPlaced(true);
 
             plannedPlacement.stepComplete = true;
 
@@ -756,6 +764,8 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
         params.put("job", job);
         params.put("jobProcessor", this);
         Configuration.get().getScripting().on("Job.Finished", params);
+        
+        fireTextStatus("Job finished - placed %s parts in %s sec. (%s CPH)", totalPartsPlaced, df.format(dtSec), df.format(totalPartsPlaced / (dtSec / 3600.0)));
     }
 
     protected void doReset() throws Exception {

--- a/src/main/java/org/openpnp/model/Placement.java
+++ b/src/main/java/org/openpnp/model/Placement.java
@@ -64,7 +64,7 @@ public class Placement extends AbstractModelObject implements Identifiable {
     @Attribute
     private boolean checkFids;
     
-    @Attribute
+    @Attribute(required = false)
     private boolean placed;
 
     @SuppressWarnings("unused")

--- a/src/main/java/org/openpnp/model/Placement.java
+++ b/src/main/java/org/openpnp/model/Placement.java
@@ -63,6 +63,9 @@ public class Placement extends AbstractModelObject implements Identifiable {
 
     @Attribute
     private boolean checkFids;
+    
+    @Attribute
+    private boolean placed;
 
     @SuppressWarnings("unused")
     private Placement() {
@@ -143,6 +146,14 @@ public class Placement extends AbstractModelObject implements Identifiable {
         firePropertyChange("check fids", oldValue, checkFids);
     }
 
+    public boolean getPlaced() { return placed; }
+    
+    public void setPlaced(boolean placed)
+    {
+        Object oldValue = this.placed;
+        this.placed = placed;
+        firePropertyChange("placed", oldValue, placed);
+    }
 
     @Override
     public String toString() {


### PR DESCRIPTION
# Description
Added a new checkbox to each component to be placed in the "Pick and Place" Tab of a board. 

# Justification
If a component is miss picked or skipped there is currently no way to see these is the component list. Now with the "placed" checkbox its easy to see which parts have been placed and which not. Also components that have successfully been placed will not be placed anymore in the next run.

I know the job processor is currently undergoing a major rewrite so things might already be diffferent behind the scenes - still I consider this is a small addition that would be extremely useful in operation.

# Implementation Details
1. How did you test the change? 
Tested with nulldriver simulated machine.

mvn test completed successfully

Real world test would be appreciated, I will get to our machine on Monday to test it.

![openpnp-placed](https://user-images.githubusercontent.com/4028409/29659514-dcd837a6-88be-11e7-98b0-33a11502a2cc.png)
