### PR TITLE
Allowing users to override the default sounds of the sound signaler

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/signaler/SoundSignaler.java
+++ b/src/main/java/org/openpnp/machine/reference/signaler/SoundSignaler.java
@@ -1,10 +1,14 @@
 package org.openpnp.machine.reference.signaler;
 
+import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 
 import javax.swing.Action;
 import javax.swing.Icon;
 
+import org.openpnp.model.Configuration;
 import org.openpnp.spi.PropertySheetHolder;
 import org.openpnp.spi.base.AbstractJobProcessor;
 import org.openpnp.spi.base.AbstractMachine;
@@ -30,8 +34,20 @@ public class SoundSignaler extends AbstractSignaler {
 
     private void playSound(String filename) {
         try {
-            AudioStream audioStream = new AudioStream(classLoader.getResourceAsStream(filename));
+            InputStream soundStream;
+
+            // Check if there is a file in the configuration directory under sounds overriding the resource files
+            File overrideFile = new File(Configuration.get().getConfigurationDirectory(), filename);
+
+            if(overrideFile.exists() && !overrideFile.isDirectory()) {
+                soundStream = new FileInputStream(overrideFile);
+            } else {
+                soundStream = classLoader.getResourceAsStream(filename);
+            }
+
+            AudioStream audioStream = new AudioStream(soundStream);
             AudioPlayer.player.start(audioStream);
+
         } catch (IOException e) {
             e.printStackTrace();
         }


### PR DESCRIPTION
# Description
The sound signaler is shipped with two default free sounds for indicating success or error. This PR allows users to override those files.

Solves #668

# Instructions for Use
There are two files which can be replaced and need to be wav files: 'error.wav' and 'success.wav'.

Place them in the OpenPnP configuration directory under sounds e.g. '~/.openpnp/sounds/success.wav' or 'C:\Users\pfried\.openpnp\sounds\success.wav' 

@vonnieda If you accept this PR I will update the Wiki accordingly
