### PR TITLE
Added autosave properties to gui plus info about possible delays

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/ReferencePnpJobProcessor.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferencePnpJobProcessor.java
@@ -972,6 +972,10 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
     public void setAutoSaveConfiguration(boolean autoSaveConfiguration) {
         this.autoSaveConfiguration = autoSaveConfiguration;
     }
+
+    public long getConfigSaveFrequencyMs() {
+        return configSaveFrequencyMs;
+    }
     
     public JobOrderHint getJobOrder() {
         return jobOrder;

--- a/src/main/java/org/openpnp/machine/reference/wizards/ReferencePnpJobProcessorConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/wizards/ReferencePnpJobProcessorConfigurationWizard.java
@@ -26,6 +26,7 @@ import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.border.TitledBorder;
 
+import org.openpnp.Translations;
 import org.openpnp.gui.support.AbstractConfigurationWizard;
 import org.openpnp.machine.reference.ReferencePnpJobProcessor;
 import org.openpnp.machine.reference.ReferencePnpJobProcessor.JobOrderHint;
@@ -40,6 +41,8 @@ public class ReferencePnpJobProcessorConfigurationWizard extends AbstractConfigu
     private final ReferencePnpJobProcessor jobProcessor;
     private JCheckBox parkWhenComplete;
     private JComboBox comboBoxJobOrder;
+    private JCheckBox checkBoxAutoSaveJobAfterPlacement;
+    private JCheckBox checkBoxAutoSaveConfiguration;
 
     public ReferencePnpJobProcessorConfigurationWizard(ReferencePnpJobProcessor jobProcessor) {
         this.jobProcessor = jobProcessor;
@@ -62,25 +65,48 @@ public class ReferencePnpJobProcessorConfigurationWizard extends AbstractConfigu
                         FormSpecs.RELATED_GAP_ROWSPEC,
                         FormSpecs.DEFAULT_ROWSPEC,
                         FormSpecs.RELATED_GAP_ROWSPEC,
+                        FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC,
+                        FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC,
+                        FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC,
                         FormSpecs.DEFAULT_ROWSPEC,}
                 ));
 
-        JLabel lblParkWhenComplete = new JLabel("Park When Complete");
-        panelGeneral.add(lblParkWhenComplete, "2, 2, right, top");
+        JLabel lblParkWhenComplete = new JLabel(Translations.getString("MachineSetup.JobProcessors.ReferencePnpJobProcessor.Label.ParkWhenComplete"));
+        panelGeneral.add(lblParkWhenComplete, "2, 2, right, default");
 
         parkWhenComplete = new JCheckBox("");
         panelGeneral.add(parkWhenComplete, "4, 2");
 
-        JLabel lblJobOrder = new JLabel("Job order");
-        panelGeneral.add(lblJobOrder, "2, 4");
+        JLabel lblJobOrder = new JLabel(Translations.getString("MachineSetup.JobProcessors.ReferencePnpJobProcessor.Label.JobOrder"));
+        panelGeneral.add(lblJobOrder, "2, 4, right, default");
 
         comboBoxJobOrder = new JComboBox(JobOrderHint.values());
         panelGeneral.add(comboBoxJobOrder, "4, 4");
+        
+        JLabel lblAutoSaveJobAfterPlacement = new JLabel(Translations.getString("MachineSetup.JobProcessors.ReferencePnpJobProcessor.Label.AutoSaveJobAfterPlacement"));
+        panelGeneral.add(lblAutoSaveJobAfterPlacement, "2, 6, right, default");
+
+        checkBoxAutoSaveJobAfterPlacement = new JCheckBox("");
+        panelGeneral.add(checkBoxAutoSaveJobAfterPlacement, "4, 6");
+        
+        JLabel lblAutoSaveConfiguration = new JLabel(Translations.getString("MachineSetup.JobProcessors.ReferencePnpJobProcessor.Label.AutoSaveConfiguration") + " " + (jobProcessor.getConfigSaveFrequencyMs() / 1000 / 60) + " min");
+        panelGeneral.add(lblAutoSaveConfiguration, "2, 8, right, default");
+
+        checkBoxAutoSaveConfiguration = new JCheckBox("");
+        panelGeneral.add(checkBoxAutoSaveConfiguration, "4, 8");
+
+        JLabel lblDelayInfo = new JLabel(Translations.getString("MachineSetup.JobProcessors.ReferencePnpJobProcessor.Label.DelayInfo"));
+        panelGeneral.add(lblDelayInfo, "4, 10, left, default");
     }
 
     @Override
     public void createBindings() {
         addWrappedBinding(jobProcessor, "parkWhenComplete", parkWhenComplete, "selected");
         addWrappedBinding(jobProcessor, "jobOrder", comboBoxJobOrder, "selectedItem");
+        addWrappedBinding(jobProcessor, "autoSaveJob", checkBoxAutoSaveJobAfterPlacement, "selected");
+        addWrappedBinding(jobProcessor, "autoSaveConfiguration", checkBoxAutoSaveConfiguration, "selected");
     }
 }

--- a/src/main/resources/org/openpnp/translations.properties
+++ b/src/main/resources/org/openpnp/translations.properties
@@ -71,3 +71,9 @@ MachineControls.Action.Home=Home
 MachineControls.Action.Start=Start
 MachineControls.Action.Stop=Stop
 MachineControls.Label=Machine Controls
+
+MachineSetup.JobProcessors.ReferencePnpJobProcessor.Label.ParkWhenComplete=Park when complete
+MachineSetup.JobProcessors.ReferencePnpJobProcessor.Label.JobOrder=Job order
+MachineSetup.JobProcessors.ReferencePnpJobProcessor.Label.AutoSaveJobAfterPlacement=Save job after each placement
+MachineSetup.JobProcessors.ReferencePnpJobProcessor.Label.AutoSaveConfiguration=Save configuration periodically, every
+MachineSetup.JobProcessors.ReferencePnpJobProcessor.Label.DelayInfo=Saving the job after each placement adds delay (see logs). Store jobs local if using this feature.


### PR DESCRIPTION
# Description
as discussed in #801 I added the autosave properties to the gui

# Justification
it's a hidden feature that should be exposed.

# Instructions for Use
The props are added to the gui at the reference processor:
![gui](https://user-images.githubusercontent.com/3868450/51025779-337e5480-158d-11e9-9758-4e12c45075b1.PNG)

# Implementation Details
1. How did you test the change? Be descriptive. Untested code will not be accepted.
eclipse started the gui and checked
2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)?
yes
