### PR TITLE
Ensure there are no dangling references to BufferedImageCamera

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/feeder/ReferenceStripFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/ReferenceStripFeeder.java
@@ -306,6 +306,8 @@ public class ReferenceStripFeeder extends ReferenceFeeder {
             return holeLocation;
         }
         finally {
+            pipeline.setProperty("camera", null);
+            pipeline.setProperty("feeder", null);
             pipeline.release();
         }
     }

--- a/src/main/java/org/openpnp/machine/reference/feeder/wizards/ReferenceStripFeederConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/wizards/ReferenceStripFeederConfigurationWizard.java
@@ -587,7 +587,7 @@ public class ReferenceStripFeederConfigurationWizard extends AbstractConfigurati
             return holeLocations;
         }
         finally {
-            pipeline.release();
+            releaseCvPipeline(pipeline);
         }
     }
 
@@ -628,7 +628,8 @@ public class ReferenceStripFeederConfigurationWizard extends AbstractConfigurati
             return showResult;
         }
         finally {
-            pipeline.release();
+            releaseCvPipeline(pipeline);
+            bufferedImageCamera.release();
         }
     }
 
@@ -880,5 +881,12 @@ public class ReferenceStripFeederConfigurationWizard extends AbstractConfigurati
         catch (CloneNotSupportedException e) {
             throw new Error(e);
         }
+    }
+
+    private void releaseCvPipeline(CvPipeline pipeline) {
+        pipeline.setProperty("camera", null);
+        pipeline.setProperty("feeder", null);
+
+        pipeline.release();
     }
 }

--- a/src/main/java/org/openpnp/spi/base/AbstractCamera.java
+++ b/src/main/java/org/openpnp/spi/base/AbstractCamera.java
@@ -40,6 +40,7 @@ public abstract class AbstractCamera extends AbstractModelObject implements Came
     @Attribute(required = false)
     protected long settleTimeMs = 250;
 
+    protected ConfigurationListenerAdapter configurationListener = new ConfigurationListenerAdapter();
     protected Set<ListenerEntry> listeners = Collections.synchronizedSet(new HashSet<>());
 
     protected Head head;
@@ -53,14 +54,11 @@ public abstract class AbstractCamera extends AbstractModelObject implements Came
     public AbstractCamera() {
         this.id = Configuration.createId("CAM");
         this.name = getClass().getSimpleName();
-        Configuration.get().addListener(new ConfigurationListener.Adapter() {
-            @Override
-            public void configurationLoaded(Configuration configuration) throws Exception {
-                if (visionProvider != null) {
-                    visionProvider.setCamera(AbstractCamera.this);
-                }
-            }
-        });
+        Configuration.get().addListener(configurationListener);
+    }
+
+    public void release() {
+        Configuration.get().removeListener(configurationListener);
     }
 
     @Override
@@ -201,6 +199,15 @@ public abstract class AbstractCamera extends AbstractModelObject implements Came
         @Override
         public boolean equals(Object obj) {
             return obj.equals(listener);
+        }
+    }
+
+    private class ConfigurationListenerAdapter extends ConfigurationListener.Adapter {
+        @Override
+        public void configurationLoaded(Configuration configuration) throws Exception {
+            if (visionProvider != null) {
+                visionProvider.setCamera(AbstractCamera.this);
+            }
         }
     }
 }


### PR DESCRIPTION
# Description
Clean up dangling references to the (transient) BufferedImageCamera in ReferenceStripFeederConfigurationWizard:
- Clear references to cameras and feeders in pipeline properties when done
- Added ability to remove the ConfigurationListener from a Camera when we're done with it, so the Configuration doesn't hold onto a reference to the Camera

# Justification
BufferedImageCamera holds onto a BufferedImage, so it's a significant memory leak if anything is still referencing the BufferedImageCamera so it can't be cleaned up by the GC.

# Instructions for Use
N/A

# Implementation Details
1. How did you test the change?
Tested by leaving the ReferenceStripFeeder Auto Setup feature running for an extended time and verifying that an OOM situation doesn't occur.
2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)?
Yes.
3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing.
Yes. AbstractCamera.release() was added to remove the ConfigurationListener.Adapter from the Configuration, as otherwise it holds onto a reference to the Camera.
4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted.
Done.