### PR TITLE
Nozzle Tip: Dwell Time

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,17 @@
 This file lists major or notable changes to OpenPnP in chronological order. This is not
 a complete change list, only those that may directly interest or affect users.
 
+
+# 2018-07-13
+
+* Dwell Times per Nozzle Tip
+
+	Pick dwell time and place dwell time has been added to nozzle tip. 
+	This means the total dwell times are now the sum of the nozzle dwell times 
+	plus nozzle tip dwell times. The idea behind this is that larger nozzle tips
+	are used to lift bigger/heavier chips and typically require a bit longer dwell
+	times in general.
+ 
 # 2018-07-08
 
 @aneox submitted a bunch of great new features. Some are still being worked on, but the following

--- a/src/main/java/org/openpnp/machine/reference/ReferenceNozzle.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceNozzle.java
@@ -138,7 +138,9 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
         this.part = part;
         getDriver().pick(this);
         getMachine().fireMachineHeadActivity(head);
-        Thread.sleep(pickDwellMilliseconds);
+        
+        // Dwell Time
+        Thread.sleep(this.getPickDwellMilliseconds() + nozzleTip.getPickDwellMilliseconds());
 
         Actuator actuator = getHead().getActuatorByName(vacuumSenseActuatorName);
         if (actuator != null) {
@@ -170,7 +172,9 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
         getDriver().place(this);
         this.part = null;
         getMachine().fireMachineHeadActivity(head);
-        Thread.sleep(placeDwellMilliseconds);
+        
+        // Dwell Time
+        Thread.sleep(this.getPlaceDwellMilliseconds() + nozzleTip.getPlaceDwellMilliseconds());
 
         Actuator actuator = getHead().getActuatorByName(vacuumSenseActuatorName);
         if (actuator != null) {

--- a/src/main/java/org/openpnp/machine/reference/ReferenceNozzleTip.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceNozzleTip.java
@@ -59,6 +59,12 @@ public class ReferenceNozzleTip extends AbstractNozzleTip {
 
     @Attribute(required = false)
     private boolean allowIncompatiblePackages;
+    
+    @Attribute(required = false)
+    private int pickDwellMilliseconds;
+
+    @Attribute(required = false)
+    private int placeDwellMilliseconds;
 
     @Element(required = false)
     private Location changerStartLocation = new Location(LengthUnit.Millimeters);
@@ -195,6 +201,22 @@ public class ReferenceNozzleTip extends AbstractNozzleTip {
 
     public void setAllowIncompatiblePackages(boolean allowIncompatiblePackages) {
         this.allowIncompatiblePackages = allowIncompatiblePackages;
+    }
+    
+    public int getPickDwellMilliseconds() {
+        return pickDwellMilliseconds;
+    }
+
+    public void setPickDwellMilliseconds(int pickDwellMilliseconds) {
+        this.pickDwellMilliseconds = pickDwellMilliseconds;
+    }
+
+    public int getPlaceDwellMilliseconds() {
+        return placeDwellMilliseconds;
+    }
+
+    public void setPlaceDwellMilliseconds(int placeDwellMilliseconds) {
+        this.placeDwellMilliseconds = placeDwellMilliseconds;
     }
 
     public Location getChangerStartLocation() {

--- a/src/main/java/org/openpnp/machine/reference/wizards/ReferenceNozzleConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/wizards/ReferenceNozzleConfigurationWizard.java
@@ -36,6 +36,7 @@ import org.openpnp.gui.support.LengthConverter;
 import org.openpnp.gui.support.MutableLocationProxy;
 import org.openpnp.machine.reference.ReferenceNozzle;
 
+import com.jgoodies.forms.layout.CellConstraints;
 import com.jgoodies.forms.layout.ColumnSpec;
 import com.jgoodies.forms.layout.FormLayout;
 import com.jgoodies.forms.layout.FormSpecs;
@@ -56,6 +57,7 @@ public class ReferenceNozzleConfigurationWizard extends AbstractConfigurationWiz
     private JPanel panelProperties;
     private JLabel lblName;
     private JTextField nameTf;
+    private JLabel lblDwellTime;
     private JLabel lblPickDwellTime;
     private JLabel lblPlaceDwellTime;
     private JTextField pickDwellTf;
@@ -166,19 +168,21 @@ public class ReferenceNozzleConfigurationWizard extends AbstractConfigurationWiz
                 FormSpecs.RELATED_GAP_ROWSPEC,
                 FormSpecs.DEFAULT_ROWSPEC,
                 FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
                 FormSpecs.DEFAULT_ROWSPEC,}));
                 
-                lblChangerEnabled = new JLabel("Changer Enabled?");
-                panelChanger.add(lblChangerEnabled, "2, 2, right, default");
+        lblChangerEnabled = new JLabel("Changer Enabled?");
+        panelChanger.add(lblChangerEnabled, "2, 2, right, default");
+
+        chckbxChangerEnabled = new JCheckBox("");
+        panelChanger.add(chckbxChangerEnabled, "4, 2");
         
-                chckbxChangerEnabled = new JCheckBox("");
-                panelChanger.add(chckbxChangerEnabled, "4, 2");
-                
-                lblLimitRota = new JLabel("Limit Rotation to 180º");
-                panelChanger.add(lblLimitRota, "2, 4, right, default");
-        
-                chckbxLimitRotationTo = new JCheckBox("");
-                panelChanger.add(chckbxLimitRotationTo, "4, 4");
+        lblLimitRota = new JLabel("Limit Rotation to 180º");
+        panelChanger.add(lblLimitRota, "2, 4, right, default");
+
+        chckbxLimitRotationTo = new JCheckBox("");
+        panelChanger.add(chckbxLimitRotationTo, "4, 4");
         
         lblPickDwellTime = new JLabel("Pick Dwell Time (ms)");
         panelChanger.add(lblPickDwellTime, "2, 6, right, default");
@@ -193,6 +197,11 @@ public class ReferenceNozzleConfigurationWizard extends AbstractConfigurationWiz
         placeDwellTf = new JTextField();
         panelChanger.add(placeDwellTf, "4, 8, fill, default");
         placeDwellTf.setColumns(10);
+        
+        CellConstraints cc = new CellConstraints();
+        lblDwellTime = new JLabel("Note: Total Dwell Time is the sum of Nozzle Dwell Time plus the Nozzle Tip Dwell Time.");
+        panelChanger.add(lblDwellTime, cc.xywh(2, 10, 7, 1));
+        
         
         panel = new JPanel();
         panel.setBorder(new TitledBorder(null, "Vacuum Sense", TitledBorder.LEADING, TitledBorder.TOP, null, null));
@@ -220,8 +229,6 @@ public class ReferenceNozzleConfigurationWizard extends AbstractConfigurationWiz
         
         invertVacuumLogicChk = new JCheckBox("");
         panel.add(invertVacuumLogicChk, "4, 4");
-
-
     }
 
     @Override

--- a/src/main/java/org/openpnp/machine/reference/wizards/ReferenceNozzleTipConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/wizards/ReferenceNozzleTipConfigurationWizard.java
@@ -55,6 +55,7 @@ import org.openpnp.util.UiUtils;
 import org.openpnp.vision.pipeline.CvPipeline;
 import org.openpnp.vision.pipeline.ui.CvPipelineEditor;
 
+import com.jgoodies.forms.layout.CellConstraints;
 import com.jgoodies.forms.layout.ColumnSpec;
 import com.jgoodies.forms.layout.FormLayout;
 import com.jgoodies.forms.layout.FormSpecs;
@@ -76,6 +77,12 @@ public class ReferenceNozzleTipConfigurationWizard extends AbstractConfiguration
     private JTextField textFieldChangerMidY;
     private JTextField textFieldChangerMidZ;
     private JLabel lblEndLocation;
+    private JPanel panelDwellTime;
+    private JLabel lblPickDwellTime;
+    private JLabel lblPlaceDwellTime;
+    private JLabel lblDwellTime;
+    private JTextField pickDwellTf;
+    private JTextField placeDwellTf;
     private JTextField textFieldChangerEndX;
     private JTextField textFieldChangerEndY;
     private JTextField textFieldChangerEndZ;
@@ -329,6 +336,43 @@ public class ReferenceNozzleTipConfigurationWizard extends AbstractConfiguration
         vacuumLevelPartOff = new JTextField();
         panelVacuumSensing.add(vacuumLevelPartOff, "4, 4");
         vacuumLevelPartOff.setColumns(10);
+        
+        panelDwellTime = new JPanel();
+        panelDwellTime.setBorder(new TitledBorder(null, "Dwell Times", TitledBorder.LEADING, TitledBorder.TOP, null, null));
+        contentPanel.add(panelDwellTime);
+        panelDwellTime.setLayout(new FormLayout(new ColumnSpec[] {
+                FormSpecs.RELATED_GAP_COLSPEC,
+                FormSpecs.DEFAULT_COLSPEC,
+                FormSpecs.RELATED_GAP_COLSPEC,
+                FormSpecs.DEFAULT_COLSPEC,
+                FormSpecs.RELATED_GAP_COLSPEC,
+                ColumnSpec.decode("default:grow"),},
+            new RowSpec[] {
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,}));
+          
+        lblPickDwellTime = new JLabel("Pick Dwell Time (ms)");
+        panelDwellTime.add(lblPickDwellTime, "2, 2, right, default");
+        
+        pickDwellTf = new JTextField();
+        panelDwellTime.add(pickDwellTf, "4, 2");
+        pickDwellTf.setColumns(10);
+        
+        lblPlaceDwellTime = new JLabel("Place Dwell Time (ms)");
+        panelDwellTime.add(lblPlaceDwellTime, "2, 4, right, default");
+        
+        placeDwellTf = new JTextField();
+        panelDwellTime.add(placeDwellTf, "4, 4");
+        placeDwellTf.setColumns(10);
+        
+        CellConstraints cc = new CellConstraints();
+        lblDwellTime = new JLabel("Note: Total Dwell Time is the sum of Nozzle Dwell Time plus the Nozzle Tip Dwell Time.");
+        panelDwellTime.add(lblDwellTime, cc.xywh(2, 6, 5, 1));
+        
 
         panelCalibration = new JPanel();
         panelCalibration.setBorder(new TitledBorder(null, "Calibration", TitledBorder.LEADING,
@@ -455,8 +499,14 @@ public class ReferenceNozzleTipConfigurationWizard extends AbstractConfiguration
         
         addWrappedBinding(nozzleTip, "vacuumLevelPartOn", vacuumLevelPartOn, "text", doubleConverter);
         addWrappedBinding(nozzleTip, "vacuumLevelPartOff", vacuumLevelPartOff, "text", doubleConverter);
-
+        
+        addWrappedBinding(nozzleTip, "pickDwellMilliseconds", pickDwellTf, "text", intConverter);
+        addWrappedBinding(nozzleTip, "placeDwellMilliseconds", placeDwellTf, "text", intConverter);
+        
         ComponentDecorators.decorateWithAutoSelect(nameTf);
+        
+        ComponentDecorators.decorateWithAutoSelect(pickDwellTf);
+        ComponentDecorators.decorateWithAutoSelect(placeDwellTf);
         
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldChangerStartX);
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldChangerStartY);


### PR DESCRIPTION
# Description
The Dwell Pick and Dwell Place times have been added to Nozzle Tip class and the Nozzle Tip Wizard GUI.
I also added a note that the total dwell time is the sum of both nozzle dwell time and nozzle tip dwell time.


I have found no reference of where/how getPlaceDwellMilliseconds() is actually used (in job planner or machine driver?) so I need some guidance before I can finish this feature.
