### PR TITLE
Feature/set color transform2

### DIFF
--- a/src/main/java/org/openpnp/spi/Camera.java
+++ b/src/main/java/org/openpnp/spi/Camera.java
@@ -65,7 +65,15 @@ public interface Camera extends HeadMountable, WizardConfigurable,
     public Location getUnitsPerPixel();
 
     public void setUnitsPerPixel(Location unitsPerPixel);
-    
+     
+    /**
+     * Applies the camera's active transformation to any compatible image.
+     *
+     * @return
+     */
+    public BufferedImage camTransformImage(BufferedImage image);
+
+   
     /**
      * Immediately captures an image from the camera and returns it in it's native format. Fires
      * the Camera.BeforeCapture and Camera.AfterCapture scripting events before and after.
@@ -121,6 +129,20 @@ public interface Camera extends HeadMountable, WizardConfigurable,
      * @return
      */
     public int getHeight();
+
+    /**
+     * Get the original capture width of image in pixels.
+     * 
+     * @return
+     */
+    public int getCaptureWidth();
+
+    /**
+     * Get the original capture height of images in pixels.
+     * 
+     * @return
+     */
+    public int getCaptureHeight();
 
     /**
      * Get the time in milliseconds that the Camera should be allowed to settle before images are

--- a/src/main/java/org/openpnp/spi/base/AbstractCamera.java
+++ b/src/main/java/org/openpnp/spi/base/AbstractCamera.java
@@ -57,7 +57,11 @@ public abstract class AbstractCamera extends AbstractModelObject implements Came
 
     protected Integer height;
     
-    private boolean headSet = false;
+    protected Integer captureWidth;
+
+    protected Integer captureHeight;
+
+     private boolean headSet = false;
     
     private Mat lastSettleMat = null;
 

--- a/src/main/java/org/openpnp/vision/pipeline/stages/SetColor.java
+++ b/src/main/java/org/openpnp/vision/pipeline/stages/SetColor.java
@@ -69,10 +69,7 @@ public class SetColor extends CvStage {
 				   parameters as the originating camera image. */
         BufferedImage i = OpenCvUtils.toBufferedImage(mat);
         mat.release();
-				Logger.trace("IMG " + i.getWidth() + " " + i.getHeight());
 				BufferedImage image = i.getSubimage(0, 0, camera.getCaptureWidth(), camera.getCaptureHeight());
-				Logger.trace("CAM " + camera.getWidth() + " " + camera.getHeight());
-				Logger.trace("IMG " + image.getWidth() + " " + image.getHeight());
 
         /* Apply camera transformation to solid block.
            We now have an image of just the camera transformation. */

--- a/src/main/java/org/openpnp/vision/pipeline/stages/SetColor.java
+++ b/src/main/java/org/openpnp/vision/pipeline/stages/SetColor.java
@@ -1,13 +1,18 @@
 package org.openpnp.vision.pipeline.stages;
 
 import java.awt.Color;
+import java.awt.image.BufferedImage;
 
+import org.openpnp.spi.Camera;
 import org.opencv.core.Mat;
+import org.openpnp.util.OpenCvUtils;
 import org.openpnp.vision.FluentCv;
 import org.openpnp.vision.pipeline.CvPipeline;
 import org.openpnp.vision.pipeline.CvStage;
 import org.openpnp.vision.pipeline.Stage;
+import org.openpnp.vision.pipeline.Property;
 import org.openpnp.vision.pipeline.stages.convert.ColorConverter;
+import org.pmw.tinylog.Logger;
 import org.simpleframework.xml.Element;
 import org.simpleframework.xml.convert.Convert;
 
@@ -25,10 +30,53 @@ public class SetColor extends CvStage {
         this.color = color;
     }
 
+    @Element(required = false)
+    @Property(description="Apply camera transformation.")
+    private boolean transform = false;
+
+    public boolean getTransform() {
+        return transform;
+    }
+
+    public void setTransform(boolean v) {
+        this.transform = v;
+    }
+
     @Override
     public Result process(CvPipeline pipeline) throws Exception {
+        /* Create a solid block of color to use as basis
+           for transform.
+
+					 If we perform a transform, we must use the pretransform
+					 image size.
+				 
+				 */
+				
         Mat mat = pipeline.getWorkingImage();
         mat.setTo(FluentCv.colorToScalar(color));
-        return null;
+				if(!this.transform){
+        	return null;
+				}
+
+        /* Get the active camera */
+        Camera camera = (Camera) pipeline.getProperty("camera");
+        if (camera == null) {
+             throw new Exception("No Camera set on pipeline.");
+        }
+
+				/* TODO Somebody else can make this more eloquent.
+				   Just trying to make an image with the same color space and
+				   parameters as the originating camera image. */
+        BufferedImage i = OpenCvUtils.toBufferedImage(mat);
+        mat.release();
+				Logger.trace("IMG " + i.getWidth() + " " + i.getHeight());
+				BufferedImage image = i.getSubimage(0, 0, camera.getCaptureWidth(), camera.getCaptureHeight());
+				Logger.trace("CAM " + camera.getWidth() + " " + camera.getHeight());
+				Logger.trace("IMG " + image.getWidth() + " " + image.getHeight());
+
+        /* Apply camera transformation to solid block.
+           We now have an image of just the camera transformation. */
+        image = camera.camTransformImage(image);
+        return new Result(OpenCvUtils.toMat(image));
     }
 }


### PR DESCRIPTION
Supersedes #887 

# Description

Extend SetColor pipeline stage to apply camera transform.

# Justification

The edges of a camera transform create a nuisance when developing vision algorithms.
This PR is one step in eliminating that nuisance by creating a transformed SetColor block.
Using this stage, one can do edge detection and create a perimeter of the image.
This perimeter can be used to mask out the edge data from an image, eliminating phantom edges.

# Instructions for Use

Just tick the transform box in SetColor

# Implementation Details
1. How did you test the change? Tested with USB camera. Applied a rotation, then checked that transformed image produced by SetColor matched the dimensions and visual appearance of the capture stream.
2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)? Yes
3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing.

I modified the .spi for this specific purpose, but the function transformImage() is generic in scope.
There was no interference in existing functionality, and modifying ReferenceCamera and AbstractCamera was sufficient to implement the interface change.

Extension of the interface is justified by code working at the calibration level. While masking and templating works at the "user" level of working fiducials and footprints, code that tackles calibration needs to be aware of more parameters.
