### PR TITLE
reintroduce multiple uplooking camera support

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/vision/ReferenceBottomVision.java
+++ b/src/main/java/org/openpnp/machine/reference/vision/ReferenceBottomVision.java
@@ -100,6 +100,7 @@ public class ReferenceBottomVision implements PartAlignment {
         try (CvPipeline pipeline = partSettings.getPipeline()) {
 
             RotatedRect rect = processPipelineAndGetResult(pipeline, camera, part, nozzle);
+            camera=(Camera)pipeline.getProperty("camera");
 
             angle = angleNorm(angleNorm(angle)
                     + angleNorm((rect.size.width < rect.size.height) ? 90 + rect.angle : rect.angle));
@@ -115,7 +116,7 @@ public class ReferenceBottomVision implements PartAlignment {
 
             rect = processPipelineAndGetResult(pipeline, camera, part, nozzle);
 
-            Logger.debug("Result rect ( center: {} size: {} angle: {} )", rect.center, rect.size, rect.angle);
+            Logger.debug("Result rect {}", rect);
             Location offsets = VisionUtils.getPixelCenterOffsets(camera, rect.center.x, rect.center.y)
                                           .derive(null, null, null, Double.NaN);
 
@@ -140,6 +141,7 @@ public class ReferenceBottomVision implements PartAlignment {
 
         try (CvPipeline pipeline = partSettings.getPipeline()) {
             RotatedRect rect = processPipelineAndGetResult(pipeline, camera, part, nozzle);
+            camera=(Camera)pipeline.getProperty("camera");
     
             Logger.debug("Result rect {}", rect);
     


### PR DESCRIPTION
This reintroduce the option to support multiple uplooking parallel cameras without the need of recompile the sources.

# Read This First
To submit a Pull Request for OpenPnP you must use this template or it will not be accepted. 

Be sure to review the [Developers Guide](https://github.com/openpnp/openpnp/wiki/Developers-Guide)
and the [Contributing Guidelines](https://github.com/openpnp/openpnp/blob/develop/CONTRIBUTING.md).

Make your Pull Request as small as possible. Only include one bug or feature.
Large pull requests that change dozens of files or add multiple features are unlikely to be accepted.

Fill out all the details below. All sections below are required. If they are not included your Pull Request
will not be accepted.

-----------------------------------------------------------------------

# Description
This reintroduce the feature of having multiple parallel uplooking cameras without need
for customizing the source.

# Justification
Remove the need to have custom version just for the parallel uplooking camera use.

# Instructions for Use
No functionaly change to existing users, 

This is documentation for a user, not for a developer.
users with parallel cameras need just exchange the camera inside vision pipeline using
scripting stage based on nozzle Id.

# Implementation Details
1. How did you test the change? Be descriptive. Untested code will not be accepted.
tested with 2-8 cameras
2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)?
yes
3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing.
4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted.
