### PR TITLE
Reference strip feeder improvements

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,33 @@
 This file lists major or notable changes to OpenPnP in chronological order. This is not
 a complete change list, only those that may directly interest or affect users.
 
+# 2017-08-28
+
+* ReferenceStripFeeder Improvements
+
+	* Added auto-thresholding to the default CvPipeline for ReferenceStripFeeder to better
+	detect tape holes and eliminate false-positives in noisy camera images. Users should
+	reset their feeder vision pipelines to the default to get this change, then re-apply
+	any pipeline changes if still necessary.
+	* Auto Setup for ReferenceStripFeeder is now a lot smarter, more accurate, and is able
+	to catch common setup issues.
+	* Fixed issue where strips with 2mm part pitch could result in the reference holes being
+	detected flipped depending on where on the two parts the user clicked.
+	* Fixed issue where part pitch was calculated in the units of the camera, not
+	necessarily millimeters.
+	* User is notified if they selected parts in the wrong order for the orientation of the
+	strip.
+	* Tightened the max distance from a component center to the feed hole centers to
+	accurately reflect the spacing as defined in the EIA-481 standard and thus reduce
+	false-positives for adjacent strips.
+	* Multiple, full lines of strip holes are detected and grouped appropriately, and only
+	the correct line of holes are used for the selected parts/strip (some spacing is still
+	required between adjacent strips, but it is much reduced and more reliable).
+	
+	Implemented in PR https://github.com/openpnp/openpnp/pull/628
+	
+	Thanks to @richard-sim for these improvements!
+
 # 2017-08-19
 
 * New Scripting Event: Job.Placement.Complete
@@ -201,7 +228,8 @@ a complete change list, only those that may directly interest or affect users.
 
 # 2017-05-15
 	
-	New tray feeder added: RotaryTrayFeeder
+* New tray feeder added: RotaryTrayFeeder
+
 	This tray feeder takes 3 points (first component, first row last component, last row last component) 
 	to measure the component grid and is rotation agnostic. Feedback and experience reports are welcome.
 

--- a/src/main/java/org/openpnp/machine/reference/feeder/ReferenceStripFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/ReferenceStripFeeder.java
@@ -141,13 +141,11 @@ public class ReferenceStripFeeder extends ReferenceFeeder {
     }
 
     public Length getHoleDistanceMax() {
-        // 2.5mm = 1.5mm holes are 1mm from the edge of the tape (it's standardized)
-        Length tapeEdgeToFeedHoleInnerEdge = new Length(2.5, LengthUnit.Millimeters);
-        // ((tape_w - 2.5) / 2 + 2.5; the distance from the centre of the component to the edge of the tape. Gives
-        // a bit of leeway for not clicking exactly in the centre of the component, that the space between the
-        // hole and the component-edge varies from 0.375mm (8mm tape) to 0.55mm (16mm ad 24mm tape), and that the
-        // distance from the component-edge to the tape-edge on the non-hole side is only specified as min 0.6mm.
-        return (getTapeWidth().subtract(tapeEdgeToFeedHoleInnerEdge)).multiply(0.5).add(tapeEdgeToFeedHoleInnerEdge);
+        // 1.75mm = 1.5mm holes are 1mm from the edge of the tape (as per EIA-481)
+        Length tapeEdgeToFeedHoleCenter = new Length(1.75, LengthUnit.Millimeters);
+        // The distance from the centre of the component to the edge of the tape. Gives a bit of leeway for not
+        // clicking exactly in the centre of the component, but is close enough to eliminate most false-positives.
+        return tapeEdgeToFeedHoleCenter.add(getHoleToPartLateral());
     }
 
     public Length getHoleLineDistanceMax() {

--- a/src/main/java/org/openpnp/machine/reference/feeder/wizards/ReferenceStripFeederConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/wizards/ReferenceStripFeederConfigurationWizard.java
@@ -24,8 +24,10 @@ import java.awt.Color;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.image.BufferedImage;
+import java.io.Console;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.concurrent.Callable;
 
 import javax.swing.AbstractAction;
@@ -63,10 +65,7 @@ import org.openpnp.gui.support.PartsComboBoxModel;
 import org.openpnp.machine.reference.camera.BufferedImageCamera;
 import org.openpnp.machine.reference.feeder.ReferenceStripFeeder;
 import org.openpnp.machine.reference.feeder.ReferenceStripFeeder.TapeType;
-import org.openpnp.model.Configuration;
-import org.openpnp.model.Length;
-import org.openpnp.model.Location;
-import org.openpnp.model.Part;
+import org.openpnp.model.*;
 import org.openpnp.spi.Camera;
 import org.openpnp.util.HslColor;
 import org.openpnp.util.OpenCvUtils;
@@ -85,6 +84,7 @@ import com.jgoodies.forms.layout.ColumnSpec;
 import com.jgoodies.forms.layout.FormLayout;
 import com.jgoodies.forms.layout.FormSpecs;
 import com.jgoodies.forms.layout.RowSpec;
+import org.pmw.tinylog.Logger;
 
 import static org.openpnp.vision.FluentCv.pointToLineDistance;
 
@@ -117,7 +117,13 @@ public class ReferenceStripFeederConfigurationWizard extends AbstractConfigurati
     private JLabel lblRotationInTape;
     private JTextField textFieldLocationRotation;
     private JButton btnAutoSetup;
+    private JCheckBox chckbxUseVision;
+    private JLabel lblUseVision;
+    private JLabel lblPart;
+    private JLabel lblRetryCount;
+    private JTextField retryCountTf;
 
+    private boolean logDebugInfo = false;
     private Location firstPartLocation;
     private Location secondPartLocation;
     private List<Location> part1HoleLocations;
@@ -397,13 +403,13 @@ public class ReferenceStripFeederConfigurationWizard extends AbstractConfigurati
             cameraView.setText("Click on the center of the first part in the tape.");
             cameraView.flash();
 
-            final boolean showDetails = (e.getModifiers() & ActionEvent.ALT_MASK) != 0;
+            logDebugInfo = (e.getModifiers() & ActionEvent.ALT_MASK) != 0;
 
             cameraView.setCameraViewFilter(new CameraViewFilter() {
                 @Override
                 public BufferedImage filterCameraImage(Camera camera, BufferedImage image) {
                     try {
-                        return showHoles(camera, image, showDetails);
+                        return showHoles(camera, image);
                     }
                     catch (Exception e) {
                         MessageBoxes.errorBox(MainFrame.get(), "Error", e);
@@ -493,6 +499,7 @@ public class ReferenceStripFeederConfigurationWizard extends AbstractConfigurati
                                  }
 
                                  List<Location> referenceHoles = deriveReferenceHoles(
+                                         firstPartLocation, secondPartLocation,
                                          part1HoleLocations, part2HoleLocations);
                                  final Location referenceHole1 = referenceHoles.get(0)
                                                                                .derive(null, null,
@@ -504,11 +511,16 @@ public class ReferenceStripFeederConfigurationWizard extends AbstractConfigurati
                                  feeder.setReferenceHoleLocation(referenceHole1);
                                  feeder.setLastHoleLocation(referenceHole2);
 
-                                 Length partPitch =
-                                         firstPartLocation.getLinearLengthTo(secondPartLocation);
-                                 partPitch.setValue(2 * (Math.round(partPitch.getValue() / 2)));
+                                 Length partPitch = firstPartLocation.getLinearLengthTo(secondPartLocation);
+                                 // Round to the nearest 2mm (parts are spaced either 2mm or 4mm in the tape)
+                                 Length partPitchMM = partPitch.convertToUnits(LengthUnit.Millimeters);
+                                 long standardPitchIncrements = Math.round(partPitchMM.getValue() / 2.0);
+                                 if (standardPitchIncrements == 0) {
+                                     throw new Exception("The same part was selected both times");
+                                 }
+                                 partPitchMM.setValue(2.0 * standardPitchIncrements);
 
-                                 final Length partPitch_ = partPitch;
+                                 final Length partPitch_ = partPitchMM.convertToUnits(firstPartLocation.getUnits());
                                  SwingUtilities.invokeLater(new Runnable() {
                                      public void run() {
                                          Helpers.copyLocationIntoTextFields(referenceHole1,
@@ -555,37 +567,151 @@ public class ReferenceStripFeederConfigurationWizard extends AbstractConfigurati
         pipeline.process();
 
         // Grab the results
-        List<CvStage.Result.Circle> results = (List<CvStage.Result.Circle>)pipeline.getResult("results").model;
-        if (results.isEmpty()) {
+        FindHoles findHolesResults = new FindHoles(camera, pipeline).invoke();
+        List<CvStage.Result.Circle> inLine = findHolesResults.getInLine();
+        if (inLine.isEmpty()) {
             throw new Exception("Feeder " + getName() + ": No tape holes found.");
         }
 
-        // Sort by the distance to the camera center (which is over the part, not the hole)
-        results.sort((a, b) -> {
-            Double da = VisionUtils.getPixelLocation(camera, a.x, a.y)
-                    .getLinearDistanceTo(camera.getLocation());
-            Double db = VisionUtils.getPixelLocation(camera, b.x, b.y)
-                    .getLinearDistanceTo(camera.getLocation());
-            return da.compareTo(db);
-        });
-
         List<Location> holeLocations = new ArrayList<>();
-        double minDistancePx = VisionUtils.toPixels(feeder.getHoleDistanceMin(), camera);
-        double maxDistancePx = VisionUtils.toPixels(feeder.getHoleDistanceMax(), camera);
-        for (int i=0; i<results.size(); i++) {
-            CvStage.Result.Circle result = results.get(i);
-            Double distance = VisionUtils.getPixelLocation(camera, result.x, result.y)
-                    .getLinearDistanceTo(camera.getLocation());
-            Double distancePx = VisionUtils.toPixels(new Length(distance, camera.getUnitsPerPixel().getUnits()), camera);
-            // Min distance is because we're centered at the part, not the hole - so we need to ignore
-            // circles found in the part
-            if ((distancePx >= minDistancePx) && (distancePx <= maxDistancePx)) {
-                Location location = VisionUtils.getPixelLocation(camera, result.x, result.y);
-                holeLocations.add(location);
-            }
+        for (int i=0; i<inLine.size(); i++) {
+            CvStage.Result.Circle result = inLine.get(i);
+            Location location = VisionUtils.getPixelLocation(camera, result.x, result.y);
+            holeLocations.add(location);
         }
 
         return holeLocations;
+    }
+
+    /**
+     * Show candidate holes in the image. Red are any holes that are found. Orange are holes that
+     * passed the distance check but failed the line check. Blue are holes that passed the line
+     * check but are considered superfluous. Green passed all checks and are considered good.
+     * 
+     * @param camera
+     * @param image
+     * @return
+     */
+    private BufferedImage showHoles(Camera camera, BufferedImage image) throws Exception {
+        // BufferedCameraImage is used as we want to run the pipeline on an existing image
+        BufferedImageCamera bufferedImageCamera = new BufferedImageCamera(camera, image);
+
+        // Process the pipeline to clean up the image and detect the tape holes
+        CvPipeline pipeline = getCvPipeline(bufferedImageCamera);
+        pipeline.process();
+        // Grab the results
+        Mat resultMat = pipeline.getWorkingImage().clone();
+        FindHoles findHolesResults = new FindHoles(camera, pipeline).invoke();
+
+        List<CvStage.Result.Circle> inLine = findHolesResults.getInLine();
+        List<Ransac.Line> lines = findHolesResults.getLines();
+        Ransac.Line bestLine = findHolesResults.getBestLine();
+
+        drawLines(resultMat, lines, Color.orange, 1);
+        if (bestLine != null) {
+            drawLine(resultMat, bestLine, Color.yellow, 2);
+        }
+        drawCircles(resultMat, inLine, inLine.size(), Color.blue);
+        drawCircles(resultMat, inLine, 2, Color.green);
+
+        BufferedImage showResult = OpenCvUtils.toBufferedImage(resultMat);
+        resultMat.release();
+        return showResult;
+    }
+
+    private class FindHoles {
+        private Camera camera;
+        private CvPipeline pipeline;
+        private List<Ransac.Line> lines;
+        private Ransac.Line bestLine;
+        private List<CvStage.Result.Circle> inLine;
+
+        public FindHoles(Camera camera, CvPipeline pipeline) {
+            this.camera = camera;
+            this.pipeline = pipeline;
+        }
+
+        public List<Ransac.Line> getLines() {
+            return lines;
+        }
+
+        public Ransac.Line getBestLine() {
+            return bestLine;
+        }
+
+        public List<CvStage.Result.Circle> getInLine() {
+            return inLine;
+        }
+
+        public FindHoles invoke() throws Exception {
+            List<CvStage.Result.Circle> results = null;
+            Object result = pipeline.getResult("results").model;
+            try {
+                results = (List<CvStage.Result.Circle>) result;
+            }
+            catch (ClassCastException e) {
+                throw new Exception("Unrecognized result type (should be Circles): " + result);
+            }
+
+            // Sort by the distance to the camera center (which is over the part, not the hole)
+            results.sort((a, b) -> {
+                Double da = VisionUtils.getPixelLocation(camera, a.x, a.y)
+                        .getLinearDistanceTo(camera.getLocation());
+                Double db = VisionUtils.getPixelLocation(camera, b.x, b.y)
+                        .getLinearDistanceTo(camera.getLocation());
+                return da.compareTo(db);
+            });
+
+            double maxDistanceToLine = VisionUtils.toPixels(feeder.getHoleLineDistanceMax(), camera);
+            double minDistancePx = VisionUtils.toPixels(feeder.getHoleDistanceMin(), camera);
+            double maxDistancePx = VisionUtils.toPixels(feeder.getHoleDistanceMax(), camera);
+            double holePitchPx = VisionUtils.toPixels(feeder.getHolePitch(), camera);
+            double minHolePitchPx = VisionUtils.toPixels(feeder.getHolePitchMin(), camera);
+
+            List<Point> points = new ArrayList<>();
+            // collect the circles into a list of points
+            for (int i = 0; i < results.size(); i++) {
+                CvStage.Result.Circle circle = results.get(i);
+                points.add(new Point(circle.x, circle.y));
+            }
+
+            lines = Ransac.ransac(points, 100, maxDistanceToLine, holePitchPx, holePitchPx - minHolePitchPx);
+
+            bestLine = null;
+            double bestLineDistance = Double.MAX_VALUE;
+            for (Ransac.Line line : lines) {
+                Point a = line.a;
+                Point b = line.b;
+
+                Location aLocation = VisionUtils.getPixelLocation(camera, a.x, a.y);
+                Location bLocation = VisionUtils.getPixelLocation(camera, b.x, b.y);
+
+                Double distance = camera.getLocation().getLinearDistanceToLine(aLocation, bLocation);
+                Double distancePx = VisionUtils.toPixels(new Length(distance, camera.getUnitsPerPixel().getUnits()), camera);
+                // Min distance is because we're centered at the part, not the hole - so we need to ignore
+                // circles found in the part
+                if ((distancePx >= minDistancePx) && (distancePx <= maxDistancePx)) {
+                    if (distance < bestLineDistance) {
+                        bestLine = line;
+                        bestLineDistance = distance;
+                    }
+                }
+            }
+
+            // filter the circles by distance from the resulting line
+            inLine = new ArrayList<CvStage.Result.Circle>();
+            if (bestLine != null) {
+                for (int i = 0; i < results.size(); i++) {
+                    CvStage.Result.Circle circle = results.get(i);
+
+                    Point p = new Point(circle.x, circle.y);
+                    if (pointToLineDistance(bestLine.a, bestLine.b, p) <= maxDistanceToLine) {
+                        inLine.add(circle);
+                    }
+                }
+            }
+            return this;
+        }
     }
 
     private void drawCircles(Mat mat, List<CvStage.Result.Circle> circles, int numToDraw, Color color) {
@@ -603,112 +729,109 @@ public class ReferenceStripFeederConfigurationWizard extends AbstractConfigurati
         }
     }
 
-    /**
-     * Show candidate holes in the image. Red are any holes that are found. Orange are holes that
-     * passed the distance check but failed the line check. Blue are holes that passed the line
-     * check but are considered superfluous. Green passed all checks and are considered good.
-     * 
-     * @param camera
-     * @param image
-     * @return
-     */
-    private BufferedImage showHoles(Camera camera, BufferedImage image, boolean showDetails) throws Exception {
-        // BufferedCameraImage is used as we want to run the pipeline on an existing image
-        BufferedImageCamera bufferedImageCamera = new BufferedImageCamera(camera, image);
-
-        // Process the pipeline to clean up the image and detect the tape holes
-        CvPipeline pipeline = getCvPipeline(bufferedImageCamera);
-        pipeline.process();
-        // Grab the results
-        Mat resultMat = pipeline.getWorkingImage().clone();
-        List<CvStage.Result.Circle> results = (List<CvStage.Result.Circle>)pipeline.getResult("results").model;
-
-        // Sort by the distance to the camera center (which is over the part, not the hole)
-        results.sort((a, b) -> {
-            Double da = VisionUtils.getPixelLocation(camera, a.x, a.y)
-                    .getLinearDistanceTo(camera.getLocation());
-            Double db = VisionUtils.getPixelLocation(camera, b.x, b.y)
-                    .getLinearDistanceTo(camera.getLocation());
-            return da.compareTo(db);
-        });
-
-        List<CvStage.Result.Circle> withinDistance = new ArrayList<CvStage.Result.Circle>();
-        double minDistancePx = VisionUtils.toPixels(feeder.getHoleDistanceMin(), camera);
-        double maxDistancePx = VisionUtils.toPixels(feeder.getHoleDistanceMax(), camera);
-        for (int i=0; i<results.size(); i++) {
-            CvStage.Result.Circle result = results.get(i);
-            Double distance = VisionUtils.getPixelLocation(camera, result.x, result.y)
-                    .getLinearDistanceTo(camera.getLocation());
-            Double distancePx = VisionUtils.toPixels(new Length(distance, camera.getUnitsPerPixel().getUnits()), camera);
-            // Min distance is because we're centered at the part, not the hole - so we need to ignore
-            // circles found in the part
-            if ((distancePx >= minDistancePx) && (distancePx <= maxDistancePx)) {
-                withinDistance.add(result);
-            }
+    private void drawLines(Mat mat, List<Ransac.Line> lines, Color color, int thickness) {
+        for (Ransac.Line line : lines) {
+            drawLine(mat, line, color, thickness);
         }
-
-        List<CvStage.Result.Circle> inLine = new ArrayList<CvStage.Result.Circle>();
-        if (withinDistance.size() <= 2) {
-            inLine.addAll(withinDistance);
-        }
-        else {
-            double maxDistanceToLine = VisionUtils.toPixels(feeder.getHoleLineDistanceMax(), camera);
-
-            List<Point> points = new ArrayList<>();
-            // collect the circles into a list of points
-            for (int i = 0; i < withinDistance.size(); i++) {
-                CvStage.Result.Circle circle = withinDistance.get(i);
-                points.add(new Point(circle.x, circle.y));
-            }
-
-            Point[] line = Ransac.ransac(points, 100, maxDistanceToLine);
-            Point a = line[0];
-            Point b = line[1];
-
-            // filter the circles by distance from the resulting line
-            for (int i = 0; i < withinDistance.size(); i++) {
-                CvStage.Result.Circle circle = withinDistance.get(i);
-
-                Point p = new Point(circle.x, circle.y);
-                if (pointToLineDistance(a, b, p) <= maxDistanceToLine) {
-                    inLine.add(circle);
-                }
-            }
-        }
-
-        if (showDetails) {
-            drawCircles(resultMat, withinDistance, withinDistance.size(), Color.orange);
-            drawCircles(resultMat, inLine, inLine.size(), Color.blue);
-            drawCircles(resultMat, inLine, 2, Color.green);
-        }
-        else {
-            drawCircles(resultMat, inLine, 2, Color.green);
-        }
-
-        BufferedImage showResult = OpenCvUtils.toBufferedImage(resultMat);
-        resultMat.release();
-        return showResult;
     }
 
-    private List<Location> deriveReferenceHoles(List<Location> part1HoleLocations,
-            List<Location> part2HoleLocations) {
+    private void drawLine(Mat mat, Ransac.Line line, Color color, int thickness) {
+        Core.line(mat, line.a, line.b, FluentCv.colorToScalar(color), thickness);
+    }
+
+    private List<Location> deriveReferenceHoles(
+            Location firstPartLocation,
+            Location secondPartLocation,
+            List<Location> part1HoleLocations,
+            List<Location> part2HoleLocations) throws Exception {
+
+        Location partsLocationRay = secondPartLocation.subtract(firstPartLocation);
+        Point feedDirection = new Point(partsLocationRay.getX(), partsLocationRay.getY());
+
         // We are only interested in the pair of holes closest to each part
         part1HoleLocations = part1HoleLocations.subList(0, Math.min(2, part1HoleLocations.size()));
         part2HoleLocations = part2HoleLocations.subList(0, Math.min(2, part2HoleLocations.size()));
 
-        // Part 1's reference hole is the one closest to either of part 2's holes.
-        Location part1ReferenceHole =
-                VisionUtils.sortLocationsByDistance(part2HoleLocations.get(0), part1HoleLocations)
-                           .get(0);
-        // Part 2's reference hole is the one farthest from part 1's reference hole.
-        Location part2ReferenceHole = Lists.reverse(
-                VisionUtils.sortLocationsByDistance(part1ReferenceHole, part2HoleLocations))
-                                           .get(0);
+        // Part 2's reference hole is the one farthest from part 1, in the direction of part 2
+        List<LocationsAlongRay> part2HoleLocationsAlongRay = new ArrayList<>(part2HoleLocations.size());
+        for (Location partLocation : part2HoleLocations) {
+            Location loc = partLocation.convertToUnits(partsLocationRay.getUnits());
+            Point p = new Point(loc.getX() - firstPartLocation.getX(), loc.getY() - firstPartLocation.getY());
+            double distanceAlongRay = feedDirection.dot(p);
+            part2HoleLocationsAlongRay.add(new LocationsAlongRay(partLocation, distanceAlongRay));
+        }
+        part2HoleLocationsAlongRay.sort(null);
+        List<Location> part2SortedLocations = new ArrayList<>(part2HoleLocationsAlongRay.size());
+        part2HoleLocationsAlongRay.forEach(locationAlongRay -> part2SortedLocations.add(locationAlongRay.location));
+        List<Location> part2ReverseSortedLocations = Lists.reverse(part2SortedLocations);
+        Location part2ReferenceHole = part2ReverseSortedLocations.get(0);
+
+        // Part 1's reference hole is the one closest to part 2's reference hole.
+        List<Location> part1SortedLocations = VisionUtils.sortLocationsByDistance(part2ReferenceHole, part1HoleLocations);
+        Location part1ReferenceHole = part1SortedLocations.get(0);
+        double holePitchMin = feeder.getHolePitchMin().convertToUnits(part1ReferenceHole.getUnits()).getValue();
+        double referenceHoleDistance = part1ReferenceHole.getLinearDistanceTo(part2ReferenceHole);
+        // Part 1 and part 2 may have the same reference holes for 2mm part-pitch tape, so "the one closest to part 2's
+        // reference hole" will be part 2's reference hole - thus we want the other hole
+        if (referenceHoleDistance < holePitchMin) {
+            part1ReferenceHole = part1SortedLocations.get(1);
+        }
+
+        // Get the vector perpendicular to feedDirection (perp dot is (-y, x) and gives the vector rotated 90° to the
+        // left, but we want the vector rotated 90° to the right and thus (y, -x))
+        Point expectedHoleHalfspace = new Point(feedDirection.y, -feedDirection.x);
+        Location hole1RelativeLocation = part1ReferenceHole.subtract(firstPartLocation);
+        Location hole2RelativeLocation = part2ReferenceHole.subtract(firstPartLocation);
+        Point h1 = new Point(hole1RelativeLocation.getX(), hole1RelativeLocation.getY());
+        Point h2 = new Point(hole2RelativeLocation.getX(), hole2RelativeLocation.getY());
+        double h1Dist = expectedHoleHalfspace.dot(h1);
+        double h2Dist = expectedHoleHalfspace.dot(h2);
+        boolean correctOrientation = (h1Dist > 0.0) && (h2Dist > 0.0);
+
+        if (this.logDebugInfo) {
+            Logger.info("deriveReferenceHoles");
+            Logger.info("  feedDirection: " + feedDirection);
+            Logger.info("  firstPartLocation: " + firstPartLocation);
+            Logger.info("  secondPartLocation: " + secondPartLocation);
+            Logger.info("  part1HoleLocations: " + part1HoleLocations);
+            Logger.info("  part2HoleLocations: " + part2HoleLocations);
+            Logger.info("  part2HoleLocationsAlongRay: " + part2HoleLocationsAlongRay);
+            Logger.info("  part2ReverseSortedLocations: " + part2ReverseSortedLocations);
+            Logger.info("  part1SortedLocations: " + part1SortedLocations);
+            Logger.info("  referenceHoleDistance: " + referenceHoleDistance);
+            Logger.info("  h1Dist: " + h1Dist);
+            Logger.info("  h2Dist: " + h2Dist);
+            Logger.info("  correctOrientation: " + correctOrientation);
+        }
+
+        if (!correctOrientation) {
+            throw new Exception("The tape is oriented incorrectly for the feed direction of the components selected");
+        }
 
         List<Location> referenceHoles = new ArrayList<>();
         referenceHoles.add(part1ReferenceHole);
         referenceHoles.add(part2ReferenceHole);
         return referenceHoles;
+    }
+
+    private static class LocationsAlongRay implements Comparable<LocationsAlongRay> {
+        public Location location;
+        public double distance;
+
+        public LocationsAlongRay(Location location, double distance) {
+            this.location = location;
+            this.distance = distance;
+        }
+
+        @Override
+        public int compareTo(LocationsAlongRay o) {
+            return Double.compare(this.distance, o.distance);
+        }
+
+        @Override
+        public String toString() {
+            return String.format(Locale.US, "(%s, %s)", Double.toString(distance), location.toString());
+        }
     }
 
     private void editPipeline() throws Exception {
@@ -739,10 +862,4 @@ public class ReferenceStripFeederConfigurationWizard extends AbstractConfigurati
         pipeline.setProperty("DetectFixedCirclesHough.maxDiameter", pxMaxDiameter);
         return pipeline;
     }
-
-    private JCheckBox chckbxUseVision;
-    private JLabel lblUseVision;
-    private JLabel lblPart;
-    private JLabel lblRetryCount;
-    private JTextField retryCountTf;
 }

--- a/src/main/java/org/openpnp/model/Location.java
+++ b/src/main/java/org/openpnp/model/Location.java
@@ -119,6 +119,18 @@ public class Location {
                 + Math.pow(this.y - location.getY(), 2) + Math.pow(this.z - location.getZ(), 2)));
     }
 
+    /**
+     * Returns the distance between this Location and the line defined by the Locations a and b,
+     * in the units of this Location.
+     * @return
+     */
+    public double getLinearDistanceToLine(Location A, Location B) {
+        A = A.convertToUnits(getUnits());
+        B = B.convertToUnits(getUnits());
+        double normalLength = Math.sqrt((B.x - A.x) * (B.x - A.x) + (B.y - A.y) * (B.y - A.y));
+        return Math.abs((this.x - A.x) * (B.y - A.y) - (this.y - A.y) * (B.x - A.x)) / normalLength;
+    }
+
     public Length getLengthX() {
         return new Length(x, units);
     }

--- a/src/main/java/org/openpnp/vision/FluentCv.java
+++ b/src/main/java/org/openpnp/vision/FluentCv.java
@@ -430,9 +430,9 @@ public class FluentCv {
             points.add(new Point(x, y));
         }
 
-        Point[] line = Ransac.ransac(points, 100, maxDistance);
-        Point a = line[0];
-        Point b = line[1];
+        List<Ransac.Line> lines = Ransac.ransac(points, 100, maxDistance);
+        Point a = lines.get(0).a;
+        Point b = lines.get(0).b;
 
         // filter the points by distance from the resulting line
         List<float[]> results = new ArrayList<>();

--- a/src/main/java/org/openpnp/vision/Ransac.java
+++ b/src/main/java/org/openpnp/vision/Ransac.java
@@ -1,38 +1,221 @@
 package org.openpnp.vision;
 
-import java.util.Collections;
-import java.util.List;
+import java.util.*;
 
 import org.opencv.core.Point;
 
 public class Ransac {
+    private static class LineIndices implements Comparable<LineIndices> {
+        public List<Integer> indices = new ArrayList<>();
+
+        public LineIndices(List<Integer> indices) {
+            this.indices.addAll(indices);
+            this.indices.sort(null);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            LineIndices that = (LineIndices) o;
+
+            return indices.equals(that.indices);
+        }
+
+        @Override
+        public int compareTo(LineIndices o) {
+            // NOTE: aIndex and bIndex don't matter for comparisons
+            int cmp = Integer.compare(this.indices.size(), o.indices.size());
+            if (cmp != 0) {
+                return cmp;
+            }
+
+            for (int i=0; i<this.indices.size(); i++) {
+                Integer a = this.indices.get(i);
+                Integer b = o.indices.get(i);
+                cmp = a.compareTo(b);
+                if (cmp != 0) {
+                    return cmp;
+                }
+            }
+
+            return 0;
+        }
+    }
+
+    public static class Line {
+        public Point a;
+        public Point b;
+
+        public Line(Point a, Point b) {
+            this.a = a;
+            this.b = b;
+        }
+    }
     /*
      * http://users.utcluj.ro/~igiosan/Resources/PRS/L1/lab_01e.pdf
      * http://cs.gmu.edu/~kosecka/cs682/lect-fitting.pdf
      * http://introcs.cs.princeton.edu/java/36inheritance/LeastSquares.java.html
      */
-    public static Point[] ransac(List<Point> points, int maxIterations, double threshold) {
-        Point bestA = null, bestB = null;
-        int bestInliers = 0;
+    public static List<Line> ransac(List<Point> points, int maxIterations, double pointToLineDistanceThreshold) {
+        List<Integer> pointMapping = new ArrayList<>(points.size());
+        for (int i=0; i<points.size(); i++) {
+            pointMapping.add(i);
+        }
+
+        List<LineIndices> resultIndices = new ArrayList<>();
         for (int i = 0; i < maxIterations; i++) {
             // take a random sample of two points
-            Collections.shuffle(points);
-            Point a = points.get(0);
-            Point b = points.get(1);
+            Collections.shuffle(pointMapping);
+            Integer aIndex = pointMapping.get(0);
+            Integer bIndex = pointMapping.get(1);
+            Point a = points.get(aIndex);
+            Point b = points.get(bIndex);
             // find the inliers
-            int inliers = 0;
-            for (Point p : points) {
+            List<Integer> inliers = new ArrayList<>();
+            for (Integer pIndex : pointMapping) {
+                Point p = points.get(pIndex);
                 double distance = FluentCv.pointToLineDistance(a, b, p);
-                if (distance <= threshold) {
-                    inliers++;
+                if (distance <= pointToLineDistanceThreshold) {
+                    inliers.add(pIndex);
                 }
             }
-            if (inliers > bestInliers) {
-                bestA = a;
-                bestB = b;
-                bestInliers = inliers;
+            if (inliers.size() >= 2) {
+                // Must check for duplicates as we're just randomly shuffling and testing again; the same line may
+                // come up many times, both from the same starting points or from other points on the same line
+                LineIndices lineIndices = new LineIndices(inliers);
+                if (!resultIndices.contains(lineIndices)) {
+                    resultIndices.add(lineIndices);
+                }
             }
         }
-        return new Point[] {bestA, bestB};
+
+        // Sort the results by the number of points, descending
+        resultIndices.sort(new Comparator<LineIndices>() {
+            @Override
+            public int compare(LineIndices o1, LineIndices o2) {
+                return -Integer.compare(o1.indices.size(), o2.indices.size());
+            }
+        });
+
+        List<Line> results = new ArrayList<>(resultIndices.size());
+        for (LineIndices lineIndices : resultIndices) {
+            Line line = getLongestLine(points, lineIndices);
+            results.add(line);
+        }
+        return results;
+    }
+
+    public static List<Line> ransac(List<Point> points, int maxIterations, double pointToLineDistanceThreshold, double pointSpacing, double pointSpacingEpsilon) {
+        if (points.size() < 2) {
+            return new ArrayList<Line>();
+        }
+
+        List<Integer> pointMapping = new ArrayList<>(points.size());
+        for (int i=0; i<points.size(); i++) {
+            pointMapping.add(i);
+        }
+
+        List<LineIndices> resultIndices = new ArrayList<>();
+        for (int i = 0; i < maxIterations; i++) {
+            // take a random sample of two points
+            Collections.shuffle(pointMapping);
+            Integer aIndex = pointMapping.get(0);
+            Integer bIndex = pointMapping.get(1);
+            Point a = points.get(aIndex);
+            Point b = points.get(bIndex);
+            // find the inliers
+            List<Integer> inliers = new ArrayList<>();
+            for (Integer pIndex : pointMapping) {
+                Point p = points.get(pIndex);
+                double distance = FluentCv.pointToLineDistance(a, b, p);
+                if (distance <= pointToLineDistanceThreshold) {
+                    inliers.add(pIndex);
+                }
+            }
+            List<Integer> spacedInliers = filterInliersWithSpacing(a, b, points, inliers, pointSpacing, pointSpacingEpsilon);
+            if (spacedInliers.size() >= 2) {
+                // Must check for duplicates as we're just randomly shuffling and testing again; the same line may
+                // come up many times, both from the same starting points or from other points on the same line
+                LineIndices lineIndices = new LineIndices(spacedInliers);
+                if (!resultIndices.contains(lineIndices)) {
+                    resultIndices.add(lineIndices);
+                }
+            }
+        }
+
+        // Sort the results by the number of points, descending
+        resultIndices.sort(new Comparator<LineIndices>() {
+            @Override
+            public int compare(LineIndices o1, LineIndices o2) {
+                return -Integer.compare(o1.indices.size(), o2.indices.size());
+            }
+        });
+
+        List<Line> results = new ArrayList<>(resultIndices.size());
+        for (LineIndices lineIndices : resultIndices) {
+            Line line = getLongestLine(points, lineIndices);
+            results.add(line);
+        }
+        return results;
+    }
+
+    private static List<Integer> filterInliersWithSpacing(Point firstPoint, Point secondPoint, List<Point> points, List<Integer> inliers, double pointSpacing, double pointSpacingEpsilon) {
+        Point lineDir = new Point(secondPoint.x - firstPoint.x, secondPoint.y - firstPoint.y);
+
+        TreeSet<Integer> indicesOnLine = new TreeSet<>();
+        List<Integer> spacedInliers = new ArrayList<>(inliers.size());
+        for (Integer pIndex : inliers) {
+            Point p = points.get(pIndex);
+
+            Point diff = new Point(p.x - firstPoint.x, p.y - firstPoint.y);
+            double distance = Math.sqrt(diff.dot(diff));
+            double variance = distance % pointSpacing;
+            if ((variance <= pointSpacingEpsilon) || ((pointSpacing - variance) <= pointSpacingEpsilon)) {
+                double signedDistance = distance * (lineDir.dot(diff) > 0.0 ? 1.0 : -1.0);
+                Integer indexOnLine = (int)Math.round(signedDistance / pointSpacing);
+                if (!indicesOnLine.contains(indexOnLine)) {
+                    indicesOnLine.add(indexOnLine);
+
+                    spacedInliers.add(pIndex);
+                }
+            }
+        }
+
+        // Discard this line if any index is missing
+        Integer minIndex = indicesOnLine.first();
+        Integer maxIndex = indicesOnLine.last();
+        for (Integer idx=minIndex + 1; idx<maxIndex; idx++) {
+            if (!indicesOnLine.contains(idx)) {
+                return new ArrayList<>();
+            }
+        }
+
+        return spacedInliers;
+    }
+
+    private static Line getLongestLine(List<Point> points, LineIndices lineIndices) {
+        Integer bestAIndex = 0;
+        Integer bestBIndex = 0;
+        double bestDistance = 0.0;
+        for (int i=0; i<(lineIndices.indices.size() - 1); i++) {
+            for (int j=i+1; j<lineIndices.indices.size(); j++) {
+                Integer aIndex = lineIndices.indices.get(i);
+                Integer bIndex = lineIndices.indices.get(j);
+                Point a = points.get(aIndex);
+                Point b = points.get(bIndex);
+
+                Point diff = new Point(b.x - a.x, b.y - a.y);
+                double distance = Math.sqrt(diff.dot(diff));
+                if (distance > bestDistance) {
+                    bestAIndex = aIndex;
+                    bestBIndex = bIndex;
+                    bestDistance = distance;
+                }
+            }
+        }
+
+        return new Line(points.get(bestAIndex), points.get(bestBIndex));
     }
 }

--- a/src/main/java/org/openpnp/vision/Ransac.java
+++ b/src/main/java/org/openpnp/vision/Ransac.java
@@ -15,8 +15,12 @@ public class Ransac {
 
         @Override
         public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
 
             LineIndices that = (LineIndices) o;
 

--- a/src/main/resources/org/openpnp/machine/reference/feeder/ReferenceStripFeeder-DefaultPipeline.xml
+++ b/src/main/resources/org/openpnp/machine/reference/feeder/ReferenceStripFeeder-DefaultPipeline.xml
@@ -2,10 +2,11 @@
    <stages>
       <cv-stage class="org.openpnp.vision.pipeline.stages.ImageCapture" name="1" enabled="true" settle-first="true"/>
       <cv-stage class="org.openpnp.vision.pipeline.stages.ConvertColor" name="2" enabled="true" conversion="Bgr2Gray"/>
+      <cv-stage class="org.openpnp.vision.pipeline.stages.Threshold" name="3" enabled="true" threshold="100" auto="true" invert="false"/>
       <cv-stage class="org.openpnp.vision.pipeline.stages.BlurGaussian" name="predetect" enabled="true" kernel-size="9"/>
       <cv-stage class="org.openpnp.vision.pipeline.stages.DetectFixedCirclesHough" name="results" enabled="true"/>
-      <cv-stage class="org.openpnp.vision.pipeline.stages.ConvertColor" name="5" enabled="true" conversion="Gray2Bgr"/>
-      <cv-stage class="org.openpnp.vision.pipeline.stages.DrawCircles" name="6" enabled="true" circles-stage-name="results" thickness="1">
+      <cv-stage class="org.openpnp.vision.pipeline.stages.ConvertColor" name="6" enabled="true" conversion="Gray2Bgr"/>
+      <cv-stage class="org.openpnp.vision.pipeline.stages.DrawCircles" name="7" enabled="true" circles-stage-name="results" thickness="1">
          <color r="255" g="0" b="0" a="255"/>
       </cv-stage>
    </stages>


### PR DESCRIPTION
# Description
Fairly large-scale improvements to the Auto Setup feature of ReferenceStripFeeder. Addresses #411, Strip Feeder Auto Setup Improvements. Holes for all strips in the camera view are now correctly identified and grouped into per-strip lines. The logic around which line of holes to use is improved, as is the final selection of what reference holes to use. A few bugs were discovered in the process and squished. More setup errors are also caught and handled.

# Justification
The Auto Setup feature is now very robust.

# Instructions for Use
No user-facing changes other than better results and catching user-/setup-errors better.

# Implementation Details
1. How did you test the change? Be descriptive. Untested code will not be accepted.
Tested extensively with all the strips in the default job/reference machine, with correct user-behaviour, incorrect user-behaviour, and just plain dumb-behaviour. Ran pnp-test.job. Ran Maven tests.
2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)?
Yes
3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing.
Location.getLinearDistanceToLine() was added to complement the existing Location.getLinearDistanceTo()
4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted.
Done.