### PR TITLE
renamed pipeline editor title for stripfeeder to prevent nullpointerexception

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/feeder/wizards/ReferenceStripFeederConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/wizards/ReferenceStripFeederConfigurationWizard.java
@@ -896,7 +896,7 @@ public class ReferenceStripFeederConfigurationWizard extends AbstractConfigurati
         Camera camera = Configuration.get().getMachine().getDefaultHead().getDefaultCamera();
         CvPipeline pipeline = getCvPipeline(camera, false);
         CvPipelineEditor editor = new CvPipelineEditor(pipeline);
-        JDialog dialog = new JDialog(MainFrame.get(), feeder.getPart().getId() + " Pipeline");
+        JDialog dialog = new JDialog(MainFrame.get(), feeder.getName() + " Pipeline");
         dialog.getContentPane().setLayout(new BorderLayout());
         dialog.getContentPane().add(editor);
         dialog.setSize(1024, 768);


### PR DESCRIPTION
# Description
had issues editing the pipeline for a feeder but didn't know what the problem was. the error message was unclear to me:
![err_feeder_no-part](https://user-images.githubusercontent.com/3868450/34319458-92ac7ffa-e7e3-11e7-971a-e6017129dbda.PNG)

so I changed the title of the pipeline editor, since it is feeder specific, not part specific...


# Justification
if a part is deleted and a feeder had it assigned, the feeder has no part any more. editing the pipeline gives the error, which is unexpected and doesn't indicate the problem.

# Instructions for Use
no instructions...


# Implementation Details
1. How did you test the change? Be descriptive. Untested code will not be accepted.
started openpnp and edited a strip feeder without part assigned. -> works now.
2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)?
yes
3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing.
no
4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted.
OK