### PR TITLE
Make nozzle info script Python 3 compatible

### DIFF
--- a/src/main/resources/scripts/Examples/Python/Print_Nozzle_Info.py
+++ b/src/main/resources/scripts/Examples/Python/Print_Nozzle_Info.py
@@ -1,8 +1,0 @@
-# Get the nozzle
-my_nozzle=machine.defaultHead.defaultNozzle
-
-# Run print information regarding nozzle
-print "###  Name &  Location of %r  %s" % (my_nozzle.name, "#"*16),
-print my_nozzle,
-print my_nozzle.name,
-print my_nozzle.location

--- a/src/main/resources/scripts/Examples/Python/print_nozzle_info.py
+++ b/src/main/resources/scripts/Examples/Python/print_nozzle_info.py
@@ -1,0 +1,6 @@
+# Get the nozzle
+my_nozzle = machine.defaultHead.defaultNozzle
+
+# Print information regarding nozzle
+print('###  Name &  Location of {}  {}'.format(my_nozzle.name, '#' * 16))
+print('{} {} {}'.format(my_nozzle, my_nozzle.name, my_nozzle.location))


### PR DESCRIPTION
# Description
Make nozzle script Python 3 compatible and PEP8 style compliant.

# Justification
This will be used as an example by others, so helping them write code that is Python 3 compatible will be useful.

According to the Python PEP8 style guide, modules should be lower_snake_case so this makes this module adhere to that standard.

The `str.format` method is used to simplify the `print` calls.

# Implementation Details
Tested in the virtual device/driver and performs the same.
