### PR TITLE
Drag feeder

### DIFF
--- a/src/main/java/org/openpnp/gui/panelization/DlgAutoPanelize.java
+++ b/src/main/java/org/openpnp/gui/panelization/DlgAutoPanelize.java
@@ -86,11 +86,11 @@ public class DlgAutoPanelize extends JDialog {
         jPanel.add(textFieldPCBRows, "4, 4, fill, default");
 
         // Spacing
-        jPanel.add(new JLabel("X Spacing", JLabel.RIGHT), "2, 6, right, default");
+        jPanel.add(new JLabel("X Gap Spacing", JLabel.RIGHT), "2, 6, right, default");
         textFieldboardXSpacing = new JTextField();
         jPanel.add(textFieldboardXSpacing, "4, 6, fill, default");
 
-        jPanel.add(new JLabel("Y Spacing", JLabel.RIGHT), "2, 8, right, default");
+        jPanel.add(new JLabel("Y Gap Spacing", JLabel.RIGHT), "2, 8, right, default");
         textFieldboardYSpacing = new JTextField();
         jPanel.add(textFieldboardYSpacing, "4, 8, fill, default");
 

--- a/src/main/java/org/openpnp/machine/reference/ReferenceHead.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceHead.java
@@ -91,26 +91,8 @@ public class ReferenceHead extends AbstractHead {
             Location maxLocation = this.maxLocation.convertToUnits(cameraLocation.getUnits());
             if (cameraLocation.getX() < minLocation.getX() || cameraLocation.getX() > maxLocation.getX() ||
                     cameraLocation.getY() < minLocation.getY() || cameraLocation.getY() > maxLocation.getY()) {
-                String limit = "";
-                if (cameraLocation.getX() < minLocation.getX()) {
-                    limit += String.format("x_camera (%f) less than x_min (%f)  ", cameraLocation.getX(),
-                            minLocation.getX());
-                }
-                if (cameraLocation.getX() > maxLocation.getX()) {
-                    limit += String.format("x_camera (%f) greater than x_max (%f)  ", cameraLocation.getX(),
-                            maxLocation.getX());
-                }
-                if (cameraLocation.getY() < minLocation.getY()) {
-                    limit += String.format("y_camera (%f) less than y_min (%f)  ", cameraLocation.getY(),
-                            minLocation.getY());
-                }
-                if (cameraLocation.getY() > maxLocation.getY()) {
-                    limit += String.format("y_camera (%f) greater than y_max (%f)  ", cameraLocation.getY(),
-                            maxLocation.getY());
-                }
-                throw new Exception(
-                        String.format("Can't move %s to %s, outside of soft limits on head %s:  %s",
-                                hm.getName(), location, getName(), limit));
+                throw new Exception(String.format("Can't move %s to %s, outside of soft limits on head %s.",
+                        hm.getName(), location, getName()));
             }
         }
         getDriver().moveTo(hm, location, speed);

--- a/src/main/java/org/openpnp/machine/reference/ReferenceHead.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceHead.java
@@ -109,7 +109,7 @@ public class ReferenceHead extends AbstractHead {
                             maxLocation.getY());
                 }
                 throw new Exception(
-                        String.format("Can't move %s to %s, outside of soft limits on head %s.  %s",
+                        String.format("Can't move %s to %s, outside of soft limits on head %s:  %s",
                                 hm.getName(), location, getName(), limit));
             }
         }

--- a/src/main/java/org/openpnp/machine/reference/ReferenceHead.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceHead.java
@@ -91,8 +91,26 @@ public class ReferenceHead extends AbstractHead {
             Location maxLocation = this.maxLocation.convertToUnits(cameraLocation.getUnits());
             if (cameraLocation.getX() < minLocation.getX() || cameraLocation.getX() > maxLocation.getX() ||
                     cameraLocation.getY() < minLocation.getY() || cameraLocation.getY() > maxLocation.getY()) {
-                throw new Exception(String.format("Can't move %s to %s, outside of soft limits on head %s.",
-                        hm.getName(), location, getName()));
+                String limit = "";
+                if (cameraLocation.getX() < minLocation.getX()) {
+                    limit += String.format("x_camera (%f) less than x_min (%f)  ", cameraLocation.getX(),
+                            minLocation.getX());
+                }
+                if (cameraLocation.getX() > maxLocation.getX()) {
+                    limit += String.format("x_camera (%f) greater than x_max (%f)  ", cameraLocation.getX(),
+                            maxLocation.getX());
+                }
+                if (cameraLocation.getY() < minLocation.getY()) {
+                    limit += String.format("y_camera (%f) less than y_min (%f)  ", cameraLocation.getY(),
+                            minLocation.getY());
+                }
+                if (cameraLocation.getY() > maxLocation.getY()) {
+                    limit += String.format("y_camera (%f) greater than y_max (%f)  ", cameraLocation.getY(),
+                            maxLocation.getY());
+                }
+                throw new Exception(
+                        String.format("Can't move %s to %s, outside of soft limits on head %s.  %s",
+                                hm.getName(), location, getName(), limit));
             }
         }
         getDriver().moveTo(hm, location, speed);

--- a/src/main/java/org/openpnp/machine/reference/feeder/ReferenceDragFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/ReferenceDragFeeder.java
@@ -84,7 +84,9 @@ public class ReferenceDragFeeder extends ReferenceFeeder {
     @Element(required = false)
     protected Vision vision = new Vision();
     @Element(required = false)
-    protected Length backoffDistance = new Length(0, LengthUnit.Millimeters);    
+    protected Length backoffDistance = new Length(0, LengthUnit.Millimeters);   
+    @Element(required = false)
+    protected int uiNextPartOffset = 0;
 
     protected Location pickLocation;
 
@@ -350,6 +352,11 @@ public class ReferenceDragFeeder extends ReferenceFeeder {
 		partPitch = null;
 	}
 
+    public void updateNextPartOffset() {
+        feededCount = uiNextPartOffset + 1;
+        Logger.debug(String.format("---: feededCount = %s", String.valueOf(feededCount)));
+    }
+    
 	public boolean isPart0402() {
 		return this.getPart().getPackage().getId().contains("C0402")
 				|| this.getPart().getPackage().getId().contains("R0402");
@@ -405,6 +412,14 @@ public class ReferenceDragFeeder extends ReferenceFeeder {
 
     public void setBackoffDistance(Length backoffDistance) {
         this.backoffDistance = backoffDistance;
+    }
+    
+    public int getUiNextPartOffset() {
+        return uiNextPartOffset;
+    }
+
+    public void setUiNextPartOffset(int uiNextPartOffset) {
+        this.uiNextPartOffset = uiNextPartOffset;
     }
 
     public Vision getVision() {

--- a/src/main/java/org/openpnp/machine/reference/feeder/wizards/ReferenceDragFeederConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/wizards/ReferenceDragFeederConfigurationWizard.java
@@ -44,8 +44,6 @@ import javax.swing.border.EtchedBorder;
 import javax.swing.border.TitledBorder;
 
 import org.jdesktop.beansbinding.AutoBinding.UpdateStrategy;
-import org.jdesktop.beansbinding.BeanProperty;
-import org.jdesktop.beansbinding.Bindings;
 import org.openpnp.gui.MainFrame;
 import org.openpnp.gui.components.CameraView;
 import org.openpnp.gui.components.ComponentDecorators;
@@ -110,6 +108,7 @@ public class ReferenceDragFeederConfigurationWizard
     private JPanel panel;
     private JButton btnCancelChangeTemplateImage;
     private JButton btnResetVisionOffsets;
+    private JButton btnSetPartOffset;
 
     public ReferenceDragFeederConfigurationWizard(ReferenceDragFeeder feeder) {
         super(feeder);
@@ -161,28 +160,17 @@ public class ReferenceDragFeederConfigurationWizard
         panelFields.add(panelLocations);
         panelLocations.setBorder(new TitledBorder(null, "Locations", TitledBorder.LEADING,
                 TitledBorder.TOP, null, null));
-        panelLocations.setLayout(new FormLayout(new ColumnSpec[] {
-                FormSpecs.RELATED_GAP_COLSPEC,
-                FormSpecs.DEFAULT_COLSPEC,
-                FormSpecs.RELATED_GAP_COLSPEC,
-                FormSpecs.DEFAULT_COLSPEC,
-                FormSpecs.RELATED_GAP_COLSPEC,
-                FormSpecs.DEFAULT_COLSPEC,
-                FormSpecs.RELATED_GAP_COLSPEC,
-                FormSpecs.DEFAULT_COLSPEC,
-                FormSpecs.RELATED_GAP_COLSPEC,
-                ColumnSpec.decode("left:default:grow"),},
-            new RowSpec[] {
-                FormSpecs.RELATED_GAP_ROWSPEC,
-                FormSpecs.DEFAULT_ROWSPEC,
-                FormSpecs.RELATED_GAP_ROWSPEC,
-                FormSpecs.DEFAULT_ROWSPEC,
-                FormSpecs.RELATED_GAP_ROWSPEC,
-                FormSpecs.DEFAULT_ROWSPEC,
-                FormSpecs.RELATED_GAP_ROWSPEC,
-                FormSpecs.DEFAULT_ROWSPEC,
-                FormSpecs.RELATED_GAP_ROWSPEC,
-                FormSpecs.DEFAULT_ROWSPEC,}));
+        panelLocations.setLayout(new FormLayout(
+                new ColumnSpec[] {FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,
+                        FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,
+                        FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,
+                        FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,
+                        FormSpecs.RELATED_GAP_COLSPEC, ColumnSpec.decode("left:default:grow"),},
+                new RowSpec[] {FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,}));
 
         JLabel lblX = new JLabel("X");
         panelLocations.add(lblX, "4, 4");
@@ -237,6 +225,14 @@ public class ReferenceDragFeederConfigurationWizard
         backoffDistTf = new JTextField();
         panelLocations.add(backoffDistTf, "4, 10");
         backoffDistTf.setColumns(10);
+
+        btnSetPartOffset = new JButton("Update next part offset to:");
+        btnSetPartOffset.setAction(setNextPartOffset);
+        panelLocations.add(btnSetPartOffset, "6, 10");
+
+        nextPartOffset = new JTextField();
+        panelLocations.add(nextPartOffset, "8, 10");
+        nextPartOffset.setColumns(10);
         //
         panelVision = new JPanel();
         panelVision.setBorder(new TitledBorder(null, "Vision", TitledBorder.LEADING,
@@ -396,6 +392,7 @@ public class ReferenceDragFeederConfigurationWizard
                 intConverter);
         
         addWrappedBinding(feeder, "backoffDistance", backoffDistTf, "text", lengthConverter);
+        addWrappedBinding(feeder, "uiNextPartOffset", nextPartOffset, "text", intConverter);
 
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldFeedRate);
         ComponentDecorators.decorateWithAutoSelect(textFieldActuatorId);
@@ -411,6 +408,7 @@ public class ReferenceDragFeederConfigurationWizard
         ComponentDecorators.decorateWithAutoSelect(textFieldAoiWidth);
         ComponentDecorators.decorateWithAutoSelect(textFieldAoiHeight);
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(backoffDistTf);
+        ComponentDecorators.decorateWithAutoSelect(nextPartOffset);
 
         bind(UpdateStrategy.READ, feeder, "actuatorName", locationButtonsPanelFeedStart, "actuatorName");
         bind(UpdateStrategy.READ, feeder, "actuatorName", locationButtonsPanelFeedEnd, "actuatorName");
@@ -560,6 +558,18 @@ public class ReferenceDragFeederConfigurationWizard
             });
         }
     };
+    
+    @SuppressWarnings("serial")
+    private Action setNextPartOffset = new AbstractAction("Set next part offset to:") {
+        @Override
+        public void actionPerformed(ActionEvent arg0) {
+            UiUtils.messageBoxOnException(() -> {
+                feeder.updateNextPartOffset();
+            });
+        }
+    };
+    
     private JLabel lblBackoffDistance;
     private JTextField backoffDistTf;
+    private JTextField nextPartOffset;
 }


### PR DESCRIPTION
# Description
ReferenceDragFeeder always pulls the tape during a feed.  There's no way to tell OpenPnP to skip a pull or to direct it to another well in the tape.  This PR addresses this issue.

# Justification
See above

# Instructions for Use
In the "Locations" section of ReferenceDragFeeder there is now a button and text field next to where the "Backoff Distance" is entered.  By putting a value in the field at the far right and clicking the "Set next part offset to:" button OpenPnP will optionally not do a feed operation on the next feed from the feeder.

The default behavior is still the same, with the drag feeder always performing a drag operation.  Entering a negative value in the field will reset any changes made and go back to this.

Entering a 0 will tell OpenPnP that a drag operation is not needed and that a part is waiting at the usual pick location.

Entering a 1 will tell OpenPnP to pick from a location that is 2mm in front of the drag feeder.  This way 0402 parts can be picked up out of the well in the tape.

# Implementation Details
1. How did you test the change? 
By testing vision pipelines with 0402 parts
2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)?
No
3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing.
4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted.
Tests pass!