### PR TITLE
Mark placed again

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/ReferencePnpJobProcessor.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferencePnpJobProcessor.java
@@ -897,7 +897,7 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
     BoardLocation getFiducialCompensatedBoardLocation(BoardLocation boardLocation) {
         // Check if there is a fiducial override for the board location and if so, use it.
         if (boardLocationFiducialOverrides.containsKey(boardLocation)) {
-        	BoardLocation boardLocation2 = new BoardLocation(boardLocation);
+            BoardLocation boardLocation2 = new BoardLocation(boardLocation);
             boardLocation2.setLocation(boardLocationFiducialOverrides.get(boardLocation));
             return boardLocation2;
         }

--- a/src/main/java/org/openpnp/machine/reference/ReferencePnpJobProcessor.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferencePnpJobProcessor.java
@@ -897,8 +897,7 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
     BoardLocation getFiducialCompensatedBoardLocation(BoardLocation boardLocation) {
         // Check if there is a fiducial override for the board location and if so, use it.
         if (boardLocationFiducialOverrides.containsKey(boardLocation)) {
-            BoardLocation boardLocation2 = new BoardLocation(boardLocation.getBoard());
-            boardLocation2.setSide(boardLocation.getSide());
+        	BoardLocation boardLocation2 = new BoardLocation(boardLocation);
             boardLocation2.setLocation(boardLocationFiducialOverrides.get(boardLocation));
             return boardLocation2;
         }

--- a/src/main/java/org/openpnp/machine/reference/vision/ReferenceBottomVision.java
+++ b/src/main/java/org/openpnp/machine/reference/vision/ReferenceBottomVision.java
@@ -83,7 +83,7 @@ public class ReferenceBottomVision implements PartAlignment {
             throws Exception {
         double angle = placementLocation.getRotation();
         if (boardLocation != null) {
-            angle = Utils2D.calculateBoardPlacementLocation(boardLocation, placementLocation)
+            angle = Utils2D.calculateFiducialCompensatedBoardPlacementLocation(boardLocation, placementLocation)
                            .getRotation();
         }
         angle = angleNorm(angle, 180.);

--- a/src/main/java/org/openpnp/model/BoardLocation.java
+++ b/src/main/java/org/openpnp/model/BoardLocation.java
@@ -30,6 +30,9 @@ import org.simpleframework.xml.core.Commit;
 public class BoardLocation extends AbstractModelObject {
     @Element
     private Location location;
+    
+    private Location locationFiducialOverrides;
+    
     @Attribute
     private Side side = Side.Top;
     private Board board;
@@ -57,6 +60,7 @@ public class BoardLocation extends AbstractModelObject {
     // Copy constructor needed for deep copy of object.
     public BoardLocation(BoardLocation obj) {
         this.location = obj.location;
+        this.locationFiducialOverrides = obj.locationFiducialOverrides;
         this.side = obj.side;
         this.board = obj.board;
         this.boardFile = obj.boardFile;
@@ -86,6 +90,30 @@ public class BoardLocation extends AbstractModelObject {
         Location oldValue = this.location;
         this.location = location;
         firePropertyChange("location", oldValue, location);
+    }
+    
+    public Location getLocationFiducialOverrides() {
+        return locationFiducialOverrides;
+    }
+
+    public void setLocationFiducialOverrides(Location locationFiducialOverrides) {
+        Location oldValue = this.locationFiducialOverrides;
+        this.locationFiducialOverrides = locationFiducialOverrides;
+        firePropertyChange("locationFiducialOverrides", oldValue, locationFiducialOverrides);
+    }
+
+    public void clearLocationFiducialOverrides() {
+        setLocationFiducialOverrides(null);
+    }
+
+    public Location getFiducialCompensatedBoardLocation() {
+        // Check if there is a fiducial override for the board location and if so, use it.
+        if ( locationFiducialOverrides != null ) {
+            return locationFiducialOverrides;
+        } else {
+            return location;            
+        }
+        
     }
 
     public Side getSide() {

--- a/src/main/java/org/openpnp/util/Utils2D.java
+++ b/src/main/java/org/openpnp/util/Utils2D.java
@@ -80,6 +80,12 @@ public class Utils2D {
         return new Point(point.getX() * scaleX, point.getY() * scaleY);
     }
 
+    public static Location calculateFiducialCompensatedBoardPlacementLocation(BoardLocation bl,
+            Location placementLocation) {
+        return calculateBoardPlacementLocation(bl.getFiducialCompensatedBoardLocation(), bl.getSide(),
+                bl.getBoard().getDimensions().getX(), placementLocation);
+    }
+
     public static Location calculateBoardPlacementLocation(BoardLocation bl,
             Location placementLocation) {
         return calculateBoardPlacementLocation(bl.getLocation(), bl.getSide(),


### PR DESCRIPTION
# Description
fixes #663: if having fiducials checked, placed flag is set correctly.
don't know whether it's an naive approach or it breaks something else? but at least it fixes the bug ;)

# Justification
it's annoying to have the placement flags not set properly.

# Instructions for Use
use as expected, no matter if with or without checking.

# Implementation Details
1. How did you test the change? Be descriptive. Untested code will not be accepted.
on my machine in a testrun
2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)?
think so
3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing.
no changes
4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted.
done.