### PR TITLE
Initialize CVPipelineEditor with last stage selected and stage grid focused

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/feeder/wizards/AdvancedLoosePartFeederConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/wizards/AdvancedLoosePartFeederConfigurationWizard.java
@@ -19,7 +19,6 @@
 
 package org.openpnp.machine.reference.feeder.wizards;
 
-import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.FlowLayout;
 import java.awt.Font;
@@ -39,6 +38,7 @@ import org.openpnp.model.Configuration;
 import org.openpnp.util.UiUtils;
 import org.openpnp.vision.pipeline.CvPipeline;
 import org.openpnp.vision.pipeline.ui.CvPipelineEditor;
+import org.openpnp.vision.pipeline.ui.CvPipelineEditorDialog;
 
 import com.jgoodies.forms.layout.ColumnSpec;
 import com.jgoodies.forms.layout.FormLayout;
@@ -108,12 +108,9 @@ public class AdvancedLoosePartFeederConfigurationWizard
         pipeline.setProperty("camera", Configuration.get().getMachine().getDefaultHead().getDefaultCamera());
         pipeline.setProperty("feeder", feeder);
         CvPipelineEditor editor = new CvPipelineEditor(pipeline);
-        JDialog dialog = new JDialog(MainFrame.get(), feeder.getPart().getId() + " Pipeline");
-        dialog.getContentPane().setLayout(new BorderLayout());
-        dialog.getContentPane().add(editor);
-        dialog.setSize(1024, 768);
+        JDialog dialog = new CvPipelineEditorDialog(MainFrame.get(), feeder.getPart().getId() + " Pipeline", editor);
         dialog.setVisible(true);
-    }
+}
 
     private void resetPipeline() {
         feeder.resetPipeline();
@@ -124,10 +121,7 @@ public class AdvancedLoosePartFeederConfigurationWizard
         pipeline.setProperty("camera", Configuration.get().getMachine().getDefaultHead().getDefaultCamera());
         pipeline.setProperty("feeder", feeder);
         CvPipelineEditor editor = new CvPipelineEditor(pipeline);
-        JDialog dialog = new JDialog(MainFrame.get(), feeder.getPart().getId() + " Training Pipeline");
-        dialog.getContentPane().setLayout(new BorderLayout());
-        dialog.getContentPane().add(editor);
-        dialog.setSize(1024, 768);
+        JDialog dialog = new CvPipelineEditorDialog(MainFrame.get(), feeder.getPart().getId() + " Training Pipeline", editor);
         dialog.setVisible(true);
     }
 

--- a/src/main/java/org/openpnp/machine/reference/feeder/wizards/ReferenceLoosePartFeederConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/wizards/ReferenceLoosePartFeederConfigurationWizard.java
@@ -19,7 +19,6 @@
 
 package org.openpnp.machine.reference.feeder.wizards;
 
-import java.awt.BorderLayout;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 
@@ -34,6 +33,7 @@ import org.openpnp.model.Configuration;
 import org.openpnp.util.UiUtils;
 import org.openpnp.vision.pipeline.CvPipeline;
 import org.openpnp.vision.pipeline.ui.CvPipelineEditor;
+import org.openpnp.vision.pipeline.ui.CvPipelineEditorDialog;
 
 import com.jgoodies.forms.layout.ColumnSpec;
 import com.jgoodies.forms.layout.FormLayout;
@@ -91,12 +91,9 @@ public class ReferenceLoosePartFeederConfigurationWizard
         pipeline.setProperty("camera", Configuration.get().getMachine().getDefaultHead().getDefaultCamera());
         pipeline.setProperty("feeder", feeder);
         CvPipelineEditor editor = new CvPipelineEditor(pipeline);
-        JDialog dialog = new JDialog(MainFrame.get(), feeder.getPart().getId() + " Pipeline");
-        dialog.getContentPane().setLayout(new BorderLayout());
-        dialog.getContentPane().add(editor);
-        dialog.setSize(1024, 768);
+        JDialog dialog = new CvPipelineEditorDialog(MainFrame.get(), feeder.getPart().getId() + " Pipeline", editor);
         dialog.setVisible(true);
-    }
+}
 
     private void resetPipeline() {
         feeder.resetPipeline();

--- a/src/main/java/org/openpnp/machine/reference/feeder/wizards/ReferenceStripFeederConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/wizards/ReferenceStripFeederConfigurationWizard.java
@@ -19,7 +19,6 @@
 
 package org.openpnp.machine.reference.feeder.wizards;
 
-import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
@@ -80,6 +79,7 @@ import org.openpnp.vision.Ransac;
 import org.openpnp.vision.pipeline.CvPipeline;
 import org.openpnp.vision.pipeline.CvStage;
 import org.openpnp.vision.pipeline.ui.CvPipelineEditor;
+import org.openpnp.vision.pipeline.ui.CvPipelineEditorDialog;
 import org.pmw.tinylog.Logger;
 
 import com.google.common.collect.Lists;
@@ -896,10 +896,7 @@ public class ReferenceStripFeederConfigurationWizard extends AbstractConfigurati
         Camera camera = Configuration.get().getMachine().getDefaultHead().getDefaultCamera();
         CvPipeline pipeline = getCvPipeline(camera, false);
         CvPipelineEditor editor = new CvPipelineEditor(pipeline);
-        JDialog dialog = new JDialog(MainFrame.get(), feeder.getName() + " Pipeline");
-        dialog.getContentPane().setLayout(new BorderLayout());
-        dialog.getContentPane().add(editor);
-        dialog.setSize(1024, 768);
+        JDialog dialog = new CvPipelineEditorDialog(MainFrame.get(), feeder.getName() + " Pipeline", editor);
         dialog.setVisible(true);
     }
 

--- a/src/main/java/org/openpnp/machine/reference/vision/wizards/ReferenceBottomVisionConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/vision/wizards/ReferenceBottomVisionConfigurationWizard.java
@@ -1,6 +1,5 @@
 package org.openpnp.machine.reference.vision.wizards;
 
-import java.awt.BorderLayout;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 
@@ -28,6 +27,7 @@ import org.openpnp.util.UiUtils;
 import org.openpnp.util.VisionUtils;
 import org.openpnp.vision.pipeline.CvPipeline;
 import org.openpnp.vision.pipeline.ui.CvPipelineEditor;
+import org.openpnp.vision.pipeline.ui.CvPipelineEditorDialog;
 
 import com.jgoodies.forms.layout.ColumnSpec;
 import com.jgoodies.forms.layout.FormLayout;
@@ -180,14 +180,9 @@ public class ReferenceBottomVisionConfigurationWizard extends AbstractConfigurat
         pipeline.setProperty("camera", VisionUtils.getBottomVisionCamera());
 		pipeline.setProperty("nozzle", MainFrame.get().getMachineControls().getSelectedNozzle());
         CvPipelineEditor editor = new CvPipelineEditor(pipeline);
-        JDialog dialog = new JDialog(MainFrame.get(), "Bottom Vision Pipeline");
-        dialog.getContentPane()
-              .setLayout(new BorderLayout());
-        dialog.getContentPane()
-              .add(editor);
-        dialog.setSize(1024, 768);
+        JDialog dialog = new CvPipelineEditorDialog(MainFrame.get(), "Bottom Vision Pipeline", editor);
         dialog.setVisible(true);
-    }
+}
 
     @Override
     public String getWizardName() {

--- a/src/main/java/org/openpnp/machine/reference/vision/wizards/ReferenceBottomVisionPartConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/vision/wizards/ReferenceBottomVisionPartConfigurationWizard.java
@@ -1,6 +1,5 @@
 package org.openpnp.machine.reference.vision.wizards;
 
-import java.awt.BorderLayout;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 
@@ -27,6 +26,7 @@ import org.openpnp.util.UiUtils;
 import org.openpnp.util.VisionUtils;
 import org.openpnp.vision.pipeline.CvPipeline;
 import org.openpnp.vision.pipeline.ui.CvPipelineEditor;
+import org.openpnp.vision.pipeline.ui.CvPipelineEditorDialog;
 
 import com.jgoodies.forms.layout.ColumnSpec;
 import com.jgoodies.forms.layout.FormLayout;
@@ -199,14 +199,9 @@ public class ReferenceBottomVisionPartConfigurationWizard extends AbstractConfig
 		pipeline.setProperty("nozzle", MainFrame.get().getMachineControls().getSelectedNozzle());
 
         CvPipelineEditor editor = new CvPipelineEditor(pipeline);
-        JDialog dialog = new JDialog(MainFrame.get(), "Bottom Vision Pipeline");
-        dialog.getContentPane()
-              .setLayout(new BorderLayout());
-        dialog.getContentPane()
-              .add(editor);
-        dialog.setSize(1024, 768);
+        JDialog dialog = new CvPipelineEditorDialog(MainFrame.get(), "Bottom Vision Pipeline", editor);
         dialog.setVisible(true);
-    }
+}
 
     @Override
     public String getWizardName() {

--- a/src/main/java/org/openpnp/machine/reference/vision/wizards/ReferenceFiducialLocatorConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/vision/wizards/ReferenceFiducialLocatorConfigurationWizard.java
@@ -1,6 +1,5 @@
 package org.openpnp.machine.reference.vision.wizards;
 
-import java.awt.BorderLayout;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.image.BufferedImage;
@@ -31,6 +30,7 @@ import org.openpnp.util.UiUtils;
 import org.openpnp.vision.pipeline.CvPipeline;
 import org.openpnp.vision.pipeline.stages.SetResult;
 import org.openpnp.vision.pipeline.ui.CvPipelineEditor;
+import org.openpnp.vision.pipeline.ui.CvPipelineEditorDialog;
 
 import com.jgoodies.forms.layout.ColumnSpec;
 import com.jgoodies.forms.layout.FormLayout;
@@ -138,12 +138,9 @@ public class ReferenceFiducialLocatorConfigurationWizard extends AbstractConfigu
         pipeline.setProperty("package", defaultPart.getPackage());
         pipeline.setProperty("footprint", defaultPart.getPackage().getFootprint());
         CvPipelineEditor editor = new CvPipelineEditor(pipeline);
-        JDialog dialog = new JDialog(MainFrame.get(), "Fiducial Locator Pipeline");
-        dialog.getContentPane().setLayout(new BorderLayout());
-        dialog.getContentPane().add(editor);
-        dialog.setSize(1024, 768);
+        JDialog dialog = new CvPipelineEditorDialog(MainFrame.get(), "Fiducial Locator Pipeline", editor);
         dialog.setVisible(true);
-    }
+}
 
     private static Part createDefaultPart() {
         Pad pad = new Pad();

--- a/src/main/java/org/openpnp/machine/reference/vision/wizards/ReferenceFiducialLocatorPartConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/vision/wizards/ReferenceFiducialLocatorPartConfigurationWizard.java
@@ -94,7 +94,6 @@ public class ReferenceFiducialLocatorPartConfigurationWizard extends AbstractCon
         CvPipelineEditor editor = new CvPipelineEditor(pipeline);
         JDialog dialog = new CvPipelineEditorDialog(MainFrame.get(), "Fiducial Locator Pipeline", editor);
         dialog.setVisible(true);
-        editor.initializeFocus();
     }
 
     @Override

--- a/src/main/java/org/openpnp/machine/reference/vision/wizards/ReferenceFiducialLocatorPartConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/vision/wizards/ReferenceFiducialLocatorPartConfigurationWizard.java
@@ -1,6 +1,5 @@
 package org.openpnp.machine.reference.vision.wizards;
 
-import java.awt.BorderLayout;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.image.BufferedImage;
@@ -24,6 +23,7 @@ import org.openpnp.util.UiUtils;
 import org.openpnp.vision.pipeline.CvPipeline;
 import org.openpnp.vision.pipeline.stages.SetResult;
 import org.openpnp.vision.pipeline.ui.CvPipelineEditor;
+import org.openpnp.vision.pipeline.ui.CvPipelineEditorDialog;
 
 import com.jgoodies.forms.layout.ColumnSpec;
 import com.jgoodies.forms.layout.FormLayout;
@@ -92,12 +92,11 @@ public class ReferenceFiducialLocatorPartConfigurationWizard extends AbstractCon
         pipeline.setProperty("package", part.getPackage());
         pipeline.setProperty("footprint", part.getPackage().getFootprint());
         CvPipelineEditor editor = new CvPipelineEditor(pipeline);
-        JDialog dialog = new JDialog(MainFrame.get(), "Fiducial Locator Pipeline");
-        dialog.getContentPane().setLayout(new BorderLayout());
-        dialog.getContentPane().add(editor);
-        dialog.setSize(1024, 768);
+        JDialog dialog = new CvPipelineEditorDialog(MainFrame.get(), "Fiducial Locator Pipeline", editor);
         dialog.setVisible(true);
+        editor.initializeFocus();
     }
+
     @Override
     public void createBindings() {
     }

--- a/src/main/java/org/openpnp/machine/reference/wizards/ReferenceNozzleTipCalibrationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/wizards/ReferenceNozzleTipCalibrationWizard.java
@@ -19,7 +19,6 @@
 
 package org.openpnp.machine.reference.wizards;
 
-import java.awt.BorderLayout;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 
@@ -51,6 +50,7 @@ import org.openpnp.util.UiUtils;
 import org.openpnp.util.VisionUtils;
 import org.openpnp.vision.pipeline.CvPipeline;
 import org.openpnp.vision.pipeline.ui.CvPipelineEditor;
+import org.openpnp.vision.pipeline.ui.CvPipelineEditorDialog;
 
 import com.jgoodies.forms.layout.CellConstraints;
 import com.jgoodies.forms.layout.ColumnSpec;
@@ -241,14 +241,9 @@ public class ReferenceNozzleTipCalibrationWizard extends AbstractConfigurationWi
         CvPipeline pipeline = nozzleTip.getCalibration()
                                        .getPipeline();
         CvPipelineEditor editor = new CvPipelineEditor(pipeline);
-        JDialog dialog = new JDialog(MainFrame.get(), "Calibration Pipeline");
-        dialog.getContentPane()
-              .setLayout(new BorderLayout());
-        dialog.getContentPane()
-              .add(editor);
-        dialog.setSize(1024, 768);
+        JDialog dialog = new CvPipelineEditorDialog(MainFrame.get(), "Calibration Pipeline", editor);
         dialog.setVisible(true);
-    }
+}
 
     private void calibrate() {
         UiUtils.submitUiMachineTask(() -> {

--- a/src/main/java/org/openpnp/machine/reference/wizards/ReferenceNozzleTipConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/wizards/ReferenceNozzleTipConfigurationWizard.java
@@ -19,7 +19,6 @@
 
 package org.openpnp.machine.reference.wizards;
 
-import java.awt.BorderLayout;
 import java.awt.event.ActionEvent;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -60,6 +59,7 @@ import org.openpnp.util.UiUtils;
 import org.openpnp.util.VisionUtils;
 import org.openpnp.vision.pipeline.CvPipeline;
 import org.openpnp.vision.pipeline.ui.CvPipelineEditor;
+import org.openpnp.vision.pipeline.ui.CvPipelineEditorDialog;
 
 import com.jgoodies.forms.layout.CellConstraints;
 import com.jgoodies.forms.layout.ColumnSpec;
@@ -397,10 +397,7 @@ public class ReferenceNozzleTipConfigurationWizard extends AbstractConfiguration
     private void editCalibrationPipeline() throws Exception {
         CvPipeline pipeline = nozzleTip.getCalibration().getPipeline();
         CvPipelineEditor editor = new CvPipelineEditor(pipeline);
-        JDialog dialog = new JDialog(MainFrame.get(), "Calibration Pipeline");
-        dialog.getContentPane().setLayout(new BorderLayout());
-        dialog.getContentPane().add(editor);
-        dialog.setSize(1024, 768);
+        JDialog dialog = new CvPipelineEditorDialog(MainFrame.get(), "Calibration Pipeline", editor);
         dialog.setVisible(true);
     }
 

--- a/src/main/java/org/openpnp/vision/pipeline/ui/CvPipelineEditor.java
+++ b/src/main/java/org/openpnp/vision/pipeline/ui/CvPipelineEditor.java
@@ -149,21 +149,25 @@ public class CvPipelineEditor extends JPanel {
         inputAndOutputSplitPane.setContinuousLayout(true);
         add(inputAndOutputSplitPane, BorderLayout.CENTER);
 
-        pipelinePanel = new PipelinePanel(this);
-        inputAndOutputSplitPane.setLeftComponent(pipelinePanel);
         resultsPanel = new ResultsPanel(this);
         inputAndOutputSplitPane.setRightComponent(resultsPanel);
-
+        pipelinePanel = new PipelinePanel(this);
+        inputAndOutputSplitPane.setLeftComponent(pipelinePanel);
+        
         addHierarchyListener(new HierarchyListener() {
             @Override
             public void hierarchyChanged(HierarchyEvent e) {
                 inputAndOutputSplitPane.setDividerLocation(0.25);
             }
         });
-
+        
         process();
     }
-
+    
+    public void initializeFocus() {
+        pipelinePanel.initializeFocus();    	
+    }
+    
     public CvPipeline getPipeline() {
         return pipeline;
     }

--- a/src/main/java/org/openpnp/vision/pipeline/ui/CvPipelineEditorDialog.java
+++ b/src/main/java/org/openpnp/vision/pipeline/ui/CvPipelineEditorDialog.java
@@ -1,0 +1,24 @@
+package org.openpnp.vision.pipeline.ui;
+
+import java.awt.BorderLayout;
+import java.awt.Frame;
+
+import javax.swing.JDialog;
+import org.openpnp.vision.pipeline.ui.CvPipelineEditor;
+
+public class CvPipelineEditorDialog extends JDialog {
+private CvPipelineEditor editor;
+
+public CvPipelineEditorDialog(Frame owner, String title, CvPipelineEditor editor) {
+	super(owner, title);
+	getContentPane().setLayout(new BorderLayout());
+    getContentPane().add(editor);
+    setSize(1024, 768);    
+    this.editor = editor;
+}
+
+public void setVisible(boolean b) {
+	super.setVisible(b);
+	editor.initializeFocus();
+}
+}

--- a/src/main/java/org/openpnp/vision/pipeline/ui/PipelinePanel.java
+++ b/src/main/java/org/openpnp/vision/pipeline/ui/PipelinePanel.java
@@ -2,14 +2,11 @@ package org.openpnp.vision.pipeline.ui;
 
 import java.awt.BorderLayout;
 import java.awt.Dimension;
-import java.awt.Rectangle;
 import java.awt.Toolkit;
 import java.awt.datatransfer.Clipboard;
 import java.awt.datatransfer.DataFlavor;
 import java.awt.datatransfer.StringSelection;
 import java.awt.event.ActionEvent;
-import java.awt.event.HierarchyEvent;
-import java.awt.event.HierarchyListener;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.util.ArrayList;
@@ -18,7 +15,6 @@ import java.util.List;
 
 import javax.swing.AbstractAction;
 import javax.swing.Action;
-import javax.swing.BoxLayout;
 import javax.swing.DropMode;
 import javax.swing.JButton;
 import javax.swing.JEditorPane;
@@ -148,12 +144,17 @@ public class PipelinePanel extends JPanel {
                 }
             }
         });
-
+        stagesTable.changeSelection(stagesTable.getRowCount()-1,  0,  false, false);
+          
         splitPaneMain.setLeftComponent(splitPaneStages);
         splitPaneMain.setRightComponent(propertySheetPanel);
         
         splitPaneMain.setResizeWeight(0.5);
         splitPaneStages.setResizeWeight(0.80);
+    }
+    
+    public void initializeFocus() {
+    	stagesTable.grabFocus();
     }
 
     public void onStagePropertySheetValueChanged(Object aValue, int row, int column) {
@@ -170,6 +171,7 @@ public class PipelinePanel extends JPanel {
         editor.process();
     }
     
+   
     private void refreshProperties() {
         CvStage stage = getSelectedStage();
         if (stage == null) {


### PR DESCRIPTION
# Description
Initialize CVPipelineEditor with last stage selected and stage grid focused

# Justification
User see immediately the result of the pipeline.
He can immediately navigate through stages using up/down arrow keys.

# Instructions for Use
Open any pipeline editor, press up/down keys.

This is documentation for a user, not for a developer.

# Implementation Details
1. How did you test the change? Be descriptive. Untested code will not be accepted.
Manual tests.
Mini refactored the actual code to remove redundant parametering of the dialog.

2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)?
Yes ! love them.

3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing.
No

4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted.
