### PR TITLE
Make hallo openpnp script Python 3 compatible

### DIFF
--- a/src/main/resources/scripts/Examples/Python/Print_Hallo_OpenPnP.py
+++ b/src/main/resources/scripts/Examples/Python/Print_Hallo_OpenPnP.py
@@ -1,2 +1,0 @@
-print "Hallo OpenPnP"
-

--- a/src/main/resources/scripts/Examples/Python/print_hallo_openpnp.py
+++ b/src/main/resources/scripts/Examples/Python/print_hallo_openpnp.py
@@ -1,0 +1,1 @@
+print("Hallo OpenPnP")


### PR DESCRIPTION
# Description
Use parenthesis when calling `print` to make Python 3 compatible.

# Justification
This will be used as an example by others, so helping them write code that is Python 3 compatible will be useful.

According to the Python PEP8 style guide, modules should be `lower_snake_case` so this makes this module adhere to that standard.

# Instructions for Use
N/A

# Implementation Details
This code was tested using the virtual device/driver and behaves the same as it did.
