### PR TITLE
Editable feeder names

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/feeder/wizards/AbstractReferenceFeederConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/wizards/AbstractReferenceFeederConfigurationWizard.java
@@ -70,6 +70,7 @@ public abstract class AbstractReferenceFeederConfigurationWizard
     private JComboBox comboBoxPart;
     private LocationButtonsPanel locationButtonsPanel;
     private JTextField retryCountTf;
+    private JTextField nameTf;
 
     /**
      * @wbp.parser.constructor
@@ -98,6 +99,8 @@ public abstract class AbstractReferenceFeederConfigurationWizard
                 FormSpecs.RELATED_GAP_ROWSPEC,
                 FormSpecs.DEFAULT_ROWSPEC,
                 FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
                 FormSpecs.DEFAULT_ROWSPEC,}));
 
         comboBoxPart = new JComboBox();
@@ -108,6 +111,14 @@ public abstract class AbstractReferenceFeederConfigurationWizard
             // Swallow this error. This happens during parsing in
             // in WindowBuilder but doesn't happen during normal run.
         }
+        
+        JLabel lblName = new JLabel("Name");
+        panelPart.add(lblName, "2, 6, right, default");
+        
+        nameTf = new JTextField();
+        nameTf.setText(feeder.getName());
+        panelPart.add(nameTf, "4, 6");
+        nameTf.setColumns(3);
         
         JLabel lblPart = new JLabel("Part");
         panelPart.add(lblPart, "2, 2, right, default");
@@ -186,6 +197,7 @@ public abstract class AbstractReferenceFeederConfigurationWizard
 
         addWrappedBinding(feeder, "part", comboBoxPart, "selectedItem");
         addWrappedBinding(feeder, "retryCount", retryCountTf, "text", intConverter);
+        addWrappedBinding(feeder, "name", nameTf, "text");
 
         if (includePickLocation) {
             MutableLocationProxy location = new MutableLocationProxy();

--- a/src/main/java/org/openpnp/machine/reference/feeder/wizards/ReferenceRotatedTrayFeederConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/wizards/ReferenceRotatedTrayFeederConfigurationWizard.java
@@ -100,6 +100,7 @@ public class ReferenceRotatedTrayFeederConfigurationWizard extends AbstractConfi
 	private LocationButtonsPanel locationButtonsPanel;
 	private LocationButtonsPanel lastLocationButtonsPanel;
 	private JTextField retryCountTf;
+	private JTextField nameTf;
 
 	/**
 	 * @wbp.parser.constructor
@@ -123,7 +124,7 @@ public class ReferenceRotatedTrayFeederConfigurationWizard extends AbstractConfi
 						FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC, FormSpecs.RELATED_GAP_COLSPEC,
 						ColumnSpec.decode("default:grow"), },
 				new RowSpec[] { FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC, FormSpecs.RELATED_GAP_ROWSPEC,
-						FormSpecs.DEFAULT_ROWSPEC, }));
+						FormSpecs.DEFAULT_ROWSPEC, FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC, }));
 
 		comboBoxPart = new JComboBox();
 		try {
@@ -143,7 +144,15 @@ public class ReferenceRotatedTrayFeederConfigurationWizard extends AbstractConfi
 		lblWarningThisFeeder.setForeground(Color.RED);
 		lblWarningThisFeeder.setHorizontalAlignment(SwingConstants.LEFT);
 		warningPanel.add(lblWarningThisFeeder);
-
+		
+		JLabel lblName = new JLabel("Name");
+        panelPart.add(lblName, "2, 6, right, default");
+        
+        nameTf = new JTextField();
+        nameTf.setText(feeder.getName());
+        panelPart.add(nameTf, "4, 6");
+        nameTf.setColumns(3);
+        
 		JLabel lblPart = new JLabel("Part");
 		panelPart.add(lblPart, "2, 2, right, default");
 		comboBoxPart.setRenderer(new IdentifiableListCellRenderer<Part>());
@@ -393,7 +402,8 @@ public class ReferenceRotatedTrayFeederConfigurationWizard extends AbstractConfi
 		LengthConverter lengthConverter = new LengthConverter();
 		IntegerConverter intConverter = new IntegerConverter();
 		DoubleConverter doubleConverter = new DoubleConverter(Configuration.get().getLengthDisplayFormat());
-
+		
+		addWrappedBinding(feeder, "name", nameTf, "text");
 		addWrappedBinding(feeder, "part", comboBoxPart, "selectedItem");
 		addWrappedBinding(feeder, "retryCount", retryCountTf, "text", intConverter);
 

--- a/src/main/java/org/openpnp/machine/reference/feeder/wizards/ReferenceStripFeederConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/wizards/ReferenceStripFeederConfigurationWizard.java
@@ -123,6 +123,7 @@ public class ReferenceStripFeederConfigurationWizard extends AbstractConfigurati
     private JLabel lblPart;
     private JLabel lblRetryCount;
     private JTextField retryCountTf;
+    private JTextField nameTf;
 
     private boolean logDebugInfo = false;
     private Location firstPartLocation;
@@ -144,6 +145,7 @@ public class ReferenceStripFeederConfigurationWizard extends AbstractConfigurati
                         FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,},
                 new RowSpec[] {FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
                         FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
                         FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,}));
         try {
         }
@@ -151,7 +153,8 @@ public class ReferenceStripFeederConfigurationWizard extends AbstractConfigurati
             // Swallow this error. This happens during parsing in
             // in WindowBuilder but doesn't happen during normal run.
         }
-
+        
+        
         lblPart = new JLabel("Part");
         panelPart.add(lblPart, "2, 2, right, default");
 
@@ -174,6 +177,15 @@ public class ReferenceStripFeederConfigurationWizard extends AbstractConfigurati
         retryCountTf.setText("3");
         panelPart.add(retryCountTf, "4, 6, fill, default");
         retryCountTf.setColumns(3);
+        
+        JLabel lblName = new JLabel("Name");
+        panelPart.add(lblName, "2, 8, right, default");
+        
+        nameTf = new JTextField();
+        nameTf.setText(feeder.getName());
+        panelPart.add(nameTf, "4, 8");
+        nameTf.setColumns(3);
+        
 
         panelTapeSettings = new JPanel();
         contentPanel.add(panelTapeSettings);
@@ -341,11 +353,12 @@ public class ReferenceStripFeederConfigurationWizard extends AbstractConfigurati
         MutableLocationProxy location = new MutableLocationProxy();
         bind(UpdateStrategy.READ_WRITE, feeder, "location", location, "location");
         addWrappedBinding(location, "rotation", textFieldLocationRotation, "text", doubleConverter);
-
+        
         addWrappedBinding(feeder, "part", comboBoxPart, "selectedItem");
         addWrappedBinding(feeder, "retryCount", retryCountTf, "text", intConverter);
+        addWrappedBinding(feeder, "name", nameTf, "text");
         addWrappedBinding(feeder, "tapeType", comboBoxTapeType, "selectedItem");
-
+        
         addWrappedBinding(feeder, "tapeWidth", textFieldTapeWidth, "text", lengthConverter);
         addWrappedBinding(feeder, "partPitch", textFieldPartPitch, "text", lengthConverter);
         addWrappedBinding(feeder, "feedCount", textFieldFeedCount, "text", intConverter);

--- a/src/main/java/org/openpnp/machine/reference/feeder/wizards/ReferenceStripFeederConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/wizards/ReferenceStripFeederConfigurationWizard.java
@@ -572,7 +572,7 @@ public class ReferenceStripFeederConfigurationWizard extends AbstractConfigurati
             FindHoles findHolesResults = new FindHoles(camera, pipeline).invoke();
             List<CvStage.Result.Circle> inLine = findHolesResults.getInLine();
             if (inLine.isEmpty()) {
-                throw new Exception("Feeder " + getName() + ": No tape holes found.");
+                throw new Exception("Feeder " + feeder.getName() + ": No tape holes found.");
             }
     
             List<Location> holeLocations = new ArrayList<>();


### PR DESCRIPTION
# Description
Added a textfield in the general settings-panel in the feeder wizards to edit the name of feeder via GUI instead of machine.xml.

# Justification
Users can easily distinct between enumerated feeder if they are able to edit the default name.

# Instructions for Use
It's easy: Just choose a name, put it into the textfield and click apply.

# Implementation Details
1. How did you test the change?
Started OpenPnP in Eclipse and tried to modify every feeders name (except SlotFeeder, didn't want to mess with the internal names that are already present).
2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)?
Yes.
3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing.
Have not.
4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted.
Don't know how to do in Eclipse, tested manually.