### PR TITLE
Fixing move camera to next buttons

### DIFF
--- a/src/main/java/org/openpnp/gui/JobPanel.java
+++ b/src/main/java/org/openpnp/gui/JobPanel.java
@@ -1272,9 +1272,9 @@ public class JobPanel extends JPanel {
             new AbstractAction("Move Camera To Board Location") { //$NON-NLS-1$
                 {
                     putValue(SMALL_ICON, Icons.centerCameraMoveNext);
-                    putValue(NAME, "Move Camera To Board Location and Move to the Next Board"); //$NON-NLS-1$
+                    putValue(NAME, "Move Camera to the Next Board"); //$NON-NLS-1$
                     putValue(SHORT_DESCRIPTION,
-                            "Position the camera at the board's location and move to the next board."); //$NON-NLS-1$
+                            "Position the camera at the next board's location."); //$NON-NLS-1$
                 }
 
                 @Override
@@ -1283,16 +1283,16 @@ public class JobPanel extends JPanel {
                         // Need to keep current focus owner so that the space bar can be
                         // used after the initial click. Otherwise, button focus is lost
                         // when table is updated
-                        Component comp = MainFrame.get().getFocusOwner();
-                        HeadMountable tool = MainFrame.get().getMachineControls().getSelectedTool();
+                    	Component comp = MainFrame.get().getFocusOwner();
+                    	Helpers.selectNextTableRow(boardLocationsTable);
+                    	comp.requestFocus();
+                       HeadMountable tool = MainFrame.get().getMachineControls().getSelectedTool();
                         Camera camera = tool.getHead().getDefaultCamera();
                         MainFrame.get().getCameraViews().ensureCameraVisible(camera);
                         Location location = getSelectedBoardLocation().getLocation();
+                        
                         MovableUtils.moveToLocationAtSafeZ(camera, location);
-                        Helpers.selectNextTableRow(boardLocationsTable);
-                        if (comp != null) {
-                            comp.requestFocus();
-                        }
+                       
                     });
                 }
             };

--- a/src/main/java/org/openpnp/gui/JobPlacementsPanel.java
+++ b/src/main/java/org/openpnp/gui/JobPlacementsPanel.java
@@ -416,7 +416,7 @@ public class JobPlacementsPanel extends JPanel {
             putValue(SMALL_ICON, Icons.centerCameraMoveNext);
             putValue(NAME, "Move Camera To Next Placement Location ");
             putValue(SHORT_DESCRIPTION,
-                    "Move to the next part and position the camera at its location.");
+                    "Position the camera at the next placements location.");
         }
 
         @Override
@@ -425,16 +425,15 @@ public class JobPlacementsPanel extends JPanel {
                 // Need to keep current focus owner so that the space bar can be
                 // used after the initial click. Otherwise, button focus is lost
                 // when table is updated
-            	Helpers.selectNextTableRow(table);
-            	Component comp = MainFrame.get().getFocusOwner();
-                Location location = Utils2D.calculateBoardPlacementLocation(boardLocation,
+               	Component comp = MainFrame.get().getFocusOwner();
+               	Helpers.selectNextTableRow(table);
+                comp.requestFocus();
+               	Location location = Utils2D.calculateBoardPlacementLocation(boardLocation,
                         getSelection().getLocation());
                 Camera camera = MainFrame.get().getMachineControls().getSelectedTool().getHead()
                         .getDefaultCamera();
                 MovableUtils.moveToLocationAtSafeZ(camera, location);
-                if (comp != null) {
-                    comp.requestFocus();
-                }
+                
             });
         };
     };


### PR DESCRIPTION
# Description
Fixed Camera move to next buttons and made button focus better.

# Justification
This change makes the board highlighted in the Job panel the same as the the board shown in the camera view

# Instructions for Use
Just push the button and the camera will move to the next board or placement depending which button is pressed.

# Implementation Details
1. How did you test the change? Be descriptive. Untested code will not be accepted.
Jogged my machine around using the button and space bar to go to the next boards and next placements.
2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)?
Yes
3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing.
4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted.
