### PR TITLE
Add scripting event after homing is complete 'Machine.AfterHoming'

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/ReferenceMachine.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceMachine.java
@@ -268,6 +268,13 @@ public class ReferenceMachine extends AbstractMachine {
         
         super.home();
 
+        try {
+            Configuration.get().getScripting().on("Machine.AfterHoming", null);
+        }
+        catch (Exception e) {
+            Logger.warn(e);
+        }
+
         // if homing went well, set machine homed-flag true
         this.setHomed(true);     
     }


### PR DESCRIPTION
# Description
Adds new scripting event 'Machine.AfterHoming'.

# Justification
Allows further setup after homing. In my case I'm using it to z-probe with vacuum sensor.

# Instructions for Use
Add Machine.AfterHoming.py to the Events directory.
