### PR TITLE
Feature/Independant Valve Switching for Nozzle.isPartOff()

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/ReferenceNozzle.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceNozzle.java
@@ -587,7 +587,7 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
             // We need vacuum on to determine the vacuum level.
             actuateVacuumValve(true);
             // Use the same dwell time as a pick.
-            Thread.sleep(this.getPickDwellMilliseconds() + nozzleTip.getPickDwellMilliseconds());
+            Thread.sleep(this.getPickDwellMilliseconds() + nt.getPickDwellMilliseconds());
             // Now read the vacuum level.
             vacuumLevel = readVacuumLevel();
         }

--- a/src/main/java/org/openpnp/machine/reference/ReferencePnpJobProcessor.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferencePnpJobProcessor.java
@@ -751,14 +751,7 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
                 return;
             }
             try {
-                // We need vacuum on to determine the vacuum level.
-                nozzle.pick(part);
-                
-                boolean partOff = nozzle.isPartOff();
-                
-                nozzle.place();
-                
-                if (!partOff) {
+                if (!nozzle.isPartOff()) {
                     throw new JobProcessorException(nozzle, "Part detected on nozzle after place.");
                 }
             }


### PR DESCRIPTION
# Description

ReferencePnpJobProcessor.Place.checkPartOff() currently uses Nozzle.pick() and Nozzle.place() for valve switching.

https://github.com/openpnp/openpnp/blob/fee9728215b6174da838a636539370c401a2287c/src/main/java/org/openpnp/machine/reference/ReferencePnpJobProcessor.java#L776-L790

This assumes that PICK_COMMAND / PLACE_COMMAND only contains G-Code to actuate the valve. That may not be true for users that add additional G-Code under the assumption that a “pick” really is a “pick” and not just a valve actuation.

E.g. my machine performs a Z-probe, valve actuation, dwell, slow (relative) retraction sequence there. I guess other users might have similarly elaborate pick and/or place commands.

This proposal actuates the valve inside Nozzle.isPartOff() using the already existing vacuum actuator (currently only used for reading) for switching the valve independently. It uses the ACTUATE_BOOLEAN_COMMAND in order to switch the valve. The same dwell time as in the Pick() operation is used. 

# Justification

PICK_COMMAND / PLACE_COMMAND should only be used for what their names imply. Separate valve switching should be independent of these. 

NOTE: this is upwards compatible. People that do not have the valve switching set up will simply not have valve switching in isPartOff() until they add it in the Actuator, so it will simply work as it did in OpenPNP 1.0 with the valve closed.  

# Instructions for Use

On your vacuum Actuator, define the ACTUATE_BOOLEAN_COMMAND. An example (for Smoothieware) could be:
```
{True:M10 ; open solenoid valve}
{False:M11 ; close solenoid valve}
```
This addition is also useful for the user to experiment with the valve and vacuum levels, using the Actuators tab and buttons in the Machine Controls.

![grafik](https://user-images.githubusercontent.com/9963310/59193847-4d958080-8b87-11e9-8a7c-58e4f1f3a35e.png)

NOTE: For the Nozzle.pick() and Nozzle.place() the valve still needs to be actuated using the PICK_COMMAND / PLACE_COMMAND G-Code as before. It may be embedded in the middle of the G-Code sequence there, so extracting it is not generally possible. In other words Nozzle.pick() and Nozzle.place() do still not use the Actuator to actuate the valve. This slight inconsistency is justified by the potential difference between a pick/place sequence down on the feeder/PCB with the part on the nozzle vs. simply actuating the valve on/off up at safe Z. 

# Implementation Details

1. This is a proposal for early OpenPNP 2.0. EDIT: it was tested on the machine, using the proven mini test job, runout calibration and multi-pass bottom vision pre-rotate. 
![OpenPNP2_1stPnP](https://user-images.githubusercontent.com/9963310/59198300-b256d800-8b93-11e9-923c-47ce821aa8ac.gif)
    Additionally the machine controles Actuator dialog was tested manually for mixed boolean and reading operation.   
2. I did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages
4. It passed `mvn test`.
