### PR TITLE
Charmhigh Safety Checks

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/ReferenceNozzle.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceNozzle.java
@@ -56,6 +56,12 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
     @Element(required = false)
     protected String vacuumSenseActuatorName;
     
+    @Element(required = false)
+    protected String zSafeActuatorName = "";
+
+    @Element(required = false)
+    protected String zSafeActuatorValue = "";
+    
     /**
      * If limitRotation is enabled the nozzle will reverse directions when commanded to rotate past
      * 180 degrees. So, 190 degrees becomes -170 and -190 becomes 170.
@@ -304,6 +310,20 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
                 safeZ.getValue(), Double.NaN);
         getDriver().moveTo(this, l, getHead().getMaxPartSpeed() * speed);
         getMachine().fireMachineHeadActivity(head);
+        
+        if (this.zSafeActuatorName.length() > 0 && this.zSafeActuatorValue.length() > 0) {
+            Actuator zSafeActuator = getHead().getActuatorByName(zSafeActuatorName);
+            if (zSafeActuator == null) {
+                throw new Exception(String.format("No Actuator found with name %s on Head %s",
+                        zSafeActuatorName, this.getName()));
+            }
+            String zProbeValue = zSafeActuator.read();
+            if (!zProbeValue.equals(zSafeActuatorValue)) {
+                throw new Exception(String.format(
+                        "Safe Z Actuator %s says Nozzle %s is not at safe Z (actuator is reading %s and not %s)",
+                        zSafeActuatorName, this.getName(), zProbeValue, zSafeActuatorValue));
+            }
+        }
     }
     
     @Override
@@ -618,5 +638,21 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
         ReferenceNozzleTip nt = getNozzleTip();
         double vacuumLevel = readVacuumLevel();
         return vacuumLevel >= nt.getVacuumLevelPartOffLow() && vacuumLevel <= nt.getVacuumLevelPartOffHigh();
+    }
+    
+    public String getzSafeActuatorName() {
+        return zSafeActuatorName;
+    }
+
+    public void setzSafeActuatorName(String zSafeActuatorName) {
+        this.zSafeActuatorName = zSafeActuatorName;
+    }
+
+    public String getzSafeActuatorValue() {
+        return zSafeActuatorValue;
+    }
+
+    public void setzSafeActuatorValue(String zSafeActuatorValue) {
+        this.zSafeActuatorValue = zSafeActuatorValue;
     }
 }

--- a/src/main/java/org/openpnp/machine/reference/feeder/ReferenceDragFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/ReferenceDragFeeder.java
@@ -157,6 +157,8 @@ public class ReferenceDragFeeder extends ReferenceFeeder {
 	        }
 		}
 
+        head.moveToSafeZ();
+
         if (vision.isEnabled()) {
             if (visionOffset == null) {
                 // This is the first feed with vision, or the offset has

--- a/src/main/java/org/openpnp/machine/reference/feeder/wizards/ReferenceDragFeederConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/wizards/ReferenceDragFeederConfigurationWizard.java
@@ -44,8 +44,6 @@ import javax.swing.border.EtchedBorder;
 import javax.swing.border.TitledBorder;
 
 import org.jdesktop.beansbinding.AutoBinding.UpdateStrategy;
-import org.jdesktop.beansbinding.BeanProperty;
-import org.jdesktop.beansbinding.Bindings;
 import org.openpnp.gui.MainFrame;
 import org.openpnp.gui.components.CameraView;
 import org.openpnp.gui.components.ComponentDecorators;
@@ -79,13 +77,13 @@ public class ReferenceDragFeederConfigurationWizard
     private JTextField textFieldFeedEndY;
     private JTextField textFieldFeedEndZ;
     private JTextField textFieldFeedRate;
-    private JLabel lblActuatorId;
-    private JLabel lblPeelOffActuatorId;
     private JLabel lbl0402PartDetected;
     private JTextField textFieldActuatorId;
     private JTextField textFieldPeelOffActuatorId;
+    private JTextField textFieldRetractActuatorValue;
     private JPanel panelGeneral;
     private JPanel panelVision;
+    private JPanel panelActuators;
     private JPanel panelLocations;
     private JCheckBox chckbxVisionEnabled;
     private JPanel panelVisionEnabled;
@@ -127,8 +125,12 @@ public class ReferenceDragFeederConfigurationWizard
                 new ColumnSpec[] {FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,
                         FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,
                         FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,
-                        FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,},
+                        FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,
+                        FormSpecs.RELATED_GAP_COLSPEC, ColumnSpec.decode("left:default:grow"),},
                 new RowSpec[] {FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
                         FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,}));
 
         JLabel lblFeedRate = new JLabel("Feed Speed %");
@@ -138,51 +140,63 @@ public class ReferenceDragFeederConfigurationWizard
         panelGeneral.add(textFieldFeedRate, "4, 2");
         textFieldFeedRate.setColumns(5);
 
-        lblActuatorId = new JLabel("Actuator Name");
-        panelGeneral.add(lblActuatorId, "2, 4, right, default");
+        if (feeder.isPart0402()) {
+            lbl0402PartDetected = new JLabel("0402 Part DETECTED");
+            panelGeneral.add(lbl0402PartDetected, "6, 2");
+        }
+
+        panelActuators = new JPanel();
+        panelFields.add(panelActuators);
+        panelActuators.setBorder(new TitledBorder(null, "Actuators", TitledBorder.LEADING,
+                TitledBorder.TOP, null, null));
+        panelActuators.setLayout(new FormLayout(
+                new ColumnSpec[] {FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,
+                        FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,
+                        FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,
+                        FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,
+                        FormSpecs.RELATED_GAP_COLSPEC, ColumnSpec.decode("left:default:grow"),},
+                new RowSpec[] {FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,}));
+
+        JLabel lblDragPin = new JLabel("Drag Pin");
+        panelActuators.add(lblDragPin, "2, 2");
+
+        JLabel lblPinRetract = new JLabel("Pin Retracted Value");
+        panelActuators.add(lblPinRetract, "4, 2");
+
+        JLabel lblPeelOff = new JLabel("Peel Off");
+        panelActuators.add(lblPeelOff, "6, 2");
 
         textFieldActuatorId = new JTextField();
-        panelGeneral.add(textFieldActuatorId, "4, 4");
-        textFieldActuatorId.setColumns(5);
+        panelActuators.add(textFieldActuatorId, "2, 4");
+        textFieldActuatorId.setColumns(12);
 
-        lblPeelOffActuatorId = new JLabel("Peel Off Actuator Name");
-        panelGeneral.add(lblPeelOffActuatorId, "6, 4, right, default");
+        textFieldRetractActuatorValue = new JTextField();
+        panelActuators.add(textFieldRetractActuatorValue, "4, 4");
+        textFieldRetractActuatorValue.setColumns(12);
 
         textFieldPeelOffActuatorId = new JTextField();
-        panelGeneral.add(textFieldPeelOffActuatorId, "8, 4");
-        textFieldPeelOffActuatorId.setColumns(5);
-
-        if (feeder.isPart0402()) {
-	        lbl0402PartDetected = new JLabel("0402 Part DETECTED");
-	        panelGeneral.add(lbl0402PartDetected, "6, 2");
-        }
+        panelActuators.add(textFieldPeelOffActuatorId, "6, 4");
+        textFieldPeelOffActuatorId.setColumns(12);
 
         panelLocations = new JPanel();
         panelFields.add(panelLocations);
         panelLocations.setBorder(new TitledBorder(null, "Locations", TitledBorder.LEADING,
                 TitledBorder.TOP, null, null));
-        panelLocations.setLayout(new FormLayout(new ColumnSpec[] {
-                FormSpecs.RELATED_GAP_COLSPEC,
-                FormSpecs.DEFAULT_COLSPEC,
-                FormSpecs.RELATED_GAP_COLSPEC,
-                FormSpecs.DEFAULT_COLSPEC,
-                FormSpecs.RELATED_GAP_COLSPEC,
-                FormSpecs.DEFAULT_COLSPEC,
-                FormSpecs.RELATED_GAP_COLSPEC,
-                FormSpecs.DEFAULT_COLSPEC,
-                FormSpecs.RELATED_GAP_COLSPEC,
-                ColumnSpec.decode("left:default:grow"),},
-            new RowSpec[] {
-                FormSpecs.RELATED_GAP_ROWSPEC,
-                FormSpecs.DEFAULT_ROWSPEC,
-                FormSpecs.RELATED_GAP_ROWSPEC,
-                FormSpecs.DEFAULT_ROWSPEC,
-                FormSpecs.RELATED_GAP_ROWSPEC,
-                FormSpecs.DEFAULT_ROWSPEC,
-                FormSpecs.RELATED_GAP_ROWSPEC,
-                FormSpecs.DEFAULT_ROWSPEC,
-                FormSpecs.RELATED_GAP_ROWSPEC,
-                FormSpecs.DEFAULT_ROWSPEC,}));
+        panelLocations.setLayout(new FormLayout(
+                new ColumnSpec[] {FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,
+                        FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,
+                        FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,
+                        FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,
+                        FormSpecs.RELATED_GAP_COLSPEC, ColumnSpec.decode("left:default:grow"),},
+                new RowSpec[] {FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,}));
 
         JLabel lblX = new JLabel("X");
         panelLocations.add(lblX, "4, 4");
@@ -300,13 +314,11 @@ public class ReferenceDragFeederConfigurationWizard
                         FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,
                         FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,
                         FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,},
-                new RowSpec[] {
-						FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
+                new RowSpec[] {FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
                         FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
                         FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
                         FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
-                        FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
-                        }));
+                        FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,}));
 
         lblX_1 = new JLabel("X");
         panelAoE.add(lblX_1, "2, 2");
@@ -367,6 +379,7 @@ public class ReferenceDragFeederConfigurationWizard
         addWrappedBinding(feeder, "feedSpeed", textFieldFeedRate, "text", percentConverter);
         addWrappedBinding(feeder, "actuatorName", textFieldActuatorId, "text");
         addWrappedBinding(feeder, "peelOffActuatorName", textFieldPeelOffActuatorId, "text");
+        addWrappedBinding(feeder, "pinReturnActuatorValue", textFieldRetractActuatorValue, "text");
 
         MutableLocationProxy feedStartLocation = new MutableLocationProxy();
         bind(UpdateStrategy.READ_WRITE, feeder, "feedStartLocation", feedStartLocation, "location");
@@ -400,6 +413,7 @@ public class ReferenceDragFeederConfigurationWizard
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldFeedRate);
         ComponentDecorators.decorateWithAutoSelect(textFieldActuatorId);
         ComponentDecorators.decorateWithAutoSelect(textFieldPeelOffActuatorId);
+        ComponentDecorators.decorateWithAutoSelect(textFieldRetractActuatorValue);
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldFeedStartX);
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldFeedStartY);
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldFeedStartZ);

--- a/src/main/java/org/openpnp/machine/reference/wizards/ReferenceHeadConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/wizards/ReferenceHeadConfigurationWizard.java
@@ -19,12 +19,6 @@
 
 package org.openpnp.machine.reference.wizards;
 
-import java.awt.event.ActionEvent;
-
-import javax.swing.AbstractAction;
-import javax.swing.Action;
-import javax.swing.JButton;
-import javax.swing.JCheckBox;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JTextField;
@@ -49,6 +43,13 @@ import com.jgoodies.forms.layout.ColumnSpec;
 import com.jgoodies.forms.layout.FormLayout;
 import com.jgoodies.forms.layout.FormSpecs;
 import com.jgoodies.forms.layout.RowSpec;
+
+import java.awt.event.ActionEvent;
+
+import javax.swing.AbstractAction;
+import javax.swing.Action;
+import javax.swing.JButton;
+import javax.swing.JCheckBox;
 
 @SuppressWarnings("serial")
 public class ReferenceHeadConfigurationWizard extends AbstractConfigurationWizard {
@@ -165,34 +166,23 @@ public class ReferenceHeadConfigurationWizard extends AbstractConfigurationWizar
         panel_1.add(softLimitsEnabled, "2, 8, 7, 1");
 
         JPanel panel_2 = new JPanel();
-        panel_2.setBorder(new TitledBorder(null, "Z Actuators", TitledBorder.LEADING,
-                TitledBorder.TOP, null, null));
+        panel_2.setBorder(new TitledBorder(null, "Z Probe", TitledBorder.LEADING, TitledBorder.TOP, null, null));
         contentPanel.add(panel_2);
-        panel_2.setLayout(new FormLayout(
-                new ColumnSpec[] {FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,
-                        FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,
-                        FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,
-                        FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,
-                        FormSpecs.RELATED_GAP_COLSPEC, ColumnSpec.decode("left:default:grow"),},
-                new RowSpec[] {FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
-                        FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
-                        FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
-                        FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
-                        FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,}));
-
-        JLabel lblNewLabel_6 = new JLabel("Z Contact Actuator");
-        panel_2.add(lblNewLabel_6, "2, 2, right, default");
-
-        zContactActuatorName = new JTextField();
-        panel_2.add(zContactActuatorName, "4, 2, fill, default");
-        zContactActuatorName.setColumns(15);
-
-        JLabel lblNewLabel_7 = new JLabel("Z Contact Actuator Value");
-        panel_2.add(lblNewLabel_7, "2, 4, right, default");
-
-        zContactActuatorValue = new JTextField();
-        panel_2.add(zContactActuatorValue, "4, 4, fill, default");
-        zContactActuatorValue.setColumns(15);
+        panel_2.setLayout(new FormLayout(new ColumnSpec[] {
+                FormSpecs.RELATED_GAP_COLSPEC,
+                FormSpecs.DEFAULT_COLSPEC,
+                FormSpecs.RELATED_GAP_COLSPEC,
+                FormSpecs.DEFAULT_COLSPEC,},
+            new RowSpec[] {
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,}));
+        
+        JLabel lblNewLabel_4 = new JLabel("Z Probe Actuator Name");
+        panel_2.add(lblNewLabel_4, "2, 2, right, default");
+        
+        zProbeActuatorName = new JTextField();
+        panel_2.add(zProbeActuatorName, "4, 2, fill, default");
+        zProbeActuatorName.setColumns(15);
     }
 
     @Override
@@ -216,8 +206,7 @@ public class ReferenceHeadConfigurationWizard extends AbstractConfigurationWizar
 
         addWrappedBinding(head, "softLimitsEnabled", softLimitsEnabled, "selected");
 
-        addWrappedBinding(head, "zContactActuatorName", zContactActuatorName, "text");
-        addWrappedBinding(head, "zContactActuatorValue", zContactActuatorValue, "text");
+        addWrappedBinding(head, "zProbeActuatorName", zProbeActuatorName, "text");
 
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(parkX);
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(parkY);
@@ -226,8 +215,7 @@ public class ReferenceHeadConfigurationWizard extends AbstractConfigurationWizar
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(maxX);
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(maxY);
 
-        ComponentDecorators.decorateWithAutoSelect(zContactActuatorName);
-        ComponentDecorators.decorateWithAutoSelect(zContactActuatorValue);
+        ComponentDecorators.decorateWithAutoSelect(zProbeActuatorName);
     }
 
     private static Location getParsedLocation(JTextField textFieldX, JTextField textFieldY) {
@@ -353,6 +341,5 @@ public class ReferenceHeadConfigurationWizard extends AbstractConfigurationWizar
     private JTextField maxX;
     private JTextField maxY;
     private JCheckBox softLimitsEnabled;
-    private JTextField zContactActuatorName;
-    private JTextField zContactActuatorValue;
+    private JTextField zProbeActuatorName;
 }

--- a/src/main/java/org/openpnp/machine/reference/wizards/ReferenceHeadConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/wizards/ReferenceHeadConfigurationWizard.java
@@ -19,6 +19,12 @@
 
 package org.openpnp.machine.reference.wizards;
 
+import java.awt.event.ActionEvent;
+
+import javax.swing.AbstractAction;
+import javax.swing.Action;
+import javax.swing.JButton;
+import javax.swing.JCheckBox;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JTextField;
@@ -43,13 +49,6 @@ import com.jgoodies.forms.layout.ColumnSpec;
 import com.jgoodies.forms.layout.FormLayout;
 import com.jgoodies.forms.layout.FormSpecs;
 import com.jgoodies.forms.layout.RowSpec;
-
-import java.awt.event.ActionEvent;
-
-import javax.swing.AbstractAction;
-import javax.swing.Action;
-import javax.swing.JButton;
-import javax.swing.JCheckBox;
 
 @SuppressWarnings("serial")
 public class ReferenceHeadConfigurationWizard extends AbstractConfigurationWizard {
@@ -166,23 +165,41 @@ public class ReferenceHeadConfigurationWizard extends AbstractConfigurationWizar
         panel_1.add(softLimitsEnabled, "2, 8, 7, 1");
 
         JPanel panel_2 = new JPanel();
-        panel_2.setBorder(new TitledBorder(null, "Z Probe", TitledBorder.LEADING, TitledBorder.TOP, null, null));
+        panel_2.setBorder(new TitledBorder(null, "Z Actuators", TitledBorder.LEADING, TitledBorder.TOP,
+                null, null));
         contentPanel.add(panel_2);
-        panel_2.setLayout(new FormLayout(new ColumnSpec[] {
-                FormSpecs.RELATED_GAP_COLSPEC,
-                FormSpecs.DEFAULT_COLSPEC,
-                FormSpecs.RELATED_GAP_COLSPEC,
-                FormSpecs.DEFAULT_COLSPEC,},
-            new RowSpec[] {
-                FormSpecs.RELATED_GAP_ROWSPEC,
-                FormSpecs.DEFAULT_ROWSPEC,}));
-        
+        panel_2.setLayout(new FormLayout(
+                new ColumnSpec[] {FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,
+                        FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,
+                        FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,
+                        FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,
+                        FormSpecs.RELATED_GAP_COLSPEC, ColumnSpec.decode("left:default:grow"),},
+                new RowSpec[] {FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,}));
+
         JLabel lblNewLabel_4 = new JLabel("Z Probe Actuator Name");
         panel_2.add(lblNewLabel_4, "2, 2, right, default");
         
         zProbeActuatorName = new JTextField();
         panel_2.add(zProbeActuatorName, "4, 2, fill, default");
         zProbeActuatorName.setColumns(15);
+
+        JLabel lblNewLabel_5 = new JLabel("Safe Z Actuator Name");
+        panel_2.add(lblNewLabel_5, "2, 4, right, default");
+
+        zSafeActuatorName = new JTextField();
+        panel_2.add(zSafeActuatorName, "4, 4, fill, default");
+        zSafeActuatorName.setColumns(15);
+
+        JLabel lblNewLabel_6 = new JLabel("Safe Z Value");
+        panel_2.add(lblNewLabel_6, "2, 6, right, default");
+
+        zSafeActuatorValue = new JTextField();
+        panel_2.add(zSafeActuatorValue, "4, 6, fill, default");
+        zSafeActuatorValue.setColumns(15);
     }
 
     @Override
@@ -207,6 +224,8 @@ public class ReferenceHeadConfigurationWizard extends AbstractConfigurationWizar
         addWrappedBinding(head, "softLimitsEnabled", softLimitsEnabled, "selected");
 
         addWrappedBinding(head, "zProbeActuatorName", zProbeActuatorName, "text");
+        addWrappedBinding(head, "zSafeActuatorName", zSafeActuatorName, "text");
+        addWrappedBinding(head, "zSafeActuatorValue", zSafeActuatorValue, "text");
 
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(parkX);
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(parkY);
@@ -216,6 +235,8 @@ public class ReferenceHeadConfigurationWizard extends AbstractConfigurationWizar
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(maxY);
 
         ComponentDecorators.decorateWithAutoSelect(zProbeActuatorName);
+        ComponentDecorators.decorateWithAutoSelect(zSafeActuatorName);
+        ComponentDecorators.decorateWithAutoSelect(zSafeActuatorValue);
     }
 
     private static Location getParsedLocation(JTextField textFieldX, JTextField textFieldY) {
@@ -342,4 +363,6 @@ public class ReferenceHeadConfigurationWizard extends AbstractConfigurationWizar
     private JTextField maxY;
     private JCheckBox softLimitsEnabled;
     private JTextField zProbeActuatorName;
+    private JTextField zSafeActuatorName;
+    private JTextField zSafeActuatorValue;
 }

--- a/src/main/java/org/openpnp/machine/reference/wizards/ReferenceHeadConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/wizards/ReferenceHeadConfigurationWizard.java
@@ -19,6 +19,12 @@
 
 package org.openpnp.machine.reference.wizards;
 
+import java.awt.event.ActionEvent;
+
+import javax.swing.AbstractAction;
+import javax.swing.Action;
+import javax.swing.JButton;
+import javax.swing.JCheckBox;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JTextField;
@@ -43,13 +49,6 @@ import com.jgoodies.forms.layout.ColumnSpec;
 import com.jgoodies.forms.layout.FormLayout;
 import com.jgoodies.forms.layout.FormSpecs;
 import com.jgoodies.forms.layout.RowSpec;
-
-import java.awt.event.ActionEvent;
-
-import javax.swing.AbstractAction;
-import javax.swing.Action;
-import javax.swing.JButton;
-import javax.swing.JCheckBox;
 
 @SuppressWarnings("serial")
 public class ReferenceHeadConfigurationWizard extends AbstractConfigurationWizard {
@@ -166,23 +165,48 @@ public class ReferenceHeadConfigurationWizard extends AbstractConfigurationWizar
         panel_1.add(softLimitsEnabled, "2, 8, 7, 1");
         
         JPanel panel_2 = new JPanel();
-        panel_2.setBorder(new TitledBorder(null, "Z Probe", TitledBorder.LEADING, TitledBorder.TOP, null, null));
+        panel_2.setBorder(new TitledBorder(null, "Z Actuators", TitledBorder.LEADING, TitledBorder.TOP,
+                null, null));
         contentPanel.add(panel_2);
-        panel_2.setLayout(new FormLayout(new ColumnSpec[] {
-                FormSpecs.RELATED_GAP_COLSPEC,
-                FormSpecs.DEFAULT_COLSPEC,
-                FormSpecs.RELATED_GAP_COLSPEC,
-                FormSpecs.DEFAULT_COLSPEC,},
-            new RowSpec[] {
-                FormSpecs.RELATED_GAP_ROWSPEC,
-                FormSpecs.DEFAULT_ROWSPEC,}));
+        panel_2.setLayout(new FormLayout(
+                new ColumnSpec[] {FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,
+                        FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,
+                        FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,
+                        FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,
+                        FormSpecs.RELATED_GAP_COLSPEC, ColumnSpec.decode("left:default:grow"),},
+                new RowSpec[] {FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,}));
         
-        JLabel lblNewLabel_4 = new JLabel("Z Probe Actuator Name");
+        JLabel lblNewLabel_4 = new JLabel("Safe Z Actuator Name");
         panel_2.add(lblNewLabel_4, "2, 2, right, default");
         
-        zProbeActuatorName = new JTextField();
-        panel_2.add(zProbeActuatorName, "4, 2, fill, default");
-        zProbeActuatorName.setColumns(15);
+        zSafeActuatorName = new JTextField();
+        panel_2.add(zSafeActuatorName, "4, 2, fill, default");
+        zSafeActuatorName.setColumns(15);
+
+        JLabel lblNewLabel_5 = new JLabel("Safe Z Value");
+        panel_2.add(lblNewLabel_5, "2, 4, right, default");
+
+        zSafeActuatorValue = new JTextField();
+        panel_2.add(zSafeActuatorValue, "4, 4, fill, default");
+        zSafeActuatorValue.setColumns(15);
+
+        JLabel lblNewLabel_6 = new JLabel("Z Contact Actuator");
+        panel_2.add(lblNewLabel_6, "2, 6, right, default");
+
+        zContactActuatorName = new JTextField();
+        panel_2.add(zContactActuatorName, "4, 6, fill, default");
+        zContactActuatorName.setColumns(15);
+
+        JLabel lblNewLabel_7 = new JLabel("Z Contact Actuator Value");
+        panel_2.add(lblNewLabel_7, "2, 8, right, default");
+
+        zContactActuatorValue = new JTextField();
+        panel_2.add(zContactActuatorValue, "4, 8, fill, default");
+        zContactActuatorValue.setColumns(15);
     }
 
     @Override
@@ -206,7 +230,10 @@ public class ReferenceHeadConfigurationWizard extends AbstractConfigurationWizar
 
         addWrappedBinding(head, "softLimitsEnabled", softLimitsEnabled, "selected");
 
-        addWrappedBinding(head, "zProbeActuatorName", zProbeActuatorName, "text");
+        addWrappedBinding(head, "zSafeActuatorName", zSafeActuatorName, "text");
+        addWrappedBinding(head, "zSafeActuatorValue", zSafeActuatorValue, "text");
+        addWrappedBinding(head, "zContactActuatorName", zContactActuatorName, "text");
+        addWrappedBinding(head, "zContactActuatorValue", zContactActuatorValue, "text");
 
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(parkX);
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(parkY);
@@ -215,7 +242,10 @@ public class ReferenceHeadConfigurationWizard extends AbstractConfigurationWizar
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(maxX);
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(maxY);
         
-        ComponentDecorators.decorateWithAutoSelect(zProbeActuatorName);
+        ComponentDecorators.decorateWithAutoSelect(zSafeActuatorName);
+        ComponentDecorators.decorateWithAutoSelect(zSafeActuatorValue);
+        ComponentDecorators.decorateWithAutoSelect(zContactActuatorName);
+        ComponentDecorators.decorateWithAutoSelect(zContactActuatorValue);
     }
 
     private static Location getParsedLocation(JTextField textFieldX, JTextField textFieldY) {
@@ -341,5 +371,8 @@ public class ReferenceHeadConfigurationWizard extends AbstractConfigurationWizar
     private JTextField maxX;
     private JTextField maxY;
     private JCheckBox softLimitsEnabled;
-    private JTextField zProbeActuatorName;
+    private JTextField zSafeActuatorName;
+    private JTextField zSafeActuatorValue;
+    private JTextField zContactActuatorName;
+    private JTextField zContactActuatorValue;
 }

--- a/src/main/java/org/openpnp/machine/reference/wizards/ReferenceHeadConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/wizards/ReferenceHeadConfigurationWizard.java
@@ -163,10 +163,10 @@ public class ReferenceHeadConfigurationWizard extends AbstractConfigurationWizar
 
         softLimitsEnabled = new JCheckBox("Enabled?");
         panel_1.add(softLimitsEnabled, "2, 8, 7, 1");
-        
+
         JPanel panel_2 = new JPanel();
-        panel_2.setBorder(new TitledBorder(null, "Z Actuators", TitledBorder.LEADING, TitledBorder.TOP,
-                null, null));
+        panel_2.setBorder(new TitledBorder(null, "Z Actuators", TitledBorder.LEADING,
+                TitledBorder.TOP, null, null));
         contentPanel.add(panel_2);
         panel_2.setLayout(new FormLayout(
                 new ColumnSpec[] {FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,
@@ -179,33 +179,19 @@ public class ReferenceHeadConfigurationWizard extends AbstractConfigurationWizar
                         FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
                         FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
                         FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,}));
-        
-        JLabel lblNewLabel_4 = new JLabel("Safe Z Actuator Name");
-        panel_2.add(lblNewLabel_4, "2, 2, right, default");
-        
-        zSafeActuatorName = new JTextField();
-        panel_2.add(zSafeActuatorName, "4, 2, fill, default");
-        zSafeActuatorName.setColumns(15);
-
-        JLabel lblNewLabel_5 = new JLabel("Safe Z Value");
-        panel_2.add(lblNewLabel_5, "2, 4, right, default");
-
-        zSafeActuatorValue = new JTextField();
-        panel_2.add(zSafeActuatorValue, "4, 4, fill, default");
-        zSafeActuatorValue.setColumns(15);
 
         JLabel lblNewLabel_6 = new JLabel("Z Contact Actuator");
-        panel_2.add(lblNewLabel_6, "2, 6, right, default");
+        panel_2.add(lblNewLabel_6, "2, 2, right, default");
 
         zContactActuatorName = new JTextField();
-        panel_2.add(zContactActuatorName, "4, 6, fill, default");
+        panel_2.add(zContactActuatorName, "4, 2, fill, default");
         zContactActuatorName.setColumns(15);
 
         JLabel lblNewLabel_7 = new JLabel("Z Contact Actuator Value");
-        panel_2.add(lblNewLabel_7, "2, 8, right, default");
+        panel_2.add(lblNewLabel_7, "2, 4, right, default");
 
         zContactActuatorValue = new JTextField();
-        panel_2.add(zContactActuatorValue, "4, 8, fill, default");
+        panel_2.add(zContactActuatorValue, "4, 4, fill, default");
         zContactActuatorValue.setColumns(15);
     }
 
@@ -230,8 +216,6 @@ public class ReferenceHeadConfigurationWizard extends AbstractConfigurationWizar
 
         addWrappedBinding(head, "softLimitsEnabled", softLimitsEnabled, "selected");
 
-        addWrappedBinding(head, "zSafeActuatorName", zSafeActuatorName, "text");
-        addWrappedBinding(head, "zSafeActuatorValue", zSafeActuatorValue, "text");
         addWrappedBinding(head, "zContactActuatorName", zContactActuatorName, "text");
         addWrappedBinding(head, "zContactActuatorValue", zContactActuatorValue, "text");
 
@@ -241,9 +225,7 @@ public class ReferenceHeadConfigurationWizard extends AbstractConfigurationWizar
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(minY);
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(maxX);
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(maxY);
-        
-        ComponentDecorators.decorateWithAutoSelect(zSafeActuatorName);
-        ComponentDecorators.decorateWithAutoSelect(zSafeActuatorValue);
+
         ComponentDecorators.decorateWithAutoSelect(zContactActuatorName);
         ComponentDecorators.decorateWithAutoSelect(zContactActuatorValue);
     }
@@ -371,8 +353,6 @@ public class ReferenceHeadConfigurationWizard extends AbstractConfigurationWizar
     private JTextField maxX;
     private JTextField maxY;
     private JCheckBox softLimitsEnabled;
-    private JTextField zSafeActuatorName;
-    private JTextField zSafeActuatorValue;
     private JTextField zContactActuatorName;
     private JTextField zContactActuatorValue;
 }

--- a/src/main/java/org/openpnp/machine/reference/wizards/ReferenceNozzleConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/wizards/ReferenceNozzleConfigurationWizard.java
@@ -62,25 +62,24 @@ public class ReferenceNozzleConfigurationWizard extends AbstractConfigurationWiz
     private JTextField pickDwellTf;
     private JTextField placeDwellTf;
     private JLabel lblLimitRota;
+    private JTextField zSafeActuatorName;
+    private JTextField zSafeActuatorValue;
 
     public ReferenceNozzleConfigurationWizard(ReferenceNozzle nozzle) {
         this.nozzle = nozzle;
-        
+
         panelProperties = new JPanel();
-        panelProperties.setBorder(new TitledBorder(null, "Properties", TitledBorder.LEADING, TitledBorder.TOP, null, null));
+        panelProperties.setBorder(new TitledBorder(null, "Properties", TitledBorder.LEADING,
+                TitledBorder.TOP, null, null));
         contentPanel.add(panelProperties);
-        panelProperties.setLayout(new FormLayout(new ColumnSpec[] {
-                FormSpecs.RELATED_GAP_COLSPEC,
-                FormSpecs.DEFAULT_COLSPEC,
-                FormSpecs.RELATED_GAP_COLSPEC,
-                FormSpecs.DEFAULT_COLSPEC,},
-            new RowSpec[] {
-                FormSpecs.RELATED_GAP_ROWSPEC,
-                FormSpecs.DEFAULT_ROWSPEC,}));
-        
+        panelProperties.setLayout(new FormLayout(
+                new ColumnSpec[] {FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,
+                        FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,},
+                new RowSpec[] {FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,}));
+
         lblName = new JLabel("Name");
         panelProperties.add(lblName, "2, 2, right, default");
-        
+
         nameTf = new JTextField();
         panelProperties.add(nameTf, "4, 2");
         nameTf.setColumns(20);
@@ -125,53 +124,62 @@ public class ReferenceNozzleConfigurationWizard extends AbstractConfigurationWiz
         contentPanel.add(panelSafeZ);
         panelSafeZ.setLayout(new FormLayout(
                 new ColumnSpec[] {FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,
-                        FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,},
-                new RowSpec[] {FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,}));
+                        FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,
+                        FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,
+                        FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,
+                        FormSpecs.RELATED_GAP_COLSPEC, ColumnSpec.decode("left:default:grow"),},
+                new RowSpec[] {FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,}));
 
-        JLabel lblSafeZ = new JLabel("Safe Z");
+        JLabel lblSafeZ = new JLabel("Safe Z Height");
         panelSafeZ.add(lblSafeZ, "2, 2, right, default");
 
         textFieldSafeZ = new JTextField();
         panelSafeZ.add(textFieldSafeZ, "4, 2, fill, default");
         textFieldSafeZ.setColumns(10);
 
+        JLabel lblNewLabel_4 = new JLabel("Safe Z Actuator Name");
+        panelSafeZ.add(lblNewLabel_4, "2, 4, right, default");
+
+        zSafeActuatorName = new JTextField();
+        panelSafeZ.add(zSafeActuatorName, "4, 4, fill, default");
+        zSafeActuatorName.setColumns(15);
+
+        JLabel lblNewLabel_5 = new JLabel("Safe Z Value");
+        panelSafeZ.add(lblNewLabel_5, "2, 6, right, default");
+
+        zSafeActuatorValue = new JTextField();
+        panelSafeZ.add(zSafeActuatorValue, "4, 6, fill, default");
+        zSafeActuatorValue.setColumns(15);
+
 
         panelChanger = new JPanel();
         panelChanger.setBorder(new TitledBorder(new EtchedBorder(EtchedBorder.LOWERED, null, null),
                 "Settings", TitledBorder.LEADING, TitledBorder.TOP, null, new Color(0, 0, 0)));
         contentPanel.add(panelChanger);
-        panelChanger
-                .setLayout(
-                        new FormLayout(new ColumnSpec[] {
-                FormSpecs.RELATED_GAP_COLSPEC,
-                FormSpecs.DEFAULT_COLSPEC,
-                FormSpecs.RELATED_GAP_COLSPEC,
-                FormSpecs.DEFAULT_COLSPEC,
-                FormSpecs.RELATED_GAP_COLSPEC,
-                ColumnSpec.decode("default:grow"),
-                FormSpecs.RELATED_GAP_COLSPEC,
-                ColumnSpec.decode("default:grow"),
-                FormSpecs.RELATED_GAP_COLSPEC,
-                ColumnSpec.decode("default:grow"),},
-            new RowSpec[] {
-                FormSpecs.RELATED_GAP_ROWSPEC,
-                FormSpecs.DEFAULT_ROWSPEC,
-                FormSpecs.RELATED_GAP_ROWSPEC,
-                FormSpecs.DEFAULT_ROWSPEC,
-                FormSpecs.RELATED_GAP_ROWSPEC,
-                FormSpecs.DEFAULT_ROWSPEC,
-                FormSpecs.RELATED_GAP_ROWSPEC,
-                FormSpecs.DEFAULT_ROWSPEC,}));
-        
+        panelChanger.setLayout(new FormLayout(
+                new ColumnSpec[] {FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,
+                        FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,
+                        FormSpecs.RELATED_GAP_COLSPEC, ColumnSpec.decode("default:grow"),
+                        FormSpecs.RELATED_GAP_COLSPEC, ColumnSpec.decode("default:grow"),
+                        FormSpecs.RELATED_GAP_COLSPEC, ColumnSpec.decode("default:grow"),},
+                new RowSpec[] {FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,}));
+
         lblLimitRota = new JLabel("Limit Rotation to 180º");
         panelChanger.add(lblLimitRota, "2, 2, right, default");
 
         chckbxLimitRotationTo = new JCheckBox("");
         panelChanger.add(chckbxLimitRotationTo, "4, 2");
-        
+
         lblPickDwellTime = new JLabel("Pick Dwell Time (ms)");
         panelChanger.add(lblPickDwellTime, "2, 4, right, default");
-        
+
         pickDwellTf = new JTextField();
         panelChanger.add(pickDwellTf, "4, 4, fill, default");
         pickDwellTf.setColumns(10);
@@ -202,6 +210,8 @@ public class ReferenceNozzleConfigurationWizard extends AbstractConfigurationWiz
 
         addWrappedBinding(nozzle, "limitRotation", chckbxLimitRotationTo, "selected");
         addWrappedBinding(nozzle, "safeZ", textFieldSafeZ, "text", lengthConverter);
+        addWrappedBinding(nozzle, "zSafeActuatorName", zSafeActuatorName, "text");
+        addWrappedBinding(nozzle, "zSafeActuatorValue", zSafeActuatorValue, "text");
         addWrappedBinding(nozzle, "pickDwellMilliseconds", pickDwellTf, "text", intConverter);
         addWrappedBinding(nozzle, "placeDwellMilliseconds", placeDwellTf, "text", intConverter);
 
@@ -212,5 +222,7 @@ public class ReferenceNozzleConfigurationWizard extends AbstractConfigurationWiz
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(locationY);
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(locationZ);
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldSafeZ);
+        ComponentDecorators.decorateWithAutoSelect(zSafeActuatorName);
+        ComponentDecorators.decorateWithAutoSelect(zSafeActuatorValue);
     }
 }

--- a/src/main/java/org/openpnp/spi/base/AbstractHead.java
+++ b/src/main/java/org/openpnp/spi/base/AbstractHead.java
@@ -49,10 +49,7 @@ public abstract class AbstractHead extends AbstractModelObject implements Head {
     protected Location maxLocation = new Location(LengthUnit.Millimeters);
 
     @Element(required = false)
-    protected String zContactActuatorName = "";
-
-    @Element(required = false)
-    protected String zContactActuatorValue = "";
+    protected String zProbeActuatorName;
 
     protected Machine machine;
 
@@ -294,22 +291,14 @@ public abstract class AbstractHead extends AbstractModelObject implements Head {
 
     @Override
     public Actuator getZProbe() {
-        return getActuatorByName(zContactActuatorName);
+        return getActuatorByName(zProbeActuatorName); 
     }
 
-    public String getzContactActuatorName() {
-        return zContactActuatorName;
+    public String getzProbeActuatorName() {
+        return zProbeActuatorName;
     }
 
-    public void setzContactActuatorName(String zContactActuatorName) {
-        this.zContactActuatorName = zContactActuatorName;
-    }
-
-    public String getzContactActuatorValue() {
-        return zContactActuatorValue;
-    }
-
-    public void setzContactActuatorValue(String zContactActuatorValue) {
-        this.zContactActuatorValue = zContactActuatorValue;
+    public void setzProbeActuatorName(String zProbeActuatorName) {
+        this.zProbeActuatorName = zProbeActuatorName;
     }
 }

--- a/src/main/java/org/openpnp/spi/base/AbstractHead.java
+++ b/src/main/java/org/openpnp/spi/base/AbstractHead.java
@@ -38,8 +38,8 @@ public abstract class AbstractHead extends AbstractModelObject implements Head {
 
     @Element(required = false)
     protected Location parkLocation = new Location(LengthUnit.Millimeters);
-    
-    @Element(required=false)
+
+    @Element(required = false)
     protected boolean softLimitsEnabled = false;
 
     @Element(required = false)
@@ -47,9 +47,18 @@ public abstract class AbstractHead extends AbstractModelObject implements Head {
 
     @Element(required = false)
     protected Location maxLocation = new Location(LengthUnit.Millimeters);
-    
+
     @Element(required = false)
-    protected String zProbeActuatorName;
+    protected String zContactActuatorName = "";
+
+    @Element(required = false)
+    protected String zContactActuatorValue = "";
+
+    @Element(required = false)
+    protected String zSafeActuatorName = "";
+
+    @Element(required = false)
+    protected String zSafeActuatorValue = "";
 
     protected Machine machine;
 
@@ -173,6 +182,20 @@ public abstract class AbstractHead extends AbstractModelObject implements Head {
         for (Actuator actuator : actuators) {
             actuator.moveToSafeZ(speed);
         }
+
+        if (this.zSafeActuatorName.length() > 0 && this.zSafeActuatorValue.length() > 0) {
+            Actuator zSafeActuator = getActuatorByName(zSafeActuatorName);
+            if (zSafeActuator == null) {
+                throw new Exception(String.format("No Actuator found with name %s on Head %s",
+                        zSafeActuatorName, this.getName()));
+            }
+            String zProbeValue = zSafeActuator.read();
+            if (!zProbeValue.equals(zSafeActuatorValue)) {
+                throw new Exception(String.format(
+                        "Z Probe Actuator %s says Head %s is not at safe Z (probe is reading %s and not %s)",
+                        zSafeActuatorName, this.getName(), zProbeValue, zSafeActuatorValue));
+            }
+        }
     }
 
     @Override
@@ -288,17 +311,41 @@ public abstract class AbstractHead extends AbstractModelObject implements Head {
     public void setSoftLimitsEnabled(boolean softLimitsEnabled) {
         this.softLimitsEnabled = softLimitsEnabled;
     }
-    
+
     @Override
     public Actuator getZProbe() {
-        return getActuatorByName(zProbeActuatorName); 
+        return getActuatorByName(zContactActuatorName);
     }
 
-    public String getzProbeActuatorName() {
-        return zProbeActuatorName;
+    public String getzSafeActuatorValue() {
+        return zSafeActuatorValue;
     }
 
-    public void setzProbeActuatorName(String zProbeActuatorName) {
-        this.zProbeActuatorName = zProbeActuatorName;
+    public void setzSafeActuatorValue(String zSafeActuatorValue) {
+        this.zSafeActuatorValue = zSafeActuatorValue;
+    }
+
+    public String getzSafeActuatorName() {
+        return zSafeActuatorName;
+    }
+
+    public void setzSafeActuatorName(String zSafeActuatorName) {
+        this.zSafeActuatorName = zSafeActuatorName;
+    }
+
+    public String getzContactActuatorName() {
+        return zContactActuatorName;
+    }
+
+    public void setzContactActuatorName(String zContactActuatorName) {
+        this.zContactActuatorName = zContactActuatorName;
+    }
+
+    public String getzContactActuatorValue() {
+        return zContactActuatorValue;
+    }
+
+    public void setzContactActuatorValue(String zContactActuatorValue) {
+        this.zContactActuatorValue = zContactActuatorValue;
     }
 }

--- a/src/main/java/org/openpnp/spi/base/AbstractHead.java
+++ b/src/main/java/org/openpnp/spi/base/AbstractHead.java
@@ -54,12 +54,6 @@ public abstract class AbstractHead extends AbstractModelObject implements Head {
     @Element(required = false)
     protected String zContactActuatorValue = "";
 
-    @Element(required = false)
-    protected String zSafeActuatorName = "";
-
-    @Element(required = false)
-    protected String zSafeActuatorValue = "";
-
     protected Machine machine;
 
     public AbstractHead() {
@@ -182,20 +176,6 @@ public abstract class AbstractHead extends AbstractModelObject implements Head {
         for (Actuator actuator : actuators) {
             actuator.moveToSafeZ(speed);
         }
-
-        if (this.zSafeActuatorName.length() > 0 && this.zSafeActuatorValue.length() > 0) {
-            Actuator zSafeActuator = getActuatorByName(zSafeActuatorName);
-            if (zSafeActuator == null) {
-                throw new Exception(String.format("No Actuator found with name %s on Head %s",
-                        zSafeActuatorName, this.getName()));
-            }
-            String zProbeValue = zSafeActuator.read();
-            if (!zProbeValue.equals(zSafeActuatorValue)) {
-                throw new Exception(String.format(
-                        "Z Probe Actuator %s says Head %s is not at safe Z (probe is reading %s and not %s)",
-                        zSafeActuatorName, this.getName(), zProbeValue, zSafeActuatorValue));
-            }
-        }
     }
 
     @Override
@@ -315,22 +295,6 @@ public abstract class AbstractHead extends AbstractModelObject implements Head {
     @Override
     public Actuator getZProbe() {
         return getActuatorByName(zContactActuatorName);
-    }
-
-    public String getzSafeActuatorValue() {
-        return zSafeActuatorValue;
-    }
-
-    public void setzSafeActuatorValue(String zSafeActuatorValue) {
-        this.zSafeActuatorValue = zSafeActuatorValue;
-    }
-
-    public String getzSafeActuatorName() {
-        return zSafeActuatorName;
-    }
-
-    public void setzSafeActuatorName(String zSafeActuatorName) {
-        this.zSafeActuatorName = zSafeActuatorName;
     }
 
     public String getzContactActuatorName() {

--- a/src/main/java/org/openpnp/spi/base/AbstractHead.java
+++ b/src/main/java/org/openpnp/spi/base/AbstractHead.java
@@ -38,8 +38,8 @@ public abstract class AbstractHead extends AbstractModelObject implements Head {
 
     @Element(required = false)
     protected Location parkLocation = new Location(LengthUnit.Millimeters);
-
-    @Element(required = false)
+    
+    @Element(required=false)
     protected boolean softLimitsEnabled = false;
 
     @Element(required = false)
@@ -47,7 +47,7 @@ public abstract class AbstractHead extends AbstractModelObject implements Head {
 
     @Element(required = false)
     protected Location maxLocation = new Location(LengthUnit.Millimeters);
-
+    
     @Element(required = false)
     protected String zProbeActuatorName;
 
@@ -288,7 +288,7 @@ public abstract class AbstractHead extends AbstractModelObject implements Head {
     public void setSoftLimitsEnabled(boolean softLimitsEnabled) {
         this.softLimitsEnabled = softLimitsEnabled;
     }
-
+    
     @Override
     public Actuator getZProbe() {
         return getActuatorByName(zProbeActuatorName); 

--- a/src/main/java/org/openpnp/spi/base/AbstractHead.java
+++ b/src/main/java/org/openpnp/spi/base/AbstractHead.java
@@ -50,6 +50,11 @@ public abstract class AbstractHead extends AbstractModelObject implements Head {
     
     @Element(required = false)
     protected String zProbeActuatorName;
+    @Element(required = false)
+    protected String zSafeActuatorName = "";
+
+    @Element(required = false)
+    protected String zSafeActuatorValue = "";
 
     protected Machine machine;
 
@@ -173,6 +178,20 @@ public abstract class AbstractHead extends AbstractModelObject implements Head {
         for (Actuator actuator : actuators) {
             actuator.moveToSafeZ(speed);
         }
+
+        if (this.zSafeActuatorName.length() > 0 && this.zSafeActuatorValue.length() > 0) {
+            Actuator zSafeActuator = getActuatorByName(zSafeActuatorName);
+            if (zSafeActuator == null) {
+                throw new Exception(String.format("No Actuator found with name %s on Head %s",
+                        zSafeActuatorName, this.getName()));
+            }
+            String zProbeValue = zSafeActuator.read();
+            if (!zProbeValue.equals(zSafeActuatorValue)) {
+                throw new Exception(String.format(
+                        "Z Probe Actuator %s says Head %s is not at safe Z (probe is reading %s and not %s)",
+                        zSafeActuatorName, this.getName(), zProbeValue, zSafeActuatorValue));
+            }
+        }
     }
 
     @Override
@@ -292,6 +311,22 @@ public abstract class AbstractHead extends AbstractModelObject implements Head {
     @Override
     public Actuator getZProbe() {
         return getActuatorByName(zProbeActuatorName); 
+    }
+
+    public String getzSafeActuatorValue() {
+        return zSafeActuatorValue;
+    }
+
+    public void setzSafeActuatorValue(String zSafeActuatorValue) {
+        this.zSafeActuatorValue = zSafeActuatorValue;
+    }
+
+    public String getzSafeActuatorName() {
+        return zSafeActuatorName;
+    }
+
+    public void setzSafeActuatorName(String zSafeActuatorName) {
+        this.zSafeActuatorName = zSafeActuatorName;
     }
 
     public String getzProbeActuatorName() {


### PR DESCRIPTION
# Description
Implements safety checks supporting PnPs from Charmhigh

# Justification
The machine should not crash into itself during operation.

# Instructions for Use
The Machine Setup > ReferenceMachine > Heads > ReferenceHead > Nozzles > ReferenceNozzle now has two new fields under "Safe Z": "Safe Z Actuator Name" is the actuator to read for a safety check to confirm that the nozzle is at safe-z, "Safe Z Value" is the value that will be compared with the reading from "Safe Z Actuator Name" to confirm the nozzle is at safe-z.

ReferenceDragFeeder now has an "Pin Retracted Value" under the "Actuators" section.  After a drag operation the drag pin actuator will be read and compared with the "Pin Retracted Value" to confirm that the pin has been safely retracted.

Edit by @vonnieda, this looks like it was reverted: ~~ReferenceHead was changed to go from saying "Z Probe" to "Z Contact" to better identify what it is for.~~

# Implementation Details
1. How did you test the change? 
By initially breaking a 502 tip and bending my drag pin and then working to correct this on my machine.
2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)?
No, minimal changes were used instead of following the coding style.

