### PR TITLE
ReferenceStripFeeder CvPipeline improvements

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/feeder/wizards/ReferenceStripFeederConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/wizards/ReferenceStripFeederConfigurationWizard.java
@@ -868,12 +868,17 @@ public class ReferenceStripFeederConfigurationWizard extends AbstractConfigurati
         Integer pxMinDiameter = (int) VisionUtils.toPixels(feeder.getHoleDiameterMin(), camera);
         Integer pxMaxDiameter = (int) VisionUtils.toPixels(feeder.getHoleDiameterMax(), camera);
 
-        CvPipeline pipeline = feeder.getPipeline();
-        pipeline.setProperty("camera", camera);
-        pipeline.setProperty("feeder", feeder);
-        pipeline.setProperty("DetectFixedCirclesHough.minDistance", pxMinDistance);
-        pipeline.setProperty("DetectFixedCirclesHough.minDiameter", pxMinDiameter);
-        pipeline.setProperty("DetectFixedCirclesHough.maxDiameter", pxMaxDiameter);
-        return pipeline;
+        try {
+            CvPipeline pipeline = feeder.getPipeline().clone();
+            pipeline.setProperty("camera", camera);
+            pipeline.setProperty("feeder", feeder);
+            pipeline.setProperty("DetectFixedCirclesHough.minDistance", pxMinDistance);
+            pipeline.setProperty("DetectFixedCirclesHough.minDiameter", pxMinDiameter);
+            pipeline.setProperty("DetectFixedCirclesHough.maxDiameter", pxMaxDiameter);
+            return pipeline;
+        }
+        catch (CloneNotSupportedException e) {
+            throw new Error(e);
+        }
     }
 }

--- a/src/main/java/org/openpnp/model/Location.java
+++ b/src/main/java/org/openpnp/model/Location.java
@@ -120,8 +120,9 @@ public class Location {
     }
 
     /**
-     * Returns the distance between this Location and the line defined by the Locations a and b,
+     * Returns the distance between this Location and the infinite line defined by the Locations a and b,
      * in the units of this Location.
+     * From http://www.ahristov.com/tutorial/geometry-games/point-line-distance.html
      * @return
      */
     public double getLinearDistanceToLine(Location A, Location B) {
@@ -129,6 +130,32 @@ public class Location {
         B = B.convertToUnits(getUnits());
         double normalLength = Math.sqrt((B.x - A.x) * (B.x - A.x) + (B.y - A.y) * (B.y - A.y));
         return Math.abs((this.x - A.x) * (B.y - A.y) - (this.y - A.y) * (B.x - A.x)) / normalLength;
+    }
+
+    /**
+     * Returns the distance between this Location and the line segment defined by the Locations a and b,
+     * in the units of this Location.
+     * From Real Time Collision Detection p/130
+     * @return
+     */
+    public double getLinearDistanceToLineSegment(Location A, Location B) {
+        A = A.convertToUnits(getUnits());
+        B = B.convertToUnits(getUnits());
+
+        org.opencv.core.Point ab = new org.opencv.core.Point(B.x - A.x, B.y - A.y);
+        org.opencv.core.Point ap = new org.opencv.core.Point(this.x - A.x, this.y - A.y);
+        org.opencv.core.Point bp = new org.opencv.core.Point(this.x - B.x, this.y - B.y);
+        // Handle cases where P projects outside of AB
+        double e = ap.dot(ab);
+        if (e <= 0.0) {
+            return Math.sqrt(ap.dot(ap));
+        }
+        double f = ab.dot(ab);
+        if (e >= f) {
+            return Math.sqrt(bp.dot(bp));
+        }
+        // P projects onto AB
+        return Math.sqrt(ap.dot(ap) - e * e / f);
     }
 
     public Length getLengthX() {

--- a/src/main/java/org/openpnp/vision/FluentCv.java
+++ b/src/main/java/org/openpnp/vision/FluentCv.java
@@ -679,10 +679,30 @@ public class FluentCv {
         return img;
     }
 
+    // Distance from a point to the closest point on an infinte line that AB are on
     // From http://www.ahristov.com/tutorial/geometry-games/point-line-distance.html
     public static double pointToLineDistance(Point A, Point B, Point P) {
         double normalLength = Math.sqrt((B.x - A.x) * (B.x - A.x) + (B.y - A.y) * (B.y - A.y));
         return Math.abs((P.x - A.x) * (B.y - A.y) - (P.y - A.y) * (B.x - A.x)) / normalLength;
+    }
+
+    // Distance from a point to the closest point on the line segment AB
+    // From Real Time Collision Detection p/130
+    public static double pointToLineSegmentDistance(Point A, Point B, Point P) {
+        Point ab = new Point(B.x - A.x, B.y - A.y);
+        Point ap = new Point(P.x - A.x, P.y - A.y);
+        Point bp = new Point(P.x - B.x, P.y - B.y);
+        // Handle cases where P projects outside of AB
+        double e = ap.dot(ab);
+        if (e <= 0.0) {
+            return Math.sqrt(ap.dot(ap));
+        }
+        double f = ab.dot(ab);
+        if (e >= f) {
+            return Math.sqrt(bp.dot(bp));
+        }
+        // P projects onto AB
+        return Math.sqrt(ap.dot(ap) - e * e / f);
     }
 
     /**

--- a/src/main/java/org/openpnp/vision/pipeline/stages/BlurGaussian.java
+++ b/src/main/java/org/openpnp/vision/pipeline/stages/BlurGaussian.java
@@ -12,7 +12,7 @@ import org.simpleframework.xml.Attribute;
 @Stage(category="Image Processing", description="Performs gaussian blurring on the working image.")
 public class BlurGaussian extends CvStage {
     @Attribute
-    @Property(description="Width and height of the blurring kernel")
+    @Property(description="Width and height of the blurring kernel. Should be and odd number greater than or equal to 3")
     private int kernelSize = 3;
 
     public int getKernelSize() {
@@ -20,7 +20,8 @@ public class BlurGaussian extends CvStage {
     }
 
     public void setKernelSize(int kernelSize) {
-        this.kernelSize = kernelSize;
+        this.kernelSize = 2 * (kernelSize / 2) + 1;
+        this.kernelSize = this.kernelSize < 3 ? 3 : this.kernelSize;
     }
 
     @Override

--- a/src/main/java/org/openpnp/vision/pipeline/stages/BlurMedian.java
+++ b/src/main/java/org/openpnp/vision/pipeline/stages/BlurMedian.java
@@ -20,7 +20,8 @@ public class BlurMedian extends CvStage {
     }
 
     public void setKernelSize(int kernelSize) {
-        this.kernelSize = kernelSize;
+        this.kernelSize = 2 * (kernelSize / 2) + 1;
+        this.kernelSize = this.kernelSize < 3 ? 3 : this.kernelSize;
     }
 
     @Override

--- a/src/main/java/org/openpnp/vision/pipeline/stages/BlurMedian.java
+++ b/src/main/java/org/openpnp/vision/pipeline/stages/BlurMedian.java
@@ -12,7 +12,7 @@ import org.simpleframework.xml.Attribute;
         description = "Performs median blurring on the working image.")
 public class BlurMedian extends CvStage {
     @Attribute
-    @Property(description = "Width and height of the blurring kernel")
+    @Property(description = "Width and height of the blurring kernel. Should be and odd number greater than or equal to 3")
     private int kernelSize = 3;
 
     public int getKernelSize() {

--- a/src/main/java/org/openpnp/vision/pipeline/stages/DetectCirclesHough.java
+++ b/src/main/java/org/openpnp/vision/pipeline/stages/DetectCirclesHough.java
@@ -34,6 +34,7 @@ public class DetectCirclesHough extends CvStage {
      * half as big width and height.
      */
     @Attribute(required = false)
+    @Property(description = "Inverse ratio of the accumulator resolution to the image resolution")
     private double dp = 1;
 
     /**
@@ -41,6 +42,7 @@ public class DetectCirclesHough extends CvStage {
      * the two passed to the Canny() edge detector (the lower one is twice smaller).
      */
     @Attribute(required = false)
+    @Property(description = "The higher threshold of the two passed to the Canny() edge detector (the lower one is twice smaller)")
     private double param1 = 80;
 
     /**
@@ -50,6 +52,7 @@ public class DetectCirclesHough extends CvStage {
      * returned first.
      */
     @Attribute(required = false)
+    @Property(description = "The accumulator threshold for the circle centers at the detection stage. The smaller it is, the more false circles may be detected")
     private double param2 = 10;
 
     public int getMinDistance() {

--- a/src/main/java/org/openpnp/vision/pipeline/stages/DetectFixedCirclesHough.java
+++ b/src/main/java/org/openpnp/vision/pipeline/stages/DetectFixedCirclesHough.java
@@ -8,6 +8,7 @@ import org.openpnp.spi.Camera;
 import org.openpnp.util.VisionUtils;
 import org.openpnp.vision.pipeline.CvPipeline;
 import org.openpnp.vision.pipeline.CvStage;
+import org.openpnp.vision.pipeline.Property;
 import org.openpnp.vision.pipeline.Stage;
 import org.simpleframework.xml.Attribute;
 
@@ -19,6 +20,57 @@ import java.util.List;
  */
 @Stage(description="Finds circles in the working image. Diameter and spacing are provided by the pipeline.")
 public class DetectFixedCirclesHough extends CvStage {
+    /**
+     * Inverse ratio of the accumulator resolution to the image resolution. For example, if dp=1 ,
+     * the accumulator has the same resolution as the input image. If dp=2 , the accumulator has
+     * half as big width and height.
+     */
+    @Attribute(required = false)
+    @Property(description = "Inverse ratio of the accumulator resolution to the image resolution")
+    private double dp = 1;
+
+    /**
+     * First method-specific parameter. In case of CV_HOUGH_GRADIENT , it is the higher threshold of
+     * the two passed to the Canny() edge detector (the lower one is twice smaller).
+     */
+    @Attribute(required = false)
+    @Property(description = "The higher threshold of the two passed to the Canny() edge detector (the lower one is twice smaller)")
+    private double param1 = 80;
+
+    /**
+     * Second method-specific parameter. In case of CV_HOUGH_GRADIENT , it is the accumulator
+     * threshold for the circle centers at the detection stage. The smaller it is, the more false
+     * circles may be detected. Circles, corresponding to the larger accumulator values, will be
+     * returned first.
+     */
+    @Attribute(required = false)
+    @Property(description = "The accumulator threshold for the circle centers at the detection stage. The smaller it is, the more false circles may be detected")
+    private double param2 = 13;
+
+    public double getDp() {
+        return dp;
+    }
+
+    public void setDp(double dp) {
+        this.dp = dp;
+    }
+
+    public double getParam1() {
+        return param1;
+    }
+
+    public void setParam1(double param1) {
+        this.param1 = param1;
+    }
+
+    public double getParam2() {
+        return param2;
+    }
+
+    public void setParam2(double param2) {
+        this.param2 = param2;
+    }
+
     @Override
     public Result process(CvPipeline pipeline) throws Exception {
         Camera camera = (Camera) pipeline.getProperty("camera");
@@ -31,25 +83,6 @@ public class DetectFixedCirclesHough extends CvStage {
         if ((minDistance == null) || (minDiameter == null) || (maxDiameter == null)) {
             throw new Exception("DetectFixedCirclesHough properties are not set on pipeline.");
         }
-
-        /**
-         * Inverse ratio of the accumulator resolution to the image resolution. For example, if dp=1 ,
-         * the accumulator has the same resolution as the input image. If dp=2 , the accumulator has
-         * half as big width and height.
-         */
-        double dp = 1;
-        /**
-         * First method-specific parameter. In case of CV_HOUGH_GRADIENT , it is the higher threshold of
-         * the two passed to the Canny() edge detector (the lower one is twice smaller).
-         */
-        double param1 = 80;
-        /**
-         * Second method-specific parameter. In case of CV_HOUGH_GRADIENT , it is the accumulator
-         * threshold for the circle centers at the detection stage. The smaller it is, the more false
-         * circles may be detected. Circles, corresponding to the larger accumulator values, will be
-         * returned first.
-         */
-        double param2 = 10;
 
         Mat mat = pipeline.getWorkingImage();
         Mat output = new Mat();

--- a/src/main/resources/org/openpnp/machine/reference/feeder/ReferenceStripFeeder-DefaultPipeline.xml
+++ b/src/main/resources/org/openpnp/machine/reference/feeder/ReferenceStripFeeder-DefaultPipeline.xml
@@ -1,9 +1,10 @@
 <cv-pipeline>
    <stages>
       <cv-stage class="org.openpnp.vision.pipeline.stages.ImageCapture" name="original" enabled="true" settle-first="true"/>
+      <cv-stage class="org.openpnp.vision.pipeline.stages.BlurMedian" name="cleanup-noise" enabled="true" kernel-size="5"/>
       <cv-stage class="org.openpnp.vision.pipeline.stages.ConvertColor" name="gray" enabled="true" conversion="Bgr2Gray"/>
-      <cv-stage class="org.openpnp.vision.pipeline.stages.Threshold" name="threshold" enabled="true" threshold="100" auto="true" invert="false"/>
-      <cv-stage class="org.openpnp.vision.pipeline.stages.BlurGaussian" name="predetect" enabled="true" kernel-size="9"/>
+      <cv-stage class="org.openpnp.vision.pipeline.stages.ThresholdAdaptive" name="threshold" enabled="true" adaptive-method="Gaussian" invert="false" block-size="9" c-parm="0"/>
+      <cv-stage class="org.openpnp.vision.pipeline.stages.BlurGaussian" name="predetect" enabled="true" kernel-size="5"/>
       <cv-stage class="org.openpnp.vision.pipeline.stages.DetectFixedCirclesHough" name="results" enabled="true"/>
       <cv-stage class="org.openpnp.vision.pipeline.stages.ImageRecall" name="recalled" enabled="true" image-stage-name="original"/>
       <cv-stage class="org.openpnp.vision.pipeline.stages.DrawCircles" name="display" enabled="true" circles-stage-name="results" thickness="1">

--- a/src/main/resources/org/openpnp/machine/reference/feeder/ReferenceStripFeeder-DefaultPipeline.xml
+++ b/src/main/resources/org/openpnp/machine/reference/feeder/ReferenceStripFeeder-DefaultPipeline.xml
@@ -1,11 +1,12 @@
 <cv-pipeline>
    <stages>
       <cv-stage class="org.openpnp.vision.pipeline.stages.ImageCapture" name="original" enabled="true" settle-first="true"/>
-      <cv-stage class="org.openpnp.vision.pipeline.stages.BlurMedian" name="cleanup-noise" enabled="true" kernel-size="5"/>
+      <cv-stage class="org.openpnp.vision.pipeline.stages.BlurMedian" name="cleanup-original" enabled="true" kernel-size="5"/>
       <cv-stage class="org.openpnp.vision.pipeline.stages.ConvertColor" name="gray" enabled="true" conversion="Bgr2Gray"/>
-      <cv-stage class="org.openpnp.vision.pipeline.stages.ThresholdAdaptive" name="threshold" enabled="true" adaptive-method="Gaussian" invert="false" block-size="9" c-parm="0"/>
-      <cv-stage class="org.openpnp.vision.pipeline.stages.BlurGaussian" name="predetect" enabled="true" kernel-size="5"/>
-      <cv-stage class="org.openpnp.vision.pipeline.stages.DetectFixedCirclesHough" name="results" enabled="true"/>
+      <cv-stage class="org.openpnp.vision.pipeline.stages.DetectEdgesCanny" name="find-edges" enabled="true" threshold-1="5.0" threshold-2="15.0"/>
+      <cv-stage class="org.openpnp.vision.pipeline.stages.BlurGaussian" name="predetect-1" enabled="true" kernel-size="5"/>
+      <cv-stage class="org.openpnp.vision.pipeline.stages.BlurMedian" name="predetect-2" enabled="false" kernel-size="7"/>
+      <cv-stage class="org.openpnp.vision.pipeline.stages.DetectFixedCirclesHough" name="results" enabled="true" dp="1.0" param-1="25.0" param-2="20.0"/>
       <cv-stage class="org.openpnp.vision.pipeline.stages.ImageRecall" name="recalled" enabled="true" image-stage-name="original"/>
       <cv-stage class="org.openpnp.vision.pipeline.stages.DrawCircles" name="display" enabled="true" circles-stage-name="results" thickness="1">
          <color r="255" g="0" b="0" a="255"/>


### PR DESCRIPTION
# Description
- Changes to the ReferenceStripFeeder default CvPipeline to improve detection accuracy with real-world cameras (works with the simulated camera too). Tested and proven quite reliable on white tape, black tape, and even transparent(!) tape
- Added descriptions for some Hough circle parameters
- Exposed the threshold/detection related parameters from DetectFixedCirclesHough, as only the feature size ought to be fixed
- Added odd-numbers-only check to BlurGaussian and BlurMedian, to avoid an assertion in OpenCV. Matches the assertion (and description) in ThresholdAdaptive for blockSize.
- Auto Setup: The best-fit line of holes for Auto Setup is now taken as the longest line that is within our desired distance ranges rather than the closest, as that would often get influenced by falsely detected circles, and there should only ever be one (long) line of holes anyway. Both works better and makes more sense.
- Auto Setup: The detected holes are now fitted to what we expect their perfect locations/spacing to be along the best-fit line. This stops them being heavily affected by not-so-consistent circle detection in the pipeline, improves the stability of the results, and as a side benefit really highlights when the tape isn't at the same height that the camera's units-per-pixel were configured for (as the resulting holes are spaced at exactly 4mm, and you can see them offset from the detected holes)

# Justification
Michael on the Google Group has been testing the new behaviour, and these changes are necessary to work with his setup (which is pretty typical of the hardware in use by users).

# Instructions for Use
To get the improved ReferenceStripFeeder CvPipeline changes, you will need to reset the pipelines of each ReferenceStripFeeder in your machine. If necessary, changes for tape hole detection for specific hardware and lighting setups can then be made to the pipeline.

# Implementation Details
1. How did you test the change?
 Tested on white tape, black tape, and even transparent(!) tape, and the simulated camera.
2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)?
Yes
3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing.
N/A
4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted.
Done.