### PR TITLE
More Robust Nozzle Tip Calibration

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/ReferenceNozzleTip.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceNozzleTip.java
@@ -542,7 +542,7 @@ public class ReferenceNozzleTip extends AbstractNozzleTip {
 	    	    kasaB = (kasaD1 - kasaG12*kasaC)/kasaG11/2.0;
 	    	    
 	    	    // assembling the output
-	    	    Double centerX = kasaB + kasaMeanX;
+                Double centerX = kasaB + kasaMeanX;
                 Double centerY = kasaC + kasaMeanY;
                 Double radius = Math.sqrt(kasaB*kasaB + kasaC*kasaC + kasaMxx + kasaMyy);
                 

--- a/src/main/java/org/openpnp/machine/reference/ReferenceNozzleTip.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceNozzleTip.java
@@ -665,7 +665,8 @@ public class ReferenceNozzleTip extends AbstractNozzleTip {
             angleIncrement = null;
         }
         
-        private Double offsetThreshold = 3.;
+        // max allowed linear distance wrt bottom camera
+        private Double offsetThreshold = 1.5;
 
         public RunoutCompensationAlgorithm getRunoutCompensationAlgorithm() {
             return this.runoutCompensationAlgorithm;

--- a/src/main/java/org/openpnp/machine/reference/wizards/ReferenceNozzleTipCalibrationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/wizards/ReferenceNozzleTipCalibrationWizard.java
@@ -74,6 +74,8 @@ public class ReferenceNozzleTipCalibrationWizard extends AbstractConfigurationWi
     private JComboBox compensationAlgorithmCb;
     private JLabel lblAngleIncrements;
     private JTextField angleIncrementsTf;
+    private JLabel lblOffsetThreshold;
+    private JTextField offsetThresholdTf;
     private JButton btnCalibrate;
     private JButton btnReset;
     private JLabel lblCalibrationInfo;
@@ -106,6 +108,8 @@ public class ReferenceNozzleTipCalibrationWizard extends AbstractConfigurationWi
                 FormSpecs.RELATED_GAP_ROWSPEC,
                 FormSpecs.DEFAULT_ROWSPEC,
                 FormSpecs.UNRELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
                 FormSpecs.DEFAULT_ROWSPEC,
                 FormSpecs.RELATED_GAP_ROWSPEC,
                 FormSpecs.DEFAULT_ROWSPEC,
@@ -170,13 +174,20 @@ public class ReferenceNozzleTipCalibrationWizard extends AbstractConfigurationWi
         panelCalibration.add(angleIncrementsTf, "4, 10, left, default");
         angleIncrementsTf.setColumns(3);
 
+        lblOffsetThreshold = new JLabel("Offset Threshold");
+        panelCalibration.add(lblOffsetThreshold, "2, 12, right, default");
+
+        offsetThresholdTf = new JTextField();
+        panelCalibration.add(offsetThresholdTf, "4, 12, left, default");
+        offsetThresholdTf.setColumns(6);
+
         lblNewLabel = new JLabel("Pipeline");
-        panelCalibration.add(lblNewLabel, "2, 12, right, default");
+        panelCalibration.add(lblNewLabel, "2, 14, right, default");
                         
                         panel = new JPanel();
                         FlowLayout flowLayout = (FlowLayout) panel.getLayout();
                         flowLayout.setVgap(0);
-                        panelCalibration.add(panel, "4, 12, left, default");
+                        panelCalibration.add(panel, "4, 14, left, default");
                         
                                 btnEditPipeline = new JButton("Edit");
                                 panel.add(btnEditPipeline);
@@ -250,6 +261,7 @@ public class ReferenceNozzleTipCalibrationWizard extends AbstractConfigurationWi
     @Override
     public void createBindings() {
         IntegerConverter intConverter = new IntegerConverter();
+        DoubleConverter doubleConverter = new DoubleConverter(Configuration.get().getLengthDisplayFormat());
 
         addWrappedBinding(nozzleTip.getCalibration(), "enabled", calibrationEnabledCheckbox,
                 "selected");
@@ -257,6 +269,8 @@ public class ReferenceNozzleTipCalibrationWizard extends AbstractConfigurationWi
                 compensationAlgorithmCb, "selectedItem");
         addWrappedBinding(nozzleTip.getCalibration(), "angleSubdivisions", angleIncrementsTf,
                 "text", intConverter);
+        addWrappedBinding(nozzleTip.getCalibration(), "offsetThreshold", offsetThresholdTf,
+                "text", doubleConverter);
         bind(UpdateStrategy.READ, nozzleTip.getCalibration(), "runoutCompensationInformation",
                 lblCalibrationResults, "text");
     }


### PR DESCRIPTION
# Description
Continue to #804. This PR adds
1. automatic removal of nozzle tip offset locations that are above offsetThreshold and
2. sorting the pipeline's result list by linear distance to the bottom camera if multiple results are returned.
3. some minor changes + debug output

# Justification
to 1) wrong configured pipelines may return large offsets -> these are eliminated by this change
to 2) if there are multiple results (though it is recommended to configure the pipeline to have only ONE result), the list is sorted by distance to bottom camera. the location with the smallest distance is taken as valid for further processing. this may improve results, but doesn't have to since there can't be made any educated guesses which is a valid offset location.


# Instructions for Use
There will be added a offsetThreshold value to the GUI later. For now it's a hardcoded variable in the calibration class to prevent cluttering machine.xml.
This PR is tested on the nulldriver only and I would like to use this PR to test (@netzmark) and discuss assumptions and implementation as we did in #804.
