### PR TITLE
Feature/add scalars

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/ReferenceCamera.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceCamera.java
@@ -304,7 +304,7 @@ public abstract class ReferenceCamera extends AbstractCamera implements Referenc
         this.deinterlace = deinterlace;
     }
 
-    protected BufferedImage transformImage(BufferedImage image) {
+    public BufferedImage transformImage(BufferedImage image) {
         Mat mat = OpenCvUtils.toMat(image);
 
         mat = crop(mat);

--- a/src/main/java/org/openpnp/spi/Camera.java
+++ b/src/main/java/org/openpnp/spi/Camera.java
@@ -58,7 +58,7 @@ public interface Camera extends HeadMountable, WizardConfigurable,
      *
      * @return
      */
-    public BufferedImage transformImage(BufferedImage image);
+    public BufferedImage camTransformImage(BufferedImage image);
 
    
     /**
@@ -112,6 +112,20 @@ public interface Camera extends HeadMountable, WizardConfigurable,
      * @return
      */
     public int getHeight();
+
+    /**
+     * Get the original capture width of image in pixels.
+     * 
+     * @return
+     */
+    public int getCaptureWidth();
+
+    /**
+     * Get the original capture height of images in pixels.
+     * 
+     * @return
+     */
+    public int getCaptureHeight();
 
     /**
      * Get the time in milliseconds that the Camera should be allowed to settle before images are

--- a/src/main/java/org/openpnp/spi/Camera.java
+++ b/src/main/java/org/openpnp/spi/Camera.java
@@ -52,7 +52,15 @@ public interface Camera extends HeadMountable, WizardConfigurable,
     public Location getUnitsPerPixel();
 
     public void setUnitsPerPixel(Location unitsPerPixel);
-    
+     
+    /**
+     * Applies the camera's active transformation to any compatible image.
+     *
+     * @return
+     */
+    public BufferedImage transformImage(BufferedImage image);
+
+   
     /**
      * Immediately captures an image from the camera and returns it in it's native format. Fires
      * the Camera.BeforeCapture and Camera.AfterCapture scripting events before and after.

--- a/src/main/java/org/openpnp/spi/base/AbstractCamera.java
+++ b/src/main/java/org/openpnp/spi/base/AbstractCamera.java
@@ -56,7 +56,11 @@ public abstract class AbstractCamera extends AbstractModelObject implements Came
 
     protected Integer height;
     
-    private boolean headSet = false;
+    protected Integer captureWidth;
+
+    protected Integer captureHeight;
+
+     private boolean headSet = false;
     
     private Mat lastSettleMat = null;
 

--- a/src/main/java/org/openpnp/vision/pipeline/stages/Add.java
+++ b/src/main/java/org/openpnp/vision/pipeline/stages/Add.java
@@ -2,6 +2,7 @@ package org.openpnp.vision.pipeline.stages;
 
 import org.opencv.core.Core;
 import org.opencv.core.Mat;
+import org.opencv.core.Scalar;
 import org.openpnp.vision.pipeline.CvPipeline;
 import org.openpnp.vision.pipeline.CvStage;
 import org.openpnp.vision.pipeline.Stage;
@@ -18,6 +19,12 @@ public class Add extends CvStage {
     @Attribute(required = false)
     private String secondStageName = null;
     
+    @Attribute(required = false)
+    private double firstScalar = 1.0;
+
+    @Attribute(required = false)
+    private double secondScalar = 1.0;
+
     public String getFirstStageName() {
         return firstStageName;
     }
@@ -34,6 +41,22 @@ public class Add extends CvStage {
         this.secondStageName = secondStageName;
     }
 
+    public double getFirstScalar() {
+        return firstScalar;
+    }
+
+    public void setFirstScalar(double v) {
+        this.firstScalar = v;
+    }
+
+    public double getSecondScalar() {
+        return secondScalar;
+    }
+
+    public void setSecondScalar(double v) {
+        this.secondScalar = v;
+    }
+
     @Override
     public Result process(CvPipeline pipeline) throws Exception {
         if (firstStageName == null) {
@@ -45,9 +68,31 @@ public class Add extends CvStage {
         // TODO STOPSHIP memory?
         Mat first = pipeline.getResult(firstStageName).image;
         Mat second = pipeline.getResult(secondStageName).image;
+
+				if(this.firstScalar < 0){
+					throw new Exception("firstScalar >= 0!");
+				}
+
+        Mat f = first.clone();
+				if(this.firstScalar != 1.0){
+					Core.multiply(first, new Scalar(this.firstScalar), f);
+				}
+
+        Mat s = second.clone();
+				if(this.secondScalar != 1.0){
+					Core.multiply(second, new Scalar(Math.abs(this.secondScalar)), s);
+				}
         
         Mat out = new Mat();
-        Core.add(first, second, out);
+				if(this.secondScalar > 0){
+	        Core.add(f, s, out);
+				}
+				else{
+	        Core.subtract(f, s, out);
+				}
+				f.release();
+				s.release();
+
         return new Result(out);
     }
 }


### PR DESCRIPTION
# Description
The Add pipeline only does a simple add and does not support subtraction.
This PR adds scalar parameters so that each stage output may be scaled.

# Justification
Subtraction lets me remove phantom edges from an image.
Default behaviour is not altered as the default scalar value is 1.

# Instructions for Use

The first scalar scales the first stage and must be non-negative.
The second scalar scales the second stage can can be negative.

# Implementation Details
1. How did you test the change? I added my change to a pipeline and verified the expected result.
2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)? Yes
