### PR TITLE
OpenBuildsDriver, GcodeDriver and LinuxCNC disconnect when disabled.

### DIFF
--- a/src/main/java/org/openpnp/machine/openbuilds/OpenBuildsDriver.java
+++ b/src/main/java/org/openpnp/machine/openbuilds/OpenBuildsDriver.java
@@ -72,6 +72,9 @@ public class OpenBuildsDriver extends AbstractReferenceDriver implements Runnabl
                 pump(false);
             }
         }
+        if (connected && !enabled) {
+            disconnect();
+        }
     }
 
     @Override

--- a/src/main/java/org/openpnp/machine/openbuilds/OpenBuildsDriver.java
+++ b/src/main/java/org/openpnp/machine/openbuilds/OpenBuildsDriver.java
@@ -73,7 +73,9 @@ public class OpenBuildsDriver extends AbstractReferenceDriver implements Runnabl
             }
         }
         if (connected && !enabled) {
-            disconnect();
+            if (!connectionKeepAlive) {
+            	disconnect();
+            }
         }
     }
 

--- a/src/main/java/org/openpnp/machine/reference/driver/AbstractReferenceDriver.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/AbstractReferenceDriver.java
@@ -32,6 +32,9 @@ public abstract class AbstractReferenceDriver extends AbstractModelObject implem
 
     @Attribute(required = false, name = "communications")
     protected String communicationsType = "serial";
+    
+    @Attribute(required = false)
+    protected boolean connectionKeepAlive = false;
 
     /**
      * TODO The following properties are for backwards compatibility and can be removed after 2019-07-15. 
@@ -85,6 +88,7 @@ public abstract class AbstractReferenceDriver extends AbstractModelObject implem
         this.setRts = null;
 
         setCommunicationsType(communicationsType);
+        setConnectionKeepAlive(connectionKeepAlive);
     }
     
     @Override
@@ -118,6 +122,14 @@ public abstract class AbstractReferenceDriver extends AbstractModelObject implem
             }
         }
         this.communicationsType = communicationsType;
+    }
+    
+    public boolean getConnectionKeepAlive() {
+    	return connectionKeepAlive;
+    }
+    
+    public void setConnectionKeepAlive(boolean connectionKeepAlive) {
+    	this.connectionKeepAlive = connectionKeepAlive;
     }
     
     protected ReferenceDriverCommunications getCommunications() {

--- a/src/main/java/org/openpnp/machine/reference/driver/GcodeDriver.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/GcodeDriver.java
@@ -272,7 +272,9 @@ public class GcodeDriver extends AbstractReferenceDriver implements Named, Runna
             driver.setEnabled(enabled);
         }
         if (connected && !enabled) {
-            disconnect();
+        	if (!connectionKeepAlive) {
+            	disconnect();
+        	}
         }
     }
 

--- a/src/main/java/org/openpnp/machine/reference/driver/GcodeDriver.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/GcodeDriver.java
@@ -271,6 +271,9 @@ public class GcodeDriver extends AbstractReferenceDriver implements Named, Runna
         for (ReferenceDriver driver : subDrivers) {
             driver.setEnabled(enabled);
         }
+        if (connected && !enabled) {
+            disconnect();
+        }
     }
 
     @Override

--- a/src/main/java/org/openpnp/machine/reference/driver/LinuxCNC.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/LinuxCNC.java
@@ -215,6 +215,9 @@ public class LinuxCNC implements ReferenceDriver, Runnable {
         if (connected) {
             sendCommand("set machine " + (enabled ? "on" : "off"));
         }
+        if (connected && !enabled) {
+            disconnect();
+        }
     }
 
     public synchronized void connect(String serverIp, int port) throws Exception {

--- a/src/main/java/org/openpnp/machine/reference/driver/wizards/AbstractReferenceDriverConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/wizards/AbstractReferenceDriverConfigurationWizard.java
@@ -36,7 +36,8 @@ public class AbstractReferenceDriverConfigurationWizard extends AbstractConfigur
     private JPanel panelSerial;
     private JPanel panelTcp;
     private JTextField commsMethod;
-
+    private JCheckBox connectionKeepAlive;
+  
     public AbstractReferenceDriverConfigurationWizard(AbstractReferenceDriver driver) {
         this.driver = driver;
 
@@ -90,6 +91,11 @@ public class AbstractReferenceDriverConfigurationWizard extends AbstractConfigur
         commsMethod.setVisible(false);
         panelComms.add(commsMethod, "4, 6, fill, default");
 
+        JLabel lblConnectionKeepAlive = new JLabel("Keep Alive");
+        panelComms.add(lblConnectionKeepAlive, "2, 8, right, default");
+        
+        connectionKeepAlive = new JCheckBox("");
+        panelComms.add(connectionKeepAlive, "4, 8");
 
         //Serial config code
         panelSerial = new JPanel();
@@ -292,7 +298,8 @@ public class AbstractReferenceDriverConfigurationWizard extends AbstractConfigur
         IntegerConverter integerConverter = new IntegerConverter();
 
         addWrappedBinding(driver, "communicationsType", commsMethod, "text");
-
+        addWrappedBinding(driver, "connectionKeepAlive", connectionKeepAlive, "selected");
+        
         addWrappedBinding(driver, "portName", comboBoxPort, "selectedItem");
         addWrappedBinding(driver, "baud", comboBoxBaud, "selectedItem");
         addWrappedBinding(driver, "parity", parityComboBox, "selectedItem");


### PR DESCRIPTION
# Description
With this Pull Request the OpenPNP drivers OpenBuildsDriver, GcodeDriver and LinuxCNC disconnect when the Machine is disabled.

# Justification
The disconnect allows for a serial port to be reused in another program (i.e. Pronterface) or unplugged, or the controller reset without closing OpenPNP. If the serial port becomes available again, the machine can be enabled again and the connection is successfully re-established.

Before this change this failed at least under Windows where a COM port name is blocked until explicitly closed by the process. Even resetting/re-plugging the controller will not free the port and also not re-establish the connection as long as a process sits on it. OpenPNP has to be closed and the controller reset/re-plugged one more time, before a freshly started OpenPNP can then reconnect.

When closing OpenPNP the user loses the GUI navigation which is annoying when editing Gcode fragments. Along with Gcode editing, users may want to test Gcode on Pronterface (or similar) or need to change config.txt on Smoothieware controllers, which requires a reset of the controller. As described above, a reset was only possible after exiting OpenPNP (at least on Windows).

# Instructions for Use
The disconnect can be used through the GUI Start/Stop button. The colour of that button will now also show the state of the connection. 

# Implementation Details
1. The code changes are small and symmetric to the enable/connect case. I added the disconnect at the end of the method after everything has been taken care of, including sub-drivers recursion in GcodeDriver. I tested the feature with the GcodeDriver plus serial port on Windows. I was able to connect/disconnect using the Start/Stop button. I alternated between using Pronterface and OpenPNP without any problems. I tested resetting, unplugging and unpowering the controller with no problems while the machine was disabled. _I wish I had this when I setup my machine :)_
2. I did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. I did not change code inside the `org.openpnp.spi` or `org.openpnp.model` packages.
4. I did run `mvn test` before submitting the Pull Request. 

I assume the justification is equally valid for OpenBuildsDriver, LinuxCNC and TCP/IP connections. However it would have to be tested by someone who has such a setup. 
