### PR TITLE
Only display the error message box once (but always log)

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/feeder/wizards/ReferenceStripFeederConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/wizards/ReferenceStripFeederConfigurationWizard.java
@@ -407,13 +407,23 @@ public class ReferenceStripFeederConfigurationWizard extends AbstractConfigurati
             logDebugInfo = (e.getModifiers() & ActionEvent.ALT_MASK) != 0;
 
             cameraView.setCameraViewFilter(new CameraViewFilter() {
+                private boolean hasShownError = false;
+
                 @Override
                 public BufferedImage filterCameraImage(Camera camera, BufferedImage image) {
                     try {
-                        return showHoles(camera, image);
+                        BufferedImage bufferedImage = showHoles(camera, image);
+                        hasShownError = false;
+                        return bufferedImage;
                     }
                     catch (Exception e) {
-                        MessageBoxes.errorBox(MainFrame.get(), "Error", e);
+                        if (!hasShownError) {
+                            hasShownError = true;
+                            MessageBoxes.errorBox(MainFrame.get(), "Error", e);
+                        }
+                        else {
+                            Logger.debug("{}: {}", "Error", e);
+                        }
                     }
 
                     return null;


### PR DESCRIPTION
# Description
Only display the error message box once (but always log), until we get a situation that no longer causes errors. Fixes #644, "Stripfeeder Autosetup pop-up loop with broken pipeline".

# Justification
Fixes #644.

# Instructions for Use
N/A

# Implementation Details
1. How did you test the change?
Tested with known-working pipeline, disabled the "results" stage, observed only a single error message box was displayed, re-enabled "results" stage, observed it was working correctly, re-disabled "results" stage and observed that a single message box was once again displayed. Checked Log tab to ensure that all errors were still being logged, and they were. Re-re-enabled "results" stage. Everything worked as expected.

2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)?
Yes
3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing.
N/A
4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted.
Done.