### PR TITLE
Backoff movement without backslash compensation.

### DIFF
--- a/src/main/java/org/openpnp/machine/openbuilds/OpenBuildsDriver.java
+++ b/src/main/java/org/openpnp/machine/openbuilds/OpenBuildsDriver.java
@@ -230,6 +230,12 @@ public class OpenBuildsDriver extends AbstractSerialPortDriver implements Runnab
         }
     }
 
+    public void moveTo(ReferenceHeadMountable hm, Location location, double speed, boolean skipBacklashCompensation)
+            throws Exception {
+
+        moveTo(hm, location, speed, false);
+    }
+
     /**
      * Returns 0 or 1 for either the first or second Nozzle.
      * 

--- a/src/main/java/org/openpnp/machine/reference/ReferenceDriver.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceDriver.java
@@ -59,6 +59,7 @@ public interface ReferenceDriver extends WizardConfigurable, PropertySheetHolder
      * @throws Exception
      */
     public void moveTo(ReferenceHeadMountable hm, Location location, double speed) throws Exception;
+    public void moveTo(ReferenceHeadMountable hm, Location location, double speed, boolean skipBacklashCompensation) throws Exception;
 
     /**
      * Returns a clone of the HeadMountable's current location. It's important that the returned

--- a/src/main/java/org/openpnp/machine/reference/driver/GcodeDriver.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/GcodeDriver.java
@@ -544,8 +544,9 @@ public class GcodeDriver extends AbstractSerialPortDriver implements Named, Runn
                 String newCommand = "";
 
                 for (int i = 0; i < commandsArray.length; i ++) {
-                    if (commandsArray[i].contains("BacklashOffset"))
+                    if (commandsArray[i].contains("BacklashOffset")) {
                         continue;
+                    }
 
                     newCommand += commandsArray[i] + "\n";
                 }

--- a/src/main/java/org/openpnp/machine/reference/driver/LinuxCNC.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/LinuxCNC.java
@@ -167,6 +167,11 @@ public class LinuxCNC implements ReferenceDriver, Runnable {
         }
     }
 
+    public void moveTo(ReferenceHeadMountable hm, Location location, double speed, boolean skipBacklashCompensation)
+            throws Exception {
+
+        moveTo(hm, location, speed, false);
+    }
 
 
     @Override

--- a/src/main/java/org/openpnp/machine/reference/driver/NullDriver.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/NullDriver.java
@@ -133,6 +133,12 @@ public class NullDriver implements ReferenceDriver {
         setHeadLocation(hm.getHead(), hl);
     }
 
+    public void moveTo(ReferenceHeadMountable hm, Location location, double speed, boolean skipBacklashCompensation)
+            throws Exception {
+
+        moveTo(hm, location, speed, false);
+    }
+
     /**
      * Simulates true machine movement, which takes time, by tracing the required movement lines
      * over a period of time based on the input speed.

--- a/src/main/java/org/openpnp/machine/reference/driver/SimulatorDriver.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/SimulatorDriver.java
@@ -155,6 +155,12 @@ public class SimulatorDriver implements ReferenceDriver {
         setHeadLocation(hm.getHead(), hl);
     }
 
+    public void moveTo(ReferenceHeadMountable hm, Location location, double speed, boolean skipBacklashCompensation)
+            throws Exception {
+
+        moveTo(hm, location, speed, false);
+    }
+
     @Override
     public void pick(ReferenceNozzle nozzle) throws Exception {
         Logger.debug("pick({})", nozzle);

--- a/src/main/java/org/openpnp/machine/reference/feeder/ReferenceDragFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/ReferenceDragFeeder.java
@@ -31,7 +31,10 @@ import javax.swing.Action;
 
 import org.openpnp.ConfigurationListener;
 import org.openpnp.gui.support.Wizard;
+import org.openpnp.machine.reference.ReferenceDriver;
 import org.openpnp.machine.reference.ReferenceFeeder;
+import org.openpnp.machine.reference.ReferenceHeadMountable;
+import org.openpnp.machine.reference.driver.GcodeDriver;
 import org.openpnp.machine.reference.feeder.wizards.ReferenceDragFeederConfigurationWizard;
 import org.openpnp.model.Configuration;
 import org.openpnp.model.Length;
@@ -41,6 +44,7 @@ import org.openpnp.model.Rectangle;
 import org.openpnp.spi.Actuator;
 import org.openpnp.spi.Camera;
 import org.openpnp.spi.Head;
+import org.openpnp.spi.Machine;
 import org.openpnp.spi.Nozzle;
 import org.openpnp.spi.PropertySheetHolder;
 import org.openpnp.spi.VisionProvider;
@@ -207,10 +211,19 @@ public class ReferenceDragFeeder extends ReferenceFeeder {
 			}
 
 	        // backoff to release tension from the pin
-	        if (backoffDistance.getValue() != 0) {
-	            Location backoffLocation = Utils2D.getPointAlongLine(feedEndLocation, feedStartLocation, backoffDistance);
-	            actuator.moveTo(backoffLocation, feedSpeed * actuator.getHead().getMachine().getSpeed());
-	        }
+			if (backoffDistance.getValue() != 0) {
+			    Location backoffLocation = Utils2D.getPointAlongLine(feedEndLocation, feedStartLocation, backoffDistance);
+
+			    ReferenceDriver driver = Configuration.get().getMachine().getDriver();
+
+			    if(driver instanceof GcodeDriver) {
+			        GcodeDriver d = (GcodeDriver) driver;
+			        d.moveTo((ReferenceHeadMountable) actuator, backoffLocation, feedSpeed * actuator.getHead().getMachine().getSpeed(), true);
+			    }
+			    else {
+			        actuator.moveTo(backoffLocation, feedSpeed * actuator.getHead().getMachine().getSpeed());
+			    }
+			}
 
 	        // retract the pin
 	        actuator.actuate(false);

--- a/src/main/java/org/openpnp/spi/Machine.java
+++ b/src/main/java/org/openpnp/spi/Machine.java
@@ -25,6 +25,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.Future;
 import java.util.Collections;
 
+import org.openpnp.machine.reference.ReferenceDriver;
 import org.openpnp.model.Location;
 
 import com.google.common.util.concurrent.FutureCallback;
@@ -160,6 +161,8 @@ public interface Machine extends WizardConfigurable, PropertySheetHolder, Closea
     public <T> Future<T> submit(Callable<T> callable);
 
     public <T> Future<T> submit(final Callable<T> callable, final FutureCallback<T> callback);
+
+    public ReferenceDriver getDriver();
 
     public boolean getHomeAfterEnabled();
 

--- a/src/test/java/org/openpnp/machine/reference/driver/test/TestDriver.java
+++ b/src/test/java/org/openpnp/machine/reference/driver/test/TestDriver.java
@@ -72,6 +72,12 @@ public class TestDriver implements ReferenceDriver {
         }
     }
 
+    public void moveTo(ReferenceHeadMountable hm, Location location, double speed, boolean skipBacklashCompensation)
+            throws Exception {
+
+        moveTo(hm, location, speed, false);
+    }
+
     @Override
     public Location getLocation(ReferenceHeadMountable hm) {
         return location;
@@ -125,6 +131,12 @@ public class TestDriver implements ReferenceDriver {
 
         @Override
         public void moveTo(ReferenceHeadMountable hm, Location location, double speed)
+                throws Exception {
+
+        }
+
+        @Override
+        public void moveTo(ReferenceHeadMountable hm, Location location, double speed, boolean skipBacklashCompensation)
                 throws Exception {
 
         }


### PR DESCRIPTION
To avoid small parts and parts in plastic tapes from bouncing.

Done in Gcode driver. Exclude Gcode lines with Backslash variables.


