### PR TITLE
Correct logic in maskHsv when hueMin is less than hueMax

### DIFF
--- a/src/main/java/org/openpnp/vision/pipeline/stages/MaskHsv.java
+++ b/src/main/java/org/openpnp/vision/pipeline/stages/MaskHsv.java
@@ -104,8 +104,8 @@ public class MaskHsv extends CvStage {
         }
         else {
             //Hue range wraps past 255 back through 0 so the mask needs to include the range from hueMin
-            //to 255 in addition to the range from 0 to hueMax so a mask for each separate range is created
-            //and ORed together to form the actual mask.
+            //to 255 in addition to the range from 0 to hueMax.  To accomplish this, a mask for each separate
+            //range is created and then ORed together to form the actual mask.
             min = new Scalar(hueMin, saturationMin, valueMin);
             max = new Scalar(255, saturationMax, valueMax);
             Core.inRange(mat, min, max, mask);

--- a/src/main/java/org/openpnp/vision/pipeline/stages/MaskHsv.java
+++ b/src/main/java/org/openpnp/vision/pipeline/stages/MaskHsv.java
@@ -8,27 +8,34 @@ import org.opencv.core.Scalar;
 import org.openpnp.vision.FluentCv;
 import org.openpnp.vision.pipeline.CvPipeline;
 import org.openpnp.vision.pipeline.CvStage;
+import org.openpnp.vision.pipeline.Property;
 import org.openpnp.vision.pipeline.Stage;
 import org.simpleframework.xml.Attribute;
 
 @Stage(description="Remove color from an image based on the HSV color space. Pixels that fall between (hueMin, saturationMin, valueMin) and (hueMax, saturationMax, valueMax) are set to black in the output image. This stage expects the input to be in HSV_FULL format, so you should do a ConvertColor with Bgr2HsvFull before this stage and ConvertColor Hsv2BgrFull after. These are not applied internally as to not complicate the use of multiple instances of this stage in series. Note that this stage can be used with any 3 channel, 8 bit per channel color space. The order of the filtered channels is hue, saturation, value, but you can use these ranges for other channels.")
 public class MaskHsv extends CvStage {
     @Attribute
+    @Property(description="First hue to be masked.  Note hues range from 0 to 255 (inclusive) but in a circular fashion so that 255 is directly adjacent to 0 (as 359 degrees is adjacent to 0 degrees).  To mask hues that cross the 255-0 boundary, set hueMin greater than hueMax.  As a rough guide, yellows fall in the range 21 to 64, greens 64 to 107, cyans 107 to 149, blues 149 to 192, magentas 192 to 235, and reds 235 to 21.")
     private int hueMin = 31;
 
     @Attribute
+    @Property(description="Last hue to be masked.  Note hues range from 0 to 255 (inclusive) but in a circular fashion so that 255 is directly adjacent to 0 (as 359 degrees is adjacent to 0 degrees).  To mask hues that cross the 255-0 boundary, set hueMin greater than hueMax.  As a rough guide, yellows fall in the range 21 to 64, greens 64 to 107, cyans 107 to 149, blues 149 to 192, magentas 192 to 235, and reds 235 to 21.")
     private int hueMax = 116;
 
     @Attribute
+    @Property(description="Minimum saturation to be masked.  Note saturations range from 0 to 255 (inclusive). Setting saturationMin greater than saturationMax will result in no pixels being masked.")
     private int saturationMin = 0;
 
     @Attribute
+    @Property(description="Maximum saturation to be masked.  Note saturations range from 0 to 255 (inclusive). Setting saturationMax less than saturationMin will result in no pixels being masked.")
     private int saturationMax = 255;
 
     @Attribute
+    @Property(description="Minimum value to be masked.  Note values range from 0 to 255 (inclusive). Setting valueMin greater than valueMax will result in no pixels being masked.")
     private int valueMin = 0;
 
     @Attribute
+    @Property(description="Maximum value to be masked.  Note values range from 0 to 255 (inclusive). Setting valueMax less than valueMin will result in no pixels being masked.")
     private int valueMax = 255;
 
     public int getHueMin() {
@@ -93,16 +100,28 @@ public class MaskHsv extends CvStage {
         if (hueMin <= hueMax) {
             min = new Scalar(hueMin, saturationMin, valueMin);
             max = new Scalar(hueMax, saturationMax, valueMax);
+            Core.inRange(mat, min, max, mask);
         }
         else {
-            min = new Scalar(hueMax, saturationMin, valueMin);
-            max = new Scalar(hueMin, saturationMax, valueMax);
+            //Hue range wraps past 255 back through 0 so the mask needs to include the range from hueMin
+            //to 255 in addition to the range from 0 to hueMax so a mask for each separate range is created
+            //and ORed together to form the actual mask.
+            min = new Scalar(hueMin, saturationMin, valueMin);
+            max = new Scalar(255, saturationMax, valueMax);
+            Core.inRange(mat, min, max, mask);
+            
+            Mat mask2 = mask.clone();
+            mask2.setTo(color);
+            min = new Scalar(0, saturationMin, valueMin);
+            max = new Scalar(hueMax, saturationMax, valueMax);
+            Core.inRange(mat, min, max, mask2);
+            
+            Core.bitwise_or(mask, mask2, mask);
         }
-        Core.inRange(mat, min, max, mask);
 
-        if (hueMin <= hueMax) {
-            Core.bitwise_not(mask, mask);
-        }
+        //The mask is inverted because it is used to copy the unmasked portions of the
+        //image into the final result.
+        Core.bitwise_not(mask, mask);
 
         mat.copyTo(masked, mask);
         return new Result(masked);

--- a/src/main/resources/org/openpnp/machine/reference/feeder/AdvancedLoosePartFeeder-DefaultPipeline.xml
+++ b/src/main/resources/org/openpnp/machine/reference/feeder/AdvancedLoosePartFeeder-DefaultPipeline.xml
@@ -5,7 +5,7 @@
       <cv-stage class="org.openpnp.vision.pipeline.stages.BlurGaussian" name="1" enabled="true" kernel-size="19"/>
       <cv-stage class="org.openpnp.vision.pipeline.stages.ConvertColor" name="19" enabled="true" conversion="Bgr2HsvFull"/>
       <cv-stage class="org.openpnp.vision.pipeline.stages.Normalize" name="2" enabled="true"/>
-      <cv-stage class="org.openpnp.vision.pipeline.stages.MaskHsv" name="3" enabled="true" hue-min="89" hue-max="115" saturation-min="20" saturation-max="95" value-min="50" value-max="130"/>
+      <cv-stage class="org.openpnp.vision.pipeline.stages.MaskHsv" name="3" enabled="true" hue-min="89" hue-max="115" saturation-min="20" saturation-max="95" value-min="50" value-max="130" invert="false"/>
       <cv-stage class="org.openpnp.vision.pipeline.stages.ConvertColor" name="4" enabled="true" conversion="Bgr2Gray"/>
       <cv-stage class="org.openpnp.vision.pipeline.stages.Threshold" name="5" enabled="true" threshold="8" auto="false" invert="false"/>
       <cv-stage class="org.openpnp.vision.pipeline.stages.FindContours" name="6" enabled="true" retrieval-mode="List" approximation-method="None"/>

--- a/src/main/resources/org/openpnp/machine/reference/feeder/AdvancedLoosePartFeeder-DefaultTrainingPipeline.xml
+++ b/src/main/resources/org/openpnp/machine/reference/feeder/AdvancedLoosePartFeeder-DefaultTrainingPipeline.xml
@@ -6,7 +6,7 @@
       <cv-stage class="org.openpnp.vision.pipeline.stages.BlurGaussian" name="2" enabled="true" kernel-size="5"/>
       <cv-stage class="org.openpnp.vision.pipeline.stages.ConvertColor" name="3" enabled="true" conversion="Bgr2HsvFull"/>
       <cv-stage class="org.openpnp.vision.pipeline.stages.Normalize" name="4" enabled="true"/>
-      <cv-stage class="org.openpnp.vision.pipeline.stages.MaskHsv" name="5" enabled="true" hue-min="90" hue-max="120" saturation-min="45" saturation-max="100" value-min="45" value-max="120"/>
+      <cv-stage class="org.openpnp.vision.pipeline.stages.MaskHsv" name="5" enabled="true" hue-min="90" hue-max="120" saturation-min="45" saturation-max="100" value-min="45" value-max="120" invert="false"/>
       <cv-stage class="org.openpnp.vision.pipeline.stages.ConvertColor" name="6" enabled="true" conversion="Bgr2Gray"/>
       <cv-stage class="org.openpnp.vision.pipeline.stages.Threshold" name="7" enabled="true" threshold="80" auto="true" invert="false"/>
       <cv-stage class="org.openpnp.vision.pipeline.stages.FindContours" name="8" enabled="true" retrieval-mode="List" approximation-method="None"/>

--- a/src/main/resources/org/openpnp/machine/reference/vision/ReferenceBottomVision-DefaultPipeline.xml
+++ b/src/main/resources/org/openpnp/machine/reference/vision/ReferenceBottomVision-DefaultPipeline.xml
@@ -12,7 +12,7 @@
 			name="1" enabled="true" conversion="Bgr2HsvFull" />
 		<cv-stage class="org.openpnp.vision.pipeline.stages.MaskHsv"
 			name="2" enabled="true" hue-min="60" hue-max="130" saturation-min="0"
-			saturation-max="255" value-min="0" value-max="255" />
+			saturation-max="255" value-min="0" value-max="255" invert="false" />
 		<cv-stage class="org.openpnp.vision.pipeline.stages.ConvertColor"
 			name="3" enabled="true" conversion="Hsv2BgrFull" />
 		<cv-stage class="org.openpnp.vision.pipeline.stages.ConvertColor"


### PR DESCRIPTION
Description:
Since hue is a circular quantity it is perfectly reasonable to mask hues that cross the 255 - 0 boundary.  For instance, red hues range roughly from 235 through 21 (passing through the 255 - 0 boundary).  To mask such a range, the user would enter a hueMin (235) that is greater than hueMax (21).  Unfortunately the logic in mashHsv is incorrect in that case.  While it does correctly mask the desired hue range under that condition, the logic for masking saturation and value get inverted so that the returned image only contains pixels that have saturations and values that are in the range that should have been masked.

The fix to this problem is to create two masks, one for the hueMin to 255 range and one for the 0 to hueMax range, OR them together and then proceeding as in the case where hueMin < hueMax.

While I was in there, I also added descriptions to each of the parameters to maskHsv.

Justification:
Fixes a bug that makes the result of maskHsv incorrect and difficult to understand by the user (under some conditions).

Instructions for Use:
No special instructions - just use maskHsv in the pipeline as normal and it will work exactly the same as before when hueMin < hueMax and will return correct results when hueMin > hueMax

Implementation Details:
This change was tested by placing objects of various colors (read, green, and blue) in the camera's field of view and trying to mask them individually.  Prior to this change, attempting to mask red hues would result in many other parts of the image being masked incorrectly.
  
The coding style was followed.

No changes were made in the org.openpnp.spi or org.openpnp.model packages.

Maven test was run and passed.