### PR TITLE
Fixes #380: overflow of the buttons in the JPanel

### DIFF
--- a/src/main/java/org/openpnp/gui/LogPanel.java
+++ b/src/main/java/org/openpnp/gui/LogPanel.java
@@ -118,7 +118,7 @@ public class LogPanel extends JPanel {
 
         filterControlPanel.add(btnScroll);
 
-        filterPanel.add(filterControlPanel, BorderLayout.EAST);
+        filterPanel.add(filterControlPanel, BorderLayout.CENTER);
 
         settingsAndFilterPanel.add(filterPanel);
 


### PR DESCRIPTION
# Description
Fixes #680 as there seems to be an issue with JPanel Border Layout if there is no center element.

# Justification
Fixes small issue with the graphics

# Implementation Details
Set the button JPanel to Center instead of East which fixes the issue. The buttons are still not visible or usable, but at least we get no problems with displaying.