### PR TITLE
serial fix

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/driver/SerialPortCommunications.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/SerialPortCommunications.java
@@ -145,9 +145,15 @@ public class SerialPortCommunications extends ReferenceDriverCommunications {
 			linuxPortNames.toArray (portNames);
 			return portNames;
 		}
-		else {
-			return SerialPortList.getPortNames();
-		}
+		else
+			if (SerialNativeInterface.getOsType () == SerialNativeInterface.OS_MAC_OS_X) {
+				String pattern = "^.*tty\\..*$";
+				Pattern rx = Pattern.compile (pattern);
+				return SerialPortList.getPortNames("/dev/", rx);
+			}
+			else {
+				return SerialPortList.getPortNames();
+			}
     }
 
     /**


### PR DESCRIPTION
My system based on Mac has 10+ serial devices connected, but openpnp with SerialPortList.getPortNames() can see only 6 of them.
This patch worked for me, now i see all devices and can easily work with them, including /dev/tty.Bluetooth...