### PR TITLE
Feature/keyevents

### DIFF
--- a/src/main/java/org/openpnp/gui/MainFrame.java
+++ b/src/main/java/org/openpnp/gui/MainFrame.java
@@ -144,6 +144,7 @@ public class MainFrame extends JFrame {
     private MachineSetupPanel machineSetupPanel;
     private JDialog frameCamera;
     private JDialog frameMachineControls;
+    private Map<KeyStroke, Action> hotkeyActionMap;
 
     public static MainFrame get() {
         return mainFrame;
@@ -195,6 +196,10 @@ public class MainFrame extends JFrame {
 
     public JTabbedPane getTabs() {
         return tabs;
+    }
+
+    public Map<KeyStroke, Action> getHotkeyActionMap() {
+        return hotkeyActionMap;
     }
 
     private Preferences prefs = Preferences.userNodeForPackage(MainFrame.class);
@@ -421,7 +426,7 @@ public class MainFrame extends JFrame {
         panelMachine.setLayout(new BorderLayout(0, 0));
 
         // Add global hotkeys for the arrow keys
-        final Map<KeyStroke, Action> hotkeyActionMap = new HashMap<>();
+        hotkeyActionMap = new HashMap<>();
 
         int mask = KeyEvent.CTRL_DOWN_MASK;
 

--- a/src/main/java/org/openpnp/gui/ScriptAction.java
+++ b/src/main/java/org/openpnp/gui/ScriptAction.java
@@ -1,0 +1,32 @@
+package org.openpnp.gui;
+
+import java.awt.event.ActionEvent;
+import java.util.Map;
+import java.util.HashMap;
+
+import javax.swing.AbstractAction;
+
+import org.openpnp.model.Configuration;
+import org.pmw.tinylog.Logger;
+
+@SuppressWarnings("serial")
+public class ScriptAction extends AbstractAction{
+
+    public ScriptAction(String eventName) {
+        this.eventName = eventName;
+    }
+    private String eventName;
+
+    @Override
+    public void actionPerformed(ActionEvent arg0) {
+        try {
+            Map<String, Object> globals = new HashMap<>();
+            Configuration.get()
+                        .getScripting()
+                        .on(this.eventName, globals);
+        }
+        catch (Exception e) {
+            Logger.warn(e);
+        }
+    }
+}


### PR DESCRIPTION
# Description
This change makes it possible for scripts to bind key press events to scripts. Two changes are made:

- Expose hotkeyActionMap. Once exposed we can add our own hotkey:actions.
- Add ScriptAction class. This allows us to create action objects that will execute scripting events.

With both of those things available scripts like 'Startup' can create keybinds for any script in the event directory.

# Justification
Allows another layer of customization. An example might be to bind machine actions like vacuum on/off, etc to hotkeys.

# Instructions for Use

Add keybinds in a script- for example in 'Startup.py':
```python
from javax.script import ScriptEngineManager
from javax.swing import KeyStroke
from java.awt.event import KeyEvent
from org.openpnp.gui import ScriptAction

actionMap = gui.getHotkeyActionMap()
hotKey = KeyStroke.getKeyStroke(KeyEvent.VK_T, KeyEvent.CTRL_DOWN_MASK)
actionMap[hotKey] = ScriptAction('MyCustomEvent')
```

Create a script in the Events directory that will be called: 'MyCustomEvent.py'
```python
print("MyCustomEvent was run!")
```
# Implementation Details
Ran with and without various scripting files in place. mvn test passed without issue.