### PR TITLE
Forced-output coordinate variables "XF", "YF", "RotationF" are omitted in moveToSafeZ()

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/ReferenceActuator.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceActuator.java
@@ -170,10 +170,12 @@ public class ReferenceActuator extends AbstractActuator implements ReferenceHead
         return getName();
     }
 
+    @Override
     public Length getSafeZ() {
         return safeZ;
     }
 
+    @Override
     public void setSafeZ(Length safeZ) {
         this.safeZ = safeZ;
     }

--- a/src/main/java/org/openpnp/machine/reference/ReferenceCamera.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceCamera.java
@@ -529,10 +529,12 @@ public abstract class ReferenceCamera extends AbstractCamera implements Referenc
         return getDriver().getLocation(this);
     }
 
+    @Override
     public Length getSafeZ() {
         return safeZ;
     }
 
+    @Override
     public void setSafeZ(Length safeZ) {
         this.safeZ = safeZ;
     }

--- a/src/main/java/org/openpnp/machine/reference/ReferenceNozzle.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceNozzle.java
@@ -411,10 +411,12 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
         return getName() + " " + getId();
     }
 
+    @Override
     public Length getSafeZ() {
         return safeZ;
     }
 
+    @Override
     public void setSafeZ(Length safeZ) {
         this.safeZ = safeZ;
     }

--- a/src/main/java/org/openpnp/machine/reference/ReferencePasteDispenser.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferencePasteDispenser.java
@@ -109,10 +109,12 @@ public class ReferencePasteDispenser extends AbstractPasteDispenser
         return getName();
     }
 
+    @Override
     public Length getSafeZ() {
         return safeZ;
     }
 
+    @Override
     public void setSafeZ(Length safeZ) {
         this.safeZ = safeZ;
     }

--- a/src/main/java/org/openpnp/machine/reference/driver/GcodeDriver.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/GcodeDriver.java
@@ -537,6 +537,23 @@ public class GcodeDriver extends AbstractReferenceDriver implements Named, Runna
         boolean includeY = (yAxis != null && hasVariable(command, "YF"));
         boolean includeZ = (zAxis != null && hasVariable(command, "ZF"));
         boolean includeRotation = (rotationAxis != null && hasVariable(command, "RotationF"));
+        
+        // There is an exception to the above, if this is a moveToSafeZ(). The safe Z move does not count as 
+        // a real move in the sense that the headmountable (usually a nozzle) is selected for real work. 
+        // Consequently the coordinates should not be restored/forced in this case.
+        boolean isMoveToSafeZ = (
+        		Double.isNaN(x) 
+        		&& Double.isNaN(y) 
+        		&& Double.isNaN(rotation) 
+        		&& (! Double.isNaN(z)) 
+        		&& (z == hm.getSafeZ().getValue())); 
+        
+        if (isMoveToSafeZ) {
+        	// do not include the forced XF, YF, RotationF variables
+        	includeX = false;
+        	includeY = false;
+        	includeRotation = false;
+        }
 
         // Handle NaNs, which means don't move this axis for this move. We set the appropriate
         // axis reference to null, which we'll check for later. If the axis is force-included 

--- a/src/main/java/org/openpnp/spi/HeadMountable.java
+++ b/src/main/java/org/openpnp/spi/HeadMountable.java
@@ -2,6 +2,7 @@ package org.openpnp.spi;
 
 import org.openpnp.model.Identifiable;
 import org.openpnp.model.Named;
+import org.openpnp.model.Length;
 
 public interface HeadMountable extends Movable, Identifiable, Named {
     /**
@@ -11,10 +12,23 @@ public interface HeadMountable extends Movable, Identifiable, Named {
      * @return
      */
     Head getHead();
-
+    
     /**
      * Set the Head that this HeadMountable is attached to. Called by the Head when the
      * HeadMountable is added to it.
      */
     void setHead(Head head);
+
+    /**
+     * Gets the Safe Z that this HeadMountable must be raised to before moving. If not needed this
+     * method returns NaN.
+     * 
+     * @return
+     */
+    Length getSafeZ();
+    
+    /**
+     * Set the Safe Z that this HeadMountable must be raised to before moving. 
+     */
+    void setSafeZ(Length safeZ);
 }

--- a/src/test/java/VisionUtilsTest.java
+++ b/src/test/java/VisionUtilsTest.java
@@ -8,6 +8,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.openpnp.CameraListener;
 import org.openpnp.gui.support.Wizard;
+import org.openpnp.model.Length;
 import org.openpnp.model.LengthUnit;
 import org.openpnp.model.Location;
 import org.openpnp.spi.Camera;
@@ -57,6 +58,15 @@ public class VisionUtilsTest {
         @Override
         public void moveToSafeZ(double speed) throws Exception {
 
+        }
+        
+        @Override
+        public Length getSafeZ() {
+            return new Length(Double.NaN, LengthUnit.Millimeters);
+        }
+
+        @Override
+        public void setSafeZ(Length safeZ) {
         }
 
         @Override


### PR DESCRIPTION
# Description
If the command has forced-output coordinate variables "XF", "YF", "ZF" and "RotationF", the corresponding axes are always includes in the G-code command (see #766). This may be employed for shared physical axes, Z-probing, relative moves in custom G-code etc. where OpenPNP cannot keep track of when an axis has physically moved behind its back. 
        
There is an exception to the above, if a moveToSafeZ() is executed. The safe Z move does not count as a _real_ move in the sense that the headmountable is selected for _real_ work. Consequently coordinates (other than Z) should not be restored/forced in this case. 

# Justification
Tests of #766 with a shared C axis machine (Marek T's) have shown that unnecessary rotations are executed. This was tracked down to moveToSafeZ() moves on all head-mountables prior to X, Y moves with the actual nozzle. 

See also:
https://groups.google.com/d/msg/openpnp/zCVlqSgxzYk/RwoexxEhDQAJ

# Instructions for Use
When employing forced-output coordinate variables "XF", "YF", "ZF" and "RotationF" for the MOVE_TO_COMMAND these will automatically be omited if a moveToSafeZ() signature is detected. 

# Implementation Details
1. Tests of the change are **pending**, I hope Marek T. can test this with his machine. **This PR is still subject to review and testing**.
2. I did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. I had to make a change to the `org.openpnp.spi` package to add a getSafeZ() and setSafeZ() getter/setter to the HeadMountable interface in order to recognize a moveToSafeZ() method call signature. These changes are benign insofar as the existing identical methods in the implementation reference classes only had be annotated as overrides. 
4. I did run `mvn test` before submitting the Pull Request. 
