### PR TITLE
Charmhigh  CHM-T48VB Integration

### DIFF
--- a/src/main/java/org/openpnp/gui/FeedersPanel.java
+++ b/src/main/java/org/openpnp/gui/FeedersPanel.java
@@ -547,8 +547,8 @@ public class FeedersPanel extends JPanel implements WizardContainer {
     public Action vacOnAction = new AbstractAction() {
         {
             putValue(SMALL_ICON, Icons.vacOn);
-            putValue(NAME, "Vacuum On");
-            putValue(SHORT_DESCRIPTION, "Turn on the vacuum.");
+            putValue(NAME, "Vacuum through nozzle");
+            putValue(SHORT_DESCRIPTION, "Call the nozzle's actuate operation");
         }
 
         @Override
@@ -557,7 +557,7 @@ public class FeedersPanel extends JPanel implements WizardContainer {
                 Nozzle nozzle = MainFrame.get()
                                          .getMachineControls()
                                          .getSelectedNozzle();
-                nozzle.pumpOn();
+                nozzle.actuate(true);
             });
         }
     };
@@ -565,8 +565,8 @@ public class FeedersPanel extends JPanel implements WizardContainer {
     public Action vacOffAction = new AbstractAction() {
         {
             putValue(SMALL_ICON, Icons.vacOff);
-            putValue(NAME, "Vacuum Off");
-            putValue(SHORT_DESCRIPTION, "Turn off the vacuum.");
+            putValue(NAME, "Purge Nozzle");
+            putValue(SHORT_DESCRIPTION, "Call the nozzle's place operation");
         }
 
         @Override
@@ -575,7 +575,7 @@ public class FeedersPanel extends JPanel implements WizardContainer {
                 Nozzle nozzle = MainFrame.get()
                                          .getMachineControls()
                                          .getSelectedNozzle();
-                nozzle.pumpOff();
+                nozzle.purge();
             });
         }
     };

--- a/src/main/java/org/openpnp/gui/panelization/DlgAutoPanelize.java
+++ b/src/main/java/org/openpnp/gui/panelization/DlgAutoPanelize.java
@@ -44,7 +44,7 @@ import org.openpnp.util.UiUtils;
 
 public class DlgAutoPanelize extends JDialog {
     final private JobPanel jobPanel;
-    
+
     private JSpinner textFieldPCBColumns;
     private JSpinner textFieldPCBRows;
     private JTextField textFieldboardXSpacing;
@@ -57,15 +57,16 @@ public class DlgAutoPanelize extends JDialog {
     private JCheckBox checkFidsCheckBox;
     private final Action okAction = new SwingAction();
     private final Action cancelAction = new SwingAction_1();
-    
-    DoubleConverter doubleConverter = new DoubleConverter(Configuration.get().getLengthDisplayFormat());
+
+    DoubleConverter doubleConverter = new DoubleConverter(Configuration.get()
+                                                                       .getLengthDisplayFormat());
     IntegerConverter integerConverter = new IntegerConverter();
     LengthConverter lengthConverter = new LengthConverter();
 
     public DlgAutoPanelize(Frame parent, JobPanel jobPanel) {
         super(parent, "Panelization Settings", true);
         this.jobPanel = jobPanel;
-        
+
         getRootPane().setLayout(new BoxLayout(getRootPane(), BoxLayout.Y_AXIS));
 
         JPanel jPanel = new JPanel();
@@ -86,11 +87,11 @@ public class DlgAutoPanelize extends JDialog {
         jPanel.add(textFieldPCBRows, "4, 4, fill, default");
 
         // Spacing
-        jPanel.add(new JLabel("X Spacing", JLabel.RIGHT), "2, 6, right, default");
+        jPanel.add(new JLabel("X Gap Spacing", JLabel.RIGHT), "2, 6, right, default");
         textFieldboardXSpacing = new JTextField();
         jPanel.add(textFieldboardXSpacing, "4, 6, fill, default");
 
-        jPanel.add(new JLabel("Y Spacing", JLabel.RIGHT), "2, 8, right, default");
+        jPanel.add(new JLabel("Y Gap Spacing", JLabel.RIGHT), "2, 8, right, default");
         textFieldboardYSpacing = new JTextField();
         jPanel.add(textFieldboardYSpacing, "4, 8, fill, default");
 
@@ -118,7 +119,7 @@ public class DlgAutoPanelize extends JDialog {
         partsComboBox.setEditable(false);
         partsComboBox.setLightWeightPopupEnabled(false);
         partsComboBox.setMaximumRowCount(7);
-        
+
         jPanel.add(partsComboBox, "4, 18, fill, default");
 
         jPanel.add(new JLabel("Check Panel Fiducials", JLabel.RIGHT), "2, 20, right, default");
@@ -146,37 +147,48 @@ public class DlgAutoPanelize extends JDialog {
         KeyStroke stroke = KeyStroke.getKeyStroke("ESCAPE");
         InputMap inputMap = rootPane.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW);
         inputMap.put(stroke, "ESCAPE");
-        rootPane.getActionMap().put("ESCAPE", cancelAction);
-        
+        rootPane.getActionMap()
+                .put("ESCAPE", cancelAction);
+
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldboardXSpacing);
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldboardYSpacing);
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldboardPanelFid1X);
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldboardPanelFid1Y);
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldboardPanelFid2X);
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldboardPanelFid2Y);
-        
+
         // Specify a placeholder panel for now if we don't have one already
-        if (jobPanel.getJob().getPanels() == null || jobPanel.getJob().getPanels().isEmpty()) {
-            jobPanel.getJob().addPanel(
-                    new Panel("Panel1", 3, 3, new Length(0, LengthUnit.Millimeters),
+        if (jobPanel.getJob()
+                    .getPanels() == null
+                || jobPanel.getJob()
+                           .getPanels()
+                           .isEmpty()) {
+            jobPanel.getJob()
+                    .addPanel(new Panel("Panel1", 3, 3, new Length(0, LengthUnit.Millimeters),
                             new Length(0, LengthUnit.Millimeters), "", false,
                             new Placement("PanelFid1"), new Placement("PanelFid2")));
         }
 
         // Set current values.
-        Panel panel = jobPanel.getJob().getPanels().get(0);
+        Panel panel = jobPanel.getJob()
+                              .getPanels()
+                              .get(0);
         int rows = panel.getRows();
         int cols = panel.getColumns();
-        
+
         textFieldPCBColumns.setValue(cols);
         textFieldPCBRows.setValue(rows);
         partsComboBox.setSelectedItem(panel.getFiducialPart());
         textFieldboardXSpacing.setText(lengthConverter.convertForward(panel.getXGap()));
         textFieldboardYSpacing.setText(lengthConverter.convertForward(panel.getYGap()));
-        Location fid0Loc = panel.getFiducials().get(0).getLocation();
+        Location fid0Loc = panel.getFiducials()
+                                .get(0)
+                                .getLocation();
         textFieldboardPanelFid1X.setText(lengthConverter.convertForward(fid0Loc.getLengthX()));
         textFieldboardPanelFid1Y.setText(lengthConverter.convertForward(fid0Loc.getLengthY()));
-        Location fid1Loc = panel.getFiducials().get(1).getLocation();
+        Location fid1Loc = panel.getFiducials()
+                                .get(1)
+                                .getLocation();
         textFieldboardPanelFid2X.setText(lengthConverter.convertForward(fid1Loc.getLengthX()));
         textFieldboardPanelFid2Y.setText(lengthConverter.convertForward(fid1Loc.getLengthY()));
         checkFidsCheckBox.setSelected(panel.isCheckFiducials());
@@ -194,41 +206,48 @@ public class DlgAutoPanelize extends JDialog {
                 int rows = (int) (textFieldPCBRows.getValue());
                 Length gapX = lengthConverter.convertReverse(textFieldboardXSpacing.getText());
                 Length gapY = lengthConverter.convertReverse(textFieldboardYSpacing.getText());
-                Length globalFid1X = lengthConverter.convertReverse(textFieldboardPanelFid1X.getText());
-                Length globalFid1Y = lengthConverter.convertReverse(textFieldboardPanelFid1Y.getText());
-                Length globalFid2X = lengthConverter.convertReverse(textFieldboardPanelFid2X.getText());
-                Length globalFid2Y = lengthConverter.convertReverse(textFieldboardPanelFid2Y.getText());
+                Length globalFid1X =
+                        lengthConverter.convertReverse(textFieldboardPanelFid1X.getText());
+                Length globalFid1Y =
+                        lengthConverter.convertReverse(textFieldboardPanelFid1Y.getText());
+                Length globalFid2X =
+                        lengthConverter.convertReverse(textFieldboardPanelFid2X.getText());
+                Length globalFid2Y =
+                        lengthConverter.convertReverse(textFieldboardPanelFid2Y.getText());
                 Part part = (Part) partsComboBox.getSelectedItem();
                 String partId = part == null ? null : part.getId();
-    
+
                 // The selected PCB is the one we'll panelize
                 BoardLocation rootPCB = jobPanel.getSelection();
-    
+
                 Placement p0 = new Placement("PanelFid1");
                 p0.setType(Placement.Type.Fiducial);
                 MutableLocationProxy p0Location = new MutableLocationProxy();
                 p0Location.setLocation(new Location(LengthUnit.Millimeters));
                 p0Location.setLengthX(globalFid1X);
                 p0Location.setLengthY(globalFid1Y);
-                p0Location.setRotation(rootPCB.getLocation().getRotation());
+                p0Location.setRotation(rootPCB.getLocation()
+                                              .getRotation());
                 p0.setLocation(p0Location.getLocation());
                 p0.setPart(part);
-                
+
                 Placement p1 = new Placement("PanelFid2");
                 p1.setType(Placement.Type.Fiducial);
                 MutableLocationProxy p1Location = new MutableLocationProxy();
                 p1Location.setLocation(new Location(LengthUnit.Millimeters));
                 p1Location.setLengthX(globalFid2X);
                 p1Location.setLengthY(globalFid2Y);
-                p1Location.setRotation(rootPCB.getLocation().getRotation());
+                p1Location.setRotation(rootPCB.getLocation()
+                                              .getRotation());
                 p1.setLocation(p1Location.getLocation());
                 p1.setPart(part);
-    
+
                 Panel pcbPanel = new Panel("Panel1", cols, rows, gapX, gapY, partId,
                         checkFidsCheckBox.isSelected(), p0, p1);
-    
-                jobPanel.getJob().removeAllPanels();
-    
+
+                jobPanel.getJob()
+                        .removeAllPanels();
+
                 if ((rows == 1) && (cols == 1)) {
                     // Here, the user has effectively shut off panelization by
                     // specifying row = col = 1. In this case, we don't
@@ -239,14 +258,19 @@ public class DlgAutoPanelize extends JDialog {
                     // this dlg was that there was a single board in the list.
                     // When this feature is turned off, there will again
                     // be a single board in the list
-                    BoardLocation b = jobPanel.getJob().getBoardLocations().get(0);
-                    jobPanel.getJob().removeAllBoards();
-                    jobPanel.getJob().addBoardLocation(b);
+                    BoardLocation b = jobPanel.getJob()
+                                              .getBoardLocations()
+                                              .get(0);
+                    jobPanel.getJob()
+                            .removeAllBoards();
+                    jobPanel.getJob()
+                            .addBoardLocation(b);
                     jobPanel.refresh();
                 }
                 else {
                     // Here, panelization is active.
-                    jobPanel.getJob().addPanel(pcbPanel);
+                    jobPanel.getJob()
+                            .addPanel(pcbPanel);
                     jobPanel.populatePanelSettingsIntoBoardLocations();
                 }
                 setVisible(false);

--- a/src/main/java/org/openpnp/gui/support/Icons.java
+++ b/src/main/java/org/openpnp/gui/support/Icons.java
@@ -10,7 +10,7 @@ public class Icons {
     public static Icon paste = getIcon("/icons/paste.svg");
     public static Icon export = getIcon("/icons/export.svg");
     public static Icon importt = getIcon("/icons/import.svg");
-    
+
     public static Icon nozzleAdd = getIcon("/icons/nozzle-add.svg");
     public static Icon nozzleRemove = getIcon("/icons/nozzle-remove.svg");
 
@@ -48,7 +48,8 @@ public class Icons {
     public static Icon showPart = getIcon("/icons/feeder-show-part-outline.svg");
     public static Icon editFeeder = getIcon("/icons/feeder-edit.svg");
     public static Icon feeder = getIcon("/icons/feeder.svg");
-    
+    public static Icon vacOn = getIcon("/icons/vac-on.svg");
+    public static Icon vacOff = getIcon("/icons/vac-off.svg");
 
     public static Icon partAlign = getIcon("/icons/part-align.svg");
 
@@ -62,7 +63,7 @@ public class Icons {
     public static Icon rotateClockwise = getIcon("/icons/rotate-clockwise.svg");
     public static Icon rotateCounterclockwise = getIcon("/icons/rotate-counterclockwise.svg");
     public static Icon zero = getIcon("/icons/zero.svg");
-    
+
     public static Icon navigateFirst = getIcon("/icons/nav-first.svg");
     public static Icon navigateLast = getIcon("/icons/nav-last.svg");
     public static Icon navigatePrevious = getIcon("/icons/nav-previous.svg");

--- a/src/main/java/org/openpnp/machine/neoden4/NeoDen4Driver.java
+++ b/src/main/java/org/openpnp/machine/neoden4/NeoDen4Driver.java
@@ -803,8 +803,5 @@ public class NeoDen4Driver extends AbstractReferenceDriver implements Named {
     }
 
     @Override
-    public void pumpOn(ReferenceNozzle nozzle) {}
-
-    @Override
-    public void pumpOff(ReferenceNozzle nozzle) {}
+    public void purge(ReferenceNozzle nozzle) {}
 }

--- a/src/main/java/org/openpnp/machine/neoden4/NeoDen4Driver.java
+++ b/src/main/java/org/openpnp/machine/neoden4/NeoDen4Driver.java
@@ -24,58 +24,58 @@ import org.simpleframework.xml.Root;
 public class NeoDen4Driver extends AbstractReferenceDriver implements Named {
     // So, turns out it's just CRC16-CCITT
     // https://www.embeddedrelated.com/showthread/msp430/29689-1.php
-    static short checksumLookupTable[] = {0, (short) 0x1021, (short) 0x2042, (short) 0x3063, (short) 0x4084,
-            (short) 0x50A5, (short) 0x60C6, (short) 0x70E7, (short) 0x8108, (short) 0x9129,
-            (short) 0x0A14A, (short) 0x0B16B, (short) 0x0C18C, (short) 0x0D1AD, (short) 0x0E1CE,
-            (short) 0x0F1EF, (short) 0x1231, (short) 0x210, (short) 0x3273, (short) 0x2252,
-            (short) 0x52B5, (short) 0x4294, (short) 0x72F7, (short) 0x62D6, (short) 0x9339,
-            (short) 0x8318, (short) 0x0B37B, (short) 0x0A35A, (short) 0x0D3BD, (short) 0x0C39C,
-            (short) 0x0F3FF, (short) 0x0E3DE, (short) 0x2462, (short) 0x3443, (short) 0x420,
-            (short) 0x1401, (short) 0x64E6, (short) 0x74C7, (short) 0x44A4, (short) 0x5485,
-            (short) 0x0A56A, (short) 0x0B54B, (short) 0x8528, (short) 0x9509, (short) 0x0E5EE,
-            (short) 0x0F5CF, (short) 0x0C5AC, (short) 0x0D58D, (short) 0x3653, (short) 0x2672,
-            (short) 0x1611, (short) 0x630, (short) 0x76D7, (short) 0x66F6, (short) 0x5695,
-            (short) 0x46B4, (short) 0x0B75B, (short) 0x0A77A, (short) 0x9719, (short) 0x8738,
-            (short) 0x0F7DF, (short) 0x0E7FE, (short) 0x0D79D, (short) 0x0C7BC, (short) 0x48C4,
-            (short) 0x58E5, (short) 0x6886, (short) 0x78A7, (short) 0x840, (short) 0x1861,
-            (short) 0x2802, (short) 0x3823, (short) 0x0C9CC, (short) 0x0D9ED, (short) 0x0E98E,
-            (short) 0x0F9AF, (short) 0x8948, (short) 0x9969, (short) 0x0A90A, (short) 0x0B92B,
-            (short) 0x5AF5, (short) 0x4AD4, (short) 0x7AB7, (short) 0x6A96, (short) 0x1A71,
-            (short) 0x0A50, (short) 0x3A33, (short) 0x2A12, (short) 0x0DBFD, (short) 0x0CBDC,
-            (short) 0x0FBBF, (short) 0x0EB9E, (short) 0x9B79, (short) 0x8B58, (short) 0x0BB3B,
-            (short) 0x0AB1A, (short) 0x6CA6, (short) 0x7C87, (short) 0x4CE4, (short) 0x5CC5,
-            (short) 0x2C22, (short) 0x3C03, (short) 0x0C60, (short) 0x1C41, (short) 0x0EDAE,
-            (short) 0x0FD8F, (short) 0x0CDEC, (short) 0x0DDCD, (short) 0x0AD2A, (short) 0x0BD0B,
-            (short) 0x8D68, (short) 0x9D49, (short) 0x7E97, (short) 0x6EB6, (short) 0x5ED5,
-            (short) 0x4EF4, (short) 0x3E13, (short) 0x2E32, (short) 0x1E51, (short) 0x0E70,
-            (short) 0x0FF9F, (short) 0x0EFBE, (short) 0x0DFDD, (short) 0x0CFFC, (short) 0x0BF1B,
-            (short) 0x0AF3A, (short) 0x9F59, (short) 0x8F78, (short) 0x9188, (short) 0x81A9,
-            (short) 0x0B1CA, (short) 0x0A1EB, (short) 0x0D10C, (short) 0x0C12D, (short) 0x0F14E,
-            (short) 0x0E16F, (short) 0x1080, (short) 0x0A1, (short) 0x30C2, (short) 0x20E3,
-            (short) 0x5004, (short) 0x4025, (short) 0x7046, (short) 0x6067, (short) 0x83B9,
-            (short) 0x9398, (short) 0x0A3FB, (short) 0x0B3DA, (short) 0x0C33D, (short) 0x0D31C,
-            (short) 0x0E37F, (short) 0x0F35E, (short) 0x2B1, (short) 0x1290, (short) 0x22F3,
-            (short) 0x32D2, (short) 0x4235, (short) 0x5214, (short) 0x6277, (short) 0x7256,
-            (short) 0x0B5EA, (short) 0x0A5CB, (short) 0x95A8, (short) 0x8589, (short) 0x0F56E,
-            (short) 0x0E54F, (short) 0x0D52C, (short) 0x0C50D, (short) 0x34E2, (short) 0x24C3,
-            (short) 0x14A0, (short) 0x481, (short) 0x7466, (short) 0x6447, (short) 0x5424,
-            (short) 0x4405, (short) 0x0A7DB, (short) 0x0B7FA, (short) 0x8799, (short) 0x97B8,
-            (short) 0x0E75F, (short) 0x0F77E, (short) 0x0C71D, (short) 0x0D73C, (short) 0x26D3,
-            (short) 0x36F2, (short) 0x691, (short) 0x16B0, (short) 0x6657, (short) 0x7676,
-            (short) 0x4615, (short) 0x5634, (short) 0x0D94C, (short) 0x0C96D, (short) 0x0F90E,
-            (short) 0x0E92F, (short) 0x99C8, (short) 0x89E9, (short) 0x0B98A, (short) 0x0A9AB,
-            (short) 0x5844, (short) 0x4865, (short) 0x7806, (short) 0x6827, (short) 0x18C0,
-            (short) 0x8E1, (short) 0x3882, (short) 0x28A3, (short) 0x0CB7D, (short) 0x0DB5C,
-            (short) 0x0EB3F, (short) 0x0FB1E, (short) 0x8BF9, (short) 0x9BD8, (short) 0x0ABBB,
-            (short) 0x0BB9A, (short) 0x4A75, (short) 0x5A54, (short) 0x6A37, (short) 0x7A16,
-            (short) 0x0AF1, (short) 0x1AD0, (short) 0x2AB3, (short) 0x3A92, (short) 0x0FD2E,
-            (short) 0x0ED0F, (short) 0x0DD6C, (short) 0x0CD4D, (short) 0x0BDAA, (short) 0x0AD8B,
-            (short) 0x9DE8, (short) 0x8DC9, (short) 0x7C26, (short) 0x6C07, (short) 0x5C64,
-            (short) 0x4C45, (short) 0x3CA2, (short) 0x2C83, (short) 0x1CE0, (short) 0x0CC1,
-            (short) 0x0EF1F, (short) 0x0FF3E, (short) 0x0CF5D, (short) 0x0DF7C, (short) 0x0AF9B,
-            (short) 0x0BFBA, (short) 0x8FD9, (short) 0x9FF8, (short) 0x6E17, (short) 0x7E36,
-            (short) 0x4E55, (short) 0x5E74, (short) 0x2E93, (short) 0x3EB2, (short) 0x0ED1,
-            (short) 0x1EF0};
+    static short checksumLookupTable[] = {0, (short) 0x1021, (short) 0x2042, (short) 0x3063,
+            (short) 0x4084, (short) 0x50A5, (short) 0x60C6, (short) 0x70E7, (short) 0x8108,
+            (short) 0x9129, (short) 0x0A14A, (short) 0x0B16B, (short) 0x0C18C, (short) 0x0D1AD,
+            (short) 0x0E1CE, (short) 0x0F1EF, (short) 0x1231, (short) 0x210, (short) 0x3273,
+            (short) 0x2252, (short) 0x52B5, (short) 0x4294, (short) 0x72F7, (short) 0x62D6,
+            (short) 0x9339, (short) 0x8318, (short) 0x0B37B, (short) 0x0A35A, (short) 0x0D3BD,
+            (short) 0x0C39C, (short) 0x0F3FF, (short) 0x0E3DE, (short) 0x2462, (short) 0x3443,
+            (short) 0x420, (short) 0x1401, (short) 0x64E6, (short) 0x74C7, (short) 0x44A4,
+            (short) 0x5485, (short) 0x0A56A, (short) 0x0B54B, (short) 0x8528, (short) 0x9509,
+            (short) 0x0E5EE, (short) 0x0F5CF, (short) 0x0C5AC, (short) 0x0D58D, (short) 0x3653,
+            (short) 0x2672, (short) 0x1611, (short) 0x630, (short) 0x76D7, (short) 0x66F6,
+            (short) 0x5695, (short) 0x46B4, (short) 0x0B75B, (short) 0x0A77A, (short) 0x9719,
+            (short) 0x8738, (short) 0x0F7DF, (short) 0x0E7FE, (short) 0x0D79D, (short) 0x0C7BC,
+            (short) 0x48C4, (short) 0x58E5, (short) 0x6886, (short) 0x78A7, (short) 0x840,
+            (short) 0x1861, (short) 0x2802, (short) 0x3823, (short) 0x0C9CC, (short) 0x0D9ED,
+            (short) 0x0E98E, (short) 0x0F9AF, (short) 0x8948, (short) 0x9969, (short) 0x0A90A,
+            (short) 0x0B92B, (short) 0x5AF5, (short) 0x4AD4, (short) 0x7AB7, (short) 0x6A96,
+            (short) 0x1A71, (short) 0x0A50, (short) 0x3A33, (short) 0x2A12, (short) 0x0DBFD,
+            (short) 0x0CBDC, (short) 0x0FBBF, (short) 0x0EB9E, (short) 0x9B79, (short) 0x8B58,
+            (short) 0x0BB3B, (short) 0x0AB1A, (short) 0x6CA6, (short) 0x7C87, (short) 0x4CE4,
+            (short) 0x5CC5, (short) 0x2C22, (short) 0x3C03, (short) 0x0C60, (short) 0x1C41,
+            (short) 0x0EDAE, (short) 0x0FD8F, (short) 0x0CDEC, (short) 0x0DDCD, (short) 0x0AD2A,
+            (short) 0x0BD0B, (short) 0x8D68, (short) 0x9D49, (short) 0x7E97, (short) 0x6EB6,
+            (short) 0x5ED5, (short) 0x4EF4, (short) 0x3E13, (short) 0x2E32, (short) 0x1E51,
+            (short) 0x0E70, (short) 0x0FF9F, (short) 0x0EFBE, (short) 0x0DFDD, (short) 0x0CFFC,
+            (short) 0x0BF1B, (short) 0x0AF3A, (short) 0x9F59, (short) 0x8F78, (short) 0x9188,
+            (short) 0x81A9, (short) 0x0B1CA, (short) 0x0A1EB, (short) 0x0D10C, (short) 0x0C12D,
+            (short) 0x0F14E, (short) 0x0E16F, (short) 0x1080, (short) 0x0A1, (short) 0x30C2,
+            (short) 0x20E3, (short) 0x5004, (short) 0x4025, (short) 0x7046, (short) 0x6067,
+            (short) 0x83B9, (short) 0x9398, (short) 0x0A3FB, (short) 0x0B3DA, (short) 0x0C33D,
+            (short) 0x0D31C, (short) 0x0E37F, (short) 0x0F35E, (short) 0x2B1, (short) 0x1290,
+            (short) 0x22F3, (short) 0x32D2, (short) 0x4235, (short) 0x5214, (short) 0x6277,
+            (short) 0x7256, (short) 0x0B5EA, (short) 0x0A5CB, (short) 0x95A8, (short) 0x8589,
+            (short) 0x0F56E, (short) 0x0E54F, (short) 0x0D52C, (short) 0x0C50D, (short) 0x34E2,
+            (short) 0x24C3, (short) 0x14A0, (short) 0x481, (short) 0x7466, (short) 0x6447,
+            (short) 0x5424, (short) 0x4405, (short) 0x0A7DB, (short) 0x0B7FA, (short) 0x8799,
+            (short) 0x97B8, (short) 0x0E75F, (short) 0x0F77E, (short) 0x0C71D, (short) 0x0D73C,
+            (short) 0x26D3, (short) 0x36F2, (short) 0x691, (short) 0x16B0, (short) 0x6657,
+            (short) 0x7676, (short) 0x4615, (short) 0x5634, (short) 0x0D94C, (short) 0x0C96D,
+            (short) 0x0F90E, (short) 0x0E92F, (short) 0x99C8, (short) 0x89E9, (short) 0x0B98A,
+            (short) 0x0A9AB, (short) 0x5844, (short) 0x4865, (short) 0x7806, (short) 0x6827,
+            (short) 0x18C0, (short) 0x8E1, (short) 0x3882, (short) 0x28A3, (short) 0x0CB7D,
+            (short) 0x0DB5C, (short) 0x0EB3F, (short) 0x0FB1E, (short) 0x8BF9, (short) 0x9BD8,
+            (short) 0x0ABBB, (short) 0x0BB9A, (short) 0x4A75, (short) 0x5A54, (short) 0x6A37,
+            (short) 0x7A16, (short) 0x0AF1, (short) 0x1AD0, (short) 0x2AB3, (short) 0x3A92,
+            (short) 0x0FD2E, (short) 0x0ED0F, (short) 0x0DD6C, (short) 0x0CD4D, (short) 0x0BDAA,
+            (short) 0x0AD8B, (short) 0x9DE8, (short) 0x8DC9, (short) 0x7C26, (short) 0x6C07,
+            (short) 0x5C64, (short) 0x4C45, (short) 0x3CA2, (short) 0x2C83, (short) 0x1CE0,
+            (short) 0x0CC1, (short) 0x0EF1F, (short) 0x0FF3E, (short) 0x0CF5D, (short) 0x0DF7C,
+            (short) 0x0AF9B, (short) 0x0BFBA, (short) 0x8FD9, (short) 0x9FF8, (short) 0x6E17,
+            (short) 0x7E36, (short) 0x4E55, (short) 0x5E74, (short) 0x2E93, (short) 0x3EB2,
+            (short) 0x0ED1, (short) 0x1EF0};
 
     @Attribute(required = false)
     protected LengthUnit units = LengthUnit.Millimeters;
@@ -85,121 +85,130 @@ public class NeoDen4Driver extends AbstractReferenceDriver implements Named {
 
     @Attribute(required = false)
     protected int connectWaitTimeMilliseconds = 3000;
-    
+
     @Attribute(required = false)
     protected String name = "NeoDen4Driver";
 
     private boolean connected;
     private Set<Nozzle> pickedNozzles = new HashSet<>();
-    
+
     double x = 0, y = 0;
     double z1 = 0, z2 = 0, z3 = 0, z4 = 0;
     double c1 = 0, c2 = 0, c3 = 0, c4 = 0;
-    
+
 
     public void createMachineObjects() throws Exception {
         // Make sure required objects exist
-        ReferenceMachine machine = ((ReferenceMachine) Configuration.get().getMachine());
-        
-//        ReferenceActuator a = (ReferenceActuator) machine.getActuatorByName("CameraUpLamp");
-//        if (a == null) {
-//            a = new ReferenceActuator();
-//            a.setName("CameraUpLamp");
-//            machine.addActuator(a);
-//        }
-//        
-//        a = (ReferenceActuator) machine.getActuatorByName("CameraDownLamp");
-//        if (a == null) {
-//            a = new ReferenceActuator();
-//            a.setName("CameraDownLamp");
-//            machine.addActuator(a);
-//        }
-//        
-//        a = (ReferenceActuator) machine.getActuatorByName("CameraSelectUp");
-//        if (a == null) {
-//            a = new ReferenceActuator();
-//            a.setName("CameraSelectUp");
-//            machine.addActuator(a);
-//        }
-//        
-//        a = (ReferenceActuator) machine.getActuatorByName("DragPin");
-//        if (a == null) {
-//            a = new ReferenceActuator();
-//            a.setName("DragPin");
-//            machine.addActuator(a);
-//        }
-//        
-//        a = (ReferenceActuator) machine.getActuatorByName("FilmPull");
-//        if (a == null) {
-//            a = new ReferenceActuator();
-//            a.setName("FilmPull");
-//            machine.addActuator(a);
-//        }
-//        
-//        a = (ReferenceActuator) machine.getActuatorByName("Pump");
-//        if (a == null) {
-//            a = new ReferenceActuator();
-//            a.setName("Pump");
-//            machine.addActuator(a);
-//        }
-//        
-//        a = (ReferenceActuator) machine.getActuatorByName("Nozzle1Vacuum");
-//        if (a == null) {
-//            a = new ReferenceActuator();
-//            a.setName("Nozzle1Vacuum");
-//            machine.addActuator(a);
-//        }
-//        
-//        a = (ReferenceActuator) machine.getActuatorByName("Nozzle2Vacuum");
-//        if (a == null) {
-//            a = new ReferenceActuator();
-//            a.setName("Nozzle2Vacuum");
-//            machine.addActuator(a);
-//        }
-//        
-//        a = (ReferenceActuator) machine.getActuatorByName("Nozzle1Down");
-//        if (a == null) {
-//            a = new ReferenceActuator();
-//            a.setName("Nozzle1Down");
-//            machine.addActuator(a);
-//        }
-//        
-//        a = (ReferenceActuator) machine.getActuatorByName("Nozzle2Down");
-//        if (a == null) {
-//            a = new ReferenceActuator();
-//            a.setName("Nozzle2Down");
-//            machine.addActuator(a);
-//        }
-        
+        ReferenceMachine machine = ((ReferenceMachine) Configuration.get()
+                                                                    .getMachine());
+
+        // ReferenceActuator a = (ReferenceActuator) machine.getActuatorByName("CameraUpLamp");
+        // if (a == null) {
+        // a = new ReferenceActuator();
+        // a.setName("CameraUpLamp");
+        // machine.addActuator(a);
+        // }
+        //
+        // a = (ReferenceActuator) machine.getActuatorByName("CameraDownLamp");
+        // if (a == null) {
+        // a = new ReferenceActuator();
+        // a.setName("CameraDownLamp");
+        // machine.addActuator(a);
+        // }
+        //
+        // a = (ReferenceActuator) machine.getActuatorByName("CameraSelectUp");
+        // if (a == null) {
+        // a = new ReferenceActuator();
+        // a.setName("CameraSelectUp");
+        // machine.addActuator(a);
+        // }
+        //
+        // a = (ReferenceActuator) machine.getActuatorByName("DragPin");
+        // if (a == null) {
+        // a = new ReferenceActuator();
+        // a.setName("DragPin");
+        // machine.addActuator(a);
+        // }
+        //
+        // a = (ReferenceActuator) machine.getActuatorByName("FilmPull");
+        // if (a == null) {
+        // a = new ReferenceActuator();
+        // a.setName("FilmPull");
+        // machine.addActuator(a);
+        // }
+        //
+        // a = (ReferenceActuator) machine.getActuatorByName("Pump");
+        // if (a == null) {
+        // a = new ReferenceActuator();
+        // a.setName("Pump");
+        // machine.addActuator(a);
+        // }
+        //
+        // a = (ReferenceActuator) machine.getActuatorByName("Nozzle1Vacuum");
+        // if (a == null) {
+        // a = new ReferenceActuator();
+        // a.setName("Nozzle1Vacuum");
+        // machine.addActuator(a);
+        // }
+        //
+        // a = (ReferenceActuator) machine.getActuatorByName("Nozzle2Vacuum");
+        // if (a == null) {
+        // a = new ReferenceActuator();
+        // a.setName("Nozzle2Vacuum");
+        // machine.addActuator(a);
+        // }
+        //
+        // a = (ReferenceActuator) machine.getActuatorByName("Nozzle1Down");
+        // if (a == null) {
+        // a = new ReferenceActuator();
+        // a.setName("Nozzle1Down");
+        // machine.addActuator(a);
+        // }
+        //
+        // a = (ReferenceActuator) machine.getActuatorByName("Nozzle2Down");
+        // if (a == null) {
+        // a = new ReferenceActuator();
+        // a.setName("Nozzle2Down");
+        // machine.addActuator(a);
+        // }
+
         ReferenceNozzle n;
-        n = (ReferenceNozzle) machine.getDefaultHead().getNozzle("N1");
+        n = (ReferenceNozzle) machine.getDefaultHead()
+                                     .getNozzle("N1");
         if (n == null) {
             n = new ReferenceNozzle("N1");
             n.setName("N1");
-            machine.getDefaultHead().addNozzle(n);
+            machine.getDefaultHead()
+                   .addNozzle(n);
         }
-        
-        n = (ReferenceNozzle) machine.getDefaultHead().getNozzle("N2");
+
+        n = (ReferenceNozzle) machine.getDefaultHead()
+                                     .getNozzle("N2");
         if (n == null) {
             n = new ReferenceNozzle("N2");
             n.setName("N2");
-            machine.getDefaultHead().addNozzle(n);
+            machine.getDefaultHead()
+                   .addNozzle(n);
         }
-        
-        n = (ReferenceNozzle) machine.getDefaultHead().getNozzle("N3");
+
+        n = (ReferenceNozzle) machine.getDefaultHead()
+                                     .getNozzle("N3");
         if (n == null) {
             n = new ReferenceNozzle("N3");
             n.setName("N3");
-            machine.getDefaultHead().addNozzle(n);
+            machine.getDefaultHead()
+                   .addNozzle(n);
         }
-        
-        n = (ReferenceNozzle) machine.getDefaultHead().getNozzle("N4");
+
+        n = (ReferenceNozzle) machine.getDefaultHead()
+                                     .getNozzle("N4");
         if (n == null) {
             n = new ReferenceNozzle("N4");
             n.setName("N4");
-            machine.getDefaultHead().addNozzle(n);
+            machine.getDefaultHead()
+                   .addNozzle(n);
         }
-        
+
 
         ReferenceActuator a;
         a = (ReferenceActuator) machine.getActuatorByName("N1-Air");
@@ -208,21 +217,21 @@ public class NeoDen4Driver extends AbstractReferenceDriver implements Named {
             a.setName("N1-Air");
             machine.addActuator(a);
         }
-        
+
         a = (ReferenceActuator) machine.getActuatorByName("N2-Air");
         if (a == null) {
             a = new ReferenceActuator();
             a.setName("N2-Air");
             machine.addActuator(a);
         }
-        
+
         a = (ReferenceActuator) machine.getActuatorByName("N3-Air");
         if (a == null) {
             a = new ReferenceActuator();
             a.setName("N3-Air");
             machine.addActuator(a);
         }
-        
+
         a = (ReferenceActuator) machine.getActuatorByName("N4-Air");
         if (a == null) {
             a = new ReferenceActuator();
@@ -230,33 +239,33 @@ public class NeoDen4Driver extends AbstractReferenceDriver implements Named {
             machine.addActuator(a);
         }
 
-        
+
         a = (ReferenceActuator) machine.getActuatorByName("Lights-Down");
         if (a == null) {
             a = new ReferenceActuator();
             a.setName("Lights-Down");
             machine.addActuator(a);
         }
-        
+
         a = (ReferenceActuator) machine.getActuatorByName("Lights-Up");
         if (a == null) {
             a = new ReferenceActuator();
             a.setName("Lights-Up");
             machine.addActuator(a);
         }
-        
+
     }
-    
+
     public synchronized void connect() throws Exception {
         createMachineObjects();
-        
+
         getCommunications().connect();
 
         connected = false;
 
         // Disable the machine
         setEnabled(false);
-        
+
         connected = true;
     }
 
@@ -278,7 +287,7 @@ public class NeoDen4Driver extends AbstractReferenceDriver implements Named {
     int read() throws Exception {
         return read(true);
     }
-    
+
     int read(boolean log) throws Exception {
         while (true) {
             try {
@@ -293,11 +302,11 @@ public class NeoDen4Driver extends AbstractReferenceDriver implements Named {
             }
         }
     }
-    
+
     void write(int d) throws Exception {
         write(d, true);
     }
-    
+
     void write(int d, boolean log) throws Exception {
         d = d & 0xff;
         if (log) {
@@ -305,7 +314,7 @@ public class NeoDen4Driver extends AbstractReferenceDriver implements Named {
         }
         getCommunications().write(d);
     }
-    
+
     void writeWithChecksum(byte[] b) throws Exception {
         StringBuffer sb = new StringBuffer();
         for (int i = 0; i < b.length; i++) {
@@ -318,7 +327,7 @@ public class NeoDen4Driver extends AbstractReferenceDriver implements Named {
         }
         getCommunications().write(checksum(b) & 0xff);
     }
-    
+
     byte[] readWithChecksum(int length) throws Exception {
         byte[] b = new byte[length];
         for (int i = 0; i < length; i++) {
@@ -334,15 +343,16 @@ public class NeoDen4Driver extends AbstractReferenceDriver implements Named {
         Logger.trace("< " + sb.toString());
         return b;
     }
-    
+
     int expect(int expected) throws Exception {
         int received = read();
         if (received != expected) {
-            throw new Exception(String.format("Expected %02x but received %02x.", expected, received));
+            throw new Exception(
+                    String.format("Expected %02x but received %02x.", expected, received));
         }
         return received;
     }
-    
+
     int pollFor(int command, int response) throws Exception {
         do {
             write(command);
@@ -356,12 +366,12 @@ public class NeoDen4Driver extends AbstractReferenceDriver implements Named {
         buffer[position + 2] = (byte) ((value >> 16) & 0xff);
         buffer[position + 3] = (byte) ((value >> 24) & 0xff);
     }
-    
+
     void putInt16(int value, byte[] buffer, int position) throws Exception {
         buffer[position + 0] = (byte) ((value >> 0) & 0xff);
         buffer[position + 1] = (byte) ((value >> 8) & 0xff);
     }
-    
+
     int checksum(byte[] b) {
         short result;
 
@@ -378,12 +388,12 @@ public class NeoDen4Driver extends AbstractReferenceDriver implements Named {
         }
         return result;
     }
-    
+
     @Override
     public void home(ReferenceHead head) throws Exception {
         write(0x47);
         expect(0x0b);
-        
+
         write(0xc7);
         expect(0x03);
 
@@ -391,12 +401,13 @@ public class NeoDen4Driver extends AbstractReferenceDriver implements Named {
         putInt32(0x01, b, 0);
         putInt32(0x00, b, 4);
         writeWithChecksum(b);
-        
+
         pollFor(0x07, 0x43);
-        
+
         this.x = -437.;
         this.y = 437.;
-        ReferenceMachine machine = ((ReferenceMachine) Configuration.get().getMachine());
+        ReferenceMachine machine = ((ReferenceMachine) Configuration.get()
+                                                                    .getMachine());
         machine.fireMachineHeadActivity(head);
     }
 
@@ -414,30 +425,30 @@ public class NeoDen4Driver extends AbstractReferenceDriver implements Named {
         }
         return new Location(units, x, y, 0, 0).add(hm.getHeadOffsets());
     }
-    
-    private void moveXy(double x, double y) throws Exception {
-      write(0x48);
-      expect(0x05);
-      
-      write(0xc8);
-      expect(0x0d);
 
-      byte[] b = new byte[8];
-      putInt32((int) (x * 100), b, 0);
-      putInt32((int) (y * 100), b, 4);
-      writeWithChecksum(b);
-      
-      pollFor(0x08, 0x4d);
+    private void moveXy(double x, double y) throws Exception {
+        write(0x48);
+        expect(0x05);
+
+        write(0xc8);
+        expect(0x0d);
+
+        byte[] b = new byte[8];
+        putInt32((int) (x * 100), b, 0);
+        putInt32((int) (y * 100), b, 4);
+        writeWithChecksum(b);
+
+        pollFor(0x08, 0x4d);
     }
-    
+
     private void moveZ(int nozzle, double z) throws Exception {
         // In our world, 0 is max up and -12 is max down. So 0 = 0 and -12 = e02e (which is 12000)
-      
+
         z = -z;
-        
+
         write(0x42);
         expect(0x0e);
-        
+
         write(0xc2);
         expect(0x06);
 
@@ -446,14 +457,14 @@ public class NeoDen4Driver extends AbstractReferenceDriver implements Named {
         b[2] = 0x32;
         b[3] = (byte) nozzle;
         writeWithChecksum(b);
-        
+
         pollFor(0x02, 0x46);
     }
-    
+
     private void moveC(int nozzle, double c) throws Exception {
         write(0x41);
         expect(0x0d);
-        
+
         write(0xc1);
         expect(0x05);
 
@@ -462,7 +473,7 @@ public class NeoDen4Driver extends AbstractReferenceDriver implements Named {
         b[2] = 0x32;
         b[3] = (byte) nozzle;
         writeWithChecksum(b);
-        
+
         pollFor(0x01, 0x45);
     }
 
@@ -483,7 +494,7 @@ public class NeoDen4Driver extends AbstractReferenceDriver implements Named {
         y = Double.isNaN(y) ? this.y : y;
         if (x != this.x || y != this.y) {
             moveXy(x, y);
-            
+
             this.x = x;
             this.y = y;
         }
@@ -497,10 +508,10 @@ public class NeoDen4Driver extends AbstractReferenceDriver implements Named {
                     moveZ(1, z);
                     this.z1 = z;
                 }
-                
+
                 c = Double.isNaN(c) ? this.c1 : c;
                 c = Math.max(c, -180.);
-                c = Math.min(c, 180.);                
+                c = Math.min(c, 180.);
                 if (c != this.c1) {
                     moveC(1, c);
                     this.c1 = c;
@@ -514,10 +525,10 @@ public class NeoDen4Driver extends AbstractReferenceDriver implements Named {
                     moveZ(2, z);
                     this.z2 = z;
                 }
-                
+
                 c = Double.isNaN(c) ? this.c2 : c;
                 c = Math.max(c, -180.);
-                c = Math.min(c, 180.);                
+                c = Math.min(c, 180.);
                 if (c != this.c2) {
                     moveC(2, c);
                     this.c2 = c;
@@ -531,10 +542,10 @@ public class NeoDen4Driver extends AbstractReferenceDriver implements Named {
                     moveZ(3, z);
                     this.z3 = z;
                 }
-                
+
                 c = Double.isNaN(c) ? this.c3 : c;
                 c = Math.max(c, -180.);
-                c = Math.min(c, 180.);                
+                c = Math.min(c, 180.);
                 if (c != this.c3) {
                     moveC(3, c);
                     this.c3 = c;
@@ -548,10 +559,10 @@ public class NeoDen4Driver extends AbstractReferenceDriver implements Named {
                     moveZ(4, z);
                     this.z4 = z;
                 }
-                
+
                 c = Double.isNaN(c) ? this.c4 : c;
                 c = Math.max(c, -180.);
-                c = Math.min(c, 180.);                
+                c = Math.min(c, 180.);
                 if (c != this.c4) {
                     moveC(4, c);
                     this.c4 = c;
@@ -572,7 +583,7 @@ public class NeoDen4Driver extends AbstractReferenceDriver implements Named {
     @Override
     public void place(ReferenceNozzle nozzle) throws Exception {
         // TODO STOPSHIP send place
-        
+
         pickedNozzles.remove(nozzle);
         if (pickedNozzles.size() < 1) {
             // TODO STOPSHIP turn off pump
@@ -590,146 +601,146 @@ public class NeoDen4Driver extends AbstractReferenceDriver implements Named {
             case "N1-Air": {
                 write(0x43);
                 expect(0x0f);
-                
+
                 write(0xc3);
                 expect(0x07);
-                
+
                 byte[] b = new byte[8];
                 b[0] = (byte) value;
                 b[1] = 1;
                 writeWithChecksum(b);
-                
-                pollFor(0x03,  0x47);
+
+                pollFor(0x03, 0x47);
                 break;
             }
             case "N2-Air": {
                 write(0x43);
                 expect(0x0f);
-                
+
                 write(0xc3);
                 expect(0x07);
-                
+
                 byte[] b = new byte[8];
                 b[0] = (byte) value;
                 b[1] = 2;
                 writeWithChecksum(b);
-                
-                pollFor(0x03,  0x47);
+
+                pollFor(0x03, 0x47);
                 break;
             }
             case "N3-Air": {
                 write(0x43);
                 expect(0x0f);
-                
+
                 write(0xc3);
                 expect(0x07);
-                
+
                 byte[] b = new byte[8];
                 b[0] = (byte) value;
                 b[1] = 3;
                 writeWithChecksum(b);
-                
-                pollFor(0x03,  0x47);
+
+                pollFor(0x03, 0x47);
                 break;
             }
             case "N4-Air": {
                 write(0x43);
                 expect(0x0f);
-                
+
                 write(0xc3);
                 expect(0x07);
-                
+
                 byte[] b = new byte[8];
                 b[0] = (byte) value;
                 b[1] = 4;
                 writeWithChecksum(b);
-                
-                pollFor(0x03,  0x47);
+
+                pollFor(0x03, 0x47);
                 break;
             }
             case "Lights-Down": {
                 write(0x44);
                 expect(0x08);
-                
+
                 write(0xc4);
                 expect(0x00);
-                
+
                 byte[] b = new byte[8];
                 b[0] = (byte) value;
                 writeWithChecksum(b);
-                
-                pollFor(0x04,  0x40);
-              break;
+
+                pollFor(0x04, 0x40);
+                break;
             }
             case "Lights-Up": {
                 write(0x47);
                 expect(0x0b);
-                
+
                 write(0xc7);
                 expect(0x03);
-                
+
                 byte[] b = new byte[8];
                 b[4] = (byte) value;
                 writeWithChecksum(b);
-                
-                pollFor(0x07,  0x43);
+
+                pollFor(0x07, 0x43);
                 break;
             }
         }
     }
-    
+
     @Override
     public String actuatorRead(ReferenceActuator actuator) throws Exception {
         switch (actuator.getName()) {
             case "N1-Air": {
                 write(0x40);
                 expect(0x0c);
-                
+
                 write(0x00);
                 expect(0x11);
-                
+
                 write(0x80);
                 expect(0x19);
-                
+
                 byte[] payload = readWithChecksum(8);
                 return Integer.toString(payload[0]);
             }
             case "N2-Air": {
                 write(0x40);
                 expect(0x0c);
-                
+
                 write(0x00);
                 expect(0x11);
-                
+
                 write(0x80);
                 expect(0x19);
-                
+
                 byte[] payload = readWithChecksum(8);
                 return Integer.toString(payload[1]);
             }
             case "N3-Air": {
                 write(0x40);
                 expect(0x0c);
-                
+
                 write(0x00);
                 expect(0x11);
-                
+
                 write(0x80);
                 expect(0x19);
-                
+
                 byte[] payload = readWithChecksum(8);
                 return Integer.toString(payload[2]);
             }
             case "N4-Air": {
                 write(0x40);
                 expect(0x0c);
-                
+
                 write(0x00);
                 expect(0x11);
-                
+
                 write(0x80);
                 expect(0x19);
-                
+
                 byte[] payload = readWithChecksum(8);
                 return Integer.toString(payload[3]);
             }
@@ -751,10 +762,9 @@ public class NeoDen4Driver extends AbstractReferenceDriver implements Named {
     @Override
     public PropertySheet[] getPropertySheets() {
         return new PropertySheet[] {
-                new PropertySheetWizardAdapter(super.getConfigurationWizard(), "Communications")
-        };
+                new PropertySheetWizardAdapter(super.getConfigurationWizard(), "Communications")};
     }
-    
+
     public String getName() {
         return name;
     }
@@ -763,7 +773,7 @@ public class NeoDen4Driver extends AbstractReferenceDriver implements Named {
         this.name = name;
         firePropertyChange("name", null, getName());
     }
-    
+
     public LengthUnit getUnits() {
         return units;
     }
@@ -787,4 +797,10 @@ public class NeoDen4Driver extends AbstractReferenceDriver implements Named {
     public void setConnectWaitTimeMilliseconds(int connectWaitTimeMilliseconds) {
         this.connectWaitTimeMilliseconds = connectWaitTimeMilliseconds;
     }
+
+    @Override
+    public void pumpOn(ReferenceNozzle nozzle) {}
+
+    @Override
+    public void pumpOff(ReferenceNozzle nozzle) {}
 }

--- a/src/main/java/org/openpnp/machine/neoden4/NeoDen4Driver.java
+++ b/src/main/java/org/openpnp/machine/neoden4/NeoDen4Driver.java
@@ -594,6 +594,10 @@ public class NeoDen4Driver extends AbstractReferenceDriver implements Named {
     public void actuate(ReferenceActuator actuator, boolean on) throws Exception {
         // TODO STOPSHIP actuate
     }
+    
+    @Override
+    public void actuate(ReferenceNozzle nozzle, boolean on) throws Exception {
+    }
 
     @Override
     public void actuate(ReferenceActuator actuator, double value) throws Exception {

--- a/src/main/java/org/openpnp/machine/openbuilds/OpenBuildsDriver.java
+++ b/src/main/java/org/openpnp/machine/openbuilds/OpenBuildsDriver.java
@@ -557,8 +557,5 @@ public class OpenBuildsDriver extends AbstractReferenceDriver implements Runnabl
     }
 
     @Override
-    public void pumpOn(ReferenceNozzle nozzle) {}
-
-    @Override
-    public void pumpOff(ReferenceNozzle nozzle) {}
+    public void purge(ReferenceNozzle nozzle) {}
 }

--- a/src/main/java/org/openpnp/machine/openbuilds/OpenBuildsDriver.java
+++ b/src/main/java/org/openpnp/machine/openbuilds/OpenBuildsDriver.java
@@ -74,7 +74,7 @@ public class OpenBuildsDriver extends AbstractReferenceDriver implements Runnabl
         }
         if (connected && !enabled) {
             if (!connectionKeepAlive) {
-            	disconnect();
+                disconnect();
             }
         }
     }
@@ -136,8 +136,8 @@ public class OpenBuildsDriver extends AbstractReferenceDriver implements Runnabl
                     Utils2D.normalizeAngle(nozzleIndex == 0 ? c : c2)).add(hm.getHeadOffsets());
         }
         else {
-            return new Location(LengthUnit.Millimeters, x, y, zA, Utils2D.normalizeAngle(c))
-                    .add(hm.getHeadOffsets());
+            return new Location(LengthUnit.Millimeters, x, y, zA, Utils2D.normalizeAngle(c)).add(
+                    hm.getHeadOffsets());
         }
     }
 
@@ -243,7 +243,9 @@ public class OpenBuildsDriver extends AbstractReferenceDriver implements Runnabl
         if (nozzle == null) {
             return 0;
         }
-        return nozzle.getHead().getNozzles().indexOf(nozzle);
+        return nozzle.getHead()
+                     .getNozzles()
+                     .indexOf(nozzle);
     }
 
     @Override
@@ -462,7 +464,8 @@ public class OpenBuildsDriver extends AbstractReferenceDriver implements Runnabl
         while (!disconnectRequested) {
             String line;
             try {
-                line = getCommunications().readLine().trim();
+                line = getCommunications().readLine()
+                                          .trim();
             }
             catch (TimeoutException ex) {
                 continue;
@@ -549,4 +552,10 @@ public class OpenBuildsDriver extends AbstractReferenceDriver implements Runnabl
     private void led(boolean on) throws Exception {
         sendCommand(on ? "M810" : "M811");
     }
+
+    @Override
+    public void pumpOn(ReferenceNozzle nozzle) {}
+
+    @Override
+    public void pumpOff(ReferenceNozzle nozzle) {}
 }

--- a/src/main/java/org/openpnp/machine/openbuilds/OpenBuildsDriver.java
+++ b/src/main/java/org/openpnp/machine/openbuilds/OpenBuildsDriver.java
@@ -121,6 +121,9 @@ public class OpenBuildsDriver extends AbstractReferenceDriver implements Runnabl
     @Override
     public void actuate(ReferenceActuator actuator, double value) throws Exception {}
 
+    @Override
+    public void actuate(ReferenceNozzle nozzle, boolean on) throws Exception {
+    }    
 
     @Override
     public Location getLocation(ReferenceHeadMountable hm) {

--- a/src/main/java/org/openpnp/machine/reference/ReferenceDriver.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceDriver.java
@@ -124,5 +124,9 @@ public interface ReferenceDriver extends WizardConfigurable, PropertySheetHolder
      */
     public void setEnabled(boolean enabled) throws Exception;
 
-    public default void createDefaults() {};
+    public default void createDefaults() {}
+
+    public void pumpOn(ReferenceNozzle nozzle) throws Exception;
+
+    public void pumpOff(ReferenceNozzle nozzle) throws Exception;
 }

--- a/src/main/java/org/openpnp/machine/reference/ReferenceDriver.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceDriver.java
@@ -129,4 +129,6 @@ public interface ReferenceDriver extends WizardConfigurable, PropertySheetHolder
     public void pumpOn(ReferenceNozzle nozzle) throws Exception;
 
     public void pumpOff(ReferenceNozzle nozzle) throws Exception;
+
+    public void actuate(ReferenceNozzle nozzle, boolean on) throws Exception;
 }

--- a/src/main/java/org/openpnp/machine/reference/ReferenceDriver.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceDriver.java
@@ -126,9 +126,7 @@ public interface ReferenceDriver extends WizardConfigurable, PropertySheetHolder
 
     public default void createDefaults() {}
 
-    public void pumpOn(ReferenceNozzle nozzle) throws Exception;
-
-    public void pumpOff(ReferenceNozzle nozzle) throws Exception;
+    public void purge(ReferenceNozzle nozzle) throws Exception;
 
     public void actuate(ReferenceNozzle nozzle, boolean on) throws Exception;
 }

--- a/src/main/java/org/openpnp/machine/reference/ReferenceHead.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceHead.java
@@ -96,18 +96,22 @@ public class ReferenceHead extends AbstractHead {
                     || cameraLocation.getY() < minLocation.getY()
                     || cameraLocation.getY() > maxLocation.getY()) {
                 String limit = "";
-                if (cameraLocation.getX() < minLocation.getX())
+                if (cameraLocation.getX() < minLocation.getX()) {
                     limit += String.format("x_camera (%f) < x_min (%f)  ", cameraLocation.getX(),
                             minLocation.getX());
-                if (cameraLocation.getX() > maxLocation.getX())
+                }
+                if (cameraLocation.getX() > maxLocation.getX()) {
                     limit += String.format("x_camera (%f) > x_max (%f)  ", cameraLocation.getX(),
                             maxLocation.getX());
-                if (cameraLocation.getY() < minLocation.getY())
+                }
+                if (cameraLocation.getY() < minLocation.getY()) {
                     limit += String.format("y_camera (%f) < y_min (%f)  ", cameraLocation.getY(),
                             minLocation.getY());
-                if (cameraLocation.getY() > maxLocation.getY())
+                }
+                if (cameraLocation.getY() > maxLocation.getY()) {
                     limit += String.format("y_camera (%f) > y_max (%f)  ", cameraLocation.getY(),
                             maxLocation.getY());
+                }
                 throw new Exception(
                         String.format("Can't move %s to %s, outside of soft limits on head %s.  %s",
                                 hm.getName(), location, getName(), limit));

--- a/src/main/java/org/openpnp/machine/reference/ReferenceHead.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceHead.java
@@ -78,21 +78,39 @@ public class ReferenceHead extends AbstractHead {
         Logger.debug("{}.moveToSafeZ({})", getName(), speed);
         super.moveToSafeZ(speed);
     }
-    
-    public void moveTo(ReferenceHeadMountable hm, Location location, double speed) throws Exception {
+
+    public void moveTo(ReferenceHeadMountable hm, Location location, double speed)
+            throws Exception {
         if (isSoftLimitsEnabled()) {
             /**
              * Since minLocation and maxLocation are captured with the Camera's coordinates, we need
              * to know where the Camera will land, not the HeadMountable.
              */
             Location cameraLocation = location.subtract(hm.getHeadOffsets());
-            cameraLocation = cameraLocation.add(((ReferenceCamera) getDefaultCamera()).getHeadOffsets());
+            cameraLocation =
+                    cameraLocation.add(((ReferenceCamera) getDefaultCamera()).getHeadOffsets());
             Location minLocation = this.minLocation.convertToUnits(cameraLocation.getUnits());
             Location maxLocation = this.maxLocation.convertToUnits(cameraLocation.getUnits());
-            if (cameraLocation.getX() < minLocation.getX() || cameraLocation.getX() > maxLocation.getX() ||
-                    cameraLocation.getY() < minLocation.getY() || cameraLocation.getY() > maxLocation.getY()) {
-                throw new Exception(String.format("Can't move %s to %s, outside of soft limits on head %s.",
-                        hm.getName(), location, getName()));
+            if (cameraLocation.getX() < minLocation.getX()
+                    || cameraLocation.getX() > maxLocation.getX()
+                    || cameraLocation.getY() < minLocation.getY()
+                    || cameraLocation.getY() > maxLocation.getY()) {
+                String limit = "";
+                if (cameraLocation.getX() < minLocation.getX())
+                    limit += String.format("x_camera (%f) < x_min (%f)  ", cameraLocation.getX(),
+                            minLocation.getX());
+                if (cameraLocation.getX() > maxLocation.getX())
+                    limit += String.format("x_camera (%f) > x_max (%f)  ", cameraLocation.getX(),
+                            maxLocation.getX());
+                if (cameraLocation.getY() < minLocation.getY())
+                    limit += String.format("y_camera (%f) < y_min (%f)  ", cameraLocation.getY(),
+                            minLocation.getY());
+                if (cameraLocation.getY() > maxLocation.getY())
+                    limit += String.format("y_camera (%f) > y_max (%f)  ", cameraLocation.getY(),
+                            maxLocation.getY());
+                throw new Exception(
+                        String.format("Can't move %s to %s, outside of soft limits on head %s.  %s",
+                                hm.getName(), location, getName(), limit));
             }
         }
         getDriver().moveTo(hm, location, speed);
@@ -103,12 +121,13 @@ public class ReferenceHead extends AbstractHead {
     public String toString() {
         return getName();
     }
-    
+
     ReferenceDriver getDriver() {
         return getMachine().getDriver();
     }
-    
+
     public ReferenceMachine getMachine() {
-        return (ReferenceMachine) Configuration.get().getMachine();
+        return (ReferenceMachine) Configuration.get()
+                                               .getMachine();
     }
 }

--- a/src/main/java/org/openpnp/machine/reference/ReferenceNozzle.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceNozzle.java
@@ -712,11 +712,16 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
 
     @Override
     public void pumpOff() throws Exception {
-        getDriver().pumpOff(this);
+        getDriver().place(this);
     }
 
     @Override
     public void pumpOn() throws Exception {
-        getDriver().pumpOn(this);
+        getDriver().pick(this);
+    }
+    
+    @Override
+    public void actuate(boolean on) throws Exception {
+        getDriver().actuate(this,on);
     }
 }

--- a/src/main/java/org/openpnp/machine/reference/ReferenceNozzle.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceNozzle.java
@@ -711,15 +711,10 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
     }
 
     @Override
-    public void pumpOff() throws Exception {
+    public void purge() throws Exception {
         getDriver().place(this);
     }
 
-    @Override
-    public void pumpOn() throws Exception {
-        getDriver().pick(this);
-    }
-    
     @Override
     public void actuate(boolean on) throws Exception {
         getDriver().actuate(this,on);

--- a/src/main/java/org/openpnp/machine/reference/ReferenceNozzle.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceNozzle.java
@@ -55,7 +55,7 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
 
     @Element(required = false)
     protected String vacuumSenseActuatorName;
-    
+
     /**
      * If limitRotation is enabled the nozzle will reverse directions when commanded to rotate past
      * 180 degrees. So, 190 degrees becomes -170 and -190 becomes 170.
@@ -66,19 +66,23 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
     protected ReferenceNozzleTip nozzleTip;
 
     public ReferenceNozzle() {
-        Configuration.get().addListener(new ConfigurationListener.Adapter() {
-            @Override
-            public void configurationLoaded(Configuration configuration) throws Exception {
-                nozzleTip = (ReferenceNozzleTip) configuration.getMachine().getNozzleTip(currentNozzleTipId);
-            }
-        });
+        Configuration.get()
+                     .addListener(new ConfigurationListener.Adapter() {
+                         @Override
+                         public void configurationLoaded(Configuration configuration)
+                                 throws Exception {
+                             nozzleTip = (ReferenceNozzleTip) configuration.getMachine()
+                                                                           .getNozzleTip(
+                                                                                   currentNozzleTipId);
+                         }
+                     });
     }
 
     public ReferenceNozzle(String id) {
         this();
         this.id = id;
     }
-    
+
     public boolean isLimitRotation() {
         return limitRotation;
     }
@@ -137,27 +141,31 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
         if (nozzleTip == null) {
             throw new Exception("Can't pick, no nozzle tip loaded");
         }
-        
+
         try {
             Map<String, Object> globals = new HashMap<>();
             globals.put("nozzle", this);
-            Configuration.get().getScripting().on("Nozzle.BeforePick", globals);
+            Configuration.get()
+                         .getScripting()
+                         .on("Nozzle.BeforePick", globals);
         }
         catch (Exception e) {
             Logger.warn(e);
         }
-        
+
         this.part = part;
         getDriver().pick(this);
         getMachine().fireMachineHeadActivity(head);
-        
+
         // Dwell Time
         Thread.sleep(this.getPickDwellMilliseconds() + nozzleTip.getPickDwellMilliseconds());
-        
+
         try {
             Map<String, Object> globals = new HashMap<>();
             globals.put("nozzle", this);
-            Configuration.get().getScripting().on("Nozzle.AfterPick", globals);
+            Configuration.get()
+                         .getScripting()
+                         .on("Nozzle.AfterPick", globals);
         }
         catch (Exception e) {
             Logger.warn(e);
@@ -170,37 +178,41 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
         if (nozzleTip == null) {
             throw new Exception("Can't place, no nozzle tip loaded");
         }
-        
+
         try {
             Map<String, Object> globals = new HashMap<>();
             globals.put("nozzle", this);
-            Configuration.get().getScripting().on("Nozzle.BeforePlace", globals);
+            Configuration.get()
+                         .getScripting()
+                         .on("Nozzle.BeforePlace", globals);
         }
         catch (Exception e) {
             Logger.warn(e);
         }
-        
+
         getDriver().place(this);
         this.part = null;
         getMachine().fireMachineHeadActivity(head);
-        
+
         // Dwell Time
         Thread.sleep(this.getPlaceDwellMilliseconds() + nozzleTip.getPlaceDwellMilliseconds());
-        
+
         try {
             Map<String, Object> globals = new HashMap<>();
             globals.put("nozzle", this);
-            Configuration.get().getScripting().on("Nozzle.AfterPlace", globals);
+            Configuration.get()
+                         .getScripting()
+                         .on("Nozzle.AfterPlace", globals);
         }
         catch (Exception e) {
             Logger.warn(e);
         }
     }
-    
+
     private ReferenceNozzleTip getUnloadedNozzleTipStandin() {
         for (NozzleTip nozzleTip : this.getCompatibleNozzleTips()) {
             if (nozzleTip instanceof ReferenceNozzleTip) {
-                ReferenceNozzleTip referenceNozzleTip = (ReferenceNozzleTip)nozzleTip;
+                ReferenceNozzleTip referenceNozzleTip = (ReferenceNozzleTip) nozzleTip;
                 if (referenceNozzleTip.isUnloadedNozzleTipStandin()) {
                     return referenceNozzleTip;
                 }
@@ -208,17 +220,18 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
         }
         return null;
     }
-    
+
     public ReferenceNozzleTip getCalibrationNozzleTip() {
         if (nozzleTip != null) {
             // normally we have the loaded nozzle tip as the calibration nozzle tip
             ReferenceNozzleTip calibrationNozzleTip = null;
             if (nozzleTip instanceof ReferenceNozzleTip) {
-                calibrationNozzleTip = (ReferenceNozzleTip)nozzleTip;
+                calibrationNozzleTip = (ReferenceNozzleTip) nozzleTip;
             }
             return calibrationNozzleTip;
-        } else {
-            // if no tip is mounted, we use the "unloaded" nozzle tip stand-in, so we 
+        }
+        else {
+            // if no tip is mounted, we use the "unloaded" nozzle tip stand-in, so we
             // can still calibrate
             return getUnloadedNozzleTipStandin();
         }
@@ -226,28 +239,33 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
 
     @Override
     public Location getCameraToolCalibratedOffset(Camera camera) {
-        // Apply the axis offset from runout calibration here. 
+        // Apply the axis offset from runout calibration here.
         ReferenceNozzleTip calibrationNozzleTip = getCalibrationNozzleTip();
-        if (calibrationNozzleTip != null && calibrationNozzleTip.getCalibration().isCalibrated(this)) {
-            return calibrationNozzleTip.getCalibration().getCalibratedCameraOffset(this, camera);
+        if (calibrationNozzleTip != null && calibrationNozzleTip.getCalibration()
+                                                                .isCalibrated(this)) {
+            return calibrationNozzleTip.getCalibration()
+                                       .getCalibratedCameraOffset(this, camera);
         }
 
-        return new Location(camera.getUnitsPerPixel().getUnits());
+        return new Location(camera.getUnitsPerPixel()
+                                  .getUnits());
     }
 
     @Override
     public void calibrate() throws Exception {
         ReferenceNozzleTip calibrationNozzleTip = getCalibrationNozzleTip();
         if (calibrationNozzleTip != null) {
-            calibrationNozzleTip.getCalibration().calibrate(this);
+            calibrationNozzleTip.getCalibration()
+                                .calibrate(this);
         }
     }
-    
+
     @Override
     public boolean isCalibrated() {
         ReferenceNozzleTip calibrationNozzleTip = getCalibrationNozzleTip();
         if (calibrationNozzleTip != null) {
-            return calibrationNozzleTip.getCalibration().isCalibrated(this);
+            return calibrationNozzleTip.getCalibration()
+                                       .isCalibrated(this);
         }
         // No calibration needed.
         return true;
@@ -285,11 +303,16 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
         }
 
         ReferenceNozzleTip calibrationNozzleTip = getCalibrationNozzleTip();
-        if (calibrationNozzleTip != null && calibrationNozzleTip.getCalibration().isCalibrated(this)) {
-            Location correctionOffset = calibrationNozzleTip.getCalibration().getCalibratedOffset(this, location.getRotation());
+        if (calibrationNozzleTip != null && calibrationNozzleTip.getCalibration()
+                                                                .isCalibrated(this)) {
+            Location correctionOffset = calibrationNozzleTip.getCalibration()
+                                                            .getCalibratedOffset(this,
+                                                                    location.getRotation());
             location = location.subtract(correctionOffset);
-            Logger.debug("{}.moveTo({}, {}) (runout compensation: {})", getName(), location, speed, correctionOffset);
-        } else {
+            Logger.debug("{}.moveTo({}, {}) (runout compensation: {})", getName(), location, speed,
+                    correctionOffset);
+        }
+        else {
             Logger.debug("{}.moveTo({}, {})", getName(), location, speed);
         }
         ((ReferenceHead) getHead()).moveTo(this, location, getHead().getMaxPartSpeed() * speed);
@@ -305,23 +328,28 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
         getDriver().moveTo(this, l, getHead().getMaxPartSpeed() * speed);
         getMachine().fireMachineHeadActivity(head);
     }
-    
+
     @Override
     public void home() throws Exception {
         Logger.debug("{}.home()", getName());
         for (NozzleTip attachedNozzleTip : this.getCompatibleNozzleTips()) {
             if (attachedNozzleTip instanceof ReferenceNozzleTip) {
-                ReferenceNozzleTip calibrationNozzleTip = (ReferenceNozzleTip)attachedNozzleTip;
-                if (calibrationNozzleTip.getCalibration().isRecalibrateOnHomeNeeded(this)) {
+                ReferenceNozzleTip calibrationNozzleTip = (ReferenceNozzleTip) attachedNozzleTip;
+                if (calibrationNozzleTip.getCalibration()
+                                        .isRecalibrateOnHomeNeeded(this)) {
                     if (calibrationNozzleTip == this.getCalibrationNozzleTip()) {
                         // The currently mounted nozzle tip.
-                        Logger.debug("{}.home() nozzle tip {} calibration neeeded", getName(), calibrationNozzleTip.getName());
-                        calibrationNozzleTip.getCalibration().calibrate(this, true, false);
+                        Logger.debug("{}.home() nozzle tip {} calibration neeeded", getName(),
+                                calibrationNozzleTip.getName());
+                        calibrationNozzleTip.getCalibration()
+                                            .calibrate(this, true, false);
                     }
                     else {
                         // Not currently mounted so just reset.
-                        Logger.debug("{}.home() nozzle tip {} calibration reset", getName(), calibrationNozzleTip.getName());
-                        calibrationNozzleTip.getCalibration().reset(this);
+                        Logger.debug("{}.home() nozzle tip {} calibration reset", getName(),
+                                calibrationNozzleTip.getName());
+                        calibrationNozzleTip.getCalibration()
+                                            .reset(this);
                     }
                 }
             }
@@ -335,16 +363,17 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
         }
 
         ReferenceNozzleTip nt = (ReferenceNozzleTip) nozzleTip;
-        
+
         if (!getCompatibleNozzleTips().contains(nt)) {
             throw new Exception("Can't load incompatible nozzle tip.");
         }
-        
+
         if (nt.getNozzleAttachedTo() != null) {
-            // Nozzle tip is on different nozzle - unload it from there first.  
-            nt.getNozzleAttachedTo().unloadNozzleTip();
+            // Nozzle tip is on different nozzle - unload it from there first.
+            nt.getNozzleAttachedTo()
+              .unloadNozzleTip();
         }
-        
+
         if (changerEnabled) {
             unloadNozzleTip();
             if (!nt.isUnloadedNozzleTipStandin()) {
@@ -364,7 +393,8 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
                     Logger.warn(e);
                 }
 
-                double speed = getHead().getMachine().getSpeed();
+                double speed = getHead().getMachine()
+                                        .getSpeed();
 
                 Logger.debug("{}.loadNozzleTip({}): moveTo Start Location",
                         new Object[] {getName(), nozzleTip.getName()});
@@ -381,7 +411,8 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
                 Logger.debug("{}.loadNozzleTip({}): moveTo End Location",
                         new Object[] {getName(), nozzleTip.getName()});
                 moveTo(nt.getChangerEndLocation(), nt.getChangerMid2ToEndSpeed() * speed);
-                moveToSafeZ(getHead().getMachine().getSpeed());
+                moveToSafeZ(getHead().getMachine()
+                                     .getSpeed());
 
                 Logger.debug("{}.loadNozzleTip({}): Finished",
                         new Object[] {getName(), nozzleTip.getName()});
@@ -391,8 +422,8 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
                     globals.put("head", getHead());
                     globals.put("nozzle", this);
                     Configuration.get()
-                    .getScripting()
-                    .on("NozzleTip.Loaded", globals);
+                                 .getScripting()
+                                 .on("NozzleTip.Loaded", globals);
                 }
                 catch (Exception e) {
                     Logger.warn(e);
@@ -402,14 +433,20 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
 
         this.nozzleTip = nt;
         currentNozzleTipId = nozzleTip.getId();
-        if (this.nozzleTip.getCalibration().isRecalibrateOnNozzleTipChangeNeeded(this)) {
-            Logger.debug("{}.loadNozzleTip() nozzle tip {} calibration needed", getName(), this.nozzleTip.getName());
-            this.nozzleTip.getCalibration().calibrate(this);
+        if (this.nozzleTip.getCalibration()
+                          .isRecalibrateOnNozzleTipChangeNeeded(this)) {
+            Logger.debug("{}.loadNozzleTip() nozzle tip {} calibration needed", getName(),
+                    this.nozzleTip.getName());
+            this.nozzleTip.getCalibration()
+                          .calibrate(this);
         }
-        else if (this.nozzleTip.getCalibration().isRecalibrateOnNozzleTipChangeInJobNeeded(this)) {
-            Logger.debug("{}.loadNozzleTip() nozzle tip {} calibration reset", getName(), this.nozzleTip.getName());
+        else if (this.nozzleTip.getCalibration()
+                               .isRecalibrateOnNozzleTipChangeInJobNeeded(this)) {
+            Logger.debug("{}.loadNozzleTip() nozzle tip {} calibration reset", getName(),
+                    this.nozzleTip.getName());
             // is will be recalibrated by the job - just reset() for now
-            this.nozzleTip.getCalibration().reset(this);
+            this.nozzleTip.getCalibration()
+                          .reset(this);
         }
         firePropertyChange("nozzleTip", null, getNozzleTip());
         ((ReferenceMachine) head.getMachine()).fireMachineHeadActivity(head);
@@ -427,21 +464,22 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
             Logger.debug("{}.unloadNozzleTip(): Start", getName());
 
             if (changerEnabled) {
-                 try {
+                try {
                     Map<String, Object> globals = new HashMap<>();
                     globals.put("head", getHead());
                     globals.put("nozzle", this);
                     globals.put("nozzleTip", nt);
                     Configuration.get()
-                    .getScripting()
-                    .on("NozzleTip.BeforeUnload", globals);
+                                 .getScripting()
+                                 .on("NozzleTip.BeforeUnload", globals);
                 }
                 catch (Exception e) {
                     Logger.warn(e);
                 }
             }
 
-            double speed = getHead().getMachine().getSpeed();
+            double speed = getHead().getMachine()
+                                    .getSpeed();
 
             Logger.debug("{}.unloadNozzleTip(): moveTo End Location", getName());
             MovableUtils.moveToLocationAtSafeZ(this, nt.getChangerEndLocation(), speed);
@@ -455,7 +493,8 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
 
                 Logger.debug("{}.unloadNozzleTip(): moveTo Start Location", getName());
                 moveTo(nt.getChangerStartLocation(), nt.getChangerStartToMidSpeed() * speed);
-                moveToSafeZ(getHead().getMachine().getSpeed());
+                moveToSafeZ(getHead().getMachine()
+                                     .getSpeed());
 
                 Logger.debug("{}.unloadNozzleTip(): Finished", getName());
 
@@ -464,8 +503,8 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
                     globals.put("head", getHead());
                     globals.put("nozzle", this);
                     Configuration.get()
-                    .getScripting()
-                    .on("NozzleTip.Unloaded", globals);
+                                 .getScripting()
+                                 .on("NozzleTip.Unloaded", globals);
                 }
                 catch (Exception e) {
                     Logger.warn(e);
@@ -481,11 +520,16 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
         if (!changerEnabled) {
             throw new Exception("Manual NozzleTip change required!");
         }
-        // May need to calibrate the "unloaded" nozzle tip stand-in i.e. the naked nozzle tip holder. 
+        // May need to calibrate the "unloaded" nozzle tip stand-in i.e. the naked nozzle tip
+        // holder.
         ReferenceNozzleTip calibrationNozzleTip = this.getCalibrationNozzleTip();
-        if (calibrationNozzleTip != null && calibrationNozzleTip.getCalibration().isRecalibrateOnNozzleTipChangeNeeded(this)) {
-            Logger.debug("{}.unloadNozzleTip() nozzle tip {} calibration needed", getName(), calibrationNozzleTip.getName());
-            calibrationNozzleTip.getCalibration().calibrate(this);
+        if (calibrationNozzleTip != null && calibrationNozzleTip.getCalibration()
+                                                                .isRecalibrateOnNozzleTipChangeNeeded(
+                                                                        this)) {
+            Logger.debug("{}.unloadNozzleTip() nozzle tip {} calibration needed", getName(),
+                    calibrationNozzleTip.getName());
+            calibrationNozzleTip.getCalibration()
+                                .calibrate(this);
         }
     }
 
@@ -493,9 +537,11 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
     public Location getLocation() {
         Location location = getDriver().getLocation(this);
         ReferenceNozzleTip calibrationNozzleTip = getCalibrationNozzleTip();
-        if (calibrationNozzleTip != null && calibrationNozzleTip.getCalibration().isCalibrated(this)) {
-            Location offset =
-                    calibrationNozzleTip.getCalibration().getCalibratedOffset(this, location.getRotation());
+        if (calibrationNozzleTip != null && calibrationNozzleTip.getCalibration()
+                                                                .isCalibrated(this)) {
+            Location offset = calibrationNozzleTip.getCalibration()
+                                                  .getCalibratedOffset(this,
+                                                          location.getRotation());
             location = location.add(offset);
         }
         return location;
@@ -526,13 +572,15 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
 
     @Override
     public PropertySheet[] getPropertySheets() {
-        return new PropertySheet[] {
-                new PropertySheetWizardAdapter(getConfigurationWizard()),
-                new PropertySheetWizardAdapter(new ReferenceNozzleCompatibleNozzleTipsWizard(this), "Nozzle Tips"),
-                new PropertySheetWizardAdapter(new ReferenceNozzlePartDetectionWizard(this), "Part Detection"),
-                new PropertySheetWizardAdapter(new ReferenceNozzleToolChangerWizard(this), "Tool Changer"),
-                new PropertySheetWizardAdapter(new ReferenceNozzleCameraOffsetWizard(this), "Offset Wizard"),
-        };
+        return new PropertySheet[] {new PropertySheetWizardAdapter(getConfigurationWizard()),
+                new PropertySheetWizardAdapter(new ReferenceNozzleCompatibleNozzleTipsWizard(this),
+                        "Nozzle Tips"),
+                new PropertySheetWizardAdapter(new ReferenceNozzlePartDetectionWizard(this),
+                        "Part Detection"),
+                new PropertySheetWizardAdapter(new ReferenceNozzleToolChangerWizard(this),
+                        "Tool Changer"),
+                new PropertySheetWizardAdapter(new ReferenceNozzleCameraOffsetWizard(this),
+                        "Offset Wizard"),};
     }
 
     @Override
@@ -549,8 +597,10 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
 
         @Override
         public void actionPerformed(ActionEvent arg0) {
-            if (getHead().getNozzles().size() == 1) {
-                MessageBoxes.errorBox(null, "Error: Nozzle Not Deleted", "Can't delete last nozzle. There must be at least one nozzle.");
+            if (getHead().getNozzles()
+                         .size() == 1) {
+                MessageBoxes.errorBox(null, "Error: Nozzle Not Deleted",
+                        "Can't delete last nozzle. There must be at least one nozzle.");
                 return;
             }
             int ret = JOptionPane.showConfirmDialog(MainFrame.get(),
@@ -577,12 +627,14 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
 
     @Override
     public void moveTo(Location location) throws Exception {
-        moveTo(location, getHead().getMachine().getSpeed());
+        moveTo(location, getHead().getMachine()
+                                  .getSpeed());
     }
 
     @Override
     public void moveToSafeZ() throws Exception {
-        moveToSafeZ(getHead().getMachine().getSpeed());
+        moveToSafeZ(getHead().getMachine()
+                             .getSpeed());
     }
 
     ReferenceDriver getDriver() {
@@ -590,18 +642,20 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
     }
 
     ReferenceMachine getMachine() {
-        return (ReferenceMachine) Configuration.get().getMachine();
+        return (ReferenceMachine) Configuration.get()
+                                               .getMachine();
     }
-    
+
     @Override
     public boolean isPartDetectionEnabled() {
         return vacuumSenseActuatorName != null && !vacuumSenseActuatorName.isEmpty();
     }
-    
+
     private double readVacuumLevel() throws Exception {
         Actuator actuator = getHead().getActuatorByName(vacuumSenseActuatorName);
         if (actuator == null) {
-            throw new Exception(String.format("Can't find vacuum actuator %s", vacuumSenseActuatorName));
+            throw new Exception(
+                    String.format("Can't find vacuum actuator %s", vacuumSenseActuatorName));
         }
         return Double.parseDouble(actuator.read());
     }
@@ -610,13 +664,25 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
     public boolean isPartOn() throws Exception {
         ReferenceNozzleTip nt = getNozzleTip();
         double vacuumLevel = readVacuumLevel();
-        return vacuumLevel >= nt.getVacuumLevelPartOnLow() && vacuumLevel <= nt.getVacuumLevelPartOnHigh();
+        return vacuumLevel >= nt.getVacuumLevelPartOnLow()
+                && vacuumLevel <= nt.getVacuumLevelPartOnHigh();
     }
 
     @Override
     public boolean isPartOff() throws Exception {
         ReferenceNozzleTip nt = getNozzleTip();
         double vacuumLevel = readVacuumLevel();
-        return vacuumLevel >= nt.getVacuumLevelPartOffLow() && vacuumLevel <= nt.getVacuumLevelPartOffHigh();
+        return vacuumLevel >= nt.getVacuumLevelPartOffLow()
+                && vacuumLevel <= nt.getVacuumLevelPartOffHigh();
+    }
+
+    @Override
+    public void pumpOff() throws Exception {
+        getDriver().pumpOff(this);
+    }
+
+    @Override
+    public void pumpOn() throws Exception {
+        getDriver().pumpOn(this);
     }
 }

--- a/src/main/java/org/openpnp/machine/reference/ReferencePnpJobProcessor.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferencePnpJobProcessor.java
@@ -795,14 +795,6 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
                 return;
             }
             try {
-<<<<<<< HEAD
-=======
-                // We need vacuum on to determine the vacuum level.
-                // nozzle.pick(part);
-
-                // nozzle.place();
-
->>>>>>> branch 'develop' of https://github.com/c-riegel/openpnp.git
                 if (!nozzle.isPartOff()) {
                     throw new JobProcessorException(nozzle, "Part detected on nozzle after place.");
                 }

--- a/src/main/java/org/openpnp/machine/reference/driver/GcodeDriver.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/GcodeDriver.java
@@ -859,6 +859,20 @@ public class GcodeDriver extends AbstractReferenceDriver implements Named, Runna
             driver.actuate(actuator, value);
         }
     }
+    
+    public void actuate(ReferenceNozzle nozzle, boolean on) throws Exception {
+        String command = getCommand(nozzle, CommandType.ACTUATE_BOOLEAN_COMMAND);
+        command = substituteVariable(command, "Id", nozzle.getId());
+        command = substituteVariable(command, "Name", nozzle.getName());
+        command = substituteVariable(command, "BooleanValue", on);
+        command = substituteVariable(command, "True", on ? on : null);
+        command = substituteVariable(command, "False", on ? null : on);
+        sendGcode(command);
+
+        for (ReferenceDriver driver : subDrivers) {
+            driver.actuate(nozzle, on);
+        }
+    }
 
     @Override
     public String actuatorRead(ReferenceActuator actuator) throws Exception {

--- a/src/main/java/org/openpnp/machine/reference/driver/GcodeDriver.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/GcodeDriver.java
@@ -785,7 +785,7 @@ public class GcodeDriver extends AbstractReferenceDriver implements Named, Runna
     public void pick(ReferenceNozzle nozzle) throws Exception {
         pickedNozzles.add(nozzle);
         if (pickedNozzles.size() > 0) {
-            pumpOn(nozzle);
+            sendGcode(getCommand(nozzle, CommandType.PUMP_ON_COMMAND));
         }
 
         String command = getCommand(nozzle, CommandType.PICK_COMMAND);
@@ -800,34 +800,27 @@ public class GcodeDriver extends AbstractReferenceDriver implements Named, Runna
     }
 
     @Override
-    public void pumpOn(ReferenceNozzle nozzle) throws Exception {
-        sendGcode(getCommand(nozzle, CommandType.PUMP_ON_COMMAND));
-    }
-
-    @Override
-    public void pumpOff(ReferenceNozzle nozzle) throws Exception {
-        sendGcode(getCommand(nozzle, CommandType.PUMP_OFF_COMMAND));
-    }
-
-    @Override
-    public void place(ReferenceNozzle nozzle) throws Exception {
-
+    public void purge(ReferenceNozzle nozzle) throws Exception {
         String command = getCommand(nozzle, CommandType.PLACE_COMMAND);
         command = substituteVariable(command, "Id", nozzle.getId());
         command = substituteVariable(command, "Name", nozzle.getName());
 
         sendGcode(command);
-
+    }
+    
+    @Override
+    public void place(ReferenceNozzle nozzle) throws Exception {
+        purge(nozzle);
+        
         pickedNozzles.remove(nozzle);
         if (pickedNozzles.size() < 1) {
-            pumpOff(nozzle);
+            sendGcode(getCommand(nozzle, CommandType.PUMP_OFF_COMMAND));
         }
 
         for (ReferenceDriver driver : subDrivers) {
             driver.place(nozzle);
         }
     }
-
 
     @Override
     public void actuate(ReferenceActuator actuator, boolean on) throws Exception {

--- a/src/main/java/org/openpnp/machine/reference/driver/LinuxCNC.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/LinuxCNC.java
@@ -453,8 +453,5 @@ public class LinuxCNC implements ReferenceDriver, Runnable {
     }
 
     @Override
-    public void pumpOn(ReferenceNozzle nozzle) {}
-
-    @Override
-    public void pumpOff(ReferenceNozzle nozzle) {}
+    public void purge(ReferenceNozzle nozzle) {}
 }

--- a/src/main/java/org/openpnp/machine/reference/driver/LinuxCNC.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/LinuxCNC.java
@@ -281,7 +281,7 @@ public class LinuxCNC implements ReferenceDriver, Runnable {
         // Reset all axes to 0, in case the firmware was not reset on
         // connect.
         sendCommand("set mdi G92 X0 Y0 Z0 A0");
-        
+
         connected = true;
     }
 
@@ -447,4 +447,10 @@ public class LinuxCNC implements ReferenceDriver, Runnable {
     public Icon getPropertySheetHolderIcon() {
         return null;
     }
+
+    @Override
+    public void pumpOn(ReferenceNozzle nozzle) {}
+
+    @Override
+    public void pumpOff(ReferenceNozzle nozzle) {}
 }

--- a/src/main/java/org/openpnp/machine/reference/driver/LinuxCNC.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/LinuxCNC.java
@@ -199,6 +199,10 @@ public class LinuxCNC implements ReferenceDriver, Runnable {
         // }
     }
 
+    
+    @Override
+    public void actuate(ReferenceNozzle nozzle, boolean on) throws Exception {
+    }
 
 
     @Override

--- a/src/main/java/org/openpnp/machine/reference/driver/NullDriver.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/NullDriver.java
@@ -239,6 +239,10 @@ public class NullDriver implements ReferenceDriver {
     }
 
     @Override
+    public void actuate(ReferenceNozzle nozzle, boolean on) throws Exception {
+    }
+    
+    @Override
     public void actuate(ReferenceActuator actuator, double value) throws Exception {
         Logger.debug("actuate({}, {})", actuator, value);
         checkEnabled();

--- a/src/main/java/org/openpnp/machine/reference/driver/NullDriver.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/NullDriver.java
@@ -204,8 +204,8 @@ public class NullDriver implements ReferenceDriver {
             setHeadLocation(hm.getHead(), hl);
 
             // Provide live updates to the Machine as the move progresses.
-            ((ReferenceMachine) Configuration.get().getMachine())
-                    .fireMachineHeadActivity(hm.getHead());
+            ((ReferenceMachine) Configuration.get()
+                                             .getMachine()).fireMachineHeadActivity(hm.getHead());
 
             try {
                 Thread.sleep(100);
@@ -255,7 +255,7 @@ public class NullDriver implements ReferenceDriver {
             Thread.sleep(500);
         }
     }
-    
+
     @Override
     public String actuatorRead(ReferenceActuator actuator) throws Exception {
         return Math.random() + "";
@@ -315,4 +315,10 @@ public class NullDriver implements ReferenceDriver {
     public void close() throws IOException {
 
     }
+
+    @Override
+    public void pumpOn(ReferenceNozzle nozzle) {}
+
+    @Override
+    public void pumpOff(ReferenceNozzle nozzle) {}
 }

--- a/src/main/java/org/openpnp/machine/reference/driver/NullDriver.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/NullDriver.java
@@ -321,8 +321,5 @@ public class NullDriver implements ReferenceDriver {
     }
 
     @Override
-    public void pumpOn(ReferenceNozzle nozzle) {}
-
-    @Override
-    public void pumpOff(ReferenceNozzle nozzle) {}
+    public void purge(ReferenceNozzle nozzle) {}
 }

--- a/src/main/java/org/openpnp/machine/reference/feeder/ReferenceDragFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/ReferenceDragFeeder.java
@@ -227,7 +227,8 @@ public class ReferenceDragFeeder extends ReferenceFeeder {
             // if possible, confirm drag pin retraction
             if (pinReturnActuatorValue.length() > 0) {
 
-                if (dragPinActuator.read() != pinReturnActuatorValue) {
+                if (!dragPinActuator.read()
+                                    .equals(pinReturnActuatorValue)) {
                     // if we're here then the pin is stuck, so what follows tries to back off a
                     // second
                     // time by the same amount to try to get the pin free from binding
@@ -244,7 +245,8 @@ public class ReferenceDragFeeder extends ReferenceFeeder {
                     dragPinActuator.actuate(false);
                 }
 
-                if (dragPinActuator.read() != pinReturnActuatorValue) {
+                if (!dragPinActuator.read()
+                                    .equals(pinReturnActuatorValue)) {
                     throw new Exception("Unable to retract drag pin");
                 }
             }

--- a/src/main/java/org/openpnp/machine/reference/feeder/ReferenceDragFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/ReferenceDragFeeder.java
@@ -172,8 +172,6 @@ public class ReferenceDragFeeder extends ReferenceFeeder {
             }
         }
 
-        head.moveToSafeZ();
-
         if (vision.isEnabled()) {
             if (visionOffset == null) {
                 // This is the first feed with vision, or the offset has
@@ -207,12 +205,15 @@ public class ReferenceDragFeeder extends ReferenceFeeder {
             }
 
             // Move the actuator to the feed start location.
+            Logger.debug("\n\nfeed: move to pin start");
             dragPinActuator.moveTo(feedStartLocation.derive(null, null, Double.NaN, Double.NaN));
 
             // extend the pin
+            Logger.debug("\n\nfeed: actuate pin");
             dragPinActuator.actuate(true);
 
             // drag the tape
+            Logger.debug("\n\nfeed: move to pin end");
             dragPinActuator.moveTo(feedEndLocation, feedSpeed * dragPinActuator.getHead()
                                                                                .getMachine()
                                                                                .getSpeed());
@@ -223,7 +224,12 @@ public class ReferenceDragFeeder extends ReferenceFeeder {
                 peelOffActuator.actuate(false);
             }
 
+            // retract the pin
+            Logger.debug("\n\nfeed: retract pin");
+            dragPinActuator.actuate(false);
+            
             // back off to release tension from the pin
+            Logger.debug("\n\nfeed: move to pin backoff 1");
             if (backoffDistance.getValue() != 0) {
                 Location backoffLocation = Utils2D.getPointAlongLine(feedEndLocation,
                         feedStartLocation, backoffDistance);
@@ -231,9 +237,6 @@ public class ReferenceDragFeeder extends ReferenceFeeder {
                                                                                    .getMachine()
                                                                                    .getSpeed());
             }
-
-            // retract the pin
-            dragPinActuator.actuate(false);
 
             // if possible, confirm drag pin retraction
             if (pinReturnActuatorValue.length() > 0) {
@@ -243,6 +246,7 @@ public class ReferenceDragFeeder extends ReferenceFeeder {
                     // if we're here then the pin is stuck, so what follows tries to back off a
                     // second
                     // time by the same amount to try to get the pin free from binding
+                    Logger.debug("\n\nfeed: move to pin backoff 2");
                     if (backoffDistance.getValue() != 0) {
                         Location backoffLocation2 = Utils2D.getPointAlongLine(feedEndLocation,
                                 feedStartLocation, backoffDistance.add(backoffDistance));
@@ -263,8 +267,6 @@ public class ReferenceDragFeeder extends ReferenceFeeder {
                 }
             }
 
-
-
             if (this.isPart0402() == true) {
                 // can change it to "feededCount = parts_count_userSettings;"
                 feededCount = 2;
@@ -274,14 +276,14 @@ public class ReferenceDragFeeder extends ReferenceFeeder {
             Logger.debug("Multi parts drag feeder: skipping drag feededCount = " + feededCount);
         }
 
-        head.moveToSafeZ();
-
         if (vision.isEnabled()) {
             visionOffset = getVisionOffsets(head, location);
 
             Logger.debug("final visionOffsets " + visionOffset);
             Logger.debug("Modified pickLocation {}", pickLocation.subtract(visionOffset));
         }
+        
+        Logger.debug("feed({}) complete", nozzle);
     }
 
     // TODO: Throw an Exception if vision fails.

--- a/src/main/java/org/openpnp/machine/reference/feeder/wizards/ReferenceDragFeederConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/wizards/ReferenceDragFeederConfigurationWizard.java
@@ -79,13 +79,13 @@ public class ReferenceDragFeederConfigurationWizard
     private JTextField textFieldFeedEndY;
     private JTextField textFieldFeedEndZ;
     private JTextField textFieldFeedRate;
-    private JLabel lblActuatorId;
-    private JLabel lblPeelOffActuatorId;
     private JLabel lbl0402PartDetected;
     private JTextField textFieldActuatorId;
     private JTextField textFieldPeelOffActuatorId;
+    private JTextField textFieldRetractActuatorValue;
     private JPanel panelGeneral;
     private JPanel panelVision;
+    private JPanel panelActuators;
     private JPanel panelLocations;
     private JCheckBox chckbxVisionEnabled;
     private JPanel panelVisionEnabled;
@@ -123,39 +123,88 @@ public class ReferenceDragFeederConfigurationWizard
                 TitledBorder.TOP, null, null));
 
         panelFields.add(panelGeneral);
-        panelGeneral.setLayout(new FormLayout(
-                new ColumnSpec[] {FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,
-                        FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,
-                        FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,
-                        FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,},
-                new RowSpec[] {FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
-                        FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,}));
+        panelGeneral.setLayout(new FormLayout(new ColumnSpec[] {
+                FormSpecs.RELATED_GAP_COLSPEC,
+                FormSpecs.DEFAULT_COLSPEC,
+                FormSpecs.RELATED_GAP_COLSPEC,
+                FormSpecs.DEFAULT_COLSPEC,
+                FormSpecs.RELATED_GAP_COLSPEC,
+                FormSpecs.DEFAULT_COLSPEC,
+                FormSpecs.RELATED_GAP_COLSPEC,
+                FormSpecs.DEFAULT_COLSPEC,
+                FormSpecs.RELATED_GAP_COLSPEC,
+                ColumnSpec.decode("left:default:grow"),},
+            new RowSpec[] {
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,}));
 
         JLabel lblFeedRate = new JLabel("Feed Speed %");
         panelGeneral.add(lblFeedRate, "2, 2");
-
+        
         textFieldFeedRate = new JTextField();
         panelGeneral.add(textFieldFeedRate, "4, 2");
         textFieldFeedRate.setColumns(5);
-
-        lblActuatorId = new JLabel("Actuator Name");
-        panelGeneral.add(lblActuatorId, "2, 4, right, default");
-
-        textFieldActuatorId = new JTextField();
-        panelGeneral.add(textFieldActuatorId, "4, 4");
-        textFieldActuatorId.setColumns(5);
-
-        lblPeelOffActuatorId = new JLabel("Peel Off Actuator Name");
-        panelGeneral.add(lblPeelOffActuatorId, "6, 4, right, default");
-
-        textFieldPeelOffActuatorId = new JTextField();
-        panelGeneral.add(textFieldPeelOffActuatorId, "8, 4");
-        textFieldPeelOffActuatorId.setColumns(5);
-
+        
         if (feeder.isPart0402()) {
 	        lbl0402PartDetected = new JLabel("0402 Part DETECTED");
 	        panelGeneral.add(lbl0402PartDetected, "6, 2");
         }
+        
+        panelActuators = new JPanel();
+        panelFields.add(panelActuators);
+        panelActuators.setBorder(new TitledBorder(null, "Actuators", TitledBorder.LEADING,
+                TitledBorder.TOP, null, null));
+        panelActuators.setLayout(new FormLayout(new ColumnSpec[] {
+                FormSpecs.RELATED_GAP_COLSPEC,
+                FormSpecs.DEFAULT_COLSPEC,
+                FormSpecs.RELATED_GAP_COLSPEC,
+                FormSpecs.DEFAULT_COLSPEC,
+                FormSpecs.RELATED_GAP_COLSPEC,
+                FormSpecs.DEFAULT_COLSPEC,
+                FormSpecs.RELATED_GAP_COLSPEC,
+                FormSpecs.DEFAULT_COLSPEC,
+                FormSpecs.RELATED_GAP_COLSPEC,
+                ColumnSpec.decode("left:default:grow"),},
+            new RowSpec[] {
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,}));
+
+        JLabel lblDragPin = new JLabel("Drag Pin");
+        panelActuators.add(lblDragPin, "2, 2");
+
+        JLabel lblPinRetract = new JLabel("Pin Retracted Value");
+        panelActuators.add(lblPinRetract, "4, 2");
+        
+        JLabel lblPeelOff = new JLabel("Peel Off");
+        panelActuators.add(lblPeelOff, "6, 2");
+
+        textFieldActuatorId = new JTextField();
+        panelActuators.add(textFieldActuatorId, "2, 4");
+        textFieldActuatorId.setColumns(12);
+        
+        textFieldRetractActuatorValue = new JTextField();
+        panelActuators.add(textFieldRetractActuatorValue, "4, 4");
+        textFieldRetractActuatorValue.setColumns(12);
+
+        textFieldPeelOffActuatorId = new JTextField();
+        panelActuators.add(textFieldPeelOffActuatorId, "6, 4");
+        textFieldPeelOffActuatorId.setColumns(12);
 
         panelLocations = new JPanel();
         panelFields.add(panelLocations);
@@ -367,7 +416,8 @@ public class ReferenceDragFeederConfigurationWizard
         addWrappedBinding(feeder, "feedSpeed", textFieldFeedRate, "text", percentConverter);
         addWrappedBinding(feeder, "actuatorName", textFieldActuatorId, "text");
         addWrappedBinding(feeder, "peelOffActuatorName", textFieldPeelOffActuatorId, "text");
-
+        addWrappedBinding(feeder, "pinReturnActuatorValue", textFieldRetractActuatorValue, "text");
+        
         MutableLocationProxy feedStartLocation = new MutableLocationProxy();
         bind(UpdateStrategy.READ_WRITE, feeder, "feedStartLocation", feedStartLocation, "location");
         addWrappedBinding(feedStartLocation, "lengthX", textFieldFeedStartX, "text",
@@ -400,6 +450,7 @@ public class ReferenceDragFeederConfigurationWizard
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldFeedRate);
         ComponentDecorators.decorateWithAutoSelect(textFieldActuatorId);
         ComponentDecorators.decorateWithAutoSelect(textFieldPeelOffActuatorId);
+        ComponentDecorators.decorateWithAutoSelect(textFieldRetractActuatorValue);
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldFeedStartX);
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldFeedStartY);
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldFeedStartZ);

--- a/src/main/java/org/openpnp/machine/reference/feeder/wizards/ReferenceDragFeederConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/wizards/ReferenceDragFeederConfigurationWizard.java
@@ -44,8 +44,6 @@ import javax.swing.border.EtchedBorder;
 import javax.swing.border.TitledBorder;
 
 import org.jdesktop.beansbinding.AutoBinding.UpdateStrategy;
-import org.jdesktop.beansbinding.BeanProperty;
-import org.jdesktop.beansbinding.Bindings;
 import org.openpnp.gui.MainFrame;
 import org.openpnp.gui.components.CameraView;
 import org.openpnp.gui.components.ComponentDecorators;
@@ -110,6 +108,7 @@ public class ReferenceDragFeederConfigurationWizard
     private JPanel panel;
     private JButton btnCancelChangeTemplateImage;
     private JButton btnResetVisionOffsets;
+    private JButton btnSetPartOffset;
 
     public ReferenceDragFeederConfigurationWizard(ReferenceDragFeeder feeder) {
         super(feeder);
@@ -123,81 +122,59 @@ public class ReferenceDragFeederConfigurationWizard
                 TitledBorder.TOP, null, null));
 
         panelFields.add(panelGeneral);
-        panelGeneral.setLayout(new FormLayout(new ColumnSpec[] {
-                FormSpecs.RELATED_GAP_COLSPEC,
-                FormSpecs.DEFAULT_COLSPEC,
-                FormSpecs.RELATED_GAP_COLSPEC,
-                FormSpecs.DEFAULT_COLSPEC,
-                FormSpecs.RELATED_GAP_COLSPEC,
-                FormSpecs.DEFAULT_COLSPEC,
-                FormSpecs.RELATED_GAP_COLSPEC,
-                FormSpecs.DEFAULT_COLSPEC,
-                FormSpecs.RELATED_GAP_COLSPEC,
-                ColumnSpec.decode("left:default:grow"),},
-            new RowSpec[] {
-                FormSpecs.RELATED_GAP_ROWSPEC,
-                FormSpecs.DEFAULT_ROWSPEC,
-                FormSpecs.RELATED_GAP_ROWSPEC,
-                FormSpecs.DEFAULT_ROWSPEC,
-                FormSpecs.RELATED_GAP_ROWSPEC,
-                FormSpecs.DEFAULT_ROWSPEC,
-                FormSpecs.RELATED_GAP_ROWSPEC,
-                FormSpecs.DEFAULT_ROWSPEC,
-                FormSpecs.RELATED_GAP_ROWSPEC,
-                FormSpecs.DEFAULT_ROWSPEC,}));
+        panelGeneral.setLayout(new FormLayout(
+                new ColumnSpec[] {FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,
+                        FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,
+                        FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,
+                        FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,
+                        FormSpecs.RELATED_GAP_COLSPEC, ColumnSpec.decode("left:default:grow"),},
+                new RowSpec[] {FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,}));
 
         JLabel lblFeedRate = new JLabel("Feed Speed %");
         panelGeneral.add(lblFeedRate, "2, 2");
-        
+
         textFieldFeedRate = new JTextField();
         panelGeneral.add(textFieldFeedRate, "4, 2");
         textFieldFeedRate.setColumns(5);
-        
+
         if (feeder.isPart0402()) {
-	        lbl0402PartDetected = new JLabel("0402 Part DETECTED");
-	        panelGeneral.add(lbl0402PartDetected, "6, 2");
+            lbl0402PartDetected = new JLabel("0402 Part DETECTED");
+            panelGeneral.add(lbl0402PartDetected, "6, 2");
         }
-        
+
         panelActuators = new JPanel();
         panelFields.add(panelActuators);
         panelActuators.setBorder(new TitledBorder(null, "Actuators", TitledBorder.LEADING,
                 TitledBorder.TOP, null, null));
-        panelActuators.setLayout(new FormLayout(new ColumnSpec[] {
-                FormSpecs.RELATED_GAP_COLSPEC,
-                FormSpecs.DEFAULT_COLSPEC,
-                FormSpecs.RELATED_GAP_COLSPEC,
-                FormSpecs.DEFAULT_COLSPEC,
-                FormSpecs.RELATED_GAP_COLSPEC,
-                FormSpecs.DEFAULT_COLSPEC,
-                FormSpecs.RELATED_GAP_COLSPEC,
-                FormSpecs.DEFAULT_COLSPEC,
-                FormSpecs.RELATED_GAP_COLSPEC,
-                ColumnSpec.decode("left:default:grow"),},
-            new RowSpec[] {
-                FormSpecs.RELATED_GAP_ROWSPEC,
-                FormSpecs.DEFAULT_ROWSPEC,
-                FormSpecs.RELATED_GAP_ROWSPEC,
-                FormSpecs.DEFAULT_ROWSPEC,
-                FormSpecs.RELATED_GAP_ROWSPEC,
-                FormSpecs.DEFAULT_ROWSPEC,
-                FormSpecs.RELATED_GAP_ROWSPEC,
-                FormSpecs.DEFAULT_ROWSPEC,
-                FormSpecs.RELATED_GAP_ROWSPEC,
-                FormSpecs.DEFAULT_ROWSPEC,}));
+        panelActuators.setLayout(new FormLayout(
+                new ColumnSpec[] {FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,
+                        FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,
+                        FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,
+                        FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,
+                        FormSpecs.RELATED_GAP_COLSPEC, ColumnSpec.decode("left:default:grow"),},
+                new RowSpec[] {FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,}));
 
         JLabel lblDragPin = new JLabel("Drag Pin");
         panelActuators.add(lblDragPin, "2, 2");
 
         JLabel lblPinRetract = new JLabel("Pin Retracted Value");
         panelActuators.add(lblPinRetract, "4, 2");
-        
+
         JLabel lblPeelOff = new JLabel("Peel Off");
         panelActuators.add(lblPeelOff, "6, 2");
 
         textFieldActuatorId = new JTextField();
         panelActuators.add(textFieldActuatorId, "2, 4");
         textFieldActuatorId.setColumns(12);
-        
+
         textFieldRetractActuatorValue = new JTextField();
         panelActuators.add(textFieldRetractActuatorValue, "4, 4");
         textFieldRetractActuatorValue.setColumns(12);
@@ -210,28 +187,17 @@ public class ReferenceDragFeederConfigurationWizard
         panelFields.add(panelLocations);
         panelLocations.setBorder(new TitledBorder(null, "Locations", TitledBorder.LEADING,
                 TitledBorder.TOP, null, null));
-        panelLocations.setLayout(new FormLayout(new ColumnSpec[] {
-                FormSpecs.RELATED_GAP_COLSPEC,
-                FormSpecs.DEFAULT_COLSPEC,
-                FormSpecs.RELATED_GAP_COLSPEC,
-                FormSpecs.DEFAULT_COLSPEC,
-                FormSpecs.RELATED_GAP_COLSPEC,
-                FormSpecs.DEFAULT_COLSPEC,
-                FormSpecs.RELATED_GAP_COLSPEC,
-                FormSpecs.DEFAULT_COLSPEC,
-                FormSpecs.RELATED_GAP_COLSPEC,
-                ColumnSpec.decode("left:default:grow"),},
-            new RowSpec[] {
-                FormSpecs.RELATED_GAP_ROWSPEC,
-                FormSpecs.DEFAULT_ROWSPEC,
-                FormSpecs.RELATED_GAP_ROWSPEC,
-                FormSpecs.DEFAULT_ROWSPEC,
-                FormSpecs.RELATED_GAP_ROWSPEC,
-                FormSpecs.DEFAULT_ROWSPEC,
-                FormSpecs.RELATED_GAP_ROWSPEC,
-                FormSpecs.DEFAULT_ROWSPEC,
-                FormSpecs.RELATED_GAP_ROWSPEC,
-                FormSpecs.DEFAULT_ROWSPEC,}));
+        panelLocations.setLayout(new FormLayout(
+                new ColumnSpec[] {FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,
+                        FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,
+                        FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,
+                        FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,
+                        FormSpecs.RELATED_GAP_COLSPEC, ColumnSpec.decode("left:default:grow"),},
+                new RowSpec[] {FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,}));
 
         JLabel lblX = new JLabel("X");
         panelLocations.add(lblX, "4, 4");
@@ -279,13 +245,21 @@ public class ReferenceDragFeederConfigurationWizard
         locationButtonsPanelFeedEnd = new LocationButtonsPanel(textFieldFeedEndX, textFieldFeedEndY,
                 textFieldFeedEndZ, null);
         panelLocations.add(locationButtonsPanelFeedEnd, "10, 8");
-        
+
         lblBackoffDistance = new JLabel("Backoff Distance");
         panelLocations.add(lblBackoffDistance, "2, 10, right, default");
-        
+
         backoffDistTf = new JTextField();
         panelLocations.add(backoffDistTf, "4, 10");
         backoffDistTf.setColumns(10);
+
+        btnSetPartOffset = new JButton("Update next part offset to:");
+        btnSetPartOffset.setAction(setNextPartOffset);
+        panelLocations.add(btnSetPartOffset, "6, 10");
+
+        nextPartOffset = new JTextField();
+        panelLocations.add(nextPartOffset, "8, 10");
+        nextPartOffset.setColumns(10);
         //
         panelVision = new JPanel();
         panelVision.setBorder(new TitledBorder(null, "Vision", TitledBorder.LEADING,
@@ -349,13 +323,11 @@ public class ReferenceDragFeederConfigurationWizard
                         FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,
                         FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,
                         FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,},
-                new RowSpec[] {
-						FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
+                new RowSpec[] {FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
                         FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
                         FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
                         FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
-                        FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
-                        }));
+                        FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,}));
 
         lblX_1 = new JLabel("X");
         panelAoE.add(lblX_1, "2, 2");
@@ -408,8 +380,8 @@ public class ReferenceDragFeederConfigurationWizard
         super.createBindings();
         LengthConverter lengthConverter = new LengthConverter();
         IntegerConverter intConverter = new IntegerConverter();
-        DoubleConverter doubleConverter =
-                new DoubleConverter(Configuration.get().getLengthDisplayFormat());
+        DoubleConverter doubleConverter = new DoubleConverter(Configuration.get()
+                                                                           .getLengthDisplayFormat());
         BufferedImageIconConverter imageConverter = new BufferedImageIconConverter();
         PercentConverter percentConverter = new PercentConverter();
 
@@ -417,7 +389,7 @@ public class ReferenceDragFeederConfigurationWizard
         addWrappedBinding(feeder, "actuatorName", textFieldActuatorId, "text");
         addWrappedBinding(feeder, "peelOffActuatorName", textFieldPeelOffActuatorId, "text");
         addWrappedBinding(feeder, "pinReturnActuatorValue", textFieldRetractActuatorValue, "text");
-        
+
         MutableLocationProxy feedStartLocation = new MutableLocationProxy();
         bind(UpdateStrategy.READ_WRITE, feeder, "feedStartLocation", feedStartLocation, "location");
         addWrappedBinding(feedStartLocation, "lengthX", textFieldFeedStartX, "text",
@@ -444,8 +416,9 @@ public class ReferenceDragFeederConfigurationWizard
                 intConverter);
         addWrappedBinding(feeder, "vision.areaOfInterest.height", textFieldAoiHeight, "text",
                 intConverter);
-        
+
         addWrappedBinding(feeder, "backoffDistance", backoffDistTf, "text", lengthConverter);
+        addWrappedBinding(feeder, "uiNextPartOffset", nextPartOffset, "text", intConverter);
 
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldFeedRate);
         ComponentDecorators.decorateWithAutoSelect(textFieldActuatorId);
@@ -462,9 +435,12 @@ public class ReferenceDragFeederConfigurationWizard
         ComponentDecorators.decorateWithAutoSelect(textFieldAoiWidth);
         ComponentDecorators.decorateWithAutoSelect(textFieldAoiHeight);
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(backoffDistTf);
+        ComponentDecorators.decorateWithAutoSelect(nextPartOffset);
 
-        bind(UpdateStrategy.READ, feeder, "actuatorName", locationButtonsPanelFeedStart, "actuatorName");
-        bind(UpdateStrategy.READ, feeder, "actuatorName", locationButtonsPanelFeedEnd, "actuatorName");
+        bind(UpdateStrategy.READ, feeder, "actuatorName", locationButtonsPanelFeedStart,
+                "actuatorName");
+        bind(UpdateStrategy.READ, feeder, "actuatorName", locationButtonsPanelFeedEnd,
+                "actuatorName");
     }
 
     @SuppressWarnings("serial")
@@ -472,9 +448,14 @@ public class ReferenceDragFeederConfigurationWizard
         @Override
         public void actionPerformed(ActionEvent arg0) {
             UiUtils.messageBoxOnException(() -> {
-                Camera camera = MainFrame.get().getMachineControls().getSelectedTool().getHead()
-                        .getDefaultCamera();
-                CameraView cameraView = MainFrame.get().getCameraViews().setSelectedCamera(camera);
+                Camera camera = MainFrame.get()
+                                         .getMachineControls()
+                                         .getSelectedTool()
+                                         .getHead()
+                                         .getDefaultCamera();
+                CameraView cameraView = MainFrame.get()
+                                                 .getCameraViews()
+                                                 .setSelectedCamera(camera);
 
                 cameraView.setSelectionEnabled(true);
                 // org.openpnp.model.Rectangle r =
@@ -498,9 +479,14 @@ public class ReferenceDragFeederConfigurationWizard
         @Override
         public void actionPerformed(ActionEvent arg0) {
             UiUtils.messageBoxOnException(() -> {
-                Camera camera = MainFrame.get().getMachineControls().getSelectedTool().getHead()
-                        .getDefaultCamera();
-                CameraView cameraView = MainFrame.get().getCameraViews().setSelectedCamera(camera);
+                Camera camera = MainFrame.get()
+                                         .getMachineControls()
+                                         .getSelectedTool()
+                                         .getHead()
+                                         .getDefaultCamera();
+                CameraView cameraView = MainFrame.get()
+                                                 .getCameraViews()
+                                                 .setSelectedCamera(camera);
 
                 BufferedImage image = cameraView.captureSelectionImage();
                 if (image == null) {
@@ -523,9 +509,14 @@ public class ReferenceDragFeederConfigurationWizard
         @Override
         public void actionPerformed(ActionEvent arg0) {
             UiUtils.messageBoxOnException(() -> {
-                Camera camera = MainFrame.get().getMachineControls().getSelectedTool().getHead()
-                        .getDefaultCamera();
-                CameraView cameraView = MainFrame.get().getCameraViews().setSelectedCamera(camera);
+                Camera camera = MainFrame.get()
+                                         .getMachineControls()
+                                         .getSelectedTool()
+                                         .getHead()
+                                         .getDefaultCamera();
+                CameraView cameraView = MainFrame.get()
+                                                 .getCameraViews()
+                                                 .setSelectedCamera(camera);
 
                 btnChangeTemplateImage.setAction(selectTemplateImageAction);
                 cancelSelectTemplateImageAction.setEnabled(false);
@@ -539,15 +530,21 @@ public class ReferenceDragFeederConfigurationWizard
         @Override
         public void actionPerformed(ActionEvent arg0) {
             UiUtils.messageBoxOnException(() -> {
-                Camera camera = MainFrame.get().getMachineControls().getSelectedTool().getHead()
-                        .getDefaultCamera();
-                CameraView cameraView = MainFrame.get().getCameraViews().setSelectedCamera(camera);
+                Camera camera = MainFrame.get()
+                                         .getMachineControls()
+                                         .getSelectedTool()
+                                         .getHead()
+                                         .getDefaultCamera();
+                CameraView cameraView = MainFrame.get()
+                                                 .getCameraViews()
+                                                 .setSelectedCamera(camera);
 
                 btnChangeAoi.setAction(confirmSelectAoiAction);
                 cancelSelectAoiAction.setEnabled(true);
 
                 cameraView.setSelectionEnabled(true);
-                org.openpnp.model.Rectangle r = feeder.getVision().getAreaOfInterest();
+                org.openpnp.model.Rectangle r = feeder.getVision()
+                                                      .getAreaOfInterest();
                 if (r == null || r.getWidth() == 0 || r.getHeight() == 0) {
                     cameraView.setSelection(0, 0, 100, 100);
                 }
@@ -563,9 +560,14 @@ public class ReferenceDragFeederConfigurationWizard
         @Override
         public void actionPerformed(ActionEvent arg0) {
             UiUtils.messageBoxOnException(() -> {
-                Camera camera = MainFrame.get().getMachineControls().getSelectedTool().getHead()
-                        .getDefaultCamera();
-                CameraView cameraView = MainFrame.get().getCameraViews().setSelectedCamera(camera);
+                Camera camera = MainFrame.get()
+                                         .getMachineControls()
+                                         .getSelectedTool()
+                                         .getHead()
+                                         .getDefaultCamera();
+                CameraView cameraView = MainFrame.get()
+                                                 .getCameraViews()
+                                                 .setSelectedCamera(camera);
 
                 btnChangeAoi.setAction(selectAoiAction);
                 cancelSelectAoiAction.setEnabled(false);
@@ -589,9 +591,14 @@ public class ReferenceDragFeederConfigurationWizard
         @Override
         public void actionPerformed(ActionEvent arg0) {
             UiUtils.messageBoxOnException(() -> {
-                Camera camera = MainFrame.get().getMachineControls().getSelectedTool().getHead()
-                        .getDefaultCamera();
-                CameraView cameraView = MainFrame.get().getCameraViews().setSelectedCamera(camera);
+                Camera camera = MainFrame.get()
+                                         .getMachineControls()
+                                         .getSelectedTool()
+                                         .getHead()
+                                         .getDefaultCamera();
+                CameraView cameraView = MainFrame.get()
+                                                 .getCameraViews()
+                                                 .setSelectedCamera(camera);
 
                 btnChangeAoi.setAction(selectAoiAction);
                 cancelSelectAoiAction.setEnabled(false);
@@ -607,10 +614,21 @@ public class ReferenceDragFeederConfigurationWizard
         @Override
         public void actionPerformed(ActionEvent arg0) {
             UiUtils.messageBoxOnException(() -> {
-				feeder.resetVisionOffsets();
+                feeder.resetVisionOffsets();
+            });
+        }
+    };
+
+    @SuppressWarnings("serial")
+    private Action setNextPartOffset = new AbstractAction("Set next part offset to:") {
+        @Override
+        public void actionPerformed(ActionEvent arg0) {
+            UiUtils.messageBoxOnException(() -> {
+                feeder.updateNextPartOffset();
             });
         }
     };
     private JLabel lblBackoffDistance;
     private JTextField backoffDistTf;
+    private JTextField nextPartOffset;
 }

--- a/src/main/java/org/openpnp/machine/reference/wizards/ReferenceHeadConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/wizards/ReferenceHeadConfigurationWizard.java
@@ -19,6 +19,12 @@
 
 package org.openpnp.machine.reference.wizards;
 
+import java.awt.event.ActionEvent;
+
+import javax.swing.AbstractAction;
+import javax.swing.Action;
+import javax.swing.JButton;
+import javax.swing.JCheckBox;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JTextField;
@@ -43,13 +49,6 @@ import com.jgoodies.forms.layout.ColumnSpec;
 import com.jgoodies.forms.layout.FormLayout;
 import com.jgoodies.forms.layout.FormSpecs;
 import com.jgoodies.forms.layout.RowSpec;
-
-import java.awt.event.ActionEvent;
-
-import javax.swing.AbstractAction;
-import javax.swing.Action;
-import javax.swing.JButton;
-import javax.swing.JCheckBox;
 
 @SuppressWarnings("serial")
 public class ReferenceHeadConfigurationWizard extends AbstractConfigurationWizard {
@@ -164,25 +163,35 @@ public class ReferenceHeadConfigurationWizard extends AbstractConfigurationWizar
 
         softLimitsEnabled = new JCheckBox("Enabled?");
         panel_1.add(softLimitsEnabled, "2, 8, 7, 1");
-        
+
         JPanel panel_2 = new JPanel();
-        panel_2.setBorder(new TitledBorder(null, "Z Probe", TitledBorder.LEADING, TitledBorder.TOP, null, null));
+        panel_2.setBorder(new TitledBorder(null, "Z Probe", TitledBorder.LEADING, TitledBorder.TOP,
+                null, null));
         contentPanel.add(panel_2);
-        panel_2.setLayout(new FormLayout(new ColumnSpec[] {
-                FormSpecs.RELATED_GAP_COLSPEC,
-                FormSpecs.DEFAULT_COLSPEC,
-                FormSpecs.RELATED_GAP_COLSPEC,
-                FormSpecs.DEFAULT_COLSPEC,},
-            new RowSpec[] {
-                FormSpecs.RELATED_GAP_ROWSPEC,
-                FormSpecs.DEFAULT_ROWSPEC,}));
-        
+        panel_2.setLayout(new FormLayout(
+                new ColumnSpec[] {FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,
+                        FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,
+                        FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,
+                        FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,
+                        FormSpecs.RELATED_GAP_COLSPEC, ColumnSpec.decode("left:default:grow"),},
+                new RowSpec[] {FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,}));
+
         JLabel lblNewLabel_4 = new JLabel("Z Probe Actuator Name");
         panel_2.add(lblNewLabel_4, "2, 2, right, default");
-        
+
         zProbeActuatorName = new JTextField();
         panel_2.add(zProbeActuatorName, "4, 2, fill, default");
         zProbeActuatorName.setColumns(15);
+
+        JLabel lblNewLabel_5 = new JLabel("Z Probe Safe Z Value");
+        panel_2.add(lblNewLabel_5, "2, 4, right, default");
+
+        zProbeActuatorSafeZValue = new JTextField();
+        panel_2.add(zProbeActuatorSafeZValue, "4, 4, fill, default");
     }
 
     @Override
@@ -207,6 +216,7 @@ public class ReferenceHeadConfigurationWizard extends AbstractConfigurationWizar
         addWrappedBinding(head, "softLimitsEnabled", softLimitsEnabled, "selected");
 
         addWrappedBinding(head, "zProbeActuatorName", zProbeActuatorName, "text");
+        addWrappedBinding(head, "zProbeActuatorSafeZValue", zProbeActuatorSafeZValue, "text");
 
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(parkX);
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(parkY);
@@ -214,8 +224,9 @@ public class ReferenceHeadConfigurationWizard extends AbstractConfigurationWizar
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(minY);
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(maxX);
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(maxY);
-        
+
         ComponentDecorators.decorateWithAutoSelect(zProbeActuatorName);
+        ComponentDecorators.decorateWithAutoSelect(zProbeActuatorSafeZValue);
     }
 
     private static Location getParsedLocation(JTextField textFieldX, JTextField textFieldY) {
@@ -342,4 +353,5 @@ public class ReferenceHeadConfigurationWizard extends AbstractConfigurationWizar
     private JTextField maxY;
     private JCheckBox softLimitsEnabled;
     private JTextField zProbeActuatorName;
+    private JTextField zProbeActuatorSafeZValue;
 }

--- a/src/main/java/org/openpnp/machine/reference/wizards/ReferenceHeadConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/wizards/ReferenceHeadConfigurationWizard.java
@@ -192,6 +192,21 @@ public class ReferenceHeadConfigurationWizard extends AbstractConfigurationWizar
 
         zProbeActuatorSafeZValue = new JTextField();
         panel_2.add(zProbeActuatorSafeZValue, "4, 4, fill, default");
+        zProbeActuatorSafeZValue.setColumns(15);
+
+        JLabel lblNewLabel_6 = new JLabel("Z Safe Check Actuator Name");
+        panel_2.add(lblNewLabel_6, "2, 6, right, default");
+
+        zSafeCheckActuatorName = new JTextField();
+        panel_2.add(zSafeCheckActuatorName, "4, 6, fill, default");
+        zSafeCheckActuatorName.setColumns(15);
+
+        JLabel lblNewLabel_7 = new JLabel("Z Safe Check Actuator Ok Value");
+        panel_2.add(lblNewLabel_7, "2, 8, right, default");
+
+        zSafeCheckActuatorOkValue = new JTextField();
+        panel_2.add(zSafeCheckActuatorOkValue, "4, 8, fill, default");
+        zSafeCheckActuatorOkValue.setColumns(15);
     }
 
     @Override
@@ -217,6 +232,8 @@ public class ReferenceHeadConfigurationWizard extends AbstractConfigurationWizar
 
         addWrappedBinding(head, "zProbeActuatorName", zProbeActuatorName, "text");
         addWrappedBinding(head, "zProbeActuatorSafeZValue", zProbeActuatorSafeZValue, "text");
+        addWrappedBinding(head, "zSafeCheckActuatorName", zSafeCheckActuatorName, "text");
+        addWrappedBinding(head, "zSafeCheckActuatorValue", zSafeCheckActuatorOkValue, "text");
 
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(parkX);
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(parkY);
@@ -227,6 +244,8 @@ public class ReferenceHeadConfigurationWizard extends AbstractConfigurationWizar
 
         ComponentDecorators.decorateWithAutoSelect(zProbeActuatorName);
         ComponentDecorators.decorateWithAutoSelect(zProbeActuatorSafeZValue);
+        ComponentDecorators.decorateWithAutoSelect(zSafeCheckActuatorName);
+        ComponentDecorators.decorateWithAutoSelect(zSafeCheckActuatorOkValue);
     }
 
     private static Location getParsedLocation(JTextField textFieldX, JTextField textFieldY) {
@@ -354,4 +373,6 @@ public class ReferenceHeadConfigurationWizard extends AbstractConfigurationWizar
     private JCheckBox softLimitsEnabled;
     private JTextField zProbeActuatorName;
     private JTextField zProbeActuatorSafeZValue;
+    private JTextField zSafeCheckActuatorName;
+    private JTextField zSafeCheckActuatorOkValue;
 }

--- a/src/main/java/org/openpnp/machine/reference/wizards/ReferenceHeadConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/wizards/ReferenceHeadConfigurationWizard.java
@@ -165,7 +165,7 @@ public class ReferenceHeadConfigurationWizard extends AbstractConfigurationWizar
         panel_1.add(softLimitsEnabled, "2, 8, 7, 1");
 
         JPanel panel_2 = new JPanel();
-        panel_2.setBorder(new TitledBorder(null, "Z Probe", TitledBorder.LEADING, TitledBorder.TOP,
+        panel_2.setBorder(new TitledBorder(null, "Z Actuators", TitledBorder.LEADING, TitledBorder.TOP,
                 null, null));
         contentPanel.add(panel_2);
         panel_2.setLayout(new FormLayout(
@@ -180,33 +180,33 @@ public class ReferenceHeadConfigurationWizard extends AbstractConfigurationWizar
                         FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
                         FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,}));
 
-        JLabel lblNewLabel_4 = new JLabel("Z Probe Actuator Name");
+        JLabel lblNewLabel_4 = new JLabel("Safe Z Actuator Name");
         panel_2.add(lblNewLabel_4, "2, 2, right, default");
 
-        zProbeActuatorName = new JTextField();
-        panel_2.add(zProbeActuatorName, "4, 2, fill, default");
-        zProbeActuatorName.setColumns(15);
+        zSafeActuatorName = new JTextField();
+        panel_2.add(zSafeActuatorName, "4, 2, fill, default");
+        zSafeActuatorName.setColumns(15);
 
-        JLabel lblNewLabel_5 = new JLabel("Z Probe Safe Z Value");
+        JLabel lblNewLabel_5 = new JLabel("Safe Z Value");
         panel_2.add(lblNewLabel_5, "2, 4, right, default");
 
-        zProbeActuatorSafeZValue = new JTextField();
-        panel_2.add(zProbeActuatorSafeZValue, "4, 4, fill, default");
-        zProbeActuatorSafeZValue.setColumns(15);
+        zSafeActuatorValue = new JTextField();
+        panel_2.add(zSafeActuatorValue, "4, 4, fill, default");
+        zSafeActuatorValue.setColumns(15);
 
-        JLabel lblNewLabel_6 = new JLabel("Z Safe Check Actuator Name");
+        JLabel lblNewLabel_6 = new JLabel("Z Contact Actuator");
         panel_2.add(lblNewLabel_6, "2, 6, right, default");
 
-        zSafeCheckActuatorName = new JTextField();
-        panel_2.add(zSafeCheckActuatorName, "4, 6, fill, default");
-        zSafeCheckActuatorName.setColumns(15);
+        zContactActuatorName = new JTextField();
+        panel_2.add(zContactActuatorName, "4, 6, fill, default");
+        zContactActuatorName.setColumns(15);
 
-        JLabel lblNewLabel_7 = new JLabel("Z Safe Check Actuator Ok Value");
+        JLabel lblNewLabel_7 = new JLabel("Z Contact Actuator Value");
         panel_2.add(lblNewLabel_7, "2, 8, right, default");
 
-        zSafeCheckActuatorOkValue = new JTextField();
-        panel_2.add(zSafeCheckActuatorOkValue, "4, 8, fill, default");
-        zSafeCheckActuatorOkValue.setColumns(15);
+        zContactActuatorValue = new JTextField();
+        panel_2.add(zContactActuatorValue, "4, 8, fill, default");
+        zContactActuatorValue.setColumns(15);
     }
 
     @Override
@@ -230,10 +230,10 @@ public class ReferenceHeadConfigurationWizard extends AbstractConfigurationWizar
 
         addWrappedBinding(head, "softLimitsEnabled", softLimitsEnabled, "selected");
 
-        addWrappedBinding(head, "zProbeActuatorName", zProbeActuatorName, "text");
-        addWrappedBinding(head, "zProbeActuatorSafeZValue", zProbeActuatorSafeZValue, "text");
-        addWrappedBinding(head, "zSafeCheckActuatorName", zSafeCheckActuatorName, "text");
-        addWrappedBinding(head, "zSafeCheckActuatorValue", zSafeCheckActuatorOkValue, "text");
+        addWrappedBinding(head, "zSafeActuatorName", zSafeActuatorName, "text");
+        addWrappedBinding(head, "zSafeActuatorValue", zSafeActuatorValue, "text");
+        addWrappedBinding(head, "zContactActuatorName", zContactActuatorName, "text");
+        addWrappedBinding(head, "zContactActuatorValue", zContactActuatorValue, "text");
 
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(parkX);
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(parkY);
@@ -242,10 +242,10 @@ public class ReferenceHeadConfigurationWizard extends AbstractConfigurationWizar
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(maxX);
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(maxY);
 
-        ComponentDecorators.decorateWithAutoSelect(zProbeActuatorName);
-        ComponentDecorators.decorateWithAutoSelect(zProbeActuatorSafeZValue);
-        ComponentDecorators.decorateWithAutoSelect(zSafeCheckActuatorName);
-        ComponentDecorators.decorateWithAutoSelect(zSafeCheckActuatorOkValue);
+        ComponentDecorators.decorateWithAutoSelect(zSafeActuatorName);
+        ComponentDecorators.decorateWithAutoSelect(zSafeActuatorValue);
+        ComponentDecorators.decorateWithAutoSelect(zContactActuatorName);
+        ComponentDecorators.decorateWithAutoSelect(zContactActuatorValue);
     }
 
     private static Location getParsedLocation(JTextField textFieldX, JTextField textFieldY) {
@@ -371,8 +371,8 @@ public class ReferenceHeadConfigurationWizard extends AbstractConfigurationWizar
     private JTextField maxX;
     private JTextField maxY;
     private JCheckBox softLimitsEnabled;
-    private JTextField zProbeActuatorName;
-    private JTextField zProbeActuatorSafeZValue;
-    private JTextField zSafeCheckActuatorName;
-    private JTextField zSafeCheckActuatorOkValue;
+    private JTextField zSafeActuatorName;
+    private JTextField zSafeActuatorValue;
+    private JTextField zContactActuatorName;
+    private JTextField zContactActuatorValue;
 }

--- a/src/main/java/org/openpnp/spi/Nozzle.java
+++ b/src/main/java/org/openpnp/spi/Nozzle.java
@@ -10,8 +10,7 @@ import org.openpnp.model.Part;
  * that defines what types of Packages it can handle and it may have the capability of changing it's
  * NozzleTip.
  */
-public interface Nozzle
-        extends HeadMountable, WizardConfigurable, PropertySheetHolder {
+public interface Nozzle extends HeadMountable, WizardConfigurable, PropertySheetHolder {
     /**
      * Get the NozzleTip currently attached to the Nozzle.
      * 
@@ -64,45 +63,52 @@ public interface Nozzle
      * @throws Exception
      */
     public void unloadNozzleTip() throws Exception;
-    
+
     /**
-     * Get the part that is currently picked on the Nozzle, or null if none is picked.
-     * Should typically be non-null after a pick operation and before a place operation and null
-     * after a pick operation. Of note, it should be non-null after a failed pick operation
-     * so that the system can determine which part it may need to discard. It may also be null
-     * if a user initiated, manual, pick is performed with no Part to reference. 
+     * Get the part that is currently picked on the Nozzle, or null if none is picked. Should
+     * typically be non-null after a pick operation and before a place operation and null after a
+     * pick operation. Of note, it should be non-null after a failed pick operation so that the
+     * system can determine which part it may need to discard. It may also be null if a user
+     * initiated, manual, pick is performed with no Part to reference.
      */
     public Part getPart();
-    
+
     /**
-     * Returns true if the isPartDetected() method is available. Some machines do not have
-     * vacuum sensors or other part detection sensors, so this feature is optional.
+     * Returns true if the isPartDetected() method is available. Some machines do not have vacuum
+     * sensors or other part detection sensors, so this feature is optional.
+     * 
      * @return
      */
     public boolean isPartDetectionEnabled();
-    
+
     /**
-     * Returns true if a part appears to be on the nozzle. This is typically implemented by
-     * checking a vacuum level range, but other methods such as laser or vision detection
-     * are possible.
+     * Returns true if a part appears to be on the nozzle. This is typically implemented by checking
+     * a vacuum level range, but other methods such as laser or vision detection are possible.
+     * 
      * @return
      */
     public boolean isPartOn() throws Exception;
-    
+
     /**
      * Returns true if a part appears to be off the nozzle. This is typically implemented by
-     * checking a vacuum level range, but other methods such as laser or vision detection
-     * are possible.
+     * checking a vacuum level range, but other methods such as laser or vision detection are
+     * possible.
+     * 
      * @return
      */
     public boolean isPartOff() throws Exception;
-    
+
     public Set<NozzleTip> getCompatibleNozzleTips();
-    
+
     public void addCompatibleNozzleTip(NozzleTip nt);
-    
+
     public void removeCompatibleNozzleTip(NozzleTip nt);
-    
+
     public void calibrate() throws Exception;
+
     public boolean isCalibrated();
+
+    void pumpOn() throws Exception;
+
+    void pumpOff() throws Exception;
 }

--- a/src/main/java/org/openpnp/spi/Nozzle.java
+++ b/src/main/java/org/openpnp/spi/Nozzle.java
@@ -109,8 +109,6 @@ public interface Nozzle extends HeadMountable, WizardConfigurable, PropertySheet
     public void calibrate() throws Exception;
 
     public boolean isCalibrated();
-
-    void pumpOn() throws Exception;
-
-    void pumpOff() throws Exception;
+    
+    void purge() throws Exception;
 }

--- a/src/main/java/org/openpnp/spi/Nozzle.java
+++ b/src/main/java/org/openpnp/spi/Nozzle.java
@@ -97,6 +97,8 @@ public interface Nozzle extends HeadMountable, WizardConfigurable, PropertySheet
      * @return
      */
     public boolean isPartOff() throws Exception;
+    
+    public void actuate(boolean on) throws Exception;
 
     public Set<NozzleTip> getCompatibleNozzleTips();
 

--- a/src/main/java/org/openpnp/spi/base/AbstractHead.java
+++ b/src/main/java/org/openpnp/spi/base/AbstractHead.java
@@ -50,16 +50,16 @@ public abstract class AbstractHead extends AbstractModelObject implements Head {
     protected Location maxLocation = new Location(LengthUnit.Millimeters);
 
     @Element(required = false)
-    protected String zProbeActuatorName = "";
+    protected String zContactActuatorName = "";
+    
+    @Element(required = false)
+    protected String zContactActuatorValue = "";
 
     @Element(required = false)
-    protected String zProbeActuatorSafeZValue = "";
+    protected String zSafeActuatorName = "";
 
     @Element(required = false)
-    protected String zSafeCheckActuatorName = "";
-
-    @Element(required = false)
-    protected String zSafeCheckActuatorOkValue = "";
+    protected String zSafeActuatorValue = "";
 
     protected Machine machine;
 
@@ -186,32 +186,18 @@ public abstract class AbstractHead extends AbstractModelObject implements Head {
         for (Actuator actuator : actuators) {
             actuator.moveToSafeZ(speed);
         }
-        if (this.zProbeActuatorName.length() > 0 && this.zProbeActuatorSafeZValue.length() > 0) {
-            if (this.getZProbe() == null) {
+
+        if (this.zSafeActuatorName.length() > 0 && this.zSafeActuatorValue.length() > 0) {
+            Actuator zSafeActuator = getActuatorByName(zSafeActuatorName);
+            if (zSafeActuator == null) {
                 throw new Exception(String.format("No Actuator found with name %s on Head %s",
-                        zProbeActuatorName, this.getName()));
+                        zSafeActuatorName, this.getName()));
             }
-            String zProbeValue = this.getZProbe()
-                                     .read();
-            if (!zProbeValue.equals(zProbeActuatorSafeZValue)) {
+            String zProbeValue = zSafeActuator.read();
+            if (!zProbeValue.equals(zSafeActuatorValue)) {
                 throw new Exception(String.format(
                         "Z Probe Actuator %s says Head %s is not at safe Z (probe is reading %s and not %s)",
-                        zProbeActuatorName, this.getName(), zProbeValue, zProbeActuatorSafeZValue));
-            }
-        }
-        if (this.zSafeCheckActuatorName.length() > 0
-                && this.zSafeCheckActuatorOkValue.length() > 0) {
-            Actuator zSafeCheckActuator = this.getActuatorByName(zSafeCheckActuatorName);
-            if (zSafeCheckActuator == null) {
-                throw new Exception(String.format("No Actuator found with name %s on Head %s",
-                        zSafeCheckActuatorName, this.getName()));
-            }
-            String actuatorValue = zSafeCheckActuator.read();
-            if (!actuatorValue.equals(zSafeCheckActuatorOkValue)) {
-                throw new Exception(String.format(
-                        "Z Probe Safe Check Actuator %s says Head %s is not at safe Z (probe is reading %s and not %s)",
-                        zSafeCheckActuatorName, this.getName(), actuatorValue,
-                        zSafeCheckActuatorOkValue));
+                        zSafeActuatorName, this.getName(), zProbeValue, zSafeActuatorValue));
             }
         }
         Logger.debug("\nAbstractHead::moveToSafeZ complete\n");
@@ -335,38 +321,38 @@ public abstract class AbstractHead extends AbstractModelObject implements Head {
 
     @Override
     public Actuator getZProbe() {
-        return getActuatorByName(zProbeActuatorName);
+        return getActuatorByName(zContactActuatorName);
     }
 
-    public String getzProbeActuatorName() {
-        return zProbeActuatorName;
+    public String getzSafeActuatorValue() {
+        return zSafeActuatorValue;
     }
 
-    public void setzProbeActuatorName(String zProbeActuatorName) {
-        this.zProbeActuatorName = zProbeActuatorName;
+    public void setzSafeActuatorValue(String zSafeActuatorValue) {
+        this.zSafeActuatorValue = zSafeActuatorValue;
     }
 
-    public String getzProbeActuatorSafeZValue() {
-        return zProbeActuatorSafeZValue;
+    public String getzSafeActuatorName() {
+        return zSafeActuatorName;
     }
 
-    public void setzProbeActuatorSafeZValue(String zProbeActuatorSafeZValue) {
-        this.zProbeActuatorSafeZValue = zProbeActuatorSafeZValue;
+    public void setzSafeActuatorName(String zSafeActuatorName) {
+        this.zSafeActuatorName = zSafeActuatorName;
     }
 
-    public String getzSafeCheckActuatorName() {
-        return zSafeCheckActuatorName;
+    public String getzContactActuatorName() {
+        return zContactActuatorName;
     }
 
-    public void setzSafeCheckActuatorName(String zSafeCheckActuatorName) {
-        this.zSafeCheckActuatorName = zSafeCheckActuatorName;
+    public void setzContactActuatorName(String zContactActuatorName) {
+        this.zContactActuatorName = zContactActuatorName;
+    }
+    
+    public String getzContactActuatorValue() {
+        return zContactActuatorValue;
     }
 
-    public String getzSafeCheckActuatorValue() {
-        return zSafeCheckActuatorOkValue;
-    }
-
-    public void setzSafeCheckActuatorValue(String zSafeCheckActuatorValue) {
-        this.zSafeCheckActuatorOkValue = zSafeCheckActuatorValue;
+    public void setzContactActuatorValue(String zContactActuatorValue) {
+        this.zContactActuatorValue = zContactActuatorValue;
     }
 }

--- a/src/main/java/org/openpnp/spi/base/AbstractHead.java
+++ b/src/main/java/org/openpnp/spi/base/AbstractHead.java
@@ -54,6 +54,12 @@ public abstract class AbstractHead extends AbstractModelObject implements Head {
     @Element(required = false)
     protected String zProbeActuatorSafeZValue;
 
+    @Element(required = false)
+    protected String zSafeCheckActuatorName;
+
+    @Element(required = false)
+    protected String zSafeCheckActuatorOkValue;
+
     protected Machine machine;
 
     public AbstractHead() {
@@ -188,6 +194,21 @@ public abstract class AbstractHead extends AbstractModelObject implements Head {
                 throw new Exception(String.format(
                         "Z Probe Actuator %s says Head %s is not at safe Z (probe is reading %s and not %s)",
                         zProbeActuatorName, this.getName(), zProbeValue, zProbeActuatorSafeZValue));
+            }
+        }
+        if (this.zSafeCheckActuatorName.length() > 0
+                && this.zSafeCheckActuatorOkValue.length() > 0) {
+            Actuator zSafeCheckActuator = this.getActuatorByName(zSafeCheckActuatorName);
+            if (zSafeCheckActuator == null) {
+                throw new Exception(String.format("No Actuator found with name %s on Head %s",
+                        zSafeCheckActuatorName, this.getName()));
+            }
+            String actuatorValue = zSafeCheckActuator.read();
+            if (!actuatorValue.equals(zSafeCheckActuatorOkValue)) {
+                throw new Exception(String.format(
+                        "Z Probe Safe Check Actuator %s says Head %s is not at safe Z (probe is reading %s and not %s)",
+                        zSafeCheckActuatorName, this.getName(), actuatorValue,
+                        zSafeCheckActuatorOkValue));
             }
         }
     }
@@ -327,5 +348,21 @@ public abstract class AbstractHead extends AbstractModelObject implements Head {
 
     public void setzProbeActuatorSafeZValue(String zProbeActuatorSafeZValue) {
         this.zProbeActuatorSafeZValue = zProbeActuatorSafeZValue;
+    }
+
+    public String getzSafeCheckActuatorName() {
+        return zSafeCheckActuatorName;
+    }
+
+    public void setzSafeCheckActuatorName(String zSafeCheckActuatorName) {
+        this.zSafeCheckActuatorName = zSafeCheckActuatorName;
+    }
+
+    public String getzSafeCheckActuatorValue() {
+        return zSafeCheckActuatorOkValue;
+    }
+
+    public void setzSafeCheckActuatorValue(String zSafeCheckActuatorValue) {
+        this.zSafeCheckActuatorOkValue = zSafeCheckActuatorValue;
     }
 }

--- a/src/main/java/org/openpnp/spi/base/AbstractHead.java
+++ b/src/main/java/org/openpnp/spi/base/AbstractHead.java
@@ -38,8 +38,8 @@ public abstract class AbstractHead extends AbstractModelObject implements Head {
 
     @Element(required = false)
     protected Location parkLocation = new Location(LengthUnit.Millimeters);
-    
-    @Element(required=false)
+
+    @Element(required = false)
     protected boolean softLimitsEnabled = false;
 
     @Element(required = false)
@@ -47,9 +47,12 @@ public abstract class AbstractHead extends AbstractModelObject implements Head {
 
     @Element(required = false)
     protected Location maxLocation = new Location(LengthUnit.Millimeters);
-    
+
     @Element(required = false)
     protected String zProbeActuatorName;
+
+    @Element(required = false)
+    protected String zProbeActuatorSafeZValue;
 
     protected Machine machine;
 
@@ -100,7 +103,8 @@ public abstract class AbstractHead extends AbstractModelObject implements Head {
     @Override
     public Actuator getActuatorByName(String name) {
         for (Actuator actuator : actuators) {
-            if (actuator.getName().equals(name)) {
+            if (actuator.getName()
+                        .equals(name)) {
                 return actuator;
             }
         }
@@ -172,6 +176,19 @@ public abstract class AbstractHead extends AbstractModelObject implements Head {
         }
         for (Actuator actuator : actuators) {
             actuator.moveToSafeZ(speed);
+        }
+        if (this.zProbeActuatorName.length() > 0 && this.zProbeActuatorSafeZValue.length() > 0) {
+            if (this.getZProbe() == null) {
+                throw new Exception(String.format("No Actuator found with name %s on Head %s",
+                        zProbeActuatorName, this.getName()));
+            }
+            String zProbeValue = this.getZProbe()
+                                     .read();
+            if (!zProbeValue.equals(zProbeActuatorSafeZValue)) {
+                throw new Exception(String.format(
+                        "Z Probe Actuator %s says Head %s is not at safe Z (probe is reading %s and not %s)",
+                        zProbeActuatorName, this.getName(), zProbeValue, zProbeActuatorSafeZValue));
+            }
         }
     }
 
@@ -258,7 +275,9 @@ public abstract class AbstractHead extends AbstractModelObject implements Head {
 
         for (Nozzle nozzle : getNozzles()) {
             if (nozzle.getPart() != null) {
-                speed = Math.min(nozzle.getPart().getSpeed(), speed);
+                speed = Math.min(nozzle.getPart()
+                                       .getSpeed(),
+                        speed);
             }
         }
 
@@ -288,10 +307,10 @@ public abstract class AbstractHead extends AbstractModelObject implements Head {
     public void setSoftLimitsEnabled(boolean softLimitsEnabled) {
         this.softLimitsEnabled = softLimitsEnabled;
     }
-    
+
     @Override
     public Actuator getZProbe() {
-        return getActuatorByName(zProbeActuatorName); 
+        return getActuatorByName(zProbeActuatorName);
     }
 
     public String getzProbeActuatorName() {
@@ -300,5 +319,13 @@ public abstract class AbstractHead extends AbstractModelObject implements Head {
 
     public void setzProbeActuatorName(String zProbeActuatorName) {
         this.zProbeActuatorName = zProbeActuatorName;
+    }
+
+    public String getzProbeActuatorSafeZValue() {
+        return zProbeActuatorSafeZValue;
+    }
+
+    public void setzProbeActuatorSafeZValue(String zProbeActuatorSafeZValue) {
+        this.zProbeActuatorSafeZValue = zProbeActuatorSafeZValue;
     }
 }

--- a/src/main/java/org/openpnp/spi/base/AbstractHead.java
+++ b/src/main/java/org/openpnp/spi/base/AbstractHead.java
@@ -15,6 +15,7 @@ import org.openpnp.spi.Head;
 import org.openpnp.spi.Machine;
 import org.openpnp.spi.Nozzle;
 import org.openpnp.util.IdentifiableList;
+import org.pmw.tinylog.Logger;
 import org.simpleframework.xml.Attribute;
 import org.simpleframework.xml.Element;
 import org.simpleframework.xml.ElementList;
@@ -49,16 +50,16 @@ public abstract class AbstractHead extends AbstractModelObject implements Head {
     protected Location maxLocation = new Location(LengthUnit.Millimeters);
 
     @Element(required = false)
-    protected String zProbeActuatorName;
+    protected String zProbeActuatorName = "";
 
     @Element(required = false)
-    protected String zProbeActuatorSafeZValue;
+    protected String zProbeActuatorSafeZValue = "";
 
     @Element(required = false)
-    protected String zSafeCheckActuatorName;
+    protected String zSafeCheckActuatorName = "";
 
     @Element(required = false)
-    protected String zSafeCheckActuatorOkValue;
+    protected String zSafeCheckActuatorOkValue = "";
 
     protected Machine machine;
 
@@ -174,6 +175,8 @@ public abstract class AbstractHead extends AbstractModelObject implements Head {
 
     @Override
     public void moveToSafeZ(double speed) throws Exception {
+        Logger.debug("\n\nAbstractHead::moveToSafeZ");
+        
         for (Nozzle nozzle : nozzles) {
             nozzle.moveToSafeZ(speed);
         }
@@ -211,6 +214,7 @@ public abstract class AbstractHead extends AbstractModelObject implements Head {
                         zSafeCheckActuatorOkValue));
             }
         }
+        Logger.debug("\nAbstractHead::moveToSafeZ complete\n");
     }
 
     @Override

--- a/src/main/resources/icons/vac-off.svg
+++ b/src/main/resources/icons/vac-off.svg
@@ -1,0 +1,173 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:sketch="http://www.bohemiancoding.com/sketch/ns"
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24px"
+   height="24px"
+   viewBox="0 0 24 24"
+   version="1.1"
+   id="svg2"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)"
+   sodipodi:docname="vac-off.svg">
+  <metadata
+     id="metadata15">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>capture-nozzle</dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="854"
+     inkscape:window-height="454"
+     id="namedview13"
+     showgrid="false"
+     showguides="false"
+     inkscape:guide-bbox="true"
+     inkscape:snap-to-guides="true"
+     inkscape:zoom="8"
+     inkscape:cx="7.4910976"
+     inkscape:cy="6.1170164"
+     inkscape:window-x="129"
+     inkscape:window-y="460"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="capture-nozzle-5"
+     inkscape:object-paths="true"
+     inkscape:snap-grids="true"
+     inkscape:object-nodes="true"
+     inkscape:snap-midpoints="true"
+     showborder="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4153" />
+    <sodipodi:guide
+       position="5.5,-4.065864"
+       orientation="1,0"
+       id="guide4147"
+       inkscape:label=""
+       inkscape:color="rgb(0,0,255)"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="12,10.385631"
+       orientation="1,0"
+       id="guide5069"
+       inkscape:label=""
+       inkscape:color="rgb(0,0,255)"
+       inkscape:locked="false" />
+  </sodipodi:namedview>
+  <!-- Generator: Sketch 3.2.2 (9983) - http://www.bohemiancoding.com/sketch -->
+  <title
+     id="title4">capture-nozzle</title>
+  <desc
+     id="desc6">Created with Sketch.</desc>
+  <defs
+     id="defs8">
+    <inkscape:path-effect
+       cusp_linecap_type="round"
+       end_linecap_type="zerowidth"
+       miter_limit="4"
+       linejoin_type="round"
+       start_linecap_type="zerowidth"
+       interpolator_beta="0.2"
+       interpolator_type="Linear"
+       sort_points="true"
+       offset_points="0,5.7604178"
+       is_visible="true"
+       id="path-effect4216"
+       effect="powerstroke" />
+    <inkscape:path-effect
+       effect="powerstroke"
+       id="path-effect4168"
+       is_visible="true"
+       offset_points="0,5.7604178"
+       sort_points="true"
+       interpolator_type="Linear"
+       interpolator_beta="0.2"
+       start_linecap_type="zerowidth"
+       linejoin_type="round"
+       miter_limit="4"
+       end_linecap_type="zerowidth"
+       cusp_linecap_type="round" />
+    <inkscape:path-effect
+       effect="powerstroke"
+       id="path-effect4164"
+       is_visible="true"
+       offset_points="0,2.5886007"
+       sort_points="true"
+       interpolator_type="Linear"
+       interpolator_beta="0.2"
+       start_linecap_type="zerowidth"
+       linejoin_type="round"
+       miter_limit="4"
+       end_linecap_type="zerowidth"
+       cusp_linecap_type="round" />
+    <inkscape:path-effect
+       effect="powerstroke"
+       id="path-effect4168-3"
+       is_visible="true"
+       offset_points="0,5.7604178"
+       sort_points="true"
+       interpolator_type="Linear"
+       interpolator_beta="0.2"
+       start_linecap_type="zerowidth"
+       linejoin_type="round"
+       miter_limit="4"
+       end_linecap_type="zerowidth"
+       cusp_linecap_type="round" />
+    <inkscape:path-effect
+       effect="powerstroke"
+       id="path-effect4168-1"
+       is_visible="true"
+       offset_points="0,5.7604178"
+       sort_points="true"
+       interpolator_type="Linear"
+       interpolator_beta="0.2"
+       start_linecap_type="zerowidth"
+       linejoin_type="round"
+       miter_limit="4"
+       end_linecap_type="zerowidth"
+       cusp_linecap_type="round" />
+  </defs>
+  <g
+     id="g4162"
+     transform="matrix(1,0,0,1.0001904,-0.5,-0.00399817)">
+    <g
+       transform="translate(0.54,-0.0078125)"
+       id="capture-nozzle-5"
+       sketch:type="MSLayerGroup"
+       style="clip-rule:evenodd;fill:#bd0404;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-linejoin:round;stroke-miterlimit:1.41420996">
+      <path
+         d="m 10.96,10 2,0 0,9 -2,0 z"
+         id="Triangle-1-3"
+         sketch:type="MSShapeGroup"
+         style="fill:#65a0ff;fill-opacity:1;stroke:none;stroke-opacity:1"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccc" />
+      <path
+         style="fill:#bd0404;fill-opacity:1;stroke:none;stroke-opacity:1"
+         sketch:type="MSShapeGroup"
+         id="path4143-5"
+         d="m 15.232727,9.0110485 2.727273,-5 -12,0 2.7272727,5 z"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccc" />
+    </g>
+  </g>
+</svg>

--- a/src/main/resources/icons/vac-on.svg
+++ b/src/main/resources/icons/vac-on.svg
@@ -1,0 +1,173 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:sketch="http://www.bohemiancoding.com/sketch/ns"
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24px"
+   height="24px"
+   viewBox="0 0 24 24"
+   version="1.1"
+   id="svg2"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)"
+   sodipodi:docname="vac-on.svg">
+  <metadata
+     id="metadata15">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>capture-nozzle</dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="641"
+     inkscape:window-height="454"
+     id="namedview13"
+     showgrid="false"
+     showguides="false"
+     inkscape:guide-bbox="true"
+     inkscape:snap-to-guides="true"
+     inkscape:zoom="8"
+     inkscape:cx="7.4910976"
+     inkscape:cy="6.1170164"
+     inkscape:window-x="267"
+     inkscape:window-y="460"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g4162"
+     inkscape:object-paths="true"
+     inkscape:snap-grids="true"
+     inkscape:object-nodes="true"
+     inkscape:snap-midpoints="true"
+     showborder="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4153" />
+    <sodipodi:guide
+       position="5.5,-4.065864"
+       orientation="1,0"
+       id="guide4147"
+       inkscape:label=""
+       inkscape:color="rgb(0,0,255)"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="12,10.385631"
+       orientation="1,0"
+       id="guide5069"
+       inkscape:label=""
+       inkscape:color="rgb(0,0,255)"
+       inkscape:locked="false" />
+  </sodipodi:namedview>
+  <!-- Generator: Sketch 3.2.2 (9983) - http://www.bohemiancoding.com/sketch -->
+  <title
+     id="title4">capture-nozzle</title>
+  <desc
+     id="desc6">Created with Sketch.</desc>
+  <defs
+     id="defs8">
+    <inkscape:path-effect
+       cusp_linecap_type="round"
+       end_linecap_type="zerowidth"
+       miter_limit="4"
+       linejoin_type="round"
+       start_linecap_type="zerowidth"
+       interpolator_beta="0.2"
+       interpolator_type="Linear"
+       sort_points="true"
+       offset_points="0,5.7604178"
+       is_visible="true"
+       id="path-effect4216"
+       effect="powerstroke" />
+    <inkscape:path-effect
+       effect="powerstroke"
+       id="path-effect4168"
+       is_visible="true"
+       offset_points="0,5.7604178"
+       sort_points="true"
+       interpolator_type="Linear"
+       interpolator_beta="0.2"
+       start_linecap_type="zerowidth"
+       linejoin_type="round"
+       miter_limit="4"
+       end_linecap_type="zerowidth"
+       cusp_linecap_type="round" />
+    <inkscape:path-effect
+       effect="powerstroke"
+       id="path-effect4164"
+       is_visible="true"
+       offset_points="0,2.5886007"
+       sort_points="true"
+       interpolator_type="Linear"
+       interpolator_beta="0.2"
+       start_linecap_type="zerowidth"
+       linejoin_type="round"
+       miter_limit="4"
+       end_linecap_type="zerowidth"
+       cusp_linecap_type="round" />
+    <inkscape:path-effect
+       effect="powerstroke"
+       id="path-effect4168-3"
+       is_visible="true"
+       offset_points="0,5.7604178"
+       sort_points="true"
+       interpolator_type="Linear"
+       interpolator_beta="0.2"
+       start_linecap_type="zerowidth"
+       linejoin_type="round"
+       miter_limit="4"
+       end_linecap_type="zerowidth"
+       cusp_linecap_type="round" />
+    <inkscape:path-effect
+       effect="powerstroke"
+       id="path-effect4168-1"
+       is_visible="true"
+       offset_points="0,5.7604178"
+       sort_points="true"
+       interpolator_type="Linear"
+       interpolator_beta="0.2"
+       start_linecap_type="zerowidth"
+       linejoin_type="round"
+       miter_limit="4"
+       end_linecap_type="zerowidth"
+       cusp_linecap_type="round" />
+  </defs>
+  <g
+     id="g4162"
+     transform="matrix(1,0,0,1.0001904,-0.5,-0.00399817)">
+    <g
+       transform="translate(0.54,-0.0078125)"
+       id="capture-nozzle-5"
+       sketch:type="MSLayerGroup"
+       style="clip-rule:evenodd;fill:#bd0404;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-linejoin:round;stroke-miterlimit:1.41420996">
+      <path
+         d="m 10.96,10 2,0 0,9 -2,0 z"
+         id="Triangle-1-3"
+         sketch:type="MSShapeGroup"
+         style="fill:#2b0000;fill-opacity:1;stroke:none;stroke-opacity:1"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccc" />
+      <path
+         style="fill:#bd0404;fill-opacity:1;stroke:none;stroke-opacity:1"
+         sketch:type="MSShapeGroup"
+         id="path4143-5"
+         d="m 15.232727,9.0110485 2.727273,-5 -12,0 2.7272727,5 z"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccc" />
+    </g>
+  </g>
+</svg>

--- a/src/test/java/org/openpnp/machine/reference/driver/test/TestDriver.java
+++ b/src/test/java/org/openpnp/machine/reference/driver/test/TestDriver.java
@@ -175,10 +175,7 @@ public class TestDriver implements ReferenceDriver {
         }
 
         @Override
-        public void pumpOn(ReferenceNozzle nozzle) {}
-
-        @Override
-        public void pumpOff(ReferenceNozzle nozzle) {}
+        public void purge(ReferenceNozzle nozzle) {}
     }
 
     @Override
@@ -213,10 +210,9 @@ public class TestDriver implements ReferenceDriver {
     public Wizard getConfigurationWizard() {
         return null;
     }
-
+    
     @Override
-    public void pumpOn(ReferenceNozzle nozzle) {}
-
-    @Override
-    public void pumpOff(ReferenceNozzle nozzle) {}
+    public void purge(ReferenceNozzle nozzle) throws Exception {
+        delegate.purge(nozzle);
+    }
 }

--- a/src/test/java/org/openpnp/machine/reference/driver/test/TestDriver.java
+++ b/src/test/java/org/openpnp/machine/reference/driver/test/TestDriver.java
@@ -75,6 +75,10 @@ public class TestDriver implements ReferenceDriver {
     }
 
     @Override
+    public void actuate(ReferenceNozzle nozzle, boolean on) throws Exception {
+    }
+    
+    @Override
     public void actuate(ReferenceActuator actuator, boolean on) throws Exception {
         delegate.actuate(actuator, on);
     }
@@ -121,6 +125,10 @@ public class TestDriver implements ReferenceDriver {
 
         }
 
+        @Override
+        public void actuate(ReferenceNozzle nozzle, boolean on) throws Exception {
+        }
+        
         @Override
         public void actuate(ReferenceActuator actuator, boolean on) throws Exception {
 

--- a/src/test/java/org/openpnp/machine/reference/driver/test/TestDriver.java
+++ b/src/test/java/org/openpnp/machine/reference/driver/test/TestDriver.java
@@ -63,7 +63,7 @@ public class TestDriver implements ReferenceDriver {
     public Location getLocation(ReferenceHeadMountable hm) {
         return location.add(hm.getHeadOffsets());
     }
-    
+
     @Override
     public void pick(ReferenceNozzle nozzle) throws Exception {
         delegate.pick(nozzle);
@@ -165,6 +165,12 @@ public class TestDriver implements ReferenceDriver {
         public void close() throws IOException {
 
         }
+
+        @Override
+        public void pumpOn(ReferenceNozzle nozzle) {}
+
+        @Override
+        public void pumpOff(ReferenceNozzle nozzle) {}
     }
 
     @Override
@@ -193,11 +199,16 @@ public class TestDriver implements ReferenceDriver {
     }
 
     @Override
-    public void close() throws IOException {
-    }
-    
+    public void close() throws IOException {}
+
     @Override
     public Wizard getConfigurationWizard() {
         return null;
     }
+
+    @Override
+    public void pumpOn(ReferenceNozzle nozzle) {}
+
+    @Override
+    public void pumpOff(ReferenceNozzle nozzle) {}
 }


### PR DESCRIPTION
# Description
These changes primarily add support for the features of the Charmhigh CHM-T48VB based on the firmware developed by Matt Baker.  Other tweaks were made along the way of implementing these features that should help with speed and safety. 

I'm new to git, so I apologize that these are all bundled together.  I thought git would let me make multiple pull requests based on my different commits and there were several issues that would come up as I was doing the integration testing.  My commits to git are more atomic if you can see them individually as part of the pull request.  However, I'm not sure how to break them up on my side.

# Justification
The changes were made so that the machine does not have to  be a T48VB.  Other machines with similar sensors can benefit.  Those without the specific sensors (photo-interrupters for the drag pin and Z-axis) will be unaffected.

# Instructions for Use
The part check was changed in ReferencePnpJobProcessor.
- This is worthy of review.  My tests have shown that the vacuum does not need to be turned back on in order to check for a part still being on the nozzle after placement.  In my experience if the part is still attached to the nozzle it is because the air line is pressurized and the reading indicates this without needing to turn the vacuum back on.

Buttons for turning the vacuum on and off were added to the Feeders tab.
- This is worthy of review.  This feature was only implemented for the Gcode driver.  As I was adding many feeder definitions it was helpful to have a quick button to control the vacuum.  The added icons attempt to reuse the openpnp color scheme.

Changes made to ReferenceDragFeeder:
 - Support was added to handle 0402 parts when not used with vision. Previously it would not get the second part that was feed from an 0402 feed when vision was not enabled.
 - The actuators section now has fields for identifying the drag pin actuator, the value the actuator will read when the pin is safely retracted, and the actuator for peeling off the film.  The feed process will try to confirm that the pin is safely retracted after backing off and if not it will try to back off again to release tension on the pin.  
 - Support was added so that the user can identify which well to pick the next part in the tape from.  This allows users to tell the machine which slots already have exposed parts (primarily useful for 0402 parts, but allows the user to not have to retract the drag feeder for parts).  The Locations section now contains a button labeled 'Set next part offset to:' that will identify which well to pick from.  Setting it to 0 will tell the machine to pick from the pick location without performing a drag operation.  Setting it to 1 will tell the machine to pick from the location in front of the pick location.  Setting it to negative values will tell it to perform a standard feed operation that would include a drag step.

Changes made to ReferenceHeadConfigurationWizard:
- The Z Probe section was implemented so that it will confirm that the Z Probe is reading an acceptable value before doing a move operation.  Fields were added to identify the actuator and the value that the actuator should read when things are safe.
- The Z Probe was also augmented with another actuator and safe value in case another, secondary check should be done to confirm things are safe for move operations.  I use this to confirm the drag pin is safely retracted prior to move operations for my machine.

Clarifications were made on some user interface elements:
 - The panelazition dialog text was modified to read "X Gap Spacing" from "X Spacing" since it was ambiguous if the distance needed was the gap between boards or the distance from a point on one board to the same point on an adjacent board.
- The software check to prevent the machine from going out of bounds was modified so the error message showed which limit was being violated.

# Implementation Details
1. Changes were tested on the CHM-T48B during a day of doing assembly on boards.
2. I told eclipse to use the format definition from the wiki, but maybe I did this wrong or it's not really being used by the group?  Many of the files submitted have whitespace modifications making them more difficult to parse and I wouldn't expect this if the code base actually used the code format definition.

