### PR TITLE
active placement number indicator

### DIFF
--- a/src/main/java/org/openpnp/gui/JobPlacementsPanel.java
+++ b/src/main/java/org/openpnp/gui/JobPlacementsPanel.java
@@ -18,6 +18,7 @@ import javax.swing.Action;
 import javax.swing.DefaultCellEditor;
 import javax.swing.JButton;
 import javax.swing.JComboBox;
+import javax.swing.JLabel;
 import javax.swing.JMenu;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
@@ -69,6 +70,7 @@ public class JobPlacementsPanel extends JPanel {
     private ActionGroup multiSelectionActionGroup;
     private ActionGroup captureAndPositionActionGroup;
     private BoardLocation boardLocation;
+    private JLabel labelActivePlacements;
 
     private static Color typeColorIgnore = new Color(252, 255, 157);
     private static Color typeColorFiducial = new Color(157, 188, 255);
@@ -141,7 +143,12 @@ public class JobPlacementsPanel extends JPanel {
         JButton btnEditFeeder = new JButton(editPlacementFeederAction);
         btnEditFeeder.setHideActionText(true);
         toolBarPlacements.add(btnEditFeeder);
-
+        
+        toolBarPlacements.addSeparator();
+        
+        labelActivePlacements = new JLabel("");
+        toolBarPlacements.add(labelActivePlacements);
+        
         tableModel = new PlacementsTableModel(configuration);
 
         table = new AutoSelectTextTable(tableModel);
@@ -155,6 +162,7 @@ public class JobPlacementsPanel extends JPanel {
         table.setDefaultRenderer(PlacementsTableModel.Status.class, new StatusRenderer());
         table.setDefaultRenderer(Placement.Type.class, new TypeRenderer());
         table.setDefaultRenderer(PartCellValue.class, new IdRenderer());
+        tableModel.setJobPlacementsPanel(this);
         table.getSelectionModel().addListSelectionListener(new ListSelectionListener() {
             @Override
             public void valueChanged(ListSelectionEvent e) {
@@ -202,6 +210,7 @@ public class JobPlacementsPanel extends JPanel {
                     Placement placement = getSelection();
                     placement.setType(placement.getType() == Type.Place ? Type.Ignore : Type.Place);
                     tableModel.fireTableRowsUpdated(table.getSelectedRow(), table.getSelectedRow());
+                    UpdateActivePlacements();
                 }
                 else {
                     super.keyTyped(e);
@@ -236,6 +245,7 @@ public class JobPlacementsPanel extends JPanel {
     
     public void refresh() {
         tableModel.fireTableDataChanged();
+        UpdateActivePlacements();
     }
 
     public void selectPlacement(Placement placement) {
@@ -248,6 +258,10 @@ public class JobPlacementsPanel extends JPanel {
             }
         }
     }
+    
+    public void UpdateActivePlacements() {
+    	labelActivePlacements.setText(boardLocation.getActivePlacements() + " of " + boardLocation.getTotalActivePlacements() + " placements active");
+    }
 
     public void setBoardLocation(BoardLocation boardLocation) {
         this.boardLocation = boardLocation;
@@ -259,6 +273,7 @@ public class JobPlacementsPanel extends JPanel {
             tableModel.setBoardLocation(boardLocation);
             boardLocationSelectionActionGroup.setEnabled(true);
         }
+        UpdateActivePlacements();
     }
 
     public Placement getSelection() {
@@ -319,6 +334,7 @@ public class JobPlacementsPanel extends JPanel {
 
             boardLocation.getBoard().addPlacement(placement);
             tableModel.fireTableDataChanged();
+            UpdateActivePlacements();
             boardLocation.setPlaced(placement.getId(), false);
             Helpers.selectLastTableRow(table);
         }
@@ -337,6 +353,7 @@ public class JobPlacementsPanel extends JPanel {
                 boardLocation.getBoard().removePlacement(placement);
             }
             tableModel.fireTableDataChanged();
+            UpdateActivePlacements();
         }
     };
 
@@ -483,6 +500,7 @@ public class JobPlacementsPanel extends JPanel {
             for (Placement placement : getSelections()) {
                 placement.setType(type);
                 tableModel.fireTableDataChanged();
+                UpdateActivePlacements();
             }
         }
     };
@@ -511,6 +529,7 @@ public class JobPlacementsPanel extends JPanel {
             for (Placement placement : getSelections()) {
                 placement.setSide(side);
                 tableModel.fireTableDataChanged();
+                UpdateActivePlacements();
             }
         }
     };
@@ -540,6 +559,7 @@ public class JobPlacementsPanel extends JPanel {
             for (Placement placement : getSelections()) {
                 boardLocation.setPlaced(placement.getId(), placed);
                 tableModel.fireTableDataChanged();   
+                UpdateActivePlacements();
             }
         }
     };

--- a/src/main/java/org/openpnp/gui/JobPlacementsPanel.java
+++ b/src/main/java/org/openpnp/gui/JobPlacementsPanel.java
@@ -210,7 +210,7 @@ public class JobPlacementsPanel extends JPanel {
                     Placement placement = getSelection();
                     placement.setType(placement.getType() == Type.Place ? Type.Ignore : Type.Place);
                     tableModel.fireTableRowsUpdated(table.getSelectedRow(), table.getSelectedRow());
-                    UpdateActivePlacements();
+                    updateActivePlacements();
                 }
                 else {
                     super.keyTyped(e);
@@ -245,7 +245,7 @@ public class JobPlacementsPanel extends JPanel {
     
     public void refresh() {
         tableModel.fireTableDataChanged();
-        UpdateActivePlacements();
+        updateActivePlacements();
     }
 
     public void selectPlacement(Placement placement) {
@@ -259,7 +259,7 @@ public class JobPlacementsPanel extends JPanel {
         }
     }
     
-    public void UpdateActivePlacements() {
+    public void updateActivePlacements() {
     	if (boardLocation != null) {
     		labelActivePlacements.setText(boardLocation.getActivePlacements() + " of " + boardLocation.getTotalActivePlacements() + " placements active");
     	}
@@ -275,7 +275,7 @@ public class JobPlacementsPanel extends JPanel {
             tableModel.setBoardLocation(boardLocation);
             boardLocationSelectionActionGroup.setEnabled(true);
         }
-        UpdateActivePlacements();
+        updateActivePlacements();
     }
 
     public Placement getSelection() {
@@ -336,7 +336,7 @@ public class JobPlacementsPanel extends JPanel {
 
             boardLocation.getBoard().addPlacement(placement);
             tableModel.fireTableDataChanged();
-            UpdateActivePlacements();
+            updateActivePlacements();
             boardLocation.setPlaced(placement.getId(), false);
             Helpers.selectLastTableRow(table);
         }
@@ -355,7 +355,7 @@ public class JobPlacementsPanel extends JPanel {
                 boardLocation.getBoard().removePlacement(placement);
             }
             tableModel.fireTableDataChanged();
-            UpdateActivePlacements();
+            updateActivePlacements();
         }
     };
 
@@ -502,7 +502,7 @@ public class JobPlacementsPanel extends JPanel {
             for (Placement placement : getSelections()) {
                 placement.setType(type);
                 tableModel.fireTableDataChanged();
-                UpdateActivePlacements();
+                updateActivePlacements();
             }
         }
     };
@@ -531,7 +531,7 @@ public class JobPlacementsPanel extends JPanel {
             for (Placement placement : getSelections()) {
                 placement.setSide(side);
                 tableModel.fireTableDataChanged();
-                UpdateActivePlacements();
+                updateActivePlacements();
             }
         }
     };
@@ -561,7 +561,7 @@ public class JobPlacementsPanel extends JPanel {
             for (Placement placement : getSelections()) {
                 boardLocation.setPlaced(placement.getId(), placed);
                 tableModel.fireTableDataChanged();   
-                UpdateActivePlacements();
+                updateActivePlacements();
             }
         }
     };

--- a/src/main/java/org/openpnp/gui/JobPlacementsPanel.java
+++ b/src/main/java/org/openpnp/gui/JobPlacementsPanel.java
@@ -260,7 +260,9 @@ public class JobPlacementsPanel extends JPanel {
     }
     
     public void UpdateActivePlacements() {
-    	labelActivePlacements.setText(boardLocation.getActivePlacements() + " of " + boardLocation.getTotalActivePlacements() + " placements active");
+    	if (boardLocation != null) {
+    		labelActivePlacements.setText(boardLocation.getActivePlacements() + " of " + boardLocation.getTotalActivePlacements() + " placements active");
+    	}
     }
 
     public void setBoardLocation(BoardLocation boardLocation) {

--- a/src/main/java/org/openpnp/gui/JobPlacementsPanel.java
+++ b/src/main/java/org/openpnp/gui/JobPlacementsPanel.java
@@ -70,7 +70,7 @@ public class JobPlacementsPanel extends JPanel {
     private ActionGroup multiSelectionActionGroup;
     private ActionGroup captureAndPositionActionGroup;
     private BoardLocation boardLocation;
-    private JLabel labelActivePlacements;
+    private JobPanel jobPanel;
 
     private static Color typeColorIgnore = new Color(252, 255, 157);
     private static Color typeColorFiducial = new Color(157, 188, 255);
@@ -84,6 +84,8 @@ public class JobPlacementsPanel extends JPanel {
     private static Color jobColorComplete = new Color(157, 255, 168);
 
     public JobPlacementsPanel(JobPanel jobPanel) {
+    	this.jobPanel = jobPanel;
+    	
         Configuration configuration = Configuration.get();
 
         boardLocationSelectionActionGroup = new ActionGroup(newAction);
@@ -143,11 +145,6 @@ public class JobPlacementsPanel extends JPanel {
         JButton btnEditFeeder = new JButton(editPlacementFeederAction);
         btnEditFeeder.setHideActionText(true);
         toolBarPlacements.add(btnEditFeeder);
-        
-        toolBarPlacements.addSeparator();
-        
-        labelActivePlacements = new JLabel("");
-        toolBarPlacements.add(labelActivePlacements);
         
         tableModel = new PlacementsTableModel(configuration);
 
@@ -261,7 +258,18 @@ public class JobPlacementsPanel extends JPanel {
     
     public void updateActivePlacements() {
     	if (boardLocation != null) {
-    		labelActivePlacements.setText(boardLocation.getActivePlacements() + " of " + boardLocation.getTotalActivePlacements() + " placements active");
+    		int activePlacements = 0;
+    		int totalActivePlacements = 0;
+    		
+    		List<BoardLocation> boardLocations = this.jobPanel.getJob().getBoardLocations();
+    		for (BoardLocation boardLocation : boardLocations) {
+    			if (boardLocation.isEnabled()) {
+    				activePlacements += boardLocation.getActivePlacements();
+    				totalActivePlacements += boardLocation.getTotalActivePlacements();
+    			}
+    		}
+    		
+    		MainFrame.get().setPlacements(totalActivePlacements - activePlacements, totalActivePlacements, boardLocation.getTotalActivePlacements() - boardLocation.getActivePlacements(), boardLocation.getTotalActivePlacements());
     	}
     }
 

--- a/src/main/java/org/openpnp/gui/JobPlacementsPanel.java
+++ b/src/main/java/org/openpnp/gui/JobPlacementsPanel.java
@@ -18,7 +18,6 @@ import javax.swing.Action;
 import javax.swing.DefaultCellEditor;
 import javax.swing.JButton;
 import javax.swing.JComboBox;
-import javax.swing.JLabel;
 import javax.swing.JMenu;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
@@ -145,7 +144,6 @@ public class JobPlacementsPanel extends JPanel {
         JButton btnEditFeeder = new JButton(editPlacementFeederAction);
         btnEditFeeder.setHideActionText(true);
         toolBarPlacements.add(btnEditFeeder);
-        
         tableModel = new PlacementsTableModel(configuration);
 
         table = new AutoSelectTextTable(tableModel);

--- a/src/main/java/org/openpnp/gui/MainFrame.java
+++ b/src/main/java/org/openpnp/gui/MainFrame.java
@@ -23,6 +23,7 @@ import java.awt.AWTEvent;
 import java.awt.BorderLayout;
 import java.awt.Component;
 import java.awt.Desktop;
+import java.awt.Dimension;
 import java.awt.EventQueue;
 import java.awt.FlowLayout;
 import java.awt.Font;
@@ -56,6 +57,7 @@ import javax.swing.JMenuBar;
 import javax.swing.JMenuItem;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
+import javax.swing.JProgressBar;
 import javax.swing.JSplitPane;
 import javax.swing.JTabbedPane;
 import javax.swing.JTextPane;
@@ -513,18 +515,40 @@ public class MainFrame extends JFrame {
         contentPane.add(panelStatusAndDros, BorderLayout.SOUTH);
         panelStatusAndDros.setLayout(new FormLayout(
                 new ColumnSpec[] {ColumnSpec.decode("default:grow"), ColumnSpec.decode("8px"),
+                        FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC, 
+                        FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,
                         FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,},
                 new RowSpec[] {RowSpec.decode("20px"),}));
 
+        
+        // Status Information
         lblStatus = new JLabel(" ");
         lblStatus.setBorder(new BevelBorder(BevelBorder.LOWERED, null, null, null, null));
         panelStatusAndDros.add(lblStatus, "1, 1");
+        
+        
+        // Placement Information
+        lblPlacements = new JLabel(" Placements: 0 / 0 Total | 0 / 0 Selected Board ");
+        lblPlacements.setBorder(new BevelBorder(BevelBorder.LOWERED, null, null, null, null));
+        panelStatusAndDros.add(lblPlacements, "4, 1");
+        
+        
+        // Placements Progress Bar
+        prgbrPlacements = new JProgressBar();
+        prgbrPlacements.setMinimum(0);
+        prgbrPlacements.setMaximum(100);
+        prgbrPlacements.setStringPainted(true);
+        prgbrPlacements.setPreferredSize(new Dimension(200, 16));
+        prgbrPlacements.setValue(0);
+        panelStatusAndDros.add(prgbrPlacements, "6, 1");
 
+        
+        // DRO 
         droLbl = new JLabel("X 0000.0000, Y 0000.0000, Z 0000.0000, R 0000.0000");
         droLbl.setOpaque(true);
         droLbl.setFont(new Font("Monospaced", Font.PLAIN, 13));
         droLbl.setBorder(new BevelBorder(BevelBorder.LOWERED, null, null, null, null));
-        panelStatusAndDros.add(droLbl, "4, 1");
+        panelStatusAndDros.add(droLbl, "8, 1");
 
         cameraPanel.setBorder(new TitledBorder(null, "Cameras", TitledBorder.LEADING,
                 TitledBorder.TOP, null, null));
@@ -752,6 +776,13 @@ public class MainFrame extends JFrame {
             lblStatus.setText(status);
         });
     }
+    
+    public void setPlacements(int CompletedPlacemnts, int TotalPlacements, int PlacementsBoard, int TotalPlacementsBoard) {
+        SwingUtilities.invokeLater(() -> {
+        	lblPlacements.setText(" Placements: " + CompletedPlacemnts + " / " + TotalPlacements + " Total | " + PlacementsBoard + " / " + TotalPlacementsBoard + " Selected Board ");
+        	prgbrPlacements.setValue((int)(((float)CompletedPlacemnts / (float)TotalPlacements) * 100.0f));
+        });
+    }
 
     public void showTab(String title) {
         int index = tabs.indexOfTab(title);
@@ -925,4 +956,6 @@ public class MainFrame extends JFrame {
     private JPanel panelStatusAndDros;
     private JLabel droLbl;
     private JLabel lblStatus;
+    private JLabel lblPlacements;
+    private JProgressBar prgbrPlacements;
 }

--- a/src/main/java/org/openpnp/gui/tablemodel/PlacementsTableModel.java
+++ b/src/main/java/org/openpnp/gui/tablemodel/PlacementsTableModel.java
@@ -114,7 +114,7 @@ public class PlacementsTableModel extends AbstractTableModel {
             }
             else if (columnIndex == 2) {
                 placement.setSide((Side) aValue);
-                jobPlacementsPanel.UpdateActivePlacements();
+                jobPlacementsPanel.updateActivePlacements();
             }
             else if (columnIndex == 3) {
                 LengthCellValue value = (LengthCellValue) aValue;
@@ -141,11 +141,11 @@ public class PlacementsTableModel extends AbstractTableModel {
             else if (columnIndex == 6) {
                 placement.setType((Type) aValue);
                 fireTableCellUpdated(rowIndex, 8);
-                jobPlacementsPanel.UpdateActivePlacements();
+                jobPlacementsPanel.updateActivePlacements();
             }
             else if (columnIndex == 7) {
             	boardLocation.setPlaced(placement.getId(), (Boolean) aValue);
-            	jobPlacementsPanel.UpdateActivePlacements();
+            	jobPlacementsPanel.updateActivePlacements();
             }
             else if (columnIndex == 9) {
                 placement.setCheckFids((Boolean) aValue);
@@ -202,7 +202,7 @@ public class PlacementsTableModel extends AbstractTableModel {
             case 6:
                 return placement.getType();
             case 7:
-            	jobPlacementsPanel.UpdateActivePlacements();
+            	jobPlacementsPanel.updateActivePlacements();
             	return boardLocation.getPlaced(placement.getId());
             case 8:
                 return getPlacementStatus(placement);

--- a/src/main/java/org/openpnp/gui/tablemodel/PlacementsTableModel.java
+++ b/src/main/java/org/openpnp/gui/tablemodel/PlacementsTableModel.java
@@ -21,6 +21,7 @@ package org.openpnp.gui.tablemodel;
 
 import javax.swing.table.AbstractTableModel;
 
+import org.openpnp.gui.JobPlacementsPanel;
 import org.openpnp.gui.support.LengthCellValue;
 import org.openpnp.gui.support.PartCellValue;
 import org.openpnp.gui.support.RotationCellValue;
@@ -54,9 +55,14 @@ public class PlacementsTableModel extends AbstractTableModel {
 
     private Board board;
     private BoardLocation boardLocation;
+    private JobPlacementsPanel jobPlacementsPanel;
 
     public PlacementsTableModel(Configuration configuration) {
         this.configuration = configuration;
+    }
+    
+    public void setJobPlacementsPanel(JobPlacementsPanel jobPlacementsPanel) {
+    	this.jobPlacementsPanel = jobPlacementsPanel;
     }
 
     public void setBoardLocation(BoardLocation boardLocation) {
@@ -108,6 +114,7 @@ public class PlacementsTableModel extends AbstractTableModel {
             }
             else if (columnIndex == 2) {
                 placement.setSide((Side) aValue);
+                jobPlacementsPanel.UpdateActivePlacements();
             }
             else if (columnIndex == 3) {
                 LengthCellValue value = (LengthCellValue) aValue;
@@ -134,10 +141,11 @@ public class PlacementsTableModel extends AbstractTableModel {
             else if (columnIndex == 6) {
                 placement.setType((Type) aValue);
                 fireTableCellUpdated(rowIndex, 8);
+                jobPlacementsPanel.UpdateActivePlacements();
             }
             else if (columnIndex == 7) {
-                //placement.setPlaced((Boolean) aValue);
             	boardLocation.setPlaced(placement.getId(), (Boolean) aValue);
+            	jobPlacementsPanel.UpdateActivePlacements();
             }
             else if (columnIndex == 9) {
                 placement.setCheckFids((Boolean) aValue);
@@ -194,6 +202,7 @@ public class PlacementsTableModel extends AbstractTableModel {
             case 6:
                 return placement.getType();
             case 7:
+            	jobPlacementsPanel.UpdateActivePlacements();
             	return boardLocation.getPlaced(placement.getId());
             case 8:
                 return getPlacementStatus(placement);

--- a/src/main/java/org/openpnp/model/BoardLocation.java
+++ b/src/main/java/org/openpnp/model/BoardLocation.java
@@ -122,6 +122,9 @@ public class BoardLocation extends AbstractModelObject {
     }
     
     public int getTotalActivePlacements(){
+    	if (board == null) {
+    		return 0;
+    	}
     	int counter = 0;
     	for(Placement placements : board.getPlacements()) {
     		// is the component on the correct boards side
@@ -137,6 +140,9 @@ public class BoardLocation extends AbstractModelObject {
     }
     
     public int getActivePlacements() {
+    	if (board == null) {
+    		return 0;
+    	}
     	int counter = 0;
     	for(Placement placements : board.getPlacements()) {
     		// is the component on the correct boards side

--- a/src/main/java/org/openpnp/model/BoardLocation.java
+++ b/src/main/java/org/openpnp/model/BoardLocation.java
@@ -22,6 +22,7 @@ package org.openpnp.model;
 import java.util.HashMap;
 import java.util.Map;
 import org.openpnp.model.Board.Side;
+import org.openpnp.model.Placement.Type;
 import org.simpleframework.xml.Attribute;
 import org.simpleframework.xml.Element;
 import org.simpleframework.xml.ElementMap;
@@ -118,6 +119,40 @@ public class BoardLocation extends AbstractModelObject {
 
     public Side getSide() {
         return side;
+    }
+    
+    public int getTotalActivePlacements(){
+    	int counter = 0;
+    	for(Placement placements : board.getPlacements()) {
+    		// is the component on the correct boards side
+    		if (placements.getSide() == getSide()) {
+    			
+    			//is the component set to be placed?
+    			if (placements.getType() == Type.Place) {		
+    				counter++;
+    			}
+        	}
+    	}
+    	return counter;
+    }
+    
+    public int getActivePlacements() {
+    	int counter = 0;
+    	for(Placement placements : board.getPlacements()) {
+    		// is the component on the correct boards side
+    		if (placements.getSide() == getSide()) {
+    			
+    			//is the component set to be placed?
+    			if (placements.getType() == Type.Place) {		
+    			
+    				// has the component been placed already?
+    				if (!getPlaced(placements.getId())) {
+    					counter++;
+    				}
+    			}
+        	}
+    	}
+    	return counter;
     }
 
     public void setSide(Side side) {


### PR DESCRIPTION
# Description
Added indicator label how many active and how many completed placements are listed in this board.

![active-placements](https://user-images.githubusercontent.com/4028409/41466621-586480c4-70a3-11e8-85cc-05d0c51e529c.jpg)


# Justification
It provides the user with better overview of the current placement progress (like a progress bar - maybe a good future addition) and before starting a job provides valuable information about the number of placements planned for this PCB.

# Instructions for Use
The label automatically updated whenever a placement is set to "fiducial", "ignore", "place", when a placed flag is set or when a placement side is changed. It also automatically updates during job runs and when a job placement status is reset.

# Implementation Details
1. How did you test the change? 
I used the nulldriver and with multiple boards and also tried the autopanel feature.
In autopanel mode the active placements are "per" board.

2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)?
yes
3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing.
4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted.
I did: BUILD SUCCESS
