### PR TITLE
Make scripts Python 3 compatible by using __future__ imports

### DIFF
--- a/src/main/resources/scripts/Examples/Python/Print_Hallo_OpenPnP.py
+++ b/src/main/resources/scripts/Examples/Python/Print_Hallo_OpenPnP.py
@@ -1,2 +1,4 @@
-print "Hallo OpenPnP"
+from __future__ import print_function
+
+print("Hallo OpenPnP")
 

--- a/src/main/resources/scripts/Examples/Python/Print_Methods_Vars.py
+++ b/src/main/resources/scripts/Examples/Python/Print_Methods_Vars.py
@@ -13,3 +13,4 @@ def print_methods_vars(element, clip=True):
       print("WARNING ... for", item, end=' ')
 
 print_methods_vars(machine.defaultHead.defaultNozzle)
+print("")

--- a/src/main/resources/scripts/Examples/Python/Print_Methods_Vars.py
+++ b/src/main/resources/scripts/Examples/Python/Print_Methods_Vars.py
@@ -1,14 +1,15 @@
+from __future__ import print_function
 import sys
 
 # Prints all methods & variables and values of defaultNozzle
 def print_methods_vars(element, clip=True):
-  print " ",
+  print(" ", end=' ')
   for item in dir(element):
     try:
       s1="%s.%s = %s" % (element.name, item, eval("element.%s" % item))
       if clip: s1=s1[:78]
-      print s1,
+      print(s1, end=' ')
     except:
-      print "WARNING ... for", item,
+      print("WARNING ... for", item, end=' ')
 
 print_methods_vars(machine.defaultHead.defaultNozzle)

--- a/src/main/resources/scripts/Examples/Python/Print_Nozzle_Info.py
+++ b/src/main/resources/scripts/Examples/Python/Print_Nozzle_Info.py
@@ -1,8 +1,10 @@
+from __future__ import print_function
+
 # Get the nozzle
 my_nozzle=machine.defaultHead.defaultNozzle
 
 # Run print information regarding nozzle
-print "###  Name &  Location of %r  %s" % (my_nozzle.name, "#"*16),
-print my_nozzle,
-print my_nozzle.name,
-print my_nozzle.location
+print("###  Name &  Location of %r  %s" % (my_nozzle.name, "#"*16), end=' ')
+print(my_nozzle, end=' ')
+print(my_nozzle.name, end=' ')
+print(my_nozzle.location)


### PR DESCRIPTION
# Description
Add Python 3 compatibility to example scripts using the built in `__future__` package.

# Justification
Since examples are used as places for users to start, this is a good practice for new Python 2 code as it will make porting to Python 3 in the future easier.

# Instructions for Use
N/A

# Implementation Details
N/A
