### PR TITLE
My changes and impromevents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ installers
 .classpath
 src/main/resources/icons/src/Soft_Scraps_by_deleket
 .github_changelog_generator
+hs_err*
+*.log

--- a/src/main/java/org/openpnp/gui/JobPanel.java
+++ b/src/main/java/org/openpnp/gui/JobPanel.java
@@ -95,6 +95,7 @@ import org.openpnp.spi.MachineListener;
 import org.openpnp.util.FiniteStateMachine;
 import org.openpnp.util.MovableUtils;
 import org.openpnp.util.UiUtils;
+import org.pmw.tinylog.Logger;
 
 import com.google.common.eventbus.Subscribe;
 
@@ -245,7 +246,12 @@ public class JobPanel extends JPanel {
                 	updatePanelizationIconState();
                 	
                 }
-
+                if (job.getBoardLocations().size() > 0) {
+					BoardLocation boardLocation = getSelectedBoardLocation();
+					jobPlacementsPanel.setBoardLocation(boardLocation);
+                }
+                else
+                    jobPlacementsPanel.setBoardLocation(null);
             }
         });
 

--- a/src/main/java/org/openpnp/gui/JobPlacementsPanel.java
+++ b/src/main/java/org/openpnp/gui/JobPlacementsPanel.java
@@ -12,6 +12,7 @@ import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.PatternSyntaxException;
 
 import javax.swing.AbstractAction;
 import javax.swing.Action;
@@ -26,11 +27,13 @@ import javax.swing.JScrollPane;
 import javax.swing.JTable;
 import javax.swing.JToolBar;
 import javax.swing.ListSelectionModel;
+import javax.swing.RowFilter;
 import javax.swing.UIManager;
 import javax.swing.border.LineBorder;
 import javax.swing.event.ListSelectionEvent;
 import javax.swing.event.ListSelectionListener;
 import javax.swing.table.DefaultTableCellRenderer;
+import javax.swing.table.TableRowSorter;
 
 import org.openpnp.events.PlacementSelectedEvent;
 import org.openpnp.gui.components.AutoSelectTextTable;
@@ -60,10 +63,12 @@ import org.openpnp.spi.PnpJobProcessor.JobPlacement;
 import org.openpnp.util.MovableUtils;
 import org.openpnp.util.UiUtils;
 import org.openpnp.util.Utils2D;
+import org.pmw.tinylog.Logger;
 
 public class JobPlacementsPanel extends JPanel {
     private JTable table;
     private PlacementsTableModel tableModel;
+    private TableRowSorter<PlacementsTableModel> tableSorter;
     private ActionGroup boardLocationSelectionActionGroup;
     private ActionGroup singleSelectionActionGroup;
     private ActionGroup multiSelectionActionGroup;
@@ -143,9 +148,10 @@ public class JobPlacementsPanel extends JPanel {
         toolBarPlacements.add(btnEditFeeder);
 
         tableModel = new PlacementsTableModel(configuration);
+        tableSorter = new TableRowSorter<>(tableModel);
 
         table = new AutoSelectTextTable(tableModel);
-        table.setAutoCreateRowSorter(true);
+        table.setRowSorter(tableSorter);
         table.getTableHeader().setDefaultRenderer(new MultisortTableHeaderCellRenderer());
         table.setSelectionMode(ListSelectionModel.MULTIPLE_INTERVAL_SELECTION);
         table.setDefaultEditor(Side.class, new DefaultCellEditor(sidesComboBox));
@@ -258,6 +264,17 @@ public class JobPlacementsPanel extends JPanel {
         else {
             tableModel.setBoardLocation(boardLocation);
             boardLocationSelectionActionGroup.setEnabled(true);
+
+            RowFilter<PlacementsTableModel, Object> rf = null;
+            // If current expression doesn't parse, don't update.
+			try {
+				rf = RowFilter.regexFilter("(?i)" + boardLocation.getSide().toString());
+			}
+            catch (PatternSyntaxException e) {
+                Logger.warn("Side sort failed", e);
+                return;
+            }
+            tableSorter.setRowFilter(rf);
         }
     }
 

--- a/src/main/java/org/openpnp/gui/MachineControlsPanel.java
+++ b/src/main/java/org/openpnp/gui/MachineControlsPanel.java
@@ -268,8 +268,11 @@ public class MachineControlsPanel extends JPanel {
                 Machine machine = Configuration.get().getMachine();
                 boolean enable = !machine.isEnabled();
                 try {
-                    Configuration.get().getMachine().setEnabled(enable);
-                    setEnabled(true);
+					Configuration.get().getMachine().setEnabled(enable);
+					setEnabled(true);
+					if (machine.getHomeAfterEnabled() && machine.isEnabled()) {
+						selectedTool.getHead().home();
+					}
                 }
                 catch (Exception t1) {
                     MessageBoxes.errorBox(MachineControlsPanel.this, "Enable Failure",

--- a/src/main/java/org/openpnp/gui/MainFrame.java
+++ b/src/main/java/org/openpnp/gui/MainFrame.java
@@ -107,6 +107,24 @@ public class MainFrame extends JFrame {
     private static final String PREF_WINDOW_STYLE_MULTIPLE = "MainFrame.windowStyleMultiple";
     private static final boolean PREF_WINDOW_STYLE_MULTIPLE_DEF = false;
 
+    private static final String PREF_CAMERA_WINDOW_X = "CameraFrame.windowX";
+    private static final int PREF_CAMERA_WINDOW_X_DEF = 0;
+    private static final String PREF_CAMERA_WINDOW_Y = "CameraFrame.windowY";
+    private static final int PREF_CAMERA_WINDOW_Y_DEF = 0;
+    private static final String PREF_CAMERA_WINDOW_WIDTH = "CameraFrame.windowWidth";
+    private static final int PREF_CAMERA_WINDOW_WIDTH_DEF = 800;
+    private static final String PREF_CAMERA_WINDOW_HEIGHT = "CameraFrame.windowHeight";
+    private static final int PREF_CAMERA_WINDOW_HEIGHT_DEF = 600;
+
+    private static final String PREF_MACHINECONTROLS_WINDOW_X = "MachineControlsFrame.windowX";
+    private static final int PREF_MACHINECONTROLS_WINDOW_X_DEF = 0;
+    private static final String PREF_MACHINECONTROLS_WINDOW_Y = "MachineControlsFrame.windowY";
+    private static final int PREF_MACHINECONTROLS_WINDOW_Y_DEF = 0;
+    private static final String PREF_MACHINECONTROLS_WINDOW_WIDTH = "MachineControlsFrame.windowWidth";
+    private static final int PREF_MACHINECONTROLS_WINDOW_WIDTH_DEF = 490;
+    private static final String PREF_MACHINECONTROLS_WINDOW_HEIGHT = "MachineControlsFrame.windowHeight";
+    private static final int PREF_MACHINECONTROLS_WINDOW_HEIGHT_DEF = 340;
+
     private final Configuration configuration;
 
     private static MainFrame mainFrame;
@@ -120,6 +138,8 @@ public class MainFrame extends JFrame {
     private JPanel panelCameraAndInstructions;
     private JPanel panelMachine;
     private MachineSetupPanel machineSetupPanel;
+    private JDialog frameCamera;
+    private JDialog frameMachineControls;
 
     public static MainFrame get() {
         return mainFrame;
@@ -232,6 +252,8 @@ public class MainFrame extends JFrame {
         mnFile.addSeparator();
         mnFile.add(new JMenuItem(jobPanel.saveJobAction));
         mnFile.add(new JMenuItem(jobPanel.saveJobAsAction));
+        mnFile.addSeparator();
+        mnFile.add(new JMenuItem(saveConfigAction));
 
 
         // File -> Import
@@ -564,21 +586,47 @@ public class MainFrame extends JFrame {
     public void splitWindows() {
         if (prefs.getBoolean(PREF_WINDOW_STYLE_MULTIPLE, PREF_WINDOW_STYLE_MULTIPLE_DEF)) {
             // pin panelCameraAndInstructions to a separate JFrame
-            JDialog frameCamera = new JDialog(this, "OpenPnp - Camera", false);
+            frameCamera = new JDialog(this, "OpenPnp - Camera", false);
             // as of today no smart way found to get an adjusted size
             // ... so main window size is used for the camera window
-            frameCamera.setSize(getFrames()[0].getSize());
             frameCamera.add(panelCameraAndInstructions);
             frameCamera.setVisible(true);
+            frameCamera.addComponentListener(cameraWindowListener);
+
+            if (prefs.getInt(PREF_CAMERA_WINDOW_WIDTH, 50) < 50) {
+                prefs.putInt(PREF_CAMERA_WINDOW_WIDTH, PREF_CAMERA_WINDOW_WIDTH_DEF);
+            }
+
+            if (prefs.getInt(PREF_CAMERA_WINDOW_HEIGHT, 50) < 50) {
+                prefs.putInt(PREF_CAMERA_WINDOW_HEIGHT, PREF_CAMERA_WINDOW_HEIGHT_DEF);
+            }
+
+            frameCamera.setBounds(prefs.getInt(PREF_CAMERA_WINDOW_X, PREF_CAMERA_WINDOW_X_DEF),
+                    prefs.getInt(PREF_CAMERA_WINDOW_Y, PREF_CAMERA_WINDOW_Y_DEF),
+                    prefs.getInt(PREF_CAMERA_WINDOW_WIDTH, PREF_CAMERA_WINDOW_WIDTH_DEF),
+                    prefs.getInt(PREF_CAMERA_WINDOW_HEIGHT, PREF_CAMERA_WINDOW_HEIGHT_DEF));
 
             // pin machineControlsPanel to a separate JFrame
-            JDialog frameMachineControls = new JDialog(this, "OpenPnp - Machine Controls", false);
+            frameMachineControls = new JDialog(this, "OpenPnp - Machine Controls", false);
             // as of today no smart way found to get an adjusted size
             // ... so hardcoded values used (usually not a good idea)
             frameMachineControls.add(machineControlsPanel);
             frameMachineControls.setVisible(true);
             frameMachineControls.pack();
+            frameMachineControls.addComponentListener(machineControlsWindowListener);
 
+            if (prefs.getInt(PREF_MACHINECONTROLS_WINDOW_WIDTH, 50) < 50) {
+                prefs.putInt(PREF_MACHINECONTROLS_WINDOW_WIDTH, PREF_MACHINECONTROLS_WINDOW_WIDTH_DEF);
+            }
+
+            if (prefs.getInt(PREF_MACHINECONTROLS_WINDOW_HEIGHT, 50) < 50) {
+                prefs.putInt(PREF_MACHINECONTROLS_WINDOW_HEIGHT, PREF_MACHINECONTROLS_WINDOW_HEIGHT_DEF);
+            }
+
+            frameMachineControls.setBounds(prefs.getInt(PREF_MACHINECONTROLS_WINDOW_X, PREF_MACHINECONTROLS_WINDOW_X_DEF),
+                    prefs.getInt(PREF_MACHINECONTROLS_WINDOW_Y, PREF_MACHINECONTROLS_WINDOW_Y_DEF),
+                    prefs.getInt(PREF_MACHINECONTROLS_WINDOW_WIDTH, PREF_MACHINECONTROLS_WINDOW_WIDTH_DEF),
+                    prefs.getInt(PREF_MACHINECONTROLS_WINDOW_HEIGHT, PREF_MACHINECONTROLS_WINDOW_HEIGHT_DEF));
             // move the splitPaneDivider to position 0 to fill the gap of the
             // relocated panels 'panelCameraAndInstructions' & 'machineControlsPanel'
             splitPaneMachineAndTabs.setDividerLocation(0);
@@ -700,6 +748,25 @@ public class MainFrame extends JFrame {
         dialog.setVisible(true);
     }
 
+    public boolean saveConfig() {
+        // Save the configuration
+        try {
+            configuration.save();
+        }
+        catch (Exception e) {
+			String message = "There was a problem saving the configuration. The reason was:\n\n" + e.getMessage()
+					+ "\n\n";
+			message = message.replaceAll("\n", "<br/>");
+			message = message.replaceAll("\r", "");
+			message = "<html><body width=\"400\">" + message + "</body></html>";
+			JOptionPane.showMessageDialog(this, message, "Configuration Save Error", JOptionPane.ERROR_MESSAGE);
+			return false;
+        }
+
+        Logger.debug("Config saved successfully!");
+        return true;
+    }
+
     public boolean quit() {
         Logger.info("Shutting down...");
         try {
@@ -772,6 +839,34 @@ public class MainFrame extends JFrame {
         }
     };
 
+    private ComponentListener cameraWindowListener = new ComponentAdapter() {
+        @Override
+        public void componentMoved(ComponentEvent e) {
+            prefs.putInt(PREF_CAMERA_WINDOW_X, frameCamera.getLocation().x);
+            prefs.putInt(PREF_CAMERA_WINDOW_Y, frameCamera.getLocation().y);
+        }
+
+        @Override
+        public void componentResized(ComponentEvent e) {
+            prefs.putInt(PREF_CAMERA_WINDOW_WIDTH, frameCamera.getSize().width);
+            prefs.putInt(PREF_CAMERA_WINDOW_HEIGHT, frameCamera.getSize().height);
+        }
+    };
+
+    private ComponentListener machineControlsWindowListener = new ComponentAdapter() {
+        @Override
+        public void componentMoved(ComponentEvent e) {
+            prefs.putInt(PREF_MACHINECONTROLS_WINDOW_X, frameMachineControls.getLocation().x);
+            prefs.putInt(PREF_MACHINECONTROLS_WINDOW_Y, frameMachineControls.getLocation().y);
+        }
+
+        @Override
+        public void componentResized(ComponentEvent e) {
+            prefs.putInt(PREF_MACHINECONTROLS_WINDOW_WIDTH, frameMachineControls.getSize().width);
+            prefs.putInt(PREF_MACHINECONTROLS_WINDOW_HEIGHT, frameMachineControls.getSize().height);
+        }
+    };
+
     private Action inchesUnitSelected = new AbstractAction(LengthUnit.Inches.name()) {
         {
             putValue(MNEMONIC_KEY, KeyEvent.VK_I);
@@ -813,6 +908,13 @@ public class MainFrame extends JFrame {
             }
             MessageBoxes.infoBox("Windows Style Changed",
                     "Window style has been changed. Please restart OpenPnP to see the changes.");
+        }
+    };
+
+    private Action saveConfigAction = new AbstractAction("Save configuration") {
+        @Override
+        public void actionPerformed(ActionEvent arg0) {
+			saveConfig();
         }
     };
 

--- a/src/main/java/org/openpnp/gui/components/CameraPanel.java
+++ b/src/main/java/org/openpnp/gui/components/CameraPanel.java
@@ -45,7 +45,8 @@ import org.openpnp.spi.Head;
 public class CameraPanel extends JPanel {
     private static int maximumFps = 15;
     private static final String SHOW_NONE_ITEM = "Show None";
-    private static final String SHOW_ALL_ITEM = "Show All";
+    private static final String SHOW_ALL_ITEM_H = "Show All Horizontal";
+    private static final String SHOW_ALL_ITEM_V = "Show All Vertical";
 
     private Map<Camera, CameraView> cameraViews = new LinkedHashMap<>();
 
@@ -111,7 +112,8 @@ public class CameraPanel extends JPanel {
         else if (cameraViews.size() == 2) {
             // Otherwise this is the second camera so mix in the
             // show all item.
-            camerasCombo.insertItemAt(SHOW_ALL_ITEM, 1);
+            camerasCombo.insertItemAt(SHOW_ALL_ITEM_H, 1);
+            camerasCombo.insertItemAt(SHOW_ALL_ITEM_V, 2);
         }
     }
     
@@ -154,7 +156,7 @@ public class CameraPanel extends JPanel {
      * @return
      */
     public void ensureCameraVisible(Camera camera) {
-        if (camerasCombo.getSelectedItem().equals(SHOW_ALL_ITEM)) {
+        if (camerasCombo.getSelectedItem().equals(SHOW_ALL_ITEM_H) || camerasCombo.getSelectedItem().equals(SHOW_ALL_ITEM_V)) {
             return;
         }
         setSelectedCamera(camera);
@@ -193,12 +195,16 @@ public class CameraPanel extends JPanel {
                 camerasPanel.add(panel);
                 selectedCameraView = null;
             }
-            else if (camerasCombo.getSelectedItem().equals(SHOW_ALL_ITEM)) {
+            else if (camerasCombo.getSelectedItem().equals(SHOW_ALL_ITEM_H) || camerasCombo.getSelectedItem().equals(SHOW_ALL_ITEM_V)) {
                 int rows = (int) Math.ceil(Math.sqrt(cameraViews.size()));
                 if (rows == 0) {
                     rows = 1;
                 }
-                camerasPanel.setLayout(new GridLayout(rows, 0, 1, 1));
+				if (camerasCombo.getSelectedItem().equals(SHOW_ALL_ITEM_H))
+					camerasPanel.setLayout(new GridLayout(rows, 0, 1, 1));
+				else
+					camerasPanel.setLayout(new GridLayout(0, rows, 1, 1));
+
                 for (CameraView cameraView : cameraViews.values()) {
                     cameraView.setMaximumFps(maximumFps / Math.max(cameraViews.size(), 1));
                     cameraView.setShowName(true);

--- a/src/main/java/org/openpnp/machine/reference/ReferenceMachine.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceMachine.java
@@ -86,6 +86,12 @@ public class ReferenceMachine extends AbstractMachine {
     @Element(required = false)
     protected FiducialLocator fiducialLocator = new ReferenceFiducialLocator();
 
+    @Element(required = false)
+    private boolean homeAfterEnabled = false;
+
+    @Element(required = false)
+    private boolean usePickRotationInsteadOfRotationInTapeForStripFeeders = false;
+
     private boolean enabled;
 
     private List<Class<? extends Feeder>> registeredFeederClasses = new ArrayList<>();
@@ -297,5 +303,21 @@ public class ReferenceMachine extends AbstractMachine {
     @Override
     public PasteDispenseJobProcessor getPasteDispenseJobProcessor() {
         return pasteDispenseJobProcessor;
+    }
+
+    public boolean getHomeAfterEnabled() {
+        return homeAfterEnabled;
+    }
+
+    public boolean getUsePickRotationInsteadOfRotationInTapeForStripFeeders() {
+        return usePickRotationInsteadOfRotationInTapeForStripFeeders;
+    }
+
+    public void setHomeAfterEnabled(boolean newValue) {
+        this.homeAfterEnabled = newValue;
+    }
+
+    public void setUsePickRotationInsteadOfRotationInTapeForStripFeeders(boolean newValue) {
+        this.usePickRotationInsteadOfRotationInTapeForStripFeeders = newValue;
     }
 }

--- a/src/main/java/org/openpnp/machine/reference/ReferencePnpJobProcessor.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferencePnpJobProcessor.java
@@ -19,6 +19,7 @@
 
 package org.openpnp.machine.reference;
 
+import java.io.File;
 import java.text.DecimalFormat;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -426,8 +427,9 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
         fireTextStatus("Planning placements.");
 
         // Get the list of unfinished placements and sort them by part height.
+
         List<JobPlacement> jobPlacements = getPendingJobPlacements().stream()
-                .sorted(Comparator.comparing(JobPlacement::getPartHeight))
+                .sorted(Comparator.comparing(JobPlacement::getPartId))
                 .collect(Collectors.toList());
 
         if (jobPlacements.isEmpty()) {
@@ -788,6 +790,10 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
 	        }
             
             Logger.debug("Place {} with {}", part, nozzle.getName());
+
+            File file = job.getFile();
+            Configuration.get().saveJob(job, file);
+            Configuration.get().save();
         }
 
         clearStepComplete();

--- a/src/main/java/org/openpnp/machine/reference/feeder/ReferenceDragFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/ReferenceDragFeeder.java
@@ -79,12 +79,18 @@ public class ReferenceDragFeeder extends ReferenceFeeder {
     protected double feedSpeed = 1.0;
     @Attribute(required = false)
     protected String actuatorName;
+    @Attribute(required = false)
+    protected String peelOffActuatorName;
     @Element(required = false)
     protected Vision vision = new Vision();
     @Element(required = false)
     protected Length backoffDistance = new Length(0, LengthUnit.Millimeters);    
 
     protected Location pickLocation;
+
+    private double feededCount = 0;
+    private double partsPitchX = -2; //-2mm for 0402
+    private double partsPitchY = 0;
 
     /*
      * visionOffset contains the difference between where the part was expected to be and where it
@@ -93,12 +99,21 @@ public class ReferenceDragFeeder extends ReferenceFeeder {
      * correct feed locations.
      */
     protected Location visionOffset;
+    protected Location partPitch;
 
     @Override
     public Location getPickLocation() throws Exception {
         if (pickLocation == null) {
             pickLocation = location;
         }
+
+        if (vision.isEnabled() && visionOffset != null) {
+			if (this.isPart_0402() && partPitch != null)
+				return pickLocation.subtract(visionOffset).add(partPitch);
+			else
+				return pickLocation.subtract(visionOffset);
+        }
+
         return pickLocation;
     }
 
@@ -127,6 +142,17 @@ public class ReferenceDragFeeder extends ReferenceFeeder {
                     actuatorName, head.getName()));
         }
 
+		Actuator peelOffActuator = null;
+
+		if (peelOffActuatorName != null) {
+			peelOffActuator = head.getActuatorByName(peelOffActuatorName);
+
+	        if (peelOffActuator == null) {
+	            throw new Exception(String.format("No Actuator found with name %s on feed Head %s",
+						peelOffActuatorName, head.getName()));
+	        }
+		}
+
         head.moveToSafeZ();
 
         if (vision.isEnabled()) {
@@ -140,6 +166,7 @@ public class ReferenceDragFeeder extends ReferenceFeeder {
                 Logger.debug("First feed, running vision pre-flight.");
 
                 visionOffset = getVisionOffsets(head, location);
+                feededCount = 0;
             }
             Logger.debug("visionOffsets " + visionOffset);
         }
@@ -149,45 +176,69 @@ public class ReferenceDragFeeder extends ReferenceFeeder {
         // feedEndLocation and pickLocation. pickLocation will be saved
         // for the pick operation while feed start and end are used
         // here and then discarded.
-        Location feedStartLocation = this.feedStartLocation;
-        Location feedEndLocation = this.feedEndLocation;
         pickLocation = this.location;
-        if (visionOffset != null) {
-            feedStartLocation = feedStartLocation.subtract(visionOffset);
-            feedEndLocation = feedEndLocation.subtract(visionOffset);
-            pickLocation = pickLocation.subtract(visionOffset);
-        }
 
-        // Move the actuator to the feed start location.
-        actuator.moveTo(feedStartLocation.derive(null, null, Double.NaN, Double.NaN));
+        if (feededCount == 0) {
+            Location feedStartLocation = this.feedStartLocation;
+            Location feedEndLocation = this.feedEndLocation;
+	        if (vision.isEnabled() && visionOffset != null) {
+	            feedStartLocation = feedStartLocation.subtract(visionOffset);
+	            Logger.debug("New drag distance with visionOffset " + feedStartLocation.subtract(feedEndLocation));
+	        }
 
-        // extend the pin
-        actuator.actuate(true);
+	        // Move the actuator to the feed start location.
+	        actuator.moveTo(feedStartLocation.derive(null, null, Double.NaN, Double.NaN));
 
-        // insert the pin
-        actuator.moveTo(feedStartLocation);
+	        // extend the pin
+	        actuator.actuate(true);
 
-        // drag the tape
-        actuator.moveTo(feedEndLocation, feedSpeed * actuator.getHead().getMachine().getSpeed());
-        
-        // backoff to release tension from the pin
-        if (backoffDistance.getValue() != 0) {
-            Location backoffLocation = Utils2D.getPointAlongLine(feedEndLocation, feedStartLocation, backoffDistance);
-            actuator.moveTo(backoffLocation, feedSpeed * actuator.getHead().getMachine().getSpeed());
-        }
-        
+	        // insert the pin
+	        actuator.moveTo(feedStartLocation);
+
+	        // drag the tape
+	        actuator.moveTo(feedEndLocation, feedSpeed * actuator.getHead().getMachine().getSpeed());
+
+			if (peelOffActuator != null) {
+				// peel off before backoff
+				peelOffActuator.actuate(true);
+				peelOffActuator.actuate(false);
+			}
+
+	        // backoff to release tension from the pin
+	        if (backoffDistance.getValue() != 0) {
+	            Location backoffLocation = Utils2D.getPointAlongLine(feedEndLocation, feedStartLocation, backoffDistance);
+	            actuator.moveTo(backoffLocation, feedSpeed * actuator.getHead().getMachine().getSpeed());
+	        }
+
+	        // retract the pin
+	        actuator.actuate(false);
+
+	        if (this.isPart_0402() == true) {
+				// can change it to "feededCount = parts_count_userSettings;"
+				feededCount = 2;
+	        }
+        } else
+			Logger.debug("Multi parts drag feeder: skipping drag " + feededCount);
+
+
         head.moveToSafeZ();
-
-        // retract the pin
-        actuator.actuate(false);
 
         if (vision.isEnabled()) {
             visionOffset = getVisionOffsets(head, location);
 
-            Logger.debug("final visionOffsets " + visionOffset);
-        }
+			if (feededCount > 0) {
+				feededCount--;
+				if (feededCount > 0) {
+					partPitch = new Location(LengthUnit.Millimeters, partsPitchX * feededCount,
+							partsPitchY * feededCount, 0, 0);
+				} else
+					partPitch = null;
+			}
 
-        Logger.debug("Modified pickLocation {}", pickLocation);
+            Logger.debug("final visionOffsets " + visionOffset);
+
+            Logger.debug("Modified pickLocation {}", pickLocation.subtract(visionOffset));
+        }
     }
 
     // TODO: Throw an Exception if vision fails.
@@ -284,6 +335,20 @@ public class ReferenceDragFeeder extends ReferenceFeeder {
         return String.format("ReferenceTapeFeeder id %s", id);
     }
 
+	public void resetVisionOffsets() {
+		if (visionOffset != null) {
+			visionOffset = null;
+			Logger.debug("resetVisionOffsets " + visionOffset);
+		}
+
+		partPitch = null;
+	}
+
+	public boolean isPart_0402() {
+		return this.getPart().getPackage().getId().contains("C0402")
+				|| this.getPart().getPackage().getId().contains("R0402");
+	}
+
     public Location getFeedStartLocation() {
         return feedStartLocation;
     }
@@ -315,6 +380,16 @@ public class ReferenceDragFeeder extends ReferenceFeeder {
     public void setActuatorName(String actuatorName) {
         String oldValue = this.actuatorName;
         this.actuatorName = actuatorName;
+        propertyChangeSupport.firePropertyChange("actuatorName", oldValue, actuatorName);
+    }
+
+    public String getPeelOffActuatorName() {
+        return peelOffActuatorName;
+    }
+
+    public void setPeelOffActuatorName(String actuatorName) {
+        String oldValue = this.peelOffActuatorName;
+        this.peelOffActuatorName = actuatorName;
         propertyChangeSupport.firePropertyChange("actuatorName", oldValue, actuatorName);
     }
 

--- a/src/main/java/org/openpnp/machine/reference/feeder/ReferenceStripFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/ReferenceStripFeeder.java
@@ -30,11 +30,13 @@ import org.openpnp.gui.MainFrame;
 import org.openpnp.gui.support.Wizard;
 import org.openpnp.machine.reference.ReferenceFeeder;
 import org.openpnp.machine.reference.feeder.wizards.ReferenceStripFeederConfigurationWizard;
+import org.openpnp.model.Configuration;
 import org.openpnp.model.Length;
 import org.openpnp.model.LengthUnit;
 import org.openpnp.model.Location;
 import org.openpnp.model.Point;
 import org.openpnp.spi.Camera;
+import org.openpnp.spi.Machine;
 import org.openpnp.spi.Nozzle;
 import org.openpnp.spi.PropertySheetHolder;
 import org.openpnp.util.MovableUtils;
@@ -177,20 +179,49 @@ public class ReferenceStripFeeder extends ReferenceFeeder {
         Length x = getHoleToPartLateral().convertToUnits(l.getUnits());
         Length y = referenceHoleToPartLinear.convertToUnits(l.getUnits());
         Point p = new Point(x.getValue(), y.getValue());
-        // Determine the angle that the tape is at
-        double angle = Utils2D.getAngleFromPoint(lineLocations[0], lineLocations[1]);
-        // Rotate the part offsets by the angle to move it into the right
-        // coordinate space
-        p = Utils2D.rotatePoint(p, angle);
-        // And add the offset to the location we calculated previously
-        l = l.add(new Location(l.getUnits(), p.x, p.y, 0, 0));
-        // Add in the angle of the tape plus the angle of the part in the tape
-        // so that the part is picked at the right angle
-        l = l.derive(null, null, null, angle + getLocation().getRotation());
+
+		Machine machine = Configuration.get().getMachine();
+
+		if (machine.getUsePickRotationInsteadOfRotationInTapeForStripFeeders()) {
+
+			double angleCorrection = 0;
+			double angleOfStrip = Utils2D.getAngleFromPoint(lineLocations[0], lineLocations[1]);
+
+			if (angleOfStrip > 90)
+				angleCorrection = angleOfStrip % 90;
+			else
+				angleCorrection = angleOfStrip;
+
+			if (angleCorrection > 45)
+				angleCorrection = 90 - angleCorrection;
+			else
+				angleCorrection *= -1;
+
+	        // Rotate the part
+	        p = Utils2D.rotatePoint(p, angleOfStrip);
+	        l = l.add(new Location(l.getUnits(), p.x, p.y, 0, 0));
+	        l = l.derive(null, null, null, getLocation().getRotation() - angleCorrection);
+
+		} else {
+
+			// Determine the angle that the tape is at
+			double angle = Utils2D.getAngleFromPoint(lineLocations[0], lineLocations[1]);
+			// Rotate the part offsets by the angle to move it into the right
+	        // coordinate space
+	        p = Utils2D.rotatePoint(p, angle);
+	        // And add the offset to the location we calculated previously
+	        l = l.add(new Location(l.getUnits(), p.x, p.y, 0, 0));
+	        // Add in the angle of the tape plus the angle of the part in the tape
+	        // so that the part is picked at the right angle
+	        l = l.derive(null, null, null, angle + getLocation().getRotation());
+
+		}
+
         // and if vision was performed, add the offsets
         if (visionEnabled && visionOffsets != null) {
             l = l.add(visionOffsets);
         }
+
         return l;
     }
 

--- a/src/main/java/org/openpnp/machine/reference/feeder/wizards/ReferenceDragFeederConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/wizards/ReferenceDragFeederConfigurationWizard.java
@@ -80,7 +80,10 @@ public class ReferenceDragFeederConfigurationWizard
     private JTextField textFieldFeedEndZ;
     private JTextField textFieldFeedRate;
     private JLabel lblActuatorId;
+    private JLabel lblPeelOffActuatorId;
+    private JLabel lbl0402PartDetected;
     private JTextField textFieldActuatorId;
+    private JTextField textFieldPeelOffActuatorId;
     private JPanel panelGeneral;
     private JPanel panelVision;
     private JPanel panelLocations;
@@ -106,6 +109,7 @@ public class ReferenceDragFeederConfigurationWizard
     private JButton btnCancelChangeAoi;
     private JPanel panel;
     private JButton btnCancelChangeTemplateImage;
+    private JButton btnResetVisionOffsets;
 
     public ReferenceDragFeederConfigurationWizard(ReferenceDragFeeder feeder) {
         super(feeder);
@@ -121,6 +125,8 @@ public class ReferenceDragFeederConfigurationWizard
         panelFields.add(panelGeneral);
         panelGeneral.setLayout(new FormLayout(
                 new ColumnSpec[] {FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,
+                        FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,
+                        FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,
                         FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,},
                 new RowSpec[] {FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
                         FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,}));
@@ -138,6 +144,18 @@ public class ReferenceDragFeederConfigurationWizard
         textFieldActuatorId = new JTextField();
         panelGeneral.add(textFieldActuatorId, "4, 4");
         textFieldActuatorId.setColumns(5);
+
+        lblPeelOffActuatorId = new JLabel("Peel Off Actuator Name");
+        panelGeneral.add(lblPeelOffActuatorId, "6, 4, right, default");
+
+        textFieldPeelOffActuatorId = new JTextField();
+        panelGeneral.add(textFieldPeelOffActuatorId, "8, 4");
+        textFieldPeelOffActuatorId.setColumns(5);
+
+        if (feeder.isPart_0402()) {
+	        lbl0402PartDetected = new JLabel("0402 Part DETECTED");
+	        panelGeneral.add(lbl0402PartDetected, "6, 2");
+        }
 
         panelLocations = new JPanel();
         panelFields.add(panelLocations);
@@ -282,8 +300,13 @@ public class ReferenceDragFeederConfigurationWizard
                         FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,
                         FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,
                         FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,},
-                new RowSpec[] {FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
-                        FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,}));
+                new RowSpec[] {
+						FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
+                        }));
 
         lblX_1 = new JLabel("X");
         panelAoE.add(lblX_1, "2, 2");
@@ -324,6 +347,10 @@ public class ReferenceDragFeederConfigurationWizard
         cancelSelectTemplateImageAction.setEnabled(false);
         cancelSelectAoiAction.setEnabled(false);
 
+        btnResetVisionOffsets = new JButton("Reset offsets");
+        btnResetVisionOffsets.setAction(resetVisionOffsets);
+        panelAoE.add(btnResetVisionOffsets, "12, 10");
+
         contentPanel.add(panelFields);
     }
 
@@ -339,6 +366,7 @@ public class ReferenceDragFeederConfigurationWizard
 
         addWrappedBinding(feeder, "feedSpeed", textFieldFeedRate, "text", percentConverter);
         addWrappedBinding(feeder, "actuatorName", textFieldActuatorId, "text");
+        addWrappedBinding(feeder, "peelOffActuatorName", textFieldPeelOffActuatorId, "text");
 
         MutableLocationProxy feedStartLocation = new MutableLocationProxy();
         bind(UpdateStrategy.READ_WRITE, feeder, "feedStartLocation", feedStartLocation, "location");
@@ -371,6 +399,7 @@ public class ReferenceDragFeederConfigurationWizard
 
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldFeedRate);
         ComponentDecorators.decorateWithAutoSelect(textFieldActuatorId);
+        ComponentDecorators.decorateWithAutoSelect(textFieldPeelOffActuatorId);
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldFeedStartX);
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldFeedStartY);
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldFeedStartZ);
@@ -518,6 +547,16 @@ public class ReferenceDragFeederConfigurationWizard
                 btnChangeAoi.setAction(selectAoiAction);
                 cancelSelectAoiAction.setEnabled(false);
                 cameraView.setSelectionEnabled(false);
+            });
+        }
+    };
+
+    @SuppressWarnings("serial")
+    private Action resetVisionOffsets = new AbstractAction("Reset vision offsets") {
+        @Override
+        public void actionPerformed(ActionEvent arg0) {
+            UiUtils.messageBoxOnException(() -> {
+				feeder.resetVisionOffsets();
             });
         }
     };

--- a/src/main/java/org/openpnp/machine/reference/feeder/wizards/ReferenceStripFeederConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/wizards/ReferenceStripFeederConfigurationWizard.java
@@ -160,7 +160,7 @@ public class ReferenceStripFeederConfigurationWizard extends AbstractConfigurati
         comboBoxPart.setRenderer(new IdentifiableListCellRenderer<Part>());
         panelPart.add(comboBoxPart, "4, 2, left, default");
 
-        lblRotationInTape = new JLabel("Rotation In Tape");
+        lblRotationInTape = new JLabel(Configuration.get().getMachine().getUsePickRotationInsteadOfRotationInTapeForStripFeeders() ? "Pick Rotation" : "Rotation In Tape");
         panelPart.add(lblRotationInTape, "2, 4, left, default");
 
         textFieldLocationRotation = new JTextField();

--- a/src/main/java/org/openpnp/machine/reference/vision/ReferenceBottomVision.java
+++ b/src/main/java/org/openpnp/machine/reference/vision/ReferenceBottomVision.java
@@ -120,6 +120,7 @@ public class ReferenceBottomVision implements PartAlignment {
             Location offsets = VisionUtils.getPixelCenterOffsets(camera, rect.center.x, rect.center.y)
                                           .derive(null, null, null, Double.NaN);
 
+            Logger.debug("Final offsets {}", offsets);
             displayResult(pipeline, part, offsets, camera);
             return new PartAlignment.PartAlignmentOffset(offsets, true);
         }

--- a/src/main/java/org/openpnp/machine/reference/wizards/ReferenceMachineConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/wizards/ReferenceMachineConfigurationWizard.java
@@ -1,6 +1,7 @@
 package org.openpnp.machine.reference.wizards;
 
 import javax.swing.JComboBox;
+import javax.swing.JCheckBox;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JTextField;
@@ -22,6 +23,7 @@ import org.openpnp.machine.reference.driver.GcodeDriver;
 import org.openpnp.machine.reference.driver.LinuxCNC;
 import org.openpnp.machine.reference.driver.NullDriver;
 import org.openpnp.model.Configuration;
+import org.simpleframework.xml.Element;
 
 import com.jgoodies.forms.layout.ColumnSpec;
 import com.jgoodies.forms.layout.FormLayout;
@@ -30,8 +32,10 @@ import com.jgoodies.forms.layout.RowSpec;
 
 public class ReferenceMachineConfigurationWizard extends AbstractConfigurationWizard {
 
-    final private ReferenceMachine machine;
+	private final ReferenceMachine machine;
     private JComboBox comboBoxDriver;
+    private JCheckBox checkBoxHomeAfterEnabled;
+    private JCheckBox checkBoxUsePickRotationInsteadOfRotationInTapeForStripFeeders;
     private String driverClassName;
     private JTextField discardXTf;
     private JTextField discardYTf;
@@ -48,12 +52,21 @@ public class ReferenceMachineConfigurationWizard extends AbstractConfigurationWi
         panelGeneral.setLayout(new FormLayout(
                 new ColumnSpec[] {FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,
                         FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,},
-                new RowSpec[] {FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,}));
+				new RowSpec[] { FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
+						FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
+						FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
+	FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,}));
         JLabel lblDriver = new JLabel("Driver");
         panelGeneral.add(lblDriver, "2, 2");
 
         comboBoxDriver = new JComboBox();
-        panelGeneral.add(comboBoxDriver, "4, 2");
+        panelGeneral.add(comboBoxDriver, "2, 4");
+
+        checkBoxHomeAfterEnabled = new JCheckBox("Home after ENABLED?");
+        panelGeneral.add(checkBoxHomeAfterEnabled, "2, 6");
+
+        checkBoxUsePickRotationInsteadOfRotationInTapeForStripFeeders = new JCheckBox("Use 'Pick Rotation' approach, instead of 'Rotation in tape', for Strip Feeders?");
+        panelGeneral.add(checkBoxUsePickRotationInsteadOfRotationInTapeForStripFeeders, "2, 8");
 
         comboBoxDriver.addItem(NullDriver.class.getCanonicalName());
         comboBoxDriver.addItem(GcodeDriver.class.getCanonicalName());
@@ -123,6 +136,8 @@ public class ReferenceMachineConfigurationWizard extends AbstractConfigurationWi
         LengthConverter lengthConverter = new LengthConverter();
 
         addWrappedBinding(this, "driverClassName", comboBoxDriver, "selectedItem");
+        addWrappedBinding(machine, "homeAfterEnabled", checkBoxHomeAfterEnabled, "selected");
+        addWrappedBinding(machine, "usePickRotationInsteadOfRotationInTapeForStripFeeders", checkBoxUsePickRotationInsteadOfRotationInTapeForStripFeeders, "selected");
 
         MutableLocationProxy discardLocation = new MutableLocationProxy();
         bind(UpdateStrategy.READ_WRITE, machine, "discardLocation", discardLocation, "location");

--- a/src/main/java/org/openpnp/spi/Machine.java
+++ b/src/main/java/org/openpnp/spi/Machine.java
@@ -161,6 +161,10 @@ public interface Machine extends WizardConfigurable, PropertySheetHolder, Closea
 
     public <T> Future<T> submit(final Callable<T> callable, final FutureCallback<T> callback);
 
+    public boolean getHomeAfterEnabled();
+
+    public boolean getUsePickRotationInsteadOfRotationInTapeForStripFeeders();
+
     /**
      * Submit a task to be run with access to the Machine. This is the primary entry point into
      * executing any blocking operation on the Machine. If you are doing anything that results in

--- a/src/main/java/org/openpnp/spi/PnpJobProcessor.java
+++ b/src/main/java/org/openpnp/spi/PnpJobProcessor.java
@@ -34,6 +34,10 @@ public interface PnpJobProcessor extends JobProcessor {
                     .getValue();
         }
 
+        public String getPartId() {
+            return placement.getPart().getId();
+        }
+
         @Override
         public String toString() {
             return placement.getId();


### PR DESCRIPTION
- Filter PlacementsTableModel, show only active board side.
- Added option to AutoHome after machine enabled. To activate, need to set checkbox in machine settings.
- Windows saves sizes and position in Multiple Windows Mode
- Save configureation menu button
- Camera window can be split in vertical or horizontal style
- Added new approach to pick rotation for Strip Feeder. To activate, need to set checkbox in machine settings. https://github.com/openpnp/openpnp/issues/715
- Some changes in job order. Now user can change job order by sorting table.
- Job autosave after each placement.
- Added peel off actuator option for Drag Feeder.
- Drag Feeder improve accurance of feed, now drag distance can be adaptive with vision enabled.
- Drag Feeder can work with 0402.