### PR TITLE
open csv file as ISO-8859-1 to allow the use of 8 bits ascii char.

### DIFF
--- a/src/main/java/org/openpnp/gui/importer/NamedCSVImporter.java
+++ b/src/main/java/org/openpnp/gui/importer/NamedCSVImporter.java
@@ -267,7 +267,7 @@ public class NamedCSVImporter implements BoardImporter {
     private static List<Placement> parseFile(File file, boolean createMissingParts,
             boolean updateHeights) throws Exception {
         BufferedReader reader =
-                new BufferedReader(new InputStreamReader(new FileInputStream(file)));
+                new BufferedReader(new InputStreamReader(new FileInputStream(file), "ISO-8859-1"));
         ArrayList<Placement> placements = new ArrayList<>();
         String line;
 


### PR DESCRIPTION
# Description and justification
Users may use extended ascii char. In particular the µ char for µF.
As a result the µ char is not correctly rendered in the gui:

![image](https://user-images.githubusercontent.com/11025667/57789175-b03a5e80-7738-11e9-9f4b-5500164902e8.png)

Current implementation opens csv file as 7bits ascii file (US-ASCII).
Switching to ISO-8859-1 does not change anything for people using only 7bits chars but allows the µ char to be displayed as it should:

![image](https://user-images.githubusercontent.com/11025667/57789284-e1b32a00-7738-11e9-94b7-3a0971850b57.png)


# Implementation Details
1. How did you test the change? Be descriptive. Untested code will not be accepted.
Imported files with µ char in.
