### PR TITLE
Added scripting support to discards made via GUI

### DIFF
--- a/src/main/java/org/openpnp/gui/JogControlsPanel.java
+++ b/src/main/java/org/openpnp/gui/JogControlsPanel.java
@@ -62,6 +62,7 @@ import org.openpnp.spi.Nozzle;
 import org.openpnp.util.BeanUtils;
 import org.openpnp.util.MovableUtils;
 import org.openpnp.util.UiUtils;
+import org.pmw.tinylog.Logger;
 
 import com.jgoodies.forms.layout.ColumnSpec;
 import com.jgoodies.forms.layout.FormLayout;
@@ -598,12 +599,28 @@ public class JogControlsPanel extends JPanel {
             UiUtils.submitUiMachineTask(() -> {
                 Nozzle nozzle = machineControlsPanel.getSelectedNozzle();
                 // move to the discard location
+                try {
+                    Map<String, Object> globals = new HashMap<>();
+                    globals.put("nozzle", nozzle);
+                    Configuration.get().getScripting().on("Job.BeforeDiscard", globals);
+                }
+                catch (Exception e) {
+                    Logger.warn(e);
+                }
                 MovableUtils.moveToLocationAtSafeZ(nozzle, Configuration.get()
                                                                         .getMachine()
                                                                         .getDiscardLocation());
                 // discard the part
                 nozzle.place();
                 nozzle.moveToSafeZ();
+                try {
+                    Map<String, Object> globals = new HashMap<>();
+                    globals.put("nozzle", nozzle);
+                    Configuration.get().getScripting().on("Job.AfterDiscard", globals);
+                }
+                catch (Exception e) {
+                    Logger.warn(e);
+                }
             });
         }
     };


### PR DESCRIPTION
# Description
Scripting events 'Job.BeforeDiscard' and 'Job.AfterDiscard' called from discards triggered via GUI.

# Justification
Discards during jobs use a different code path that discards triggered via the GUI. This adds the scripting events to the later.  

# Instructions for Use
Add scripts/Events/Job.BeforeDiscard.js and/or scripts/Events/Job.AfterDiscard.js

This is documentation for a user, not for a developer.

# Implementation Details
Ran mvn test.
Compiled new build and ran discards with and without scripts installed.
