### PR TITLE
New event "Camera.BeforeSettle"

### DIFF
--- a/src/main/java/org/openpnp/spi/base/AbstractCamera.java
+++ b/src/main/java/org/openpnp/spi/base/AbstractCamera.java
@@ -3,7 +3,9 @@ package org.openpnp.spi.base;
 import java.awt.image.BufferedImage;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 
 import javax.swing.Icon;
@@ -18,6 +20,7 @@ import org.openpnp.model.Location;
 import org.openpnp.spi.Camera;
 import org.openpnp.spi.Head;
 import org.openpnp.spi.VisionProvider;
+import org.pmw.tinylog.Logger;
 import org.simpleframework.xml.Attribute;
 import org.simpleframework.xml.Element;
 
@@ -136,6 +139,17 @@ public abstract class AbstractCamera extends AbstractModelObject implements Came
     }
 
     public BufferedImage settleAndCapture() {
+
+        try {
+            Map<String, Object> globals = new HashMap<>();
+            globals.put("camera", this);
+            Configuration.get().getScripting().on("Camera.BeforeSettle", globals);
+        }
+        catch (Exception e) {
+            Logger.warn(e);
+        }
+        
+    	
         try {
             Thread.sleep(getSettleTimeMs());
         }


### PR DESCRIPTION
# Description
New event to turn on lighting earlier than triggered by Camera.BeforeCapture. Leaves the camera time to settle indeed to the new lighting conditions. Fires early enough if the lighting starts with a little delay.

# Justification
The settle time is granted to the camera to adapt to new lighting conditions if dynamically switching light and to have the machine parts standing still. Would be great to be able to change the lighting condition at the beginning of the settle time, which the new event allows for.

# Instructions for Use
use as Camera.BeforeCapture. SettleBeforeCapture is triggered "Settle Time" earlier than BeforeCapture.



# Implementation Details
1. How did you test the change?
Yes, script is fired as expected.
2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)?
Yes.
3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing.
okay.
4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted.
Tested manually. In Ecliplse "Run As" -> Maven Test doesn't work due to dependency issues:
[INFO] --- maven-checkstyle-plugin:2.17:check (validate) @ openpnp-gui ---
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 1.677 s
[INFO] Finished at: 2017-10-09T21:31:54+02:00
[INFO] Final Memory: 14M/220M
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-checkstyle-plugin:2.17:check (validate) on project openpnp-gui: Execution validate of goal org.apache.maven.plugins:maven-checkstyle-plugin:2.17:check failed: Plugin org.apache.maven.plugins:maven-checkstyle-plugin:2.17 or one of its dependencies could not be resolved: Could not find artifact com.sun:tools:jar:1.8.0 at specified path C:\Program Files\Java\jre1.8.0_144/../lib/tools.jar -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/PluginResolutionException