### PR TITLE
Add Python script example that moves the nozzle

### DIFF
--- a/src/main/resources/scripts/Examples/Python/move_machine.py
+++ b/src/main/resources/scripts/Examples/Python/move_machine.py
@@ -1,0 +1,40 @@
+from __future__ import absolute_import, division
+
+from org.openpnp.model import LengthUnit, Location
+
+
+def main():
+    move_nozzle()
+
+
+def print_location(location):
+    print('Location: {}'.format(location.toString()))
+
+
+def move_nozzle():
+    nozzle = machine.defaultHead.defaultNozzle
+    location = nozzle.location
+    print_location(location)
+
+    # Move 10mm right
+    location = location.add(Location(LengthUnit.Millimeters, 10, 0, 0, 0))
+    print_location(location)
+    nozzle.moveTo(location)
+
+    # Move 10mm up
+    location = location.add(Location(LengthUnit.Millimeters, 0, 10, 0, 0))
+    print_location(location)
+    nozzle.moveTo(location)
+
+    # Move 10mm left
+    location = location.add(Location(LengthUnit.Millimeters, -10, 0, 0, 0))
+    print_location(location)
+    nozzle.moveTo(location)
+
+    # Move 10mm down
+    location = location.add(Location(LengthUnit.Millimeters, 0, -10, 0, 0))
+    print_location(location)
+    nozzle.moveTo(location)
+
+
+main()


### PR DESCRIPTION
# Description
Add Python script that moves the nozzle in a similar way to the Javascript example `Move_Machine.js`

# Justification
There is currently no Python script example that moves the 

# Instructions for Use
Enable the machine, select Scripts | Examples | Python | move_machine.py

# Implementation Details
Tested on virtual device/driver.
