### PR TITLE
Configurable repetition of fiducial recognition and averaging result

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/vision/ReferenceFiducialLocator.java
+++ b/src/main/java/org/openpnp/machine/reference/vision/ReferenceFiducialLocator.java
@@ -241,8 +241,7 @@ public class ReferenceFiducialLocator implements FiducialLocator {
             location = locations.get(0);
             
             if (i > 0) {
-            	//hold all matches to calculate the average later
-            	//keep a list, but don't keep the first match, since its probably most off
+            	//to average, keep a list of all matches except the first, since its probably most off
             	matchedLocations.add(location);
             }
             
@@ -260,8 +259,11 @@ public class ReferenceFiducialLocator implements FiducialLocator {
         		sumY+=matchedLocation.getY();
         	}
         	
-        	location=location.derive((sumX/(this.repeatFiducialRecognition-1)), sumY/(this.repeatFiducialRecognition-1),null,null);
+        	//set the location to the averaged one
+        	location=location.derive(sumX/matchedLocations.size(), sumY/matchedLocations.size(),null,null);
         	
+        	Logger.debug("{} averaged location is at {}", part.getId(), location);
+
         	camera.moveTo(location);
         }
         

--- a/src/main/java/org/openpnp/machine/reference/vision/ReferenceFiducialLocator.java
+++ b/src/main/java/org/openpnp/machine/reference/vision/ReferenceFiducialLocator.java
@@ -185,6 +185,11 @@ public class ReferenceFiducialLocator implements FiducialLocator {
                     "Package %s has an invalid or empty footprint.  See https://github.com/openpnp/openpnp/wiki/Fiducials.",
                     pkg.getId()));
         }
+        
+        int repeatFiducialRecognition = 3;
+        if ( this.repeatFiducialRecognition > 3 ) {
+        	repeatFiducialRecognition = this.repeatFiducialRecognition;
+        }
 
         Logger.debug("Looking for {} at {}", part.getId(), location);
         MovableUtils.moveToLocationAtSafeZ(camera, location);
@@ -200,7 +205,7 @@ public class ReferenceFiducialLocator implements FiducialLocator {
         pipeline.setProperty("package", pkg);
         pipeline.setProperty("footprint", footprint);
         
-        for (int i = 0; i < this.repeatFiducialRecognition; i++) {
+        for (int i = 0; i < repeatFiducialRecognition; i++) {
             List<KeyPoint> keypoints;
             try {
                 // Perform vision operation
@@ -250,7 +255,8 @@ public class ReferenceFiducialLocator implements FiducialLocator {
             camera.moveTo(location);
         }
         
-        if (this.enabledAveraging) {
+        if (this.enabledAveraging && matchedLocations.size() >= 2) {
+        	//the arithmetic average is calculated if user wishes to do so and there were at least 2 matches
         	double sumX=0;
         	double sumY=0;
         	
@@ -259,7 +265,7 @@ public class ReferenceFiducialLocator implements FiducialLocator {
         		sumY+=matchedLocation.getY();
         	}
         	
-        	//set the location to the averaged one
+        	//update the location to the arithmetic average
         	location=location.derive(sumX/matchedLocations.size(), sumY/matchedLocations.size(),null,null);
         	
         	Logger.debug("{} averaged location is at {}", part.getId(), location);

--- a/src/main/java/org/openpnp/machine/reference/vision/wizards/ReferenceFiducialLocatorConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/vision/wizards/ReferenceFiducialLocatorConfigurationWizard.java
@@ -11,10 +11,12 @@ import javax.swing.JDialog;
 import javax.swing.JLabel;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
+import javax.swing.JTextField;
 import javax.swing.border.TitledBorder;
 
 import org.openpnp.gui.MainFrame;
 import org.openpnp.gui.support.AbstractConfigurationWizard;
+import org.openpnp.gui.support.IntegerConverter;
 import org.openpnp.gui.support.MessageBoxes;
 import org.openpnp.machine.reference.vision.ReferenceFiducialLocator;
 import org.openpnp.machine.reference.vision.ReferenceFiducialLocator.PartSettings;
@@ -37,6 +39,9 @@ import com.jgoodies.forms.layout.RowSpec;
 public class ReferenceFiducialLocatorConfigurationWizard extends AbstractConfigurationWizard {
     private final ReferenceFiducialLocator fiducialLocator;
     private static Part defaultPart = createDefaultPart();
+    
+    JCheckBox enabledAveragingCheckbox; 
+    JTextField textFieldRepeatFiducialRecognition;
 
     public ReferenceFiducialLocatorConfigurationWizard(ReferenceFiducialLocator fiducialLocator) {
         this.fiducialLocator = fiducialLocator;
@@ -55,6 +60,10 @@ public class ReferenceFiducialLocatorConfigurationWizard extends AbstractConfigu
                 FormSpecs.RELATED_GAP_COLSPEC,
                 FormSpecs.DEFAULT_COLSPEC,},
             new RowSpec[] {
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
                 FormSpecs.RELATED_GAP_ROWSPEC,
                 FormSpecs.DEFAULT_ROWSPEC,}));
 
@@ -102,6 +111,20 @@ public class ReferenceFiducialLocatorConfigurationWizard extends AbstractConfigu
             }
         });
         panel.add(btnResetAllTo, "8, 2");
+        
+        JLabel lblRepeatFiducialRecognition = new JLabel("Repeat Recognition");
+        panel.add(lblRepeatFiducialRecognition, "2, 4");
+        
+        textFieldRepeatFiducialRecognition = new JTextField();
+        panel.add(textFieldRepeatFiducialRecognition, "4, 4");
+        textFieldRepeatFiducialRecognition.setColumns(2);
+
+        JLabel lblEnabledAveraging = new JLabel("Average?");
+        panel.add(lblEnabledAveraging, "2, 6");
+
+        enabledAveragingCheckbox = new JCheckBox("");
+        panel.add(enabledAveragingCheckbox, "4, 6");
+
     }
     
     private void editPipeline() throws Exception {
@@ -138,6 +161,10 @@ public class ReferenceFiducialLocatorConfigurationWizard extends AbstractConfigu
 
     @Override
     public void createBindings() {
+    	IntegerConverter intConverter = new IntegerConverter();
+    	
+    	addWrappedBinding(fiducialLocator, "enabledAveraging", enabledAveragingCheckbox, "selected");
+    	addWrappedBinding(fiducialLocator, "repeatFiducialRecognition", textFieldRepeatFiducialRecognition, "text", intConverter);
     }
     
     @Override

--- a/src/main/java/org/openpnp/machine/reference/vision/wizards/ReferenceFiducialLocatorConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/vision/wizards/ReferenceFiducialLocatorConfigurationWizard.java
@@ -116,10 +116,12 @@ public class ReferenceFiducialLocatorConfigurationWizard extends AbstractConfigu
         panel.add(lblRepeatFiducialRecognition, "2, 4");
         
         textFieldRepeatFiducialRecognition = new JTextField();
+        textFieldRepeatFiducialRecognition.setToolTipText("To dial-in on fiducials the recognition is repeated several times, but at least 3 times. (default: 3)");
         panel.add(textFieldRepeatFiducialRecognition, "4, 4");
         textFieldRepeatFiducialRecognition.setColumns(2);
 
-        JLabel lblEnabledAveraging = new JLabel("Average?");
+        JLabel lblEnabledAveraging = new JLabel("Average Matches?");
+        lblEnabledAveraging.setToolTipText("Finally calculates the arithmetic average over all matches (except the first). Needs 3 or more repeated recognitions to work.");
         panel.add(lblEnabledAveraging, "2, 6");
 
         enabledAveragingCheckbox = new JCheckBox("");


### PR DESCRIPTION
# Description
While fiddling with the machine I found it would be nice if the number of "dial ins" while recognizing fiducials would be configurable. Additionally some type of averaging as option would be great. With just 3 repetitions and without averaging it happens sometimes, the machine goes back and forth in a very small amount but never hitting the exact center... For my setup this improved the accuracy of detection (used 6 matches instead default 3). 

Maybe how the average is calculated could be thought over: Is it better to calculate a moving average while dialing in or just apply the average in the end, as it is implemented now.

# Justification
Giving the user the ability to configure the number of repetitions and averaging enables him with little effort to check whether the accuracy can be enhanced further or not. Anyway it defaults to the detection algorithm used until today, that is 3 repetitions and no averaging.
Having the idea of the planned feature "affine transformation" in my mind, a very accurate detection would be needed.


# Instructions for Use
See screenshot where settings were added:
![fidusetup](https://user-images.githubusercontent.com/3868450/31469061-acf86d9c-aee0-11e7-9a75-e94afa5ea71c.PNG)
after configuring start a fiducial scan on an board.

# Implementation Details
1. How did you test the change?
with simulated machine and eagle demo-board as well as my machine.
3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing.
no changes there.
4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted.
JUnit tests passed.



Any chance to have that within OpenPnP? Otherwise it would be no problem to cancel the pull request. 
kind regards.