### PR TITLE
Nozzle Tip Changing and Calibration UI Touches

### DIFF
--- a/src/main/java/org/openpnp/gui/MachineControlsPanel.java
+++ b/src/main/java/org/openpnp/gui/MachineControlsPanel.java
@@ -127,6 +127,7 @@ public class MachineControlsPanel extends JPanel {
     }
 
     public void setSelectedTool(HeadMountable hm) {
+        HeadMountable oldValue = selectedTool;
         selectedTool = hm;
         for (int i = 0; i < comboBoxHeadMountable.getItemCount(); i++) {
             HeadMountableItem item = (HeadMountableItem) comboBoxHeadMountable.getItemAt(i); 
@@ -136,6 +137,9 @@ public class MachineControlsPanel extends JPanel {
             }
         }
         updateDros();
+        if (oldValue != hm) {
+            firePropertyChange("selectedTool", oldValue, hm);
+        }
     }
 
     public JogControlsPanel getJogControlsPanel() {

--- a/src/main/java/org/openpnp/machine/reference/ReferenceNozzle.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceNozzle.java
@@ -340,6 +340,11 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
             throw new Exception("Can't load incompatible nozzle tip.");
         }
         
+        if (nt.getNozzleAttachedTo() != null) {
+            // Nozzle tip is on different nozzle - unload it from there first.  
+            nt.getNozzleAttachedTo().unloadNozzleTip();
+        }
+        
         if (changerEnabled) {
             unloadNozzleTip();
             if (!nt.isUnloadedNozzleTipStandin()) {

--- a/src/main/java/org/openpnp/machine/reference/ReferenceNozzleTip.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceNozzleTip.java
@@ -21,6 +21,7 @@ import org.openpnp.spi.Head;
 import org.openpnp.spi.Nozzle;
 import org.openpnp.spi.PropertySheetHolder;
 import org.openpnp.spi.base.AbstractNozzleTip;
+import org.openpnp.util.UiUtils;
 import org.simpleframework.xml.Attribute;
 import org.simpleframework.xml.Element;
 import org.simpleframework.xml.core.Commit;
@@ -108,7 +109,7 @@ public class ReferenceNozzleTip extends AbstractNozzleTip {
 
     @Override
     public Action[] getPropertySheetHolderActions() {
-        return new Action[] { deleteAction };
+        return new Action[] {unloadAction, loadAction, deleteAction};
     }
 
     @Override
@@ -249,6 +250,36 @@ public class ReferenceNozzleTip extends AbstractNozzleTip {
         return calibration;
     }
     
+
+    public Action loadAction = new AbstractAction("Load") {
+        {
+            putValue(SMALL_ICON, Icons.nozzleTipLoad);
+            putValue(NAME, "Load");
+            putValue(SHORT_DESCRIPTION, "Load the currently selected nozzle tip.");
+        }
+
+        @Override
+        public void actionPerformed(final ActionEvent arg0) {
+            UiUtils.submitUiMachineTask(() -> {
+                MainFrame.get().getMachineControls().getSelectedNozzle().loadNozzleTip(ReferenceNozzleTip.this);
+            });
+        }
+    };
+
+    public Action unloadAction = new AbstractAction("Unload") {
+        {
+            putValue(SMALL_ICON, Icons.nozzleTipUnload);
+            putValue(NAME, "Unload");
+            putValue(SHORT_DESCRIPTION, "Unload the currently loaded nozzle tip.");
+        }
+
+        @Override
+        public void actionPerformed(final ActionEvent arg0) {
+            UiUtils.submitUiMachineTask(() -> {
+                MainFrame.get().getMachineControls().getSelectedNozzle().unloadNozzleTip();
+            });
+        }
+    };
     public Action deleteAction = new AbstractAction("Delete Nozzle Tip") {
         {
             putValue(SMALL_ICON, Icons.nozzleTipRemove);

--- a/src/main/java/org/openpnp/machine/reference/ReferenceNozzleTipCalibration.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceNozzleTipCalibration.java
@@ -416,8 +416,10 @@ public class ReferenceNozzleTipCalibration extends AbstractModelObject {
     }
 
     @Attribute(required = false)
-    private ReferenceNozzleTipCalibration.RunoutCompensationAlgorithm runoutCompensationAlgorithm = RunoutCompensationAlgorithm.Model;      // modelBased or tableBased? Two implementations are available
-
+    private ReferenceNozzleTipCalibration.RunoutCompensationAlgorithm runoutCompensationAlgorithm = RunoutCompensationAlgorithm.ModelCameraOffset;
+    
+    @Attribute(required = false)
+    private double version = 1.0;
 
     @Attribute(required = false)
     private RecalibrationTrigger recalibrationTrigger = RecalibrationTrigger.NozzleTipChangeInJob;
@@ -432,6 +434,13 @@ public class ReferenceNozzleTipCalibration extends AbstractModelObject {
     @Commit
     public void commit() {
         angleIncrement = null;
+        
+        // OpenPNP Version update
+        if (version < 2) {
+            version = 2.0;
+            // Force ModelCameraOffset calibration system.
+            runoutCompensationAlgorithm = RunoutCompensationAlgorithm.ModelCameraOffset;
+        }
 
         // We need to invoke this even later than the commit(), as the Configuration is not yet ready.
         SwingUtilities.invokeLater(() -> {

--- a/src/main/java/org/openpnp/machine/reference/ReferenceNozzleTipCalibration.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceNozzleTipCalibration.java
@@ -8,8 +8,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
-import javax.swing.SwingUtilities;
-
 import org.apache.commons.io.IOUtils;
 import org.opencv.core.KeyPoint;
 import org.opencv.core.RotatedRect;
@@ -21,7 +19,6 @@ import org.openpnp.model.LengthUnit;
 import org.openpnp.model.Location;
 import org.openpnp.model.Point;
 import org.openpnp.spi.Camera;
-import org.openpnp.spi.Head;
 import org.openpnp.spi.Nozzle;
 import org.openpnp.spi.NozzleTip;
 import org.openpnp.util.MovableUtils;
@@ -441,25 +438,6 @@ public class ReferenceNozzleTipCalibration extends AbstractModelObject {
             // Force ModelCameraOffset calibration system.
             runoutCompensationAlgorithm = RunoutCompensationAlgorithm.ModelCameraOffset;
         }
-
-        // We need to invoke this even later than the commit(), as the Configuration is not yet ready.
-        SwingUtilities.invokeLater(() -> {
-            MainFrame.get().getMachineControls().addPropertyChangeListener("selectedTool", e -> {
-                // inform UI about changed information
-                this.firePropertyChange("runoutCompensationInformation", null, null);
-            });
-            for (Head head : Configuration.get().getMachine().getHeads()) {
-                for (Nozzle nozzle : head.getNozzles()) {
-                    if (nozzle instanceof ReferenceNozzle) {
-                        ReferenceNozzle refNozzle = (ReferenceNozzle)nozzle;
-                        refNozzle.addPropertyChangeListener("nozzleTip", e -> {
-                            // inform UI about changed information
-                            this.firePropertyChange("runoutCompensationInformation", null, null);
-                        });
-                    }
-                }
-            }
-        });
     }
 
     // Max allowed linear distance w.r.t. bottom camera for an offset measurement - measurements above threshold are removed from pipelines results 
@@ -477,72 +455,6 @@ public class ReferenceNozzleTipCalibration extends AbstractModelObject {
 
     public void setRunoutCompensationAlgorithm(ReferenceNozzleTipCalibration.RunoutCompensationAlgorithm runoutCompensationAlgorithm) {
         this.runoutCompensationAlgorithm = runoutCompensationAlgorithm;
-    }
-
-    public ReferenceNozzle getUiCalibrationNozzle(ReferenceNozzleTip nozzleTip) throws Exception {
-        ReferenceNozzle refNozzle; 
-        if (nozzleTip.isUnloadedNozzleTipStandin()) {
-            // For the "unloaded" stand-in it is not well-defined where it is currently "loaded"
-            // if multiple nozzles are currently naked. Therefore the currently selected nozzle from 
-            // the machine controls is preferred.
-            Nozzle nozzle = MainFrame.get().getMachineControls().getSelectedNozzle();
-            if (nozzle instanceof ReferenceNozzle) {
-                refNozzle = (ReferenceNozzle)nozzle;
-                if (refNozzle.getCalibrationNozzleTip() == nozzleTip) {
-                    // Yes, it's a match.
-                    return refNozzle; 
-                }
-            }
-            throw new Exception("Please unload the nozzle tip on the selected nozzle.");
-        }
-        else {
-            // For real nozzle tips, the nozzle where it is currently attached is well-defined.
-            refNozzle = nozzleTip.getNozzleAttachedTo();
-            if (refNozzle == null) {
-                throw new Exception("Please load the nozzle tip on a nozzle.");
-            }
-            return refNozzle;
-        }
-    }
-
-    private ReferenceNozzleTip getNozzleTip() {
-        // Note this is a bit of a hack, used to get the nozzleTip back from the calibration.
-        for (NozzleTip nozzleTip : Configuration.get().getMachine().getNozzleTips()) {
-            if (nozzleTip instanceof ReferenceNozzleTip) {
-                if (((ReferenceNozzleTip)nozzleTip).getCalibration() == this) {
-                    return (ReferenceNozzleTip)nozzleTip;
-                }
-            }
-        }
-        return null;
-    }
-
-    public String getRunoutCompensationInformation() {
-        StringBuffer info = new StringBuffer();
-        // In the UI property getter (no parameter passing) we need to reconstruct things a bit. 
-        ReferenceNozzleTip nozzleTip = getNozzleTip();
-        ReferenceNozzle nozzle = null;
-        if (nozzleTip != null) {
-            try {
-                nozzle = nozzleTip.getCalibration().getUiCalibrationNozzle(nozzleTip);
-            }
-            catch (Exception e) {
-                info.append(e.getMessage());
-            }
-        }
-        if (nozzle != null) {
-            info.append(nozzleTip.getName());
-            info.append(" on ");
-            info.append(nozzle.getName());
-            info.append(": ");
-            if (isCalibrated(nozzle)) {
-                info.append(getRunoutCompensation(nozzle).toString());
-            }
-            else {
-                info.append("Uncalibrated");
-            }
-        }
-        return info.toString();
     }
 
     public void calibrate(ReferenceNozzle nozzle, boolean homing, boolean calibrateCamera) throws Exception {
@@ -844,7 +756,7 @@ public class ReferenceNozzleTipCalibration extends AbstractModelObject {
         // i.e. just wipe the whole lookup table
         runoutCompensationLookup.clear();
         // inform UI about changed information
-        firePropertyChange("runoutCompensationInformation", null, null);
+        firePropertyChange("calibrationInformation", null, null);
         // deprecated
         runoutCompensation = null;
     }
@@ -868,10 +780,14 @@ public class ReferenceNozzleTipCalibration extends AbstractModelObject {
             }
                 
             // inform UI about changed information
-            firePropertyChange("runoutCompensationInformation", null, null);
+            firePropertyChange("calibrationInformation", null, null);
         }
         // deprecated
         runoutCompensation = null;
+    }
+
+    public String getCalibrationInformation(ReferenceNozzle nozzle) { 
+        return getRunoutCompensation(nozzle).toString();
     }
 
     public boolean isCalibrated(ReferenceNozzle nozzle) {

--- a/src/main/java/org/openpnp/machine/reference/wizards/ReferenceNozzleTipCalibrationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/wizards/ReferenceNozzleTipCalibrationWizard.java
@@ -73,9 +73,6 @@ public class ReferenceNozzleTipCalibrationWizard extends AbstractConfigurationWi
     private JButton btnEditPipeline;
     private JButton btnResetPipeline;
     private JButton buttonCenterTool;
-
-    private JLabel lblCompensationAlgorithm;
-    private JComboBox compensationAlgorithmCb;
     private JLabel lblAngleIncrements;
     private JTextField angleIncrementsTf;
     private JLabel lblOffsetThreshold;
@@ -105,7 +102,7 @@ public class ReferenceNozzleTipCalibrationWizard extends AbstractConfigurationWi
                 FormSpecs.RELATED_GAP_COLSPEC,
                 FormSpecs.DEFAULT_COLSPEC,
                 FormSpecs.RELATED_GAP_COLSPEC,
-                FormSpecs.DEFAULT_COLSPEC,
+                ColumnSpec.decode("max(96dlu;default)"),
                 FormSpecs.UNRELATED_GAP_COLSPEC,
                 FormSpecs.DEFAULT_COLSPEC,},
             new RowSpec[] {
@@ -114,8 +111,6 @@ public class ReferenceNozzleTipCalibrationWizard extends AbstractConfigurationWi
                 FormSpecs.RELATED_GAP_ROWSPEC,
                 FormSpecs.DEFAULT_ROWSPEC,
                 FormSpecs.RELATED_GAP_ROWSPEC,
-                FormSpecs.DEFAULT_ROWSPEC,
-                FormSpecs.UNRELATED_GAP_ROWSPEC,
                 FormSpecs.DEFAULT_ROWSPEC,
                 FormSpecs.RELATED_GAP_ROWSPEC,
                 FormSpecs.DEFAULT_ROWSPEC,
@@ -174,64 +169,57 @@ public class ReferenceNozzleTipCalibrationWizard extends AbstractConfigurationWi
 
         btnCalibrateCamera = new JButton("Calibrate Camera Position and Rotation");
         btnCalibrateCamera.setToolTipText("<html>\r\nCalibrate the bottom vision camera position and rotation <br />\r\naccording to a pattern of measured nozzle positions.\r\n</html>");
-        panelCalibration.add(btnCalibrateCamera, "6, 6");
+        panelCalibration.add(btnCalibrateCamera, "6, 6, 3, 1");
         btnCalibrateCamera.addActionListener(new ActionListener() {
             public void actionPerformed(ActionEvent e) {
                 calibrateCamera();
             }
         });
-        lblCompensationAlgorithm = new JLabel("Calibration System");
-        lblCompensationAlgorithm.setToolTipText("<html>\r\n<p>The following calibration systems are available:</p>\r\n<p><ul><li>Model based system using the Kasa model to approximate<br /> \r\n a runout radius and center offset.</li>\r\n<li>Model based system without using the center offset. <br /> \r\nCalibrate the bottom camera position and rotation instead. </li> \r\n<li>Model based system using the center offset as the bottom camera<br />\r\ncalibrated nozzle offset.</li> \r\n<li>Table based system using interpolation between points. </li></ul></p>\r\n</html>\r\n");
-        panelCalibration.add(lblCompensationAlgorithm, "2, 8, right, default");
-
-        compensationAlgorithmCb =
-                new JComboBox(ReferenceNozzleTipCalibration.RunoutCompensationAlgorithm.values());
-        panelCalibration.add(compensationAlgorithmCb, "4, 8, left, default");
 
         lblAngleIncrements = new JLabel("Circle Divisions");
-        panelCalibration.add(lblAngleIncrements, "2, 10, right, default");
+        panelCalibration.add(lblAngleIncrements, "2, 8, right, default");
 
         angleIncrementsTf = new JTextField();
-        panelCalibration.add(angleIncrementsTf, "4, 10, left, default");
+        panelCalibration.add(angleIncrementsTf, "4, 8, left, default");
         angleIncrementsTf.setColumns(3);
 
         lblAllowMisdectects = new JLabel("Allowed Misdectects");
         lblAllowMisdectects.setToolTipText("Number of missed detections tolerated before a calibration fails.");
-        panelCalibration.add(lblAllowMisdectects, "6, 10, right, default");
+        panelCalibration.add(lblAllowMisdectects, "6, 8, right, default");
 
         allowMisdetectsTf = new JTextField();
-        panelCalibration.add(allowMisdetectsTf, "8, 10, left, default");
+        panelCalibration.add(allowMisdetectsTf, "8, 8, left, default");
         allowMisdetectsTf.setColumns(3);
 
         lblOffsetThreshold = new JLabel("Offset Threshold");
-        panelCalibration.add(lblOffsetThreshold, "2, 12, right, default");
+        panelCalibration.add(lblOffsetThreshold, "2, 10, right, default");
 
         offsetThresholdTf = new JTextField();
-        panelCalibration.add(offsetThresholdTf, "4, 12, left, default");
+        panelCalibration.add(offsetThresholdTf, "4, 10, left, default");
         offsetThresholdTf.setColumns(6);
 
         lblCalibrationZOffset = new JLabel("Calibration Z Offset");
         lblCalibrationZOffset.setToolTipText("<html>\r\n<p>\r\nWhen the vision-detected feature of a nozzle is higher up on the nozzle tip <br />\r\nit is recommended to shift the focus plane with the \"Z Offset\".\r\n</p>\r\n<p>If a nozzle tip is named \"unloaded\" it is used as a stand-in for calibration<br />\r\nof the bare nozzle tip holder. Again the \"Z Offset\" can be used to calibrate at the <br />\r\nproper focal plane. \r\n</p>\r\n</html>");
-        panelCalibration.add(lblCalibrationZOffset, "6, 12, right, default");
+        panelCalibration.add(lblCalibrationZOffset, "6, 10, right, default");
 
         calibrationZOffsetTf = new JTextField();
-        panelCalibration.add(calibrationZOffsetTf, "8, 12, left, default");
+        panelCalibration.add(calibrationZOffsetTf, "8, 10, left, default");
         calibrationZOffsetTf.setColumns(6);
 
         lblRecalibration = new JLabel("Automatic Recalibration");
         lblRecalibration.setToolTipText("<html>\r\n<p>Determines when a recalibration is automatically executed:</p>\r\n<p><ul><li>On each nozzle tip change.</li>\r\n<li>On each nozzle tip change but only in Jobs.</li>\r\n<li>On machine homing and when first loaded. </li></ul></p>\r\n<p>Manual with stored calibration (only recommended for machines <br /> \r\nwith C axis homing).</p>\r\n</html>");
-        panelCalibration.add(lblRecalibration, "2, 14, right, default");
+        panelCalibration.add(lblRecalibration, "2, 12, right, default");
 
         recalibrationCb = new JComboBox(ReferenceNozzleTipCalibration.RecalibrationTrigger.values());
-        panelCalibration.add(recalibrationCb, "4, 14, left, default");
+        panelCalibration.add(recalibrationCb, "4, 12, left, default");
 
         lblNewLabel = new JLabel("Pipeline");
-        panelCalibration.add(lblNewLabel, "2, 16, right, default");
+        panelCalibration.add(lblNewLabel, "2, 14, right, default");
 
         panel = new JPanel();
         FlowLayout flowLayout = (FlowLayout) panel.getLayout();
         flowLayout.setVgap(0);
-        panelCalibration.add(panel, "4, 16, left, default");
+        panelCalibration.add(panel, "4, 14, left, default");
 
         btnEditPipeline = new JButton("Edit");
         panel.add(btnEditPipeline);
@@ -320,8 +308,6 @@ public class ReferenceNozzleTipCalibrationWizard extends AbstractConfigurationWi
         
         addWrappedBinding(nozzleTip.getCalibration(), "enabled", calibrationEnabledCheckbox,
                 "selected");
-        addWrappedBinding(nozzleTip.getCalibration(), "runoutCompensationAlgorithm",
-                compensationAlgorithmCb, "selectedItem");
         addWrappedBinding(nozzleTip.getCalibration(), "angleSubdivisions", angleIncrementsTf,
                 "text", intConverter);
         addWrappedBinding(nozzleTip.getCalibration(), "allowMisdetections", allowMisdetectsTf,
@@ -351,10 +337,6 @@ public class ReferenceNozzleTipCalibrationWizard extends AbstractConfigurationWi
         AutoBinding<JCheckBox, Boolean, JButton, Boolean> autoBinding_10 = Bindings.createAutoBinding(UpdateStrategy.READ, calibrationEnabledCheckbox, jCheckBoxBeanProperty, btnCalibrateCamera, jButtonBeanProperty);
         autoBinding_10.bind();
         //
-        BeanProperty<JComboBox, Boolean> jComboBoxBeanProperty = BeanProperty.create("enabled");
-        AutoBinding<JCheckBox, Boolean, JComboBox, Boolean> autoBinding_2 = Bindings.createAutoBinding(UpdateStrategy.READ, calibrationEnabledCheckbox, jCheckBoxBeanProperty, compensationAlgorithmCb, jComboBoxBeanProperty);
-        autoBinding_2.bind();
-        //
         BeanProperty<JTextField, Boolean> jTextFieldBeanProperty = BeanProperty.create("enabled");
         AutoBinding<JCheckBox, Boolean, JTextField, Boolean> autoBinding_3 = Bindings.createAutoBinding(UpdateStrategy.READ, calibrationEnabledCheckbox, jCheckBoxBeanProperty, angleIncrementsTf, jTextFieldBeanProperty);
         autoBinding_3.bind();
@@ -374,6 +356,7 @@ public class ReferenceNozzleTipCalibrationWizard extends AbstractConfigurationWi
         AutoBinding<JCheckBox, Boolean, JButton, Boolean> autoBinding_5 = Bindings.createAutoBinding(UpdateStrategy.READ, calibrationEnabledCheckbox, jCheckBoxBeanProperty, btnResetPipeline, jButtonBeanProperty);
         autoBinding_5.bind();
         //
+        BeanProperty<JComboBox, Boolean> jComboBoxBeanProperty = BeanProperty.create("enabled");
         AutoBinding<JCheckBox, Boolean, JComboBox, Boolean> autoBinding_9 = Bindings.createAutoBinding(UpdateStrategy.READ, calibrationEnabledCheckbox, jCheckBoxBeanProperty, recalibrationCb, jComboBoxBeanProperty);
         autoBinding_9.bind();
     }


### PR DESCRIPTION
# Description

- Bringing back the buttons to load/unload nozzle tips from the NozzleTip Wizards. The nozzle currently selected in the machine controls panel is used to perform the load/unload (or the default, if no nozzle is selected).
- Updating the Calibration Status info-text when a nozzle tip is loaded/unloaded or the if the currently selected nozzle changes in the machine controls panel. The latter is only relevant for the "unloaded" stand-in nozzle tip used to calibrate the naked nozzle. 
- Fix: when a nozzle tip is requested to be loaded on a nozzle tip, it needs to be unloaded first, if it is currently loaded on another nozzle.  
- EDIT: Removing the choice of the calibration system from the UI. On update, all configurations are forced to the "Model & Camera Offset" system. The calibration system can later still be changed through the `machine.xml`.

# Justification
The nozzle tip load/unload buttons are very useful when setting up the nozzle tip changer or runout calibration (pipelines etc.). 

The removal of the calibration system choice simplyfies the usage significantly. All other calibrations systems have pitfalls that can now be evaded for future users. For exotic cases, the other systems (e.g. the "Table" system) can still be enabled in the `machine.xml`. 

# Instructions for Use
- Use the buttons to load/unload nozzle tips (see screen shot). 
- On the Nozzle Tip Calibration Wizard try loading/unloading the current tip. See if the Status info changes correctly.
- Using a multi-nozzle machine, test if the Machine Control Panel selected nozzle is properly used in all load/unload operations.
- Using a multi-nozzle machine, test if the Nozzle Tip Calibration Wizard Status info of the "unloaded" stand-in nozzle tip is updated properly for the Machine Control Panel selected nozzle (even if other nozzles are unloaded too). 
- Using a multi-nozzle machine, try loading an already loaded tip on another nozzle. 
- Using a multi-nozzle machine, on the Nozzle Tip Calibration Wizard try calibrating the current nozzle tip if is loaded on a nozzle different that the Machine Control Panel selected nozzle (it should still work).

![grafik](https://user-images.githubusercontent.com/9963310/59878072-a941e400-93a7-11e9-9b66-124567f73832.png)

# Implementation Details
1. Dry tested as far as possible, but not on machine. Changes affect multi-nozzle machines, so my testing would be mostly inconclusive anyway. 
2. I did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. Ran `mvn test` before submitting the Pull Request. 
