### PR TITLE
Allow escaped character sequences in Gcode strings

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/driver/AbstractReferenceDriver.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/AbstractReferenceDriver.java
@@ -265,8 +265,15 @@ public abstract class AbstractReferenceDriver extends AbstractModelObject implem
                   if (i<len) {
                        c = s.charAt(i++);
                        if ((c == 'u') || (c == 'U')) {
-                            c = (char) Integer.parseInt(s.substring(i,i+4),16);
-                            i += 4;
+                          try {
+                               c = (char) Integer.parseInt(s.substring(i,i+4),16);
+                               i += 4;
+                          }
+                          catch (Exception e) {
+                              //the escaped unicode character doesn't have the correct form (four hexidecimal digits) so just pass it along
+                              //as a string
+                              sb.append('\\');
+                          }
                        }
                        else if ((c == 't') || (c == 'T')) {
                            c = 0x0009; //unicode tab

--- a/src/main/java/org/openpnp/machine/reference/driver/AbstractReferenceDriver.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/AbstractReferenceDriver.java
@@ -252,4 +252,47 @@ public abstract class AbstractReferenceDriver extends AbstractModelObject implem
         return new AbstractReferenceDriverConfigurationWizard(this);
     }
 
+    
+    // Replaces each backslash escaped sequence within a string with its actual unicode character
+    public static String unescape(String s) {
+        int i = 0;
+        char c;
+        int len = s.length();
+        StringBuffer sb = new StringBuffer(len);
+        while (i<len) {
+             c = s.charAt(i++);
+             if (c == '\\') {
+                  if (i<len) {
+                       c = s.charAt(i++);
+                       if ((c == 'u') || (c == 'U')) {
+                            c = (char) Integer.parseInt(s.substring(i,i+4),16);
+                            i += 4;
+                       }
+                       else if ((c == 't') || (c == 'T')) {
+                           c = 0x0009; //unicode tab
+                       }
+                       else if ((c == 'b') || (c == 'B')) {
+                           c = 0x0008; //unicode backspace
+                       }
+                       else if ((c == 'n') || (c == 'N')) {
+                           c = 0x000A; //unicode line feed
+                       }
+                       else if ((c == 'r') || (c == 'R')) {
+                           c = 0x000D; //unicode carriage return
+                       }
+                       else if ((c == 'f') || (c == 'F')) {
+                           c = 0x000C; //unicode form feed
+                       }
+                       else {
+                           //in all other cases just pass the backslash along
+                           sb.append('\\');
+                       }
+                  }
+             }
+        sb.append(c);
+        }
+        return sb.toString();
+    }
+
+
 }

--- a/src/main/java/org/openpnp/machine/reference/driver/GcodeDriver.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/GcodeDriver.java
@@ -162,6 +162,9 @@ public class GcodeDriver extends AbstractReferenceDriver implements Named, Runna
     @Attribute(required = false)
     protected boolean visualHomingEnabled = true;
 
+    @Attribute(required = false)
+    protected boolean backslashEscapedCharactersEnabled = false;
+
     @Element(required = false)
     protected Location homingFiducialLocation = new Location(LengthUnit.Millimeters);
 
@@ -914,6 +917,9 @@ public class GcodeDriver extends AbstractReferenceDriver implements Named, Runna
 
         // Send the command, if one was specified
         if (command != null) {
+            if (backslashEscapedCharactersEnabled) {
+                command = unescape(command);
+            }
             Logger.trace("[{}] >> {}", getCommunications().getConnectionName(), command);
             getCommunications().writeLine(command);
         }
@@ -1220,6 +1226,14 @@ public class GcodeDriver extends AbstractReferenceDriver implements Named, Runna
         this.visualHomingEnabled = visualHomingEnabled;
     }
 
+    public boolean isBackslashEscapedCharactersEnabled() {
+        return backslashEscapedCharactersEnabled;
+    }
+
+    public void setBackslashEscapedCharactersEnabled(boolean backslashEscapedCharactersEnabled) {
+        this.backslashEscapedCharactersEnabled = backslashEscapedCharactersEnabled;
+    }
+
     public static class Axis {
         public enum Type {
             X,
@@ -1436,4 +1450,5 @@ public class GcodeDriver extends AbstractReferenceDriver implements Named, Runna
             return transformedCoordinate;
         }
     }
+    
 }

--- a/src/main/java/org/openpnp/machine/reference/driver/wizards/GcodeDriverSettings.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/wizards/GcodeDriverSettings.java
@@ -144,16 +144,16 @@ public class GcodeDriverSettings extends AbstractConfigurationWizard {
         visualHoming = new JCheckBox("");
         settingsPanel.add(visualHoming, "8, 10");
         
-        JLabel lblBackslashEscapedCharacters = new JLabel("Allow Backslash Escaped Characters");
-        lblBackslashEscapedCharacters.setToolTipText("Allows inserting unicode characters into Gcode strings as \\uxxxx "
+        JLabel lblBackslashEscapedCharacters = new JLabel("Backslash Escaped Characters");
+        lblBackslashEscapedCharacters.setToolTipText("Allows insertion of unicode characters into Gcode strings as \\uxxxx "
                 + "where xxxx is four hexidecimal characters.  Also permits \\t for tab, \\b for backspace, \\n for line "
-                + "feed, \\r for carriage return, and \\f, for form feed.");
+                + "feed, \\r for carriage return, and \\f for form feed.");
         settingsPanel.add(lblBackslashEscapedCharacters, "2, 12, right, default");
         
         backslashEscapedCharacters = new JCheckBox("");
-        backslashEscapedCharacters.setToolTipText("Allows inserting unicode characters into Gcode strings as \\uxxxx "
+        backslashEscapedCharacters.setToolTipText("Allows insertion of unicode characters into Gcode strings as \\uxxxx "
                 + "where xxxx is four hexidecimal characters.  Also permits \\t for tab, \\b for backspace, \\n for line "
-                + "feed, \\r for carriage return, and \\f, for form feed.");
+                + "feed, \\r for carriage return, and \\f for form feed.");
         settingsPanel.add(backslashEscapedCharacters, "4, 12");
     }
 

--- a/src/main/java/org/openpnp/machine/reference/driver/wizards/GcodeDriverSettings.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/wizards/GcodeDriverSettings.java
@@ -72,6 +72,8 @@ public class GcodeDriverSettings extends AbstractConfigurationWizard {
                 FormSpecs.RELATED_GAP_ROWSPEC,
                 FormSpecs.DEFAULT_ROWSPEC,
                 FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
                 FormSpecs.DEFAULT_ROWSPEC,}));
         
         JLabel lblUnits = new JLabel("Units");
@@ -141,6 +143,18 @@ public class GcodeDriverSettings extends AbstractConfigurationWizard {
         
         visualHoming = new JCheckBox("");
         settingsPanel.add(visualHoming, "8, 10");
+        
+        JLabel lblBackslashEscapedCharacters = new JLabel("Allow Backslash Escaped Characters");
+        lblBackslashEscapedCharacters.setToolTipText("Allows inserting unicode characters into Gcode strings as \\uxxxx "
+                + "where xxxx is four hexidecimal characters.  Also permits \\t for tab, \\b for backspace, \\n for line "
+                + "feed, \\r for carriage return, and \\f, for form feed.");
+        settingsPanel.add(lblBackslashEscapedCharacters, "2, 12, right, default");
+        
+        backslashEscapedCharacters = new JCheckBox("");
+        backslashEscapedCharacters.setToolTipText("Allows inserting unicode characters into Gcode strings as \\uxxxx "
+                + "where xxxx is four hexidecimal characters.  Also permits \\t for tab, \\b for backspace, \\n for line "
+                + "feed, \\r for carriage return, and \\f, for form feed.");
+        settingsPanel.add(backslashEscapedCharacters, "4, 12");
     }
 
     @Override
@@ -160,6 +174,7 @@ public class GcodeDriverSettings extends AbstractConfigurationWizard {
         addWrappedBinding(driver, "connectWaitTimeMilliseconds", connectWaitTimeTf, "text", intConverter);
         addWrappedBinding(driver, "name", driverName, "text");
         addWrappedBinding(driver, "visualHomingEnabled", visualHoming, "selected");
+        addWrappedBinding(driver, "backslashEscapedCharactersEnabled", backslashEscapedCharacters, "selected");
         
         ComponentDecorators.decorateWithAutoSelect(maxFeedRateTf);
         ComponentDecorators.decorateWithAutoSelect(backlashOffsetXTf);
@@ -307,6 +322,7 @@ public class GcodeDriverSettings extends AbstractConfigurationWizard {
     private JComboBox unitsCb;
     private JTextField driverName;
     private JCheckBox visualHoming;
+    private JCheckBox backslashEscapedCharacters;
 
     static class HeadMountableItem {
         private HeadMountable hm;


### PR DESCRIPTION
# Description
This feature allows usage of Java style escape sequences to insert arbitrary Unicode characters in Gcode strings.  

# Justification
Some machine controllers may require special character sequences to perform certain actions.  For instance, recovering a TinyG from a hard alarm state (such as after a limit switch hit) can be accomplished by sending a ctrl-x character (\u0018) to its serial port (typically as part of the DISABLE_COMMAND).

# Instructions for Use
This feature is disabled by default and needs to be enabled  prior to use by checking the "Backslash Escaped Characters" checkbox on the GcodeDriver General Setting tab.  Then any occurrences of  \uxxxx (that is a backslash followed by a lower or upper case u followed by exactly four hexadecimal characters) in any Gcode string will be replaced by the Unicode character represented by that hexadecimal value prior to the string being sent to the controller.  In addition, the following escape sequences are also recognized: \t for tab, \b for backspace, \n for line feed, \r for carriage return, and \f for form feed.  Any other occurrences of backslashes will not be treated as an escape sequence and will be passed as-is to the controller. 

# Implementation Details
1. This change was tested both with the featured enabled and disabled as well to ensure no impact to those not desiring to use it.  
2. The coding style was followed.
3. No changes where made in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. Maven tests were run and passed.
