### PR TITLE
Bugfix: On Skip discard right nozzle

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/ReferencePnpJobProcessor.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferencePnpJobProcessor.java
@@ -804,14 +804,29 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
      * @throws Exception
      */
     protected void doSkip() throws Exception {
-        if (plannedPlacements.size() > 0) {
-            PlannedPlacement plannedPlacement = plannedPlacements.remove(0);
-            JobPlacement jobPlacement = plannedPlacement.jobPlacement;
-            Nozzle nozzle = plannedPlacement.nozzle;
-            discard(nozzle);
-            jobPlacement.status = Status.Skipped;
-            Logger.debug("Skipped {}", jobPlacement.placement);
-        }
+    	if (plannedPlacements.size() > 0) {
+    		
+    		//iterate through nozzles to determine which one to clear
+    		for (int i = 0; i < head.getNozzles().size(); i++) {
+    	 		PlannedPlacement plannedPlacement = plannedPlacements.get(i);
+    	 		JobPlacement jobPlacement = plannedPlacement.jobPlacement;
+    	 		
+    	 		if (plannedPlacement.stepComplete) {
+    	 			//go over placements having the current step already completed
+    	             continue;
+    	         }
+    	 		
+    	 		//remove the placement from list
+    	 		plannedPlacements.remove(i);
+    	 		
+    	 		//discard
+    	 		Nozzle nozzle = plannedPlacement.nozzle;
+    	         discard(nozzle);
+    	         
+    	         jobPlacement.status = Status.Skipped;
+    	         Logger.debug("Skipped {}", jobPlacement.placement);
+    	 	}    		
+    	}
     }
 
     protected void clearStepComplete() {

--- a/src/main/java/org/openpnp/machine/reference/ReferencePnpJobProcessor.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferencePnpJobProcessor.java
@@ -25,6 +25,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -805,19 +806,23 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
      */
     protected void doSkip() throws Exception {
         if (plannedPlacements.size() > 0) {
-
+            
+            // get iterator to avoid ConcurrentModificationException (list is modified within iteration)
+            Iterator<PlannedPlacement> plannedPlacementIter = plannedPlacements.iterator();
+            
             // iterate through planned placement in this cycle (number of planned placements ==
             // number of nozzles)
-            for (PlannedPlacement plannedPlacement : plannedPlacements) {
+            while (plannedPlacementIter.hasNext()) {
+                PlannedPlacement plannedPlacement=plannedPlacementIter.next();
                 JobPlacement jobPlacement = plannedPlacement.jobPlacement;
-
+                
                 if (plannedPlacement.stepComplete) {
                     // go over placements having the current step already completed
                     continue;
                 }
 
                 // remove the placement to be skipped from list
-                plannedPlacements.remove(plannedPlacements.indexOf(plannedPlacement));
+                plannedPlacementIter.remove();
 
                 // discard
                 Nozzle nozzle = plannedPlacement.nozzle;
@@ -826,13 +831,9 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
                 jobPlacement.status = Status.Skipped;
                 Logger.debug("Skipped {}", jobPlacement.placement);
 
-                /*
-                 * stop iterating through plannedPlacements to prevent the
-                 * ConcurrentModificationException (list is modified within iteration)
-                 * https://docs.oracle.com/javase/7/docs/api/java/util/
-                 * ConcurrentModificationException.html
-                 */
+                // stop iterating through plannedPlacements, since only one part is handled at a time
                 break;
+                
             }
         }
     }

--- a/src/main/java/org/openpnp/machine/reference/ReferencePnpJobProcessor.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferencePnpJobProcessor.java
@@ -806,18 +806,17 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
     protected void doSkip() throws Exception {
     	if (plannedPlacements.size() > 0) {
     		
-    		//iterate through nozzles to determine which one to clear
-    		for (int i = 0; i < head.getNozzles().size(); i++) {
-    	 		PlannedPlacement plannedPlacement = plannedPlacements.get(i);
+    		//iterate through planned placement in this cycle (number of planned placements == number of nozzles)
+    		for (PlannedPlacement plannedPlacement : plannedPlacements) {
     	 		JobPlacement jobPlacement = plannedPlacement.jobPlacement;
     	 		
     	 		if (plannedPlacement.stepComplete) {
     	 			//go over placements having the current step already completed
     	             continue;
-    	         }
+    	        }
     	 		
-    	 		//remove the placement from list
-    	 		plannedPlacements.remove(i);
+    	 		//remove the placement to be skipped from list
+    	 		plannedPlacements.remove(plannedPlacements.indexOf(plannedPlacement));
     	 		
     	 		//discard
     	 		Nozzle nozzle = plannedPlacement.nozzle;
@@ -825,6 +824,11 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
     	         
     	        jobPlacement.status = Status.Skipped;
     	        Logger.debug("Skipped {}", jobPlacement.placement);
+    	        
+    	        /* stop iterating through plannedPlacements to prevent the ConcurrentModificationException
+    	 		 * https://docs.oracle.com/javase/7/docs/api/java/util/ConcurrentModificationException.html (cite) Note that this exception does not always indicate that an object has been concurrently modified by a different thread. If a single thread issues a sequence of method invocations that violates the contract of an object, the object may throw this exception. For example, if a thread modifies a collection directly while it is iterating over the collection with a fail-fast iterator, the iterator will throw this exception. 
+    	 		*/
+    	        break;
     	 	}    		
     	}
     }

--- a/src/main/java/org/openpnp/machine/reference/ReferencePnpJobProcessor.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferencePnpJobProcessor.java
@@ -804,33 +804,37 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
      * @throws Exception
      */
     protected void doSkip() throws Exception {
-    	if (plannedPlacements.size() > 0) {
-    		
-    		//iterate through planned placement in this cycle (number of planned placements == number of nozzles)
-    		for (PlannedPlacement plannedPlacement : plannedPlacements) {
-    	 		JobPlacement jobPlacement = plannedPlacement.jobPlacement;
-    	 		
-    	 		if (plannedPlacement.stepComplete) {
-    	 			//go over placements having the current step already completed
-    	             continue;
-    	        }
-    	 		
-    	 		//remove the placement to be skipped from list
-    	 		plannedPlacements.remove(plannedPlacements.indexOf(plannedPlacement));
-    	 		
-    	 		//discard
-    	 		Nozzle nozzle = plannedPlacement.nozzle;
-    	        discard(nozzle);
-    	         
-    	        jobPlacement.status = Status.Skipped;
-    	        Logger.debug("Skipped {}", jobPlacement.placement);
-    	        
-    	        /* stop iterating through plannedPlacements to prevent the ConcurrentModificationException
-    	 		 * https://docs.oracle.com/javase/7/docs/api/java/util/ConcurrentModificationException.html (cite) Note that this exception does not always indicate that an object has been concurrently modified by a different thread. If a single thread issues a sequence of method invocations that violates the contract of an object, the object may throw this exception. For example, if a thread modifies a collection directly while it is iterating over the collection with a fail-fast iterator, the iterator will throw this exception. 
-    	 		*/
-    	        break;
-    	 	}    		
-    	}
+        if (plannedPlacements.size() > 0) {
+
+            // iterate through planned placement in this cycle (number of planned placements ==
+            // number of nozzles)
+            for (PlannedPlacement plannedPlacement : plannedPlacements) {
+                JobPlacement jobPlacement = plannedPlacement.jobPlacement;
+
+                if (plannedPlacement.stepComplete) {
+                    // go over placements having the current step already completed
+                    continue;
+                }
+
+                // remove the placement to be skipped from list
+                plannedPlacements.remove(plannedPlacements.indexOf(plannedPlacement));
+
+                // discard
+                Nozzle nozzle = plannedPlacement.nozzle;
+                discard(nozzle);
+
+                jobPlacement.status = Status.Skipped;
+                Logger.debug("Skipped {}", jobPlacement.placement);
+
+                /*
+                 * stop iterating through plannedPlacements to prevent the
+                 * ConcurrentModificationException (list is modified within iteration)
+                 * https://docs.oracle.com/javase/7/docs/api/java/util/
+                 * ConcurrentModificationException.html
+                 */
+                break;
+            }
+        }
     }
 
     protected void clearStepComplete() {

--- a/src/main/java/org/openpnp/machine/reference/ReferencePnpJobProcessor.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferencePnpJobProcessor.java
@@ -821,10 +821,10 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
     	 		
     	 		//discard
     	 		Nozzle nozzle = plannedPlacement.nozzle;
-    	         discard(nozzle);
+    	        discard(nozzle);
     	         
-    	         jobPlacement.status = Status.Skipped;
-    	         Logger.debug("Skipped {}", jobPlacement.placement);
+    	        jobPlacement.status = Status.Skipped;
+    	        Logger.debug("Skipped {}", jobPlacement.placement);
     	 	}    		
     	}
     }


### PR DESCRIPTION
# Description
until today if skipping a part due to an error (vac/aligning failed) always nozzle 1 is cleared per discarding a part into the discard box. this patch fixes this an takes the right nozzle into account.

# Justification
it's very annoying to have the wrong nozzle cleared and investigate which part was assembled, which not and remember which parts to fix in next run...

# Instructions for Use
click "skip" if an error occured. now the correct nozzle is cleared and the assembly for the rest goes on.

# Implementation Details
1. How did you test the change? Be descriptive. Untested code will not be accepted.
tested on my machine with 2 nozzles on one head.
I tested 2 cases:
1: removed nozzle tip from nozzle 1. pickup from feeder failed of course, vacuum sense check failed and it gave me the option to skip/retry, etc. -> clicked skip -> nozzle 1 went to discard location, discarded and went with nozzle 2 to the feeder and continues as usual.
2:  removed nozzle tip from nozzle 2. pickup from feeder failed of course, vacuum sense check failed and it gave me the option to skip/retry, etc. -> clicked skip -> nozzle 2 went to discard location, discarded and went with nozzle 1 to the feeder and continiues as normal.

2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)?
yes
3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing.
no changes
4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted.
done.