### PR TITLE
Improve display of scripting exceptions 

### DIFF
--- a/src/main/java/org/openpnp/Scripting.java
+++ b/src/main/java/org/openpnp/Scripting.java
@@ -292,6 +292,7 @@ public class Scripting {
         engine.put("machine", Configuration.get().getMachine());
         engine.put("gui", MainFrame.get());
         engine.put("scripting", this);
+        engine.put(ScriptEngine.FILENAME, script.getName());
 
         if (additionalGlobals != null) {
             for (String name : additionalGlobals.keySet()) {

--- a/src/main/java/org/openpnp/gui/support/MessageBoxes.java
+++ b/src/main/java/org/openpnp/gui/support/MessageBoxes.java
@@ -49,6 +49,8 @@ public class MessageBoxes {
         Logger.debug("{}: {}", title, cause);
         message = message.replaceAll("\n", "<br/>");
         message = message.replaceAll("\r", "");
+        message = message.replaceAll("<", "&lt;");
+        message = message.replaceAll(">", "&gt;");
         message = "<html><body width=\"400\">" + message + "</body></html>";
         JOptionPane.showMessageDialog(parent, message, title, JOptionPane.ERROR_MESSAGE);
     }


### PR DESCRIPTION
# Description
Jython exceptions with messages like `NameError: name 'prit' is not defined in <script> at line number 2` got truncated in the GUI message box because of the angle brackets. Also, since the script's filename was not populated prior to execution, the error message unhelpfully stated that the error occured in `<script>`.

# Justification
The change improves script error handling for developers and users who did not set the loglevel to debug prior to execution.

# Instructions for Use
Just execute any script that throws an exception.

# Implementation Details
I tested with a bunch of broken and exception-raising Python scripts. I could not find other causes for truncation of the messages.
