### PR TITLE
Feature/set color transform

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/ReferenceCamera.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceCamera.java
@@ -304,7 +304,7 @@ public abstract class ReferenceCamera extends AbstractCamera implements Referenc
         this.deinterlace = deinterlace;
     }
 
-    protected BufferedImage transformImage(BufferedImage image) {
+    public BufferedImage transformImage(BufferedImage image) {
         Mat mat = OpenCvUtils.toMat(image);
 
         mat = crop(mat);

--- a/src/main/java/org/openpnp/spi/Camera.java
+++ b/src/main/java/org/openpnp/spi/Camera.java
@@ -58,7 +58,7 @@ public interface Camera extends HeadMountable, WizardConfigurable,
      *
      * @return
      */
-    public BufferedImage transformImage(BufferedImage image);
+    public BufferedImage camTransformImage(BufferedImage image);
 
    
     /**
@@ -112,6 +112,20 @@ public interface Camera extends HeadMountable, WizardConfigurable,
      * @return
      */
     public int getHeight();
+
+    /**
+     * Get the original capture width of image in pixels.
+     * 
+     * @return
+     */
+    public int getCaptureWidth();
+
+    /**
+     * Get the original capture height of images in pixels.
+     * 
+     * @return
+     */
+    public int getCaptureHeight();
 
     /**
      * Get the time in milliseconds that the Camera should be allowed to settle before images are

--- a/src/main/java/org/openpnp/spi/Camera.java
+++ b/src/main/java/org/openpnp/spi/Camera.java
@@ -52,7 +52,15 @@ public interface Camera extends HeadMountable, WizardConfigurable,
     public Location getUnitsPerPixel();
 
     public void setUnitsPerPixel(Location unitsPerPixel);
-    
+     
+    /**
+     * Applies the camera's active transformation to any compatible image.
+     *
+     * @return
+     */
+    public BufferedImage transformImage(BufferedImage image);
+
+   
     /**
      * Immediately captures an image from the camera and returns it in it's native format. Fires
      * the Camera.BeforeCapture and Camera.AfterCapture scripting events before and after.

--- a/src/main/java/org/openpnp/spi/base/AbstractCamera.java
+++ b/src/main/java/org/openpnp/spi/base/AbstractCamera.java
@@ -56,7 +56,11 @@ public abstract class AbstractCamera extends AbstractModelObject implements Came
 
     protected Integer height;
     
-    private boolean headSet = false;
+    protected Integer captureWidth;
+
+    protected Integer captureHeight;
+
+     private boolean headSet = false;
     
     private Mat lastSettleMat = null;
 


### PR DESCRIPTION
# Description
Extend SetColor pipeline stage to apply camera transform.

# Justification
The edges of a camera transform create a nuisance when developing vision algorithms.
This PR is one step in eliminating that nuisance by creating a transformed SetColor block.
Using this stage, one can do edge detection and create a perimeter of the image.
This perimeter can be used to mask out the edge data from an image, eliminating phantom edges.

# Instructions for Use
Just tick the transform box in SetColor

# Implementation Details
1. How did you test the change? I applied a rotation in Image Transform to a camera. I tested by ticking/unticking the transform box. Default behaviour was preserved, and expected behaviour was correct.
2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)? Yes
3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing.

I modified the .spi for this specific purpose, but the function transformImage() is generic in scope.
There was no interference in existing functionality, and modifying ReferenceCamera was sufficient to implement the interface change.
