### PR TITLE
Add Python script example that imports another Python module

### DIFF
--- a/src/main/resources/scripts/Examples/Python/use_module.py
+++ b/src/main/resources/scripts/Examples/Python/use_module.py
@@ -1,0 +1,17 @@
+from __future__ import absolute_import, division
+import os.path
+import sys
+
+# Get location of the utility module.
+python_scripts_folder = os.path.join(scripting.getScriptsDirectory().toString(),
+                                     'Examples', 'Python')
+print('Adding {} to import path'.format(python_scripts_folder))
+
+# Add the path to the utility module to PYTHONPATH.
+sys.path.append(python_scripts_folder)
+print('New import paths: '.format(sys.path))
+
+# Import and use the module.
+from utility import print_hello
+
+print_hello()

--- a/src/main/resources/scripts/Examples/Python/utility.py
+++ b/src/main/resources/scripts/Examples/Python/utility.py
@@ -1,0 +1,5 @@
+from __future__ import absolute_import, division
+
+
+def print_hello():
+    print('Hello from a module!')


### PR DESCRIPTION
# Description
Add a Python example the imports another Python module, similar to `Move_Machine.js`.

# Justification
This shows users how they can decompose their software into more than one Python module.

# Implementation Details
Tested in OpenPnP