### PR TITLE
Fixed backlash for GCode not retracting in the opposite signed direction

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/driver/GcodeDriver.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/GcodeDriver.java
@@ -144,10 +144,10 @@ public class GcodeDriver extends AbstractSerialPortDriver implements Named, Runn
     protected int maxFeedRate = 1000;
     
     @Attribute(required = false)
-    protected double backlashOffsetX = -1;
+    protected double backlashOffsetX = 0;
     
     @Attribute(required = false)
-    protected double backlashOffsetY = -1;
+    protected double backlashOffsetY = 0;
     
     @Attribute(required = false)
     protected double nonSquarenessFactor = 0;
@@ -235,6 +235,10 @@ public class GcodeDriver extends AbstractSerialPortDriver implements Named, Runn
         sendGcode(getCommand(null, CommandType.CONNECT_COMMAND));
 
         connected = true;
+
+        //Set backlash offsets back to positive value if they were negative on load.
+        setBacklashOffsetX(backlashOffsetX);
+        setBacklashOffsetY(backlashOffsetY);
     }
 
     @Override
@@ -564,8 +568,22 @@ public class GcodeDriver extends AbstractSerialPortDriver implements Named, Runn
             }
             
             if (includeX) {
+                double backLashX = 0;
+                // Save some useless cpu cycles if backlash is not being used.
+                if(backlashOffsetX != 0) {
+                    // Calculate Backlash Compensation for X axis
+                    if (hm.getLocation().subtract(hm.getHeadOffsets()).getX() - x < 0) {
+                        // The head is going positive
+                        backLashX = x + backlashOffsetX;
+                    }
+                    else {
+                        // The head is going negative
+                        backLashX = x - backlashOffsetX;
+                    }
+                }
+
                 command = substituteVariable(command, "X", x + nonSquarenessFactor * y);
-                command = substituteVariable(command, "BacklashOffsetX", x + backlashOffsetX + nonSquarenessFactor * y); // Backlash Compensation
+                command = substituteVariable(command, "BacklashOffsetX", backLashX + nonSquarenessFactor * y); // Backlash Compensation
                 if (xAxis.getPreMoveCommand() != null) {
                     String preMoveCommand = xAxis.getPreMoveCommand();
                     preMoveCommand = substituteVariable(preMoveCommand, "Coordinate", xAxis.getCoordinate());
@@ -579,8 +597,22 @@ public class GcodeDriver extends AbstractSerialPortDriver implements Named, Runn
             }
 
             if (includeY) {
+                double backLashY = 0;
+                // Save some useless cpu cycles if backlash is not being used.
+                if(backlashOffsetY != 0) {
+                    // Calculate Backlash Compensation for Y axis
+                    if (hm.getLocation().subtract(hm.getHeadOffsets()).getY() - y < 0) {
+                        // The head is going negative
+                        backLashY = y + backlashOffsetY;
+                    }
+                    else {
+                        // The head is going positive
+                        backLashY = y - backlashOffsetY;
+                    }
+                }
+
                 command = substituteVariable(command, "Y", y);
-                command = substituteVariable(command, "BacklashOffsetY", y + backlashOffsetY); // Backlash Compensation
+                command = substituteVariable(command, "BacklashOffsetY", backLashY); // Backlash Compensation
                 if (yAxis.getPreMoveCommand() != null) {
                     String preMoveCommand = yAxis.getPreMoveCommand();
                     preMoveCommand = substituteVariable(preMoveCommand, "Coordinate", yAxis.getCoordinate());
@@ -1083,7 +1115,7 @@ public class GcodeDriver extends AbstractSerialPortDriver implements Named, Runn
     }
     
     public void setBacklashOffsetX(double BacklashOffsetX) {
-        this.backlashOffsetX = BacklashOffsetX;
+        this.backlashOffsetX = Math.abs(BacklashOffsetX); // Make sure its always a positive unit to deal with it easier.
     }
     
     public double getBacklashOffsetY() {
@@ -1091,7 +1123,7 @@ public class GcodeDriver extends AbstractSerialPortDriver implements Named, Runn
     }
     
     public void setBacklashOffsetY(double BacklashOffsetY) {
-        this.backlashOffsetY = BacklashOffsetY;
+        this.backlashOffsetY = Math.abs(BacklashOffsetY); // Make sure its always a positive unit to deal with it easier.
     }
     
     public double getBacklashFeedRateFactor() {


### PR DESCRIPTION
# Description
Fixed backlash for GCode not retracting in the opposite signed direction

# Justification
Currently, backlash only works for one direction depending on if you make it a negative number or a positive. In the direction it does not work with it just moves in the same direction twice. 

# Instructions for Use
You use backlash like you always have, I have put code in place to make sure you do not need to change any settings. The only thing users will see in an improvement in accuracy in the direction that was lacking backlashing.

This is documentation for a user, not for a developer.

# Implementation Details
1. How did you test the change? 

I noticed when I changed the sign of the backlash that the machine acted differently. The way you can test this now is simply put around 2mm of backlash on and jog in the x+ and x-. Notice how it overshoots then moves back in the opposite moving direction. Repeat the same thing with the y+ and y-direction. 


2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)? yes
3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing.
4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted.
