### PR TITLE
Fixing an issue where an already present head offset will lead to wro…

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/wizards/ReferenceNozzleCameraOffsetWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/wizards/ReferenceNozzleCameraOffsetWizard.java
@@ -190,7 +190,7 @@ public class ReferenceNozzleCameraOffsetWizard extends AbstractConfigurationWiza
     private Action storePositionAction = new AbstractAction("Store nozzle mark position") {
         @Override
         public void actionPerformed(ActionEvent e) {
-            nozzleMarkLocation.setLocation(nozzle.getLocation());;
+            nozzleMarkLocation.setLocation(nozzle.getLocation().subtract(nozzle.getHeadOffsets()));
         }
     };
 


### PR DESCRIPTION
# Description
Fixes an issue where the nozzle to head offset is not calculated correctly if an offset is already entered

# Justification
Calculation is wrong if using already corrected value

# Implementation Details
I did test on the machine as this happened to me and I figured out what the issue was since getLocation on the nozzle returns the corrected position already