### PR TITLE
Added option to ignore error and continue assembly

### DIFF
--- a/src/main/java/org/openpnp/gui/JobPanel.java
+++ b/src/main/java/org/openpnp/gui/JobPanel.java
@@ -884,12 +884,14 @@ public class JobPanel extends JPanel {
             List<String> options = new ArrayList<>();
             String retryOption = "Try Again";
             String skipOption = "Skip";
+            String ignoreContinueOption = "Ignore and Continue";
             String pauseOption = "Pause Job";
 
             options.add(retryOption);
             if (jobProcessor.canSkip()) {
                 options.add(skipOption);
             }
+            options.add(ignoreContinueOption);
             options.add(pauseOption);
             int result = JOptionPane.showOptionDialog(getTopLevelAncestor(), t.getMessage(),
                     "Job Error", JOptionPane.YES_NO_CANCEL_OPTION, JOptionPane.ERROR_MESSAGE, null,
@@ -904,6 +906,13 @@ public class JobPanel extends JPanel {
                     // Tell the job processor to skip the current placement and then call jobRun()
                     // to start things back up, either running or stepping.
                     jobSkip();
+                });
+            }
+            //ignore/continue
+            else if (selectedOption.equals(ignoreContinueOption)) {
+                UiUtils.messageBoxOnException(() -> {
+                    // Tell the job processor ignore error and continue as if everything were normal
+                    jobIgnoreContinue();
                 });
             }
             // Pause or cancel dialog
@@ -929,6 +938,13 @@ public class JobPanel extends JPanel {
     public void jobSkip() {
         UiUtils.submitUiMachineTask(() -> {
             jobProcessor.skip();
+            jobRun();
+        });
+    }
+
+    public void jobIgnoreContinue() {
+        UiUtils.submitUiMachineTask(() -> {
+            jobProcessor.ignoreContinue();
             jobRun();
         });
     }

--- a/src/main/java/org/openpnp/gui/JobPanel.java
+++ b/src/main/java/org/openpnp/gui/JobPanel.java
@@ -891,7 +891,9 @@ public class JobPanel extends JPanel {
             if (jobProcessor.canSkip()) {
                 options.add(skipOption);
             }
-            options.add(ignoreContinueOption);
+            if (jobProcessor.canSkip()) {
+            	options.add(ignoreContinueOption);
+            }
             options.add(pauseOption);
             int result = JOptionPane.showOptionDialog(getTopLevelAncestor(), t.getMessage(),
                     "Job Error", JOptionPane.YES_NO_CANCEL_OPTION, JOptionPane.ERROR_MESSAGE, null,

--- a/src/main/java/org/openpnp/machine/reference/ReferencePasteDispenseJobProcessor.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferencePasteDispenseJobProcessor.java
@@ -62,6 +62,7 @@ public class ReferencePasteDispenseJobProcessor extends AbstractPasteDispenseJob
         Complete,
         Abort,
         Skip,
+        IgnoreContinue,
         Reset
     }
 
@@ -171,6 +172,10 @@ public class ReferencePasteDispenseJobProcessor extends AbstractPasteDispenseJob
 
     public synchronized void skip() throws Exception {
         fsm.send(Message.Skip);
+    }
+    
+    public synchronized void ignoreContinue() throws Exception {
+        fsm.send(Message.IgnoreContinue);
     }
 
 

--- a/src/main/java/org/openpnp/machine/reference/ReferencePasteDispenseJobProcessor.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferencePasteDispenseJobProcessor.java
@@ -183,6 +183,10 @@ public class ReferencePasteDispenseJobProcessor extends AbstractPasteDispenseJob
         return fsm.canSend(Message.Skip);
     }
 
+	public boolean canIgnoreContinue() {
+		return fsm.canSend(Message.IgnoreContinue);
+	}
+
     /**
      * Validate that there is a job set before allowing it to start.
      *
@@ -330,6 +334,7 @@ public class ReferencePasteDispenseJobProcessor extends AbstractPasteDispenseJob
     protected boolean isJobComplete() {
         return jobDispenses.isEmpty();
     }
+
 
     /*
     @Override

--- a/src/main/java/org/openpnp/machine/reference/ReferencePnpJobProcessor.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferencePnpJobProcessor.java
@@ -81,6 +81,7 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
         Complete,
         Abort,
         Skip,
+        IgnoreContinue,
         Reset
     }
 
@@ -161,6 +162,7 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
 
         fsm.add(State.Align, Message.Next, State.Place, this::doAlign, Message.Next);
         fsm.add(State.Align, Message.Skip, State.Align, this::doSkip, Message.Next);
+        fsm.add(State.Align, Message.IgnoreContinue, State.Place, Message.Next);
         fsm.add(State.Align, Message.Abort, State.Cleanup, Message.Next);
 
         fsm.add(State.Place, Message.Next, State.Plan, this::doPlace);
@@ -214,6 +216,10 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
 
     public synchronized void skip() throws Exception {
         fsm.send(Message.Skip);
+    }
+    
+    public synchronized void ignoreContinue() throws Exception {
+        fsm.send(Message.IgnoreContinue);
     }
 
     /*
@@ -813,7 +819,7 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
             Logger.debug("Skipped {}", jobPlacement.placement);
         }
     }
-
+    
     protected void clearStepComplete() {
         for (PlannedPlacement plannedPlacement : plannedPlacements) {
             plannedPlacement.stepComplete = false;

--- a/src/main/java/org/openpnp/machine/reference/ReferencePnpJobProcessor.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferencePnpJobProcessor.java
@@ -149,6 +149,7 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
 
         fsm.add(State.Feed, Message.Next, State.Align, this::doFeedAndPick, Message.Next);
         fsm.add(State.Feed, Message.Skip, State.Feed, this::doSkip, Message.Next);
+        fsm.add(State.Feed, Message.IgnoreContinue, State.Align, Message.Next);
         fsm.add(State.Feed, Message.Abort, State.Cleanup, Message.Next);
 
         // TODO: See notes on doFeedAndPick()
@@ -240,6 +241,10 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
      */
     public boolean canSkip() {
         return fsm.canSend(Message.Skip);
+    }
+
+    public boolean canIgnoreContinue() {
+        return fsm.canSend(Message.IgnoreContinue);
     }
 
     /**

--- a/src/main/java/org/openpnp/spi/JobProcessor.java
+++ b/src/main/java/org/openpnp/spi/JobProcessor.java
@@ -18,6 +18,8 @@ public interface JobProcessor extends PropertySheetHolder, WizardConfigurable {
     public void ignoreContinue() throws Exception;
 
     public boolean canSkip();
+    
+    public boolean canIgnoreContinue();
 
     public void addTextStatusListener(TextStatusListener listener);
 

--- a/src/main/java/org/openpnp/spi/JobProcessor.java
+++ b/src/main/java/org/openpnp/spi/JobProcessor.java
@@ -14,6 +14,8 @@ public interface JobProcessor extends PropertySheetHolder, WizardConfigurable {
     public void abort() throws Exception;
 
     public void skip() throws Exception;
+    
+    public void ignoreContinue() throws Exception;
 
     public boolean canSkip();
 


### PR DESCRIPTION
# Description
Gives the user one more option on how to handle errors while assembly. The new option ignore and continue allows the user to ignore errors raised from alignment per bottom vision as if everything is right.

# Justification
if user checked for pick being ok, it should be allowed to continue.

# Instructions for Use
![ignore_continue](https://user-images.githubusercontent.com/3868450/34318825-176558ec-e7d1-11e7-9cd6-ec9ad931eb4f.PNG)
1. pick a part with insufficient vac (vac sensor needed) and click continue -> it goes to alignment
2. picked part will be checked on bottom camera -> if it fails, one could continue anyway.

# Implementation Details
1. How did you test the change? Be descriptive. Untested code will not be accepted.
unit test and on real machine (vac insufficient and bottom vision failed if removed part).
2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)?
yes
3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing.
maybe @netzmark can test further?

4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted.
OK