### PR TITLE
Adjust homing location for non-squareness when Y home non-zero

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/driver/GcodeDriver.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/GcodeDriver.java
@@ -287,8 +287,44 @@ public class GcodeDriver extends AbstractSerialPortDriver implements Named, Runn
         command = substituteVariable(command, "Name", head.getName());
         sendGcode(command, -1);
 
+        // We need to specially handle X and Y axes to support the non-squareness factor.
+        Axis xAxis = null;
+        Axis yAxis = null;
+        double xHomeCoordinateNonSquare = 0;
+        double yHomeCoordinate = 0;
         for (Axis axis : axes) {
-            axis.setCoordinate(axis.getHomeCoordinate());
+            if (axis.getType() == Axis.Type.X) {
+                xAxis = axis;
+                xHomeCoordinateNonSquare = axis.getHomeCoordinate();
+            }
+            if (axis.getType() == Axis.Type.Y) {
+                yAxis = axis;
+                yHomeCoordinate = axis.getHomeCoordinate();
+            }
+        }
+        // Compensate non-squareness factor: 
+        // We are homing to the native controller's non-square coordinate system, this does not
+        // match OpenPNP's square coordinate system, if the controller's Y home is non-zero. 
+        // The two coordinate systems coincide at Y0 only, see the non-squareness 
+        // transformation. It is not a good idea to change the transformation i.e. for the coordinate 
+        // systems to coincide at Y home, as this would break coordinates captured before this change. 
+        // In order to home the square internal coordinate system we need to account for the 
+        // non-squareness X offset here.  
+        // NOTE this changes nothing in the behavior or the coordinate system of the machine. It just
+        // sets the internal X coordinate correctly immediately after homing, so we can capture the 
+        // home location correctly. Without this compensation the discrepancy between internal and 
+        // machines coordinates was resolved with the first move, as it is done in absolute mode. 
+        double xHomeCoordinateSquare = xHomeCoordinateNonSquare - nonSquarenessFactor*yHomeCoordinate;
+        
+        for (Axis axis : axes) {
+            if (axis == xAxis) {
+            	// for X use the coordinate adjusted for non-squareness.
+            	axis.setCoordinate(xHomeCoordinateSquare);
+            }
+            else {
+            	// otherwise just use the standard coordinate.
+            	axis.setCoordinate(axis.getHomeCoordinate());
+            }
         }
 
         for (ReferenceDriver driver : subDrivers) {
@@ -309,21 +345,16 @@ public class GcodeDriver extends AbstractSerialPortDriver implements Named, Runn
 
                 // homeOffset contains the offset, but we are not really concerned with that,
                 // we just reset X,Y back to the home-coordinate at this point.
-                double xHomeCoordinate = 0;
-                double yHomeCoordinate = 0;
-                for (Axis axis : axes) {
-                    if (axis.getType() == Axis.Type.X) {
-                        axis.setCoordinate(axis.getHomeCoordinate());
-                        xHomeCoordinate = axis.getHomeCoordinate();
-                    }
-                    if (axis.getType() == Axis.Type.Y) {
-                        axis.setCoordinate(axis.getHomeCoordinate());
-                        yHomeCoordinate = axis.getHomeCoordinate();
-                    }
+                if (xAxis != null) { 
+                	xAxis.setCoordinate(xHomeCoordinateSquare);
                 }
-
+                if (yAxis != null) { 
+                	yAxis.setCoordinate(yHomeCoordinate);
+                }
+                
                 String g92command = getCommand(null, CommandType.POST_VISION_HOME_COMMAND);
-                g92command = substituteVariable(g92command, "X", xHomeCoordinate);
+                // make sure to use the native non-square X home coordinate.
+                g92command = substituteVariable(g92command, "X", xHomeCoordinateNonSquare);
                 g92command = substituteVariable(g92command, "Y", yHomeCoordinate);
                 sendGcode(g92command, -1);
             }


### PR DESCRIPTION
# Description
When having a non-zero Y home, the non-squareness factor X offset is not applied to the internal X coordinate immediately after homing. Instead the internal X is simply set to the non-square machine home X. If you capture the home location and later return to it, you will have an offset. Best observed with a homing fiducial. 

NOTE that this bug (and its resolution) does not concern the machine operation after that. The discrepancy between internal (square) coordinates and machine (non-square) coordinates is resolved as soon as the first move command is issued. Because the controller moves in absolute mode, the offset is corrected.  

# Justification
The homing fiducial is a useful point of reference. It is useful to capture this after-homing location as a park location. This is currently broken if you have a non-zero Y home and a non-zero non-squareness factor. 
EDIT: see also [this post.](https://github.com/openpnp/openpnp/pull/725#issuecomment-385275135)

# Instructions for Use
It just makes sure OpenPNP has the right square coordinates stored from the beginning.

# Implementation Details
1. My machine has a Y home at 600mm and a non-squareness factor of -0.0011. I tested the code change with that. It now works perfectly. All coordinates captured before (feeders, nozzle tip changer) work as before. Because the non-squareness transformation is linear, this test is representative.   
2. I did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. This change does not concern the `org.openpnp.spi` or `org.openpnp.model` packages.
4. The `mvn test` has passed.
5. For additional discussion, justification and rejection of other possible solutions, please see [the issue](https://github.com/openpnp/openpnp/issues/724).