### PR TITLE
Adding a tooltip showing the full filename of a board within a job

### DIFF
--- a/src/main/java/org/openpnp/gui/JobPanel.java
+++ b/src/main/java/org/openpnp/gui/JobPanel.java
@@ -179,7 +179,27 @@ public class JobPanel extends JPanel {
         @SuppressWarnings({"unchecked", "rawtypes"})
         JComboBox sidesComboBox = new JComboBox(Side.values());
 
-        boardLocationsTable = new AutoSelectTextTable(boardLocationsTableModel);
+        boardLocationsTable = new AutoSelectTextTable(boardLocationsTableModel) {
+            @Override
+            public String getToolTipText(MouseEvent e) {
+
+                java.awt.Point p = e.getPoint();
+                int row = rowAtPoint(p);
+                int col = columnAtPoint(p);
+
+                if(row >= 0){
+                    if(col == 0) {
+                         BoardLocation boardLocation = boardLocationsTableModel.getBoardLocation(row);
+                         if(boardLocation != null) {
+                             return boardLocation.getBoard().getFile().toString();
+                         }
+                    }
+                }
+
+                return super.getToolTipText();
+            }
+        };
+
         boardLocationsTable.setAutoCreateRowSorter(true);
         boardLocationsTable.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
         boardLocationsTable.setDefaultEditor(Side.class, new DefaultCellEditor(sidesComboBox));


### PR DESCRIPTION
Solves #652 

# Description
Adding a tooltip to the job table where the full filename of a board will be shown if hovering the first column (short filename column).

# Justification
Was suggested by tisco24 and Jason liked the idea. Also I needed a short break of my other stuff.

# Instructions for Use
Hover the first column of the job board list and a tooltip displaying the full filename will come up

# Implementation Details
Manual testing with the example files. Also ran the tests
