### PR TITLE
Clear search field on new feeder created, fixes #714

### DIFF
--- a/src/main/java/org/openpnp/gui/FeedersPanel.java
+++ b/src/main/java/org/openpnp/gui/FeedersPanel.java
@@ -223,7 +223,7 @@ public class FeedersPanel extends JPanel implements WizardContainer {
      * Activate the Feeders tab and show the Feeder for the specified Part. If none exists, prompt
      * the user to create a new one.
      * 
-     * @param feeder
+     * @param part
      */
     public void showFeederForPart(Part part) {
         mainFrame.showTab("Feeders");
@@ -324,8 +324,13 @@ public class FeedersPanel extends JPanel implements WizardContainer {
 
             configuration.getMachine().addFeeder(feeder);
             tableModel.refresh();
+
+            searchTextField.setText("");
+            search();
+
             Helpers.selectLastTableRow(table);
         }
+
         catch (Exception e) {
             MessageBoxes.errorBox(JOptionPane.getFrameForComponent(FeedersPanel.this),
                     "Feeder Error", e);


### PR DESCRIPTION
Also Correct wrong javadoc param

# Description
Clears the feeder search textfield when a new feeder is created so it can be selected in the list, avoids the index error filed in #714

# Justification
Its best to show the new feeder in the list. If it is not visible the user might think it has not been created

# Implementation Details
Clears the textfield and triggers search
