### PR TITLE
Offset for fiducial recognition configurable per part

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/vision/ReferenceFiducialLocator.java
+++ b/src/main/java/org/openpnp/machine/reference/vision/ReferenceFiducialLocator.java
@@ -181,7 +181,7 @@ public class ReferenceFiducialLocator implements FiducialLocator {
         }
 
         //detect fid at offset?
-        Location offsetVision = new Location(LengthUnit.Millimeters,4,0,0,0);
+        Location offsetVision = new Location(LengthUnit.Millimeters,part.getOffsetVision().getValue(),0,0,0);
         Location offsetLocation = location.add(offsetVision);
         
         Logger.debug("Looking for {} at {} including {} offset", part.getId(), offsetLocation, offsetVision);

--- a/src/main/java/org/openpnp/machine/reference/vision/wizards/ReferenceFiducialLocatorPartConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/vision/wizards/ReferenceFiducialLocatorPartConfigurationWizard.java
@@ -13,9 +13,13 @@ import javax.swing.JPanel;
 import javax.swing.JTextField;
 import javax.swing.border.TitledBorder;
 
+import org.jdesktop.beansbinding.AutoBinding.UpdateStrategy;
 import org.openpnp.gui.MainFrame;
+import org.openpnp.gui.components.ComponentDecorators;
+import org.openpnp.gui.components.LocationButtonsPanel;
 import org.openpnp.gui.support.AbstractConfigurationWizard;
 import org.openpnp.gui.support.LengthConverter;
+import org.openpnp.gui.support.MutableLocationProxy;
 import org.openpnp.machine.reference.vision.ReferenceFiducialLocator;
 import org.openpnp.machine.reference.vision.ReferenceFiducialLocator.PartSettings;
 import org.openpnp.model.Configuration;
@@ -37,8 +41,8 @@ public class ReferenceFiducialLocatorPartConfigurationWizard extends AbstractCon
     private final Part part;
     private final PartSettings partSettings;
     
-    private JLabel lblOffsetVision;
-    private JTextField textFieldOffsetVision;
+    private JTextField textFieldVisionOffsetX;
+    private JTextField textFieldVisionOffsetY;
 
     public ReferenceFiducialLocatorPartConfigurationWizard(ReferenceFiducialLocator fiducialLocator,
             Part part) {
@@ -90,12 +94,45 @@ public class ReferenceFiducialLocatorPartConfigurationWizard extends AbstractCon
         });
         panel.add(btnLoadDefault, "6, 2");
         
-        lblOffsetVision = new JLabel("Offset Vision");
-        panel.add(lblOffsetVision, "2, 4, left, default");
-
+        /*
         textFieldOffsetVision = new JTextField();
         panel.add(textFieldOffsetVision, "4, 4, fill, default");
         textFieldOffsetVision.setColumns(4);
+        */
+        
+        JPanel panelVisionOffset = new JPanel();
+        contentPanel.add(panelVisionOffset);
+        panelVisionOffset.setBorder(new TitledBorder(null, "Vision Offset", TitledBorder.LEADING,
+                TitledBorder.TOP, null, null));
+        panelVisionOffset.setLayout(new FormLayout(
+                new ColumnSpec[] {FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,
+                        FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,
+                        FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,
+                        FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,
+                        ColumnSpec.decode("left:default:grow"),},
+                new RowSpec[] {FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,}));
+
+        JLabel lblX = new JLabel("X");
+        panelVisionOffset.add(lblX, "4, 2");
+
+        JLabel lblY = new JLabel("Y");
+        panelVisionOffset.add(lblY, "6, 2");
+
+        JLabel lblFeedStartLocation = new JLabel("Offset");
+        lblFeedStartLocation.setToolTipText(
+                "TODO.");
+        panelVisionOffset.add(lblFeedStartLocation, "2, 4, right, default");
+
+        textFieldVisionOffsetX = new JTextField();
+        panelVisionOffset.add(textFieldVisionOffsetX, "4, 4");
+        textFieldVisionOffsetX.setColumns(8);
+
+        textFieldVisionOffsetY = new JTextField();
+        panelVisionOffset.add(textFieldVisionOffsetY, "6, 4");
+        textFieldVisionOffsetY.setColumns(8);
+
     }
 
     private void editPipeline() throws Exception {
@@ -116,7 +153,13 @@ public class ReferenceFiducialLocatorPartConfigurationWizard extends AbstractCon
     public void createBindings() {
     	LengthConverter lengthConverter = new LengthConverter();
     	
-    	addWrappedBinding(part, "offsetVision", textFieldOffsetVision, "text", lengthConverter);
+    	MutableLocationProxy visionOffsetLocation = new MutableLocationProxy();
+        bind(UpdateStrategy.READ_WRITE, part, "offsetVision", visionOffsetLocation, "location");
+        addWrappedBinding(visionOffsetLocation, "lengthX", textFieldVisionOffsetX, "text", lengthConverter);
+        addWrappedBinding(visionOffsetLocation, "lengthY", textFieldVisionOffsetY, "text", lengthConverter);
+        
+        ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldVisionOffsetX);
+        ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldVisionOffsetY);
     }
         
     

--- a/src/main/java/org/openpnp/machine/reference/vision/wizards/ReferenceFiducialLocatorPartConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/vision/wizards/ReferenceFiducialLocatorPartConfigurationWizard.java
@@ -94,12 +94,6 @@ public class ReferenceFiducialLocatorPartConfigurationWizard extends AbstractCon
         });
         panel.add(btnLoadDefault, "6, 2");
         
-        /*
-        textFieldOffsetVision = new JTextField();
-        panel.add(textFieldOffsetVision, "4, 4, fill, default");
-        textFieldOffsetVision.setColumns(4);
-        */
-        
         JPanel panelVisionOffset = new JPanel();
         contentPanel.add(panelVisionOffset);
         panelVisionOffset.setBorder(new TitledBorder(null, "Vision Offset", TitledBorder.LEADING,
@@ -122,7 +116,7 @@ public class ReferenceFiducialLocatorPartConfigurationWizard extends AbstractCon
 
         JLabel lblFeedStartLocation = new JLabel("Offset");
         lblFeedStartLocation.setToolTipText(
-                "TODO.");
+                "Detection of reflective surfaces can be improved if doing vision with an offset to the camera's center.");
         panelVisionOffset.add(lblFeedStartLocation, "2, 4, right, default");
 
         textFieldVisionOffsetX = new JTextField();

--- a/src/main/java/org/openpnp/machine/reference/vision/wizards/ReferenceFiducialLocatorPartConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/vision/wizards/ReferenceFiducialLocatorPartConfigurationWizard.java
@@ -10,10 +10,12 @@ import javax.swing.JDialog;
 import javax.swing.JLabel;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
+import javax.swing.JTextField;
 import javax.swing.border.TitledBorder;
 
 import org.openpnp.gui.MainFrame;
 import org.openpnp.gui.support.AbstractConfigurationWizard;
+import org.openpnp.gui.support.LengthConverter;
 import org.openpnp.machine.reference.vision.ReferenceFiducialLocator;
 import org.openpnp.machine.reference.vision.ReferenceFiducialLocator.PartSettings;
 import org.openpnp.model.Configuration;
@@ -34,6 +36,9 @@ public class ReferenceFiducialLocatorPartConfigurationWizard extends AbstractCon
     private final ReferenceFiducialLocator fiducialLocator;
     private final Part part;
     private final PartSettings partSettings;
+    
+    private JLabel lblOffsetVision;
+    private JTextField textFieldOffsetVision;
 
     public ReferenceFiducialLocatorPartConfigurationWizard(ReferenceFiducialLocator fiducialLocator,
             Part part) {
@@ -53,6 +58,8 @@ public class ReferenceFiducialLocatorPartConfigurationWizard extends AbstractCon
                 FormSpecs.RELATED_GAP_COLSPEC,
                 FormSpecs.DEFAULT_COLSPEC,},
             new RowSpec[] {
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
                 FormSpecs.RELATED_GAP_ROWSPEC,
                 FormSpecs.DEFAULT_ROWSPEC,}));
 
@@ -82,6 +89,13 @@ public class ReferenceFiducialLocatorPartConfigurationWizard extends AbstractCon
             }
         });
         panel.add(btnLoadDefault, "6, 2");
+        
+        lblOffsetVision = new JLabel("Offset Vision");
+        panel.add(lblOffsetVision, "2, 4, left, default");
+
+        textFieldOffsetVision = new JTextField();
+        panel.add(textFieldOffsetVision, "4, 4, fill, default");
+        textFieldOffsetVision.setColumns(4);
     }
 
     private void editPipeline() throws Exception {
@@ -100,8 +114,11 @@ public class ReferenceFiducialLocatorPartConfigurationWizard extends AbstractCon
     }
     @Override
     public void createBindings() {
+    	LengthConverter lengthConverter = new LengthConverter();
+    	
+    	addWrappedBinding(part, "offsetVision", textFieldOffsetVision, "text", lengthConverter);
     }
-    
+        
     
     @Override
     public String getWizardName() {

--- a/src/main/java/org/openpnp/model/Part.java
+++ b/src/main/java/org/openpnp/model/Part.java
@@ -21,6 +21,7 @@ package org.openpnp.model;
 
 import org.openpnp.ConfigurationListener;
 import org.simpleframework.xml.Attribute;
+import org.simpleframework.xml.Element;
 import org.simpleframework.xml.core.Persist;
 
 /**
@@ -47,10 +48,8 @@ public class Part extends AbstractModelObject implements Identifiable {
     @Attribute(required = false)
     private double speed = 1.0;
     
-    @Attribute(required = false)
-    private LengthUnit offsetVisionUnits = LengthUnit.Millimeters;
-    @Attribute(required = false)
-    private double offsetVision = 0.0;
+    @Element(required = false)
+    private Location offsetVision = new Location(LengthUnit.Millimeters);
 
     @SuppressWarnings("unused")
     private Part() {
@@ -99,23 +98,14 @@ public class Part extends AbstractModelObject implements Identifiable {
         firePropertyChange("speed", oldValue, speed);
     }
 
-    public Length getOffsetVision() {
-        return new Length(offsetVision,offsetVisionUnits);
-    }
-    
-    public void setOffsetVision(Length offsetVision) {
-    	Object oldValue = getOffsetVision();
-        if (offsetVision == null) {
-            this.offsetVision = 0;
-            this.offsetVisionUnits = null;
-        }
-        else {
-            this.offsetVision = offsetVision.getValue();
-            this.offsetVisionUnits = offsetVision.getUnits();
-        }
-        firePropertyChange("offsetVision", oldValue, getOffsetVision());
+    public Location getOffsetVision() {
+        return offsetVision;
     }
 
+    public void setOffsetVision(Location offsetVision) {
+        this.offsetVision = offsetVision;
+    }
+    
     public Length getHeight() {
         return new Length(height, heightUnits);
     }

--- a/src/main/java/org/openpnp/model/Part.java
+++ b/src/main/java/org/openpnp/model/Part.java
@@ -46,7 +46,11 @@ public class Part extends AbstractModelObject implements Identifiable {
 
     @Attribute(required = false)
     private double speed = 1.0;
-
+    
+    @Attribute(required = false)
+    private LengthUnit offsetVisionUnits = LengthUnit.Millimeters;
+    @Attribute(required = false)
+    private double offsetVision = 0.0;
 
     @SuppressWarnings("unused")
     private Part() {
@@ -88,11 +92,28 @@ public class Part extends AbstractModelObject implements Identifiable {
     public double getSpeed() {
         return speed;
     }
-
+    
     public void setSpeed(double speed) {
         Object oldValue = this.speed;
         this.speed = speed;
         firePropertyChange("speed", oldValue, speed);
+    }
+
+    public Length getOffsetVision() {
+        return new Length(offsetVision,offsetVisionUnits);
+    }
+    
+    public void setOffsetVision(Length offsetVision) {
+    	Object oldValue = getOffsetVision();
+        if (offsetVision == null) {
+            this.offsetVision = 0;
+            this.offsetVisionUnits = null;
+        }
+        else {
+            this.offsetVision = offsetVision.getValue();
+            this.offsetVisionUnits = offsetVision.getUnits();
+        }
+        firePropertyChange("offsetVision", oldValue, getOffsetVision());
     }
 
     public Length getHeight() {


### PR DESCRIPTION
# Description
Watching videos of other PnP software I noticed there was a configuration for offset when doing vision tasks on fiducials. Using an offset would be helpful if the fids to be detected are very glossy or mirroring. The camera is mirrored in the fiducials if centered over them. See images attached. In this case, the fids would be recognized better if moved about 4mm off center.

![fiducial_centered](https://user-images.githubusercontent.com/3868450/31437439-92f32424-ae85-11e7-98ca-1a2f445c2416.png)
![fiducial_offcenter](https://user-images.githubusercontent.com/3868450/31437440-93102f2e-ae85-11e7-9e2a-d4edf4b580bc.png)

# Justification
Everyone having cheap glossy pcbs could profit by the feature.

# Instructions for Use
In current implementation the configured offset is added to the actual fiducial's x-location. Configure a value in the part's referenceFiducialLocator tab and click apply. the next fiducial recognition is made with respect to the offset.
![screenshot](https://user-images.githubusercontent.com/3868450/31437519-d4c26fae-ae85-11e7-99ba-e3ca3a913130.PNG)




# Implementation Details
1. How did you test the change?
with simulated machine and eagle demo-board.
3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing.
no changes there.
4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted.
JUnit tests passed.


# Notes
This patch works, but needs cleanup for sure. So this pull request is just for discussion as there are some decisions to be made / questions left open for me.
-Would you think it's valuable for OpenPnP?
-Is it needed to be configured per part? Or per machine?
-The offset-value should be validated

Would like to hear feedback.