### PR TITLE
fix XML syntax error

### DIFF
--- a/src/main/resources/scripts/Examples/JavaScript/Pipeline.js
+++ b/src/main/resources/scripts/Examples/JavaScript/Pipeline.js
@@ -13,6 +13,7 @@ with (imports) {
               '<cv-stage class="org.openpnp.vision.pipeline.stages.ImageCapture" name="0" enabled="true" settle-first="true"/>' +
 		      '<cv-stage class="org.openpnp.vision.pipeline.stages.BlurGaussian" name="1" enabled="true" kernel-size="15"/>' +
 		      '<cv-stage class="org.openpnp.vision.pipeline.stages.ImageWriteDebug" name="2" enabled="true" prefix="bv_source_" suffix=".png"/>' +
+		   '</stages>' +
 		'</cv-pipeline>';
 
 		var pipeline = new CvPipeline(xml);


### PR DESCRIPTION

# Description
Pipeline.js example failed to execute.

# Justification
This fixes a bug in the example Pipeline.js scripts

# Implementation Details
1. How did you test the change? Be descriptive. Untested code will not be accepted.
I changed the Pipeline.js script file and saw the blur.
2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)?
Yes

