### PR TITLE
ReferenceCamera: adding support for auto centering to nozzle

### DIFF
--- a/src/main/resources/org/openpnp/machine/reference/vision/ReferenceCamera-Location-DefaultPipeline.xml
+++ b/src/main/resources/org/openpnp/machine/reference/vision/ReferenceCamera-Location-DefaultPipeline.xml
@@ -1,0 +1,15 @@
+<pipeline>
+   <stages>
+      <cv-stage class="org.openpnp.vision.pipeline.stages.ImageCapture" name="9" enabled="true" settle-first="true"/>
+      <cv-stage class="org.openpnp.vision.pipeline.stages.ConvertColor" name="1" enabled="true" conversion="Bgr2Gray"/>
+      <cv-stage class="org.openpnp.vision.pipeline.stages.BlurMedian" name="4" enabled="true" kernel-size="3"/>
+      <cv-stage class="org.openpnp.vision.pipeline.stages.MaskCircle" name="3" enabled="true" diameter="200"/>
+      <cv-stage class="org.openpnp.vision.pipeline.stages.Threshold" name="2" enabled="true" threshold="190" auto="true" invert="false"/>
+      <cv-stage class="org.openpnp.vision.pipeline.stages.MaskCircle" name="5" enabled="true" diameter="100"/>
+      <cv-stage class="org.openpnp.vision.pipeline.stages.SimpleBlobDetector" name="result" enabled="true" threshold-step="10.0" threshold-min="50.0" threshold-max="220.0" repeatability="2" dist-between-blobs="10.0" color="true" color-value="0.0" area="true" area-min="25.0" area-max="5000.0" circularity="false" circularity-min="0.800000011920929" circularity-max="-1.0" inertia="true" inertia-ratio-min="0.10000000149011612" inertia-ratio-max="-1.0" convexity="true" convexity-min="0.949999988079071" convexity-max="-1.0"/>
+      <cv-stage class="org.openpnp.vision.pipeline.stages.ImageRecall" name="0" enabled="true" image-stage-name="9"/>
+      <cv-stage class="org.openpnp.vision.pipeline.stages.DrawKeyPoints" name="7" enabled="true" key-points-stage-name="result">
+         <color r="255" g="0" b="204" a="255"/>
+      </cv-stage>
+   </stages>
+</pipeline>


### PR DESCRIPTION
# Description
Adds automatic object detection via a OpenCV pipeline to the camera wizard.

# Justification
This feature is intended to be used for calibrating the bottom vision position. Calibrating the bottom vision by hand is a cumbersome task that may be repeated at each machine startup (if your end stops aren't precise). This step is easy to automate.

In theory, this feature can be useful for other things as well.

# Instructions for Use
* Select a camera in the machine configuration.
* Navigate to "Camera Specific" > "Center Detected Object to Camera"
* Edit the Pipeline for your needs.
![image](https://user-images.githubusercontent.com/1467368/31903575-c97509de-b828-11e7-9ae0-17f24c630502.png)
* Press "Detect and Center" to auto center on the detected object.
![image](https://user-images.githubusercontent.com/1467368/31903642-fb5d22b0-b828-11e7-9fad-3ef57f438118.png)

# Implementation Details
The feature was detected on a real machine with the bottom vision to detect the nozzle position.
