### PR TITLE
Add Python script example that calls Java

### DIFF
--- a/src/main/resources/scripts/Examples/Python/call_java.py
+++ b/src/main/resources/scripts/Examples/Python/call_java.py
@@ -1,0 +1,3 @@
+from javax.swing.JOptionPane import showMessageDialog
+
+showMessageDialog(None, 'Hello!')


### PR DESCRIPTION
# Description
Reproduce Javascript `Call_Java.js` in Python.

# Justification
Add another example in Python.

# Instructions for Use
Run Scripts | Examples | Python | call_java.py. A java window should pop up.

# Implementation Details
Tested in OpenPnP
