### PR TITLE
Add support for serial ports named tty.wchusbserial* on macOS.

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/driver/SerialPortCommunications.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/SerialPortCommunications.java
@@ -131,21 +131,23 @@ public class SerialPortCommunications extends ReferenceDriverCommunications {
      * @return array of Strings of serial port names
      */
     public static String[] getPortNames() {
-		if (SerialNativeInterface.getOsType () == SerialNativeInterface.OS_LINUX) {
-			ArrayList<String> linuxPortNames = new ArrayList<String>();
-			String pattern = ".*";
-			Pattern rx = Pattern.compile (pattern);
-			for (String portName : SerialPortList.getPortNames ("/dev/serial/by-id/", rx))  {
-				linuxPortNames.add (portName);
-			}
-			for (String portName : SerialPortList.getPortNames ())  {
-				linuxPortNames.add (portName);
-			}
-			String[] portNames = new String[linuxPortNames.size()];
-			linuxPortNames.toArray (portNames);
-			return portNames;
-		}
-		else {
+    	switch (SerialNativeInterface.getOsType()) {
+    	case SerialNativeInterface.OS_LINUX:
+    		ArrayList<String> linuxPortNames = new ArrayList<String>();
+    		String pattern = ".*";
+    		Pattern rx = Pattern.compile(pattern);
+    		for (String portName: SerialPortList.getPortNames("/dev/serial/by-id/", rx))  {
+    			linuxPortNames.add(portName);
+    		}
+    		for (String portName: SerialPortList.getPortNames())  {
+    			linuxPortNames.add(portName);
+    		}
+    		String[] portNames = new String[linuxPortNames.size()];
+    		linuxPortNames.toArray(portNames);
+    		return portNames;
+    	case SerialNativeInterface.OS_MAC_OS_X:
+    		return SerialPortList.getPortNames(Pattern.compile("tty.(serial|usbserial|wchusbserial|usbmodem).*"));
+    	default:
 			return SerialPortList.getPortNames();
 		}
     }


### PR DESCRIPTION
# Description
WCH's CH340 chips show up on macOS as `/dev/tty.wchusberial*`. I added a search pattern to the macOS defaults from jssc.

# Justification
WCH chips are common cheap USB serial converters. Users should be able to select those on macOS.

# Instructions for Use
Connect a WCH based USB serial converter and pick it from the list of serial ports in the machine setup.

# Implementation Details
I tested the code with a bunch of USB serial adapters from different manufacturers on macOS. I changed the if/else to a switch statement for cleanliness, which should not affect the Linux case at all. Though I have technically touched but not tested the Linux case ;)