### PR TITLE
Add new Gcode MOVE_TO_COMMAND variables XF, YF, ZF, RotationF

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/driver/GcodeDriver.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/GcodeDriver.java
@@ -511,41 +511,83 @@ public class GcodeDriver extends AbstractReferenceDriver implements Named, Runna
         Axis yAxis = getAxis(hm, Axis.Type.Y);
         Axis zAxis = getAxis(hm, Axis.Type.Z);
         Axis rotationAxis = getAxis(hm, Axis.Type.Rotation);
+        
+        String command = getCommand(hm, CommandType.MOVE_TO_COMMAND);
+        
+        // If the command has forced-output coordinate variables "XF", "YF", "ZF" and "RotationF", 
+        // always include the corresponding axis in the command.
+        // This may be employed for shared physical axes, where OpenPNP cannot not keep track when an axis 
+        // has physically moved behind its back through another axis. Consequently getCoordinate() 
+        // may not reflect the actual physical coordinate. By always forcing the axis coordinate output, 
+        // the controller will take care of restoring the shared axis' correct position, if necessary. 
+        // As we are always moving in absolute coordinates this has no ill effect if it results in no 
+        // position change after all. 
+        // The same can be applied for other situations where OpenPNP may lose track of the physical 
+        // location such as with Z-probing or relative moves in custom Gcode.
+        // Note there is no need for separate backlash compensation variables, as these are always 
+        // substituted alongside. 
+        boolean includeX = (xAxis != null && hasVariable(command, "XF"));
+        boolean includeY = (yAxis != null && hasVariable(command, "YF"));
+        boolean includeZ = (zAxis != null && hasVariable(command, "ZF"));
+        boolean includeRotation = (rotationAxis != null && hasVariable(command, "RotationF"));
 
         // Handle NaNs, which means don't move this axis for this move. We set the appropriate
-        // axis reference to null, which we'll check for later.
+        // axis reference to null, which we'll check for later. If the axis is force-included 
+        // take the recorded current coordinate instead.  
+    	
+        // For each given coordinate, if the axis has a transform, transform the target coordinate
+        // to it's raw value.
         if (Double.isNaN(x)) {
-            xAxis = null;
+            if (includeX) {
+            	x = xAxis.getCoordinate();
+            }
+            else {
+            	xAxis = null;
+            }
         }
+        else if (xAxis != null && xAxis.getTransform() != null) {
+            x = xAxis.getTransform().toRaw(xAxis, hm, x);
+        }
+        
         if (Double.isNaN(y)) {
-            yAxis = null;
+        	if (includeY) {
+            	y = yAxis.getCoordinate();
+            }
+            else {
+            	yAxis = null;
+            }
         }
+        else if (yAxis != null && yAxis.getTransform() != null) {
+            y = yAxis.getTransform().toRaw(yAxis, hm, y);
+        }
+        
         if (Double.isNaN(z)) {
-            zAxis = null;
+        	if (includeZ) {
+            	z = zAxis.getCoordinate();
+            }
+            else {
+            	zAxis = null;
+            }
         }
+        else if (zAxis != null && zAxis.getTransform() != null) {
+            z = zAxis.getTransform().toRaw(zAxis, hm, z);
+        }
+        
         if (Double.isNaN(rotation)) {
-            rotationAxis = null;
+        	if (includeRotation) {
+            	rotation = rotationAxis.getCoordinate();
+            }
+            else {
+            	rotationAxis = null;
+            }
+        }
+        else if (rotationAxis != null && rotationAxis.getTransform() != null) {
+            rotation = rotationAxis.getTransform().toRaw(rotationAxis, hm, rotation);
         }
 
         // Only do something if there at least one axis included in the move
         if (xAxis != null || yAxis != null || zAxis != null || rotationAxis != null) {
 
-            // For each included axis, if the axis has a transform, transform the target coordinate
-            // to it's raw value.
-            if (xAxis != null && xAxis.getTransform() != null) {
-                x = xAxis.getTransform().toRaw(xAxis, hm, x);
-            }
-            if (yAxis != null && yAxis.getTransform() != null) {
-                y = yAxis.getTransform().toRaw(yAxis, hm, y);
-            }
-            if (zAxis != null && zAxis.getTransform() != null) {
-                z = zAxis.getTransform().toRaw(zAxis, hm, z);
-            }
-            if (rotationAxis != null && rotationAxis.getTransform() != null) {
-                rotation = rotationAxis.getTransform().toRaw(rotationAxis, hm, rotation);
-            }
-
-            String command = getCommand(hm, CommandType.MOVE_TO_COMMAND);
             command = substituteVariable(command, "Id", hm.getId());
             command = substituteVariable(command, "Name", hm.getName());
             command = substituteVariable(command, "FeedRate", maxFeedRate * speed);
@@ -555,8 +597,6 @@ public class GcodeDriver extends AbstractReferenceDriver implements Named, Runna
              * NSF gets applied to X and is multiplied by Y
              * 
              */
-            
-            boolean includeX = false, includeY = false, includeZ = false, includeRotation = false;
             
             // Primary checks to see if an axis should move
             if (xAxis != null && xAxis.getCoordinate() != x) {
@@ -577,21 +617,6 @@ public class GcodeDriver extends AbstractReferenceDriver implements Named, Runna
             if (includeY && nonSquarenessFactor != 0 && xAxis != null) {
                 includeX = true;
             }
-            
-            // If the command has forced-output coordinate variables "XF", "YF", "ZF" and "RotationF", 
-            // always include the corresponding axis in the command.
-            // This may be employed for shared axes, where OpenPNP cannot not keep track when an axis 
-            // has physically moved behind its back through another shared axis. Consequently getCoordinate() 
-            // may not reflect the actual physical coordinate. By always forcing the axis coordinate output, 
-            // the controller will take care of restoring the shared axis' correct position, if necessary. 
-            // As we are always moving in absolute coordinates this has no ill effect if it results in no 
-            // position change after all.   
-            // Note there is no need for separate backlash compensation variables, as these are always 
-            // substituted alongside. 
-            includeX = includeX || (xAxis != null && hasVariable(command, "XF"));
-            includeY = includeX || (yAxis != null && hasVariable(command, "YF"));
-            includeZ = includeX || (zAxis != null && hasVariable(command, "ZF"));
-            includeRotation = includeX || (rotationAxis != null && hasVariable(command, "RotationF"));
             
             if (includeX) {
                 command = substituteVariable(command, "X", x + nonSquarenessFactor * y);


### PR DESCRIPTION
# Description
This will add new Gcode MOVE_TO_COMMAND coordinate variables XF, YF, ZF, RotationF that are force-output even if the coordinate has not changed according to the internal Axis getCoordinate() record. 

# Justification
These variables may be employed for shared axes, where OpenPNP cannot not keep track of when an axis has physically moved behind its back through a shared actuator. Consequently getCoordinate() may not reflect the actual physical coordinate. By always forcing the axis coordinate output, the controller will take care of restoring the shared axis' correct position, if necessary. As we are always moving in absolute coordinates this has no ill effect if it results in no position change after all (i.e. when there was no coordinate change behind its back).

Switching back and forth between shared axes and restoring their proper positions is automatically done according to the ReferenceHeadMountable's (hm) axis mapping, when moveTo() is called. No change in calling code is needed.

Note there is no need for separate backlash compensation variables, as these are always substituted alongside.

Also note that as long as the user does not employ these new variables, no behaviour change happens.

# Instructions for Use
The table in the MOVE_TO_COMMAND documentation here:
https://github.com/openpnp/openpnp/wiki/GcodeDriver:-Command-Reference#move_to_command
must be updated to include the new variables. The situation when these should be used instead of the normal ones should be explained. I leave this to someone that actually owns such a machine (Help wanted). 

Pointers from here
https://github.com/openpnp/openpnp/wiki/GcodeDriver:-Axis-Mapping#axis-transforms
might be in order. 

# Implementation Details
1. **I cannot test the shared axes situation as I have no multi-nozzle machine. Help wanted!** I still think this Pull Request is useful even if untested at the moment. Will help to fix issues, if any were to pop up. Also I accept when this PR is rejected based on the "untested" rule. 
2. I did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages (as far as I understand).
4. Ran `mvn test` before submitting the Pull Request. 

I noticed a slight change in white-space in the merge. I don't know why this happens as I just copied the substitution lines in Eclipse. Instruction of how to avoid this effect is welcome.