### PR TITLE
BottomVision should store rotation offset in the PartAlignmentOffset

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/vision/ReferenceBottomVision.java
+++ b/src/main/java/org/openpnp/machine/reference/vision/ReferenceBottomVision.java
@@ -47,6 +47,15 @@ public class ReferenceBottomVision implements PartAlignment {
     @Attribute(required = false)
     protected boolean preRotate = false;
 
+    @Attribute(required = false)
+    protected int maxVisionPasses = 3;
+
+    @Element(required = false)
+    protected Length maxLinearOffset = new Length(1, LengthUnit.Millimeters);
+
+    @Attribute(required = false)
+    protected double maxAngularOffset = 10;
+
     @ElementMap(required = false)
     protected Map<String, PartSettings> partSettingsByPartId = new HashMap<>();
 
@@ -77,120 +86,120 @@ public class ReferenceBottomVision implements PartAlignment {
                     partSettings);
         }
     }
+    
+    public Location getCameraLocationAtPartHeight(Part part, Camera camera, double angle) {
+        return camera.getLocation()
+                .add(new Location(part.getHeight()
+                        .getUnits(),
+                        0.0, 0.0, part.getHeight()
+                        .getValue(),
+                        0.0))
+                .derive(null, null, null, angle);
+    }
 
-    private static PartAlignmentOffset findOffsetsPreRotate(Part part, BoardLocation boardLocation,
+    private PartAlignmentOffset findOffsetsPreRotate(Part part, BoardLocation boardLocation,
             Location placementLocation, Nozzle nozzle, Camera camera, PartSettings partSettings)
             throws Exception {
-        double angle = placementLocation.getRotation();
+        double wantedAngle = placementLocation.getRotation();
         if (boardLocation != null) {
-            angle = Utils2D.calculateBoardPlacementLocation(boardLocation, placementLocation)
+            wantedAngle = Utils2D.calculateBoardPlacementLocation(boardLocation, placementLocation)
                            .getRotation();
         }
-        angle = angleNorm(angle, 180.);
-        Location location = camera.getLocation()
-                                  .add(new Location(part.getHeight()
-                                                        .getUnits(),
-                                          0.0, 0.0, part.getHeight()
-                                                        .getValue(),
-                                          0.0))
-                                  .derive(null, null, null, angle);
-        MovableUtils.moveToLocationAtSafeZ(nozzle, location);
+        wantedAngle = angleNorm(wantedAngle, 180.);
+        // Wanted location.
+        Location wantedLocation = getCameraLocationAtPartHeight(part, camera, wantedAngle);
+                
+        Location nozzleLocation = wantedLocation;
+        MovableUtils.moveToLocationAtSafeZ(nozzle, nozzleLocation);
+        final Location offsetZero = new Location(maxLinearOffset.getUnits());
 
         try (CvPipeline pipeline = partSettings.getPipeline()) {
 
-        	Location offsets = new Location(location.getUnits());
-        	// Try getting a good fix on the part in multiple passes.
-        	for(int pass = 0;;) {
-	            RotatedRect rect = processPipelineAndGetResult(pipeline, camera, part, nozzle);
-	            camera=(Camera)pipeline.getProperty("camera");
-	            
-	            Logger.debug("Result rect {}", rect);
-	            
-	            // Create the offsets object. This is the physical distance from
-	            // the center of the camera to the located part.
-	            offsets = VisionUtils.getPixelCenterOffsets(camera, rect.center.x, rect.center.y);
-	            
-	            // OpenCV can only tell us the angle of the recognized rectangle in a   
-	            // range of 0° .. 90° as it has no notion of which rectangle side 
-	            // is the true "bottom" side for instance. The angle will abruptly wrap 
-	            // around from 90° to 0° (and vice versa), as another of the four sides 
-	            // becomes the "bottom" side, as perceived by OpenCV.    
-	            // We can assume that the part is never picked more than +/-45º rotated.
-	            // So we change the wrapping-around into one that produces a range from 
-	            // -45° .. +45°. See angleNorm():
-	            angle = angleNorm(location.getRotation() + rect.angle);
-	            
-	            // When we rotate the nozzle later to compensate the angle, the X, Y offsets 
-	            // will change too, as the off-center part rotates around the nozzle axis.
-	            // So we need to compensate for that.
-	            // TODO: verify angle sign here. 
-	            offsets = offsets.rotateXy(-angle)
-	            			.derive(null, null,	null, -angle);
-	                
-	            if (++pass > 2) {
-	            	// Maximum number of passes. 
-	            	break;
-	            }
-	            
-	            if (Math.sqrt(offsets.getX()*offsets.getX() + offsets.getY()*offsets.getY()) < 2.0
-	            		&& Math.abs(angle) < 10.0) {
-	            	// We have a good enough fix - go on with that.
-	            	break;
-	            }
-	            
-	            Logger.debug("Large offsets {}", offsets);
-	            
-	            // Not a good enough fix - try again with corrected position.
-	            location = location.subtractWithRotation(offsets);
-                nozzle.moveTo(location);
-            }
+            // The running, iterative offset.
+            Location offsets = new Location(nozzleLocation.getUnits());
+            // Try getting a good fix on the part in multiple passes.
+            for(int pass = 0;;) {
+                RotatedRect rect = processPipelineAndGetResult(pipeline, camera, part, nozzle);
+                camera=(Camera)pipeline.getProperty("camera");
 
+                Logger.debug("Bottom vision part {} result rect {}", part.getId(), rect);
+
+                // Create the offsets object. This is the physical distance from
+                // the center of the camera to the located part.
+                offsets = VisionUtils.getPixelCenterOffsets(camera, rect.center.x, rect.center.y);
+
+                // OpenCV can only tell us the angle of the recognized rectangle in a   
+                // wrapping-around range of 0° .. 90° as it has no notion of which rectangle side 
+                // is which. We can assume that the part is never picked more than +/-45º rotated.
+                // So we change the range wrapping-around to -45° .. +45°. See angleNorm():
+                double angleOffset = angleNorm(VisionUtils.getPixelAngle(camera, rect.angle) - wantedAngle);
+
+                // When we rotate the nozzle later to compensate for the angle offset, the X, Y offsets 
+                // will change too, as the off-center part rotates around the nozzle axis.
+                // So we need to compensate for that.
+                offsets = offsets.rotateXy(-angleOffset)
+                        .derive(null, null,	null, angleOffset);
+                nozzleLocation = nozzleLocation.subtractWithRotation(offsets);
+
+                if (++pass >= maxVisionPasses) {
+                    // Maximum number of passes reached. 
+                    break;
+                }
+                
+                // We not only check the center offset but also the corner offset brought about by the angular offset. 
+                Location corner = VisionUtils.getPixelCenterOffsets(camera, rect.size.width/2, rect.size.height/2);
+                if (offsetZero.getLinearDistanceTo(offsets) <= getMaxLinearOffset().getValue()
+                        && offsetZero.getLinearDistanceTo(corner)*Math.sin(Math.toRadians(angleOffset)) <=  getMaxLinearOffset().getValue()
+                        && Math.abs(angleOffset) <= getMaxAngularOffset()) {
+                    // We have a good enough fix - go on with that.
+                    break;
+                }
+
+                Logger.debug("Offsets too large {}", offsets);
+
+                // Not a good enough fix - try again with corrected position.
+                nozzle.moveTo(nozzleLocation);
+            }
+            Logger.debug("Offsets accepted {}", offsets);
+            // Calculate cumulative offsets over all the passes.  
+            offsets = wantedLocation.subtractWithRotation(nozzleLocation);
             Logger.debug("Final offsets {}", offsets);
             displayResult(pipeline, part, offsets, camera);
             return new PartAlignment.PartAlignmentOffset(offsets, true);
         }
     }
 
-    private static PartAlignmentOffset findOffsetsPostRotate(Part part, BoardLocation boardLocation,
+    private PartAlignmentOffset findOffsetsPostRotate(Part part, BoardLocation boardLocation,
             Location placementLocation, Nozzle nozzle, Camera camera, PartSettings partSettings)
-            throws Exception {
+                    throws Exception {
         // Create a location that is the Camera's X, Y, it's Z + part height
         // and a rotation of 0, unless preRotate is enabled
-        Location startLocation = camera.getLocation();
-        Length partHeight = part.getHeight();
-        Location partHeightLocation =
-                new Location(partHeight.getUnits(), 0, 0, partHeight.getValue(), 0);
-        startLocation = startLocation.add(partHeightLocation)
-                                     .derive(null, null, null, 0.);
-
-        MovableUtils.moveToLocationAtSafeZ(nozzle, startLocation);
+        Location wantedLocation = getCameraLocationAtPartHeight(part, camera, 0.);
+        
+        MovableUtils.moveToLocationAtSafeZ(nozzle, wantedLocation);
 
         try (CvPipeline pipeline = partSettings.getPipeline()) {
             RotatedRect rect = processPipelineAndGetResult(pipeline, camera, part, nozzle);
             camera=(Camera)pipeline.getProperty("camera");
-    
-            Logger.debug("Result rect {}", rect);
-    
+
+            Logger.debug("Bottom vision part {} result rect {}", part.getId(), rect);
+
             // Create the offsets object. This is the physical distance from
             // the center of the camera to the located part.
             Location offsets = VisionUtils.getPixelCenterOffsets(camera, rect.center.x, rect.center.y);
-    
-            // OpenCV can only tell us the angle of the recognized rectangle in a  
-            // range of 0° .. 90° as it has no notion of which rectangle side 
-            // is the true "bottom" side for instance. The angle will abruptly wrap 
-            // around from 90° to 0° (and vice versa), as another of the four sides 
-            // becomes the "bottom" side, as perceived by OpenCV.    
-            // We can assume that the part is never picked more than +/-45º rotated.
-            // So we change the wrapping-around into one that produces a range from 
-            // -45° .. +45°. See angleNorm():
-            double angle = angleNorm(rect.angle);
-    
+
+            // OpenCV can only tell us the angle of the recognized rectangle in a   
+            // wrapping-around range of 0° .. 90° as it has no notion of which rectangle side 
+            // is which. We can assume that the part is never picked more than +/-45º rotated.
+            // So we change the range wrapping-around to -45° .. +45°. See angleNorm():
+            double angleOffset = angleNorm(VisionUtils.getPixelAngle(camera, rect.angle));
+
             // Set the angle on the offsets.
-            offsets = offsets.derive(null, null, null, -angle);
+            offsets = offsets.derive(null, null, null, angleOffset);
             Logger.debug("Final offsets {}", offsets);
-    
+
             displayResult(pipeline, part, offsets, camera);
-    
+
             return new PartAlignmentOffset(offsets, false);
         }
     }
@@ -312,6 +321,30 @@ public class ReferenceBottomVision implements PartAlignment {
 
     public void setPreRotate(boolean preRotate) {
         this.preRotate = preRotate;
+    }
+
+    public int getMaxVisionPasses() {
+        return maxVisionPasses;
+    }
+
+    public void setMaxVisionPasses(int maxVisionPasses) {
+        this.maxVisionPasses = maxVisionPasses;
+    }
+
+    public Length getMaxLinearOffset() {
+        return maxLinearOffset;
+    }
+
+    public void setMaxLinearOffset(Length maxLinearOffset) {
+        this.maxLinearOffset = maxLinearOffset;
+    }
+
+    public double getMaxAngularOffset() {
+        return maxAngularOffset;
+    }
+
+    public void setMaxAngularOffset(double maxAngularOffset) {
+        this.maxAngularOffset = maxAngularOffset;
     }
 
     @Override

--- a/src/main/java/org/openpnp/machine/reference/vision/ReferenceBottomVision.java
+++ b/src/main/java/org/openpnp/machine/reference/vision/ReferenceBottomVision.java
@@ -149,7 +149,7 @@ public class ReferenceBottomVision implements PartAlignment {
                 // We not only check the center offset but also the corner offset brought about by the angular offset. 
                 Location corner = VisionUtils.getPixelCenterOffsets(camera, rect.size.width/2, rect.size.height/2);
                 if (offsetZero.getLinearDistanceTo(offsets) <= getMaxLinearOffset().getValue()
-                        && offsetZero.getLinearDistanceTo(corner)*Math.sin(Math.toRadians(angleOffset)) <=  getMaxLinearOffset().getValue()
+                        && offsetZero.getLinearDistanceTo(corner)*Math.sin(Math.toRadians(Math.abs(angleOffset))) <=  getMaxLinearOffset().getValue()
                         && Math.abs(angleOffset) <= getMaxAngularOffset()) {
                     // We have a good enough fix - go on with that.
                     break;

--- a/src/main/java/org/openpnp/machine/reference/vision/ReferenceBottomVision.java
+++ b/src/main/java/org/openpnp/machine/reference/vision/ReferenceBottomVision.java
@@ -77,7 +77,8 @@ public class ReferenceBottomVision implements PartAlignment {
 
         Camera camera = VisionUtils.getBottomVisionCamera();
 
-        if (preRotate) {
+        if ((partSettings.getPreRotateUsage() == PreRotateUsage.Default && preRotate)
+                || (partSettings.getPreRotateUsage() == PreRotateUsage.AlwaysOn)) {
             return findOffsetsPreRotate(part, boardLocation, placementLocation, nozzle, camera,
                     partSettings);
         }
@@ -397,11 +398,16 @@ public class ReferenceBottomVision implements PartAlignment {
         }
         return new ReferenceBottomVisionPartConfigurationWizard(this, part);
     }
-
+    
+    public enum PreRotateUsage {
+        Default, AlwaysOn, AlwaysOff
+    }
     @Root
     public static class PartSettings {
         @Attribute
         protected boolean enabled;
+        @Attribute(required = false)
+        protected PreRotateUsage preRotateUsage = PreRotateUsage.Default;
 
         @Element
         protected CvPipeline pipeline;
@@ -427,6 +433,14 @@ public class ReferenceBottomVision implements PartAlignment {
 
         public void setEnabled(boolean enabled) {
             this.enabled = enabled;
+        }
+
+        public PreRotateUsage getPreRotateUsage() {
+            return preRotateUsage;
+        }
+
+        public void setPreRotateUsage(PreRotateUsage preRotateUsage) {
+            this.preRotateUsage = preRotateUsage;
         }
 
         public CvPipeline getPipeline() {

--- a/src/main/java/org/openpnp/machine/reference/vision/wizards/ReferenceBottomVisionConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/vision/wizards/ReferenceBottomVisionConfigurationWizard.java
@@ -12,11 +12,18 @@ import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.border.TitledBorder;
 
+import org.jdesktop.beansbinding.AutoBinding.UpdateStrategy;
 import org.openpnp.gui.MainFrame;
+import org.openpnp.gui.components.ComponentDecorators;
 import org.openpnp.gui.support.AbstractConfigurationWizard;
+import org.openpnp.gui.support.DoubleConverter;
+import org.openpnp.gui.support.IntegerConverter;
+import org.openpnp.gui.support.LengthConverter;
 import org.openpnp.gui.support.MessageBoxes;
+import org.openpnp.gui.support.MutableLocationProxy;
 import org.openpnp.machine.reference.vision.ReferenceBottomVision;
 import org.openpnp.machine.reference.vision.ReferenceBottomVision.PartSettings;
+import org.openpnp.model.Configuration;
 import org.openpnp.util.UiUtils;
 import org.openpnp.util.VisionUtils;
 import org.openpnp.vision.pipeline.CvPipeline;
@@ -26,12 +33,17 @@ import com.jgoodies.forms.layout.ColumnSpec;
 import com.jgoodies.forms.layout.FormLayout;
 import com.jgoodies.forms.layout.FormSpecs;
 import com.jgoodies.forms.layout.RowSpec;
+import javax.swing.JTextField;
 
 public class ReferenceBottomVisionConfigurationWizard extends AbstractConfigurationWizard {
     private final ReferenceBottomVision bottomVision;
     private JCheckBox enabledCheckbox;
     private JCheckBox preRotCheckbox;
+    private JTextField textFieldMaxVisionPasses;
+    private JTextField textFieldMaxLinearOffset;
+    private JTextField textFieldMaxAngularOffset;
 
+    
     public ReferenceBottomVisionConfigurationWizard(ReferenceBottomVision bottomVision) {
         this.bottomVision = bottomVision;
 
@@ -39,14 +51,26 @@ public class ReferenceBottomVisionConfigurationWizard extends AbstractConfigurat
         panel.setBorder(new TitledBorder(null, "General", TitledBorder.LEADING, TitledBorder.TOP,
                 null, null));
         contentPanel.add(panel);
-        panel.setLayout(new FormLayout(
-                new ColumnSpec[] {FormSpecs.RELATED_GAP_COLSPEC, ColumnSpec.decode("right:default"),
-                        FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,
-                        FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,
-                        FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,},
-                new RowSpec[] {FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
-                        FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
-                        FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,}));
+        panel.setLayout(new FormLayout(new ColumnSpec[] {
+                FormSpecs.RELATED_GAP_COLSPEC,
+                ColumnSpec.decode("right:default"),
+                FormSpecs.RELATED_GAP_COLSPEC,
+                ColumnSpec.decode("default:grow"),
+                FormSpecs.RELATED_GAP_COLSPEC,
+                FormSpecs.DEFAULT_COLSPEC,
+                FormSpecs.RELATED_GAP_COLSPEC,
+                ColumnSpec.decode("default:grow"),},
+            new RowSpec[] {
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,}));
 
         JLabel lblEnabled = new JLabel("Enabled?");
         panel.add(lblEnabled, "2, 2");
@@ -105,8 +129,47 @@ public class ReferenceBottomVisionConfigurationWizard extends AbstractConfigurat
 
         preRotCheckbox = new JCheckBox("");
         panel.add(preRotCheckbox, "4, 6");
+        
+        JLabel lblMaxVisionPasses = new JLabel("Max. vision passes");
+        lblMaxVisionPasses.setToolTipText("The maximum number of bottom vision passes performed to get a good fix on the part.");
+        panel.add(lblMaxVisionPasses, "2, 8, right, default");
+        
+        textFieldMaxVisionPasses = new JTextField();
+        panel.add(textFieldMaxVisionPasses, "4, 8");
+        textFieldMaxVisionPasses.setColumns(10);
+        
+        JLabel lblMaxLinearOffset = new JLabel("Max. linear offset");
+        lblMaxLinearOffset.setToolTipText("The maximum linear part offset accepted as a good fix i.e. where no additional vision pass is needed.");
+        panel.add(lblMaxLinearOffset, "2, 10, right, default");
+        
+        textFieldMaxLinearOffset = new JTextField();
+        panel.add(textFieldMaxLinearOffset, "4, 10, fill, default");
+        textFieldMaxLinearOffset.setColumns(10);
+        
+        JLabel lblMaxAngularOffset = new JLabel("Max. angular offset");
+        lblMaxAngularOffset.setToolTipText("The maximum angular part offset accepted as a good fix i.e. where no additional vision pass is needed.");
+        panel.add(lblMaxAngularOffset, "6, 10, right, default");
+        
+        textFieldMaxAngularOffset = new JTextField();
+        panel.add(textFieldMaxAngularOffset, "8, 10, fill, default");
+        textFieldMaxAngularOffset.setColumns(10);
+
+        preRotCheckbox.addActionListener(new ActionListener()
+        {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                updateEnabledState();
+            }
+        });
     }
 
+    private void updateEnabledState() {
+        boolean enabled = (preRotCheckbox.getModel().isSelected());
+        textFieldMaxVisionPasses.setEnabled(enabled);
+        textFieldMaxLinearOffset.setEnabled(enabled);
+        textFieldMaxAngularOffset.setEnabled(enabled);
+    }
+    
     private void editPipeline() throws Exception {
         CvPipeline pipeline = bottomVision.getPipeline();
         pipeline.setProperty("camera", VisionUtils.getBottomVisionCamera());
@@ -125,10 +188,25 @@ public class ReferenceBottomVisionConfigurationWizard extends AbstractConfigurat
     public String getWizardName() {
         return "ReferenceBottomVision";
     }
-
+    
     @Override
     public void createBindings() {
         addWrappedBinding(bottomVision, "enabled", enabledCheckbox, "selected");
         addWrappedBinding(bottomVision, "preRotate", preRotCheckbox, "selected");
+        
+        LengthConverter lengthConverter = new LengthConverter();
+        IntegerConverter intConverter = new IntegerConverter();
+        DoubleConverter doubleConverter = new DoubleConverter(Configuration.get()
+                                                                           .getLengthDisplayFormat());
+
+        addWrappedBinding(bottomVision, "maxVisionPasses", textFieldMaxVisionPasses, "text", intConverter);
+        addWrappedBinding(bottomVision, "maxLinearOffset", textFieldMaxLinearOffset, "text", lengthConverter);
+        addWrappedBinding(bottomVision, "maxAngularOffset", textFieldMaxAngularOffset, "text", doubleConverter);
+        
+        ComponentDecorators.decorateWithAutoSelect(textFieldMaxVisionPasses);
+        ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldMaxLinearOffset);
+        ComponentDecorators.decorateWithAutoSelect(textFieldMaxAngularOffset);
+        
+        updateEnabledState();
     }
 }

--- a/src/main/java/org/openpnp/machine/reference/vision/wizards/ReferenceBottomVisionConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/vision/wizards/ReferenceBottomVisionConfigurationWizard.java
@@ -125,6 +125,7 @@ public class ReferenceBottomVisionConfigurationWizard extends AbstractConfigurat
         panel.add(btnResetAllTo, "8, 4");
 
         JLabel lblPreRot = new JLabel("Rotate parts prior to vision?");
+        lblPreRot.setToolTipText("Pre-rotate default setting for bottom vision. Can be overridden on individual parts.");
         panel.add(lblPreRot, "2, 6");
 
         preRotCheckbox = new JCheckBox("");
@@ -165,9 +166,13 @@ public class ReferenceBottomVisionConfigurationWizard extends AbstractConfigurat
 
     private void updateEnabledState() {
         boolean enabled = (preRotCheckbox.getModel().isSelected());
+        /* No longer disable the config, as the enabled checkbox is only the system default
+         * and pre-rotate can still be enabled on individual parts. Left the code for the moment
+           as this might be reconsidered.
         textFieldMaxVisionPasses.setEnabled(enabled);
         textFieldMaxLinearOffset.setEnabled(enabled);
         textFieldMaxAngularOffset.setEnabled(enabled);
+        */
     }
     
     private void editPipeline() throws Exception {

--- a/src/main/java/org/openpnp/machine/reference/vision/wizards/ReferenceBottomVisionPartConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/vision/wizards/ReferenceBottomVisionPartConfigurationWizard.java
@@ -147,7 +147,7 @@ public class ReferenceBottomVisionPartConfigurationWizard extends AbstractConfig
                 throw new Exception("Offset too big");
             }
             nozzle.moveTo(nozzle.getLocation()
-                                .subtract(alignmentOffset.getLocation()));
+                                .subtractWithRotation(alignmentOffset.getLocation()));
             return;
         }
 

--- a/src/main/java/org/openpnp/machine/reference/vision/wizards/ReferenceBottomVisionPartConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/vision/wizards/ReferenceBottomVisionPartConfigurationWizard.java
@@ -15,6 +15,7 @@ import javax.swing.border.TitledBorder;
 import org.openpnp.gui.MainFrame;
 import org.openpnp.gui.support.AbstractConfigurationWizard;
 import org.openpnp.gui.support.MessageBoxes;
+import org.openpnp.machine.reference.ReferenceNozzleTip;
 import org.openpnp.machine.reference.vision.ReferenceBottomVision;
 import org.openpnp.machine.reference.vision.ReferenceBottomVision.PartSettings;
 import org.openpnp.model.LengthUnit;
@@ -31,6 +32,7 @@ import com.jgoodies.forms.layout.ColumnSpec;
 import com.jgoodies.forms.layout.FormLayout;
 import com.jgoodies.forms.layout.FormSpecs;
 import com.jgoodies.forms.layout.RowSpec;
+import javax.swing.JComboBox;
 
 public class ReferenceBottomVisionPartConfigurationWizard extends AbstractConfigurationWizard {
     private final ReferenceBottomVision bottomVision;
@@ -39,6 +41,7 @@ public class ReferenceBottomVisionPartConfigurationWizard extends AbstractConfig
 
     private JCheckBox enabledCheckbox;
     private JCheckBox chckbxCenterAfterTest;
+    private JComboBox comboBoxPreRotate;
 
     public ReferenceBottomVisionPartConfigurationWizard(ReferenceBottomVision bottomVision,
             Part part) {
@@ -50,13 +53,22 @@ public class ReferenceBottomVisionPartConfigurationWizard extends AbstractConfig
         panel.setBorder(new TitledBorder(null, "General", TitledBorder.LEADING, TitledBorder.TOP,
                 null, null));
         contentPanel.add(panel);
-        panel.setLayout(new FormLayout(
-                new ColumnSpec[] {FormSpecs.RELATED_GAP_COLSPEC, ColumnSpec.decode("right:default"),
-                        FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,
-                        FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,},
-                new RowSpec[] {FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
-                        FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
-                        FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,}));
+        panel.setLayout(new FormLayout(new ColumnSpec[] {
+                FormSpecs.RELATED_GAP_COLSPEC,
+                ColumnSpec.decode("right:default"),
+                FormSpecs.RELATED_GAP_COLSPEC,
+                FormSpecs.DEFAULT_COLSPEC,
+                FormSpecs.RELATED_GAP_COLSPEC,
+                FormSpecs.DEFAULT_COLSPEC,},
+            new RowSpec[] {
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,}));
 
         JLabel lblEnabled = new JLabel("Enabled?");
         panel.add(lblEnabled, "2, 2");
@@ -70,17 +82,23 @@ public class ReferenceBottomVisionPartConfigurationWizard extends AbstractConfig
                 testAlignment();
             });
         });
+        
+        JLabel lblPrerotate = new JLabel("Pre-rotate");
+        panel.add(lblPrerotate, "2, 4, right, default");
+        
+        comboBoxPreRotate = new JComboBox(ReferenceBottomVision.PreRotateUsage.values());
+        panel.add(comboBoxPreRotate, "4, 4");
 
         JLabel lblTest = new JLabel("Test");
-        panel.add(lblTest, "2, 4");
-        panel.add(btnTestAlighment, "4, 4");
+        panel.add(lblTest, "2, 6");
+        panel.add(btnTestAlighment, "4, 6");
 
         chckbxCenterAfterTest = new JCheckBox("Center After Test");
         chckbxCenterAfterTest.setSelected(true);
-        panel.add(chckbxCenterAfterTest, "6, 4");
+        panel.add(chckbxCenterAfterTest, "6, 6");
 
         JLabel lblPipeline = new JLabel("Pipeline");
-        panel.add(lblPipeline, "2, 6");
+        panel.add(lblPipeline, "2, 8");
 
         JButton editPipelineButton = new JButton("Edit");
         editPipelineButton.addActionListener(new ActionListener() {
@@ -90,7 +108,7 @@ public class ReferenceBottomVisionPartConfigurationWizard extends AbstractConfig
                 });
             }
         });
-        panel.add(editPipelineButton, "4, 6");
+        panel.add(editPipelineButton, "4, 8");
 
         JButton btnLoadDefault = new JButton("Reset to Default");
         btnLoadDefault.addActionListener((e) -> {
@@ -105,7 +123,7 @@ public class ReferenceBottomVisionPartConfigurationWizard extends AbstractConfig
                 });
             }
         });
-        panel.add(btnLoadDefault, "6, 6");
+        panel.add(btnLoadDefault, "6, 8");
     }
 
     private void testAlignment() throws Exception {
@@ -198,5 +216,6 @@ public class ReferenceBottomVisionPartConfigurationWizard extends AbstractConfig
     @Override
     public void createBindings() {
         addWrappedBinding(partSettings, "enabled", enabledCheckbox, "selected");
+        addWrappedBinding(partSettings, "preRotateUsage", comboBoxPreRotate, "selectedItem");
     }
 }

--- a/src/main/java/org/openpnp/machine/reference/vision/wizards/ReferenceBottomVisionPartConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/vision/wizards/ReferenceBottomVisionPartConfigurationWizard.java
@@ -135,8 +135,8 @@ public class ReferenceBottomVisionPartConfigurationWizard extends AbstractConfig
         }
 
         // position the part over camera center
-        Location cameraLocation = VisionUtils.getBottomVisionCamera()
-                                             .getLocation();
+        Location cameraLocation = bottomVision.getCameraLocationAtPartHeight(part, 
+                VisionUtils.getBottomVisionCamera(), 0.);
 
         if (alignmentOffset.getPreRotated()) {
             // See https://github.com/openpnp/openpnp/pull/590 for explanations of the magic
@@ -146,7 +146,7 @@ public class ReferenceBottomVisionPartConfigurationWizard extends AbstractConfig
                                         .getLinearDistanceTo(0., 0.)) > 19.999) {
                 throw new Exception("Offset too big");
             }
-            nozzle.moveTo(nozzle.getLocation()
+            nozzle.moveTo(cameraLocation
                                 .subtractWithRotation(alignmentOffset.getLocation()));
             return;
         }
@@ -169,8 +169,7 @@ public class ReferenceBottomVisionPartConfigurationWizard extends AbstractConfig
         location = location.add(cameraLocation);
 
         // Subtract the bottom vision offsets to move the part to the final location,
-        // instead of
-        // the nozzle.
+        // instead of the nozzle.
         location = location.subtract(offsets);
 
         nozzle.moveTo(location);

--- a/src/main/java/org/openpnp/util/VisionUtils.java
+++ b/src/main/java/org/openpnp/util/VisionUtils.java
@@ -76,6 +76,23 @@ public class VisionUtils {
         return camera.getLocation().add(getPixelCenterOffsets(camera, x, y));
     }
 
+    /**
+     * Get an angle in the OpenPNP coordinate system from an angle in the camera pixel  
+     * coordinate system. 
+     * The angle needs to be sign reversed to reflect the fact that the Z and Y axis are sign reversed.
+     * OpenPNP uses a coordinate system with Z pointing towards the viewer, Y pointing up. OpenCV
+     * however uses one with Z pointing away from the viewer, Y pointing downwards. Right-handed
+     * rotation must be sign-reversed.   
+     * See {@link VisionUtils#getPixelCenterOffsets(Camera, double, double)}.
+     * 
+     * @param camera
+     * @param angle
+     * @return
+     */
+    public static double getPixelAngle(Camera camera, double angle) {
+        return -angle;
+    }
+    
     public static List<Location> sortLocationsByDistance(final Location origin,
             List<Location> locations) {
         // sort the results by distance from center ascending


### PR DESCRIPTION
# Description
The PR contains the following extensions and cleanup:
* Bottom Vision now stores the rotation offset in the `PartAlignmentOffset`. 
* The angle calculation is simplified with regard to [distributive modulo equivalences](https://en.wikipedia.org/wiki/Modulo_operation#Equivalences).
* pre-rotate BottomVision is done in a multi-pass loop until a good fix is obtained.
* X, Y offsets are obtained together with the rotation offset, so with a good fix only one vision pass is needed.
* X, Y offsets are therefore compensated for rotation.
* Maximum allowed linear and angular offsets can be configured (GUI).
* `angleNorm()` is used instead of duplicated code in `findOffsetsPostRotate()`
* a redundant `Location.derive()` is removed in `findOffsetsPostRotate()`

# Justification
By storing the rotation offset in the `PartAlignmentOffset` the rotation can be restored when the part is actually placed later. Today the proper rotation is only "stored" in the current C axis rotation. However this information is lost with shared C axis heads when another nozzle picks a second part before the first one has been placed. The PR also helps removing `Double.NaN` from driver workflows. In addition the "smart" multi-pass vision process speeds up bottom vision in most cases. It is now as fast as post-rotate bottom vision in all but the most challenging situations and more robust in the rest. 

See also:
BottomVision Pre-Rotate Fails on Shared C Heads
https://github.com/openpnp/openpnp/issues/599

Remove Double.NaN from Driver workflows
https://github.com/openpnp/openpnp/issues/255

# Instructions for Use
Enable bottom vision on a part and pre-rotate in "Machine Seup / ReferenceMachine / Vision / Bottom Vision". Configure the multi-pass vision criteria (more info in the tooltips):
![grafik](https://user-images.githubusercontent.com/9963310/56387688-45733180-6225-11e9-8e88-99bc08afd128.png)

# Implementation Details
1. Several testings were done in the meantime. Thank you to all the testers!
2. I did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. No changes were made in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. I did run `mvn test` before submitting the Pull Request. 

