### PR TITLE
Add NozzleTip.BeforeLoad and BeforeUnload events

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/ReferenceNozzle.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceNozzle.java
@@ -271,6 +271,19 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
             
             unloadNozzleTip();
             Logger.debug("{}.loadNozzleTip({}): Start", getName(), nozzleTip.getName());
+            
+            try {
+                Map<String, Object> globals = new HashMap<>();
+                globals.put("head", getHead());
+                globals.put("nozzle", this);
+                globals.put("nozzleTip", nt);
+                Configuration.get()
+                             .getScripting()
+                             .on("NozzleTip.BeforeLoad", globals);
+            }
+            catch (Exception e) {
+                Logger.warn(e);
+            }
 
             Logger.debug("{}.loadNozzleTip({}): moveTo Start Location",
                     new Object[] {getName(), nozzleTip.getName()});
@@ -322,6 +335,19 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
         
         Logger.debug("{}.unloadNozzleTip(): Start", getName());
         ReferenceNozzleTip nt = (ReferenceNozzleTip) nozzleTip;
+
+        try {
+            Map<String, Object> globals = new HashMap<>();
+            globals.put("head", getHead());
+            globals.put("nozzle", this);
+            globals.put("nozzleTip", nt);
+            Configuration.get()
+                         .getScripting()
+                         .on("NozzleTip.BeforeUnload", globals);
+        }
+        catch (Exception e) {
+            Logger.warn(e);
+        }
 
         Logger.debug("{}.unloadNozzleTip(): moveTo End Location", getName());
         MovableUtils.moveToLocationAtSafeZ(this, nt.getChangerEndLocation(), speed);


### PR DESCRIPTION
# Description
Add scripting events NozzleTip.BeforeLoad and NozzleTip.BeforeUnload

# Justification
Script events before loads/unloads allows full access to the nozzle change process and can be used to adjust behavior as needed. 

# Instructions for Use
Add NozzleTip.BeforeLoad.js and/or NozzleTip.BeforeUnload.js to the Events directory.

# Implementation Details
Tested by forcing nozzle changes, both with and without scripts in the Events directory.

mvn test run was clean and without errors.
