### PR TITLE
Allow histogram equalization on color images.

### DIFF
--- a/src/main/java/org/openpnp/vision/pipeline/stages/HistogramEqualize.java
+++ b/src/main/java/org/openpnp/vision/pipeline/stages/HistogramEqualize.java
@@ -1,17 +1,64 @@
 package org.openpnp.vision.pipeline.stages;
 
+import org.opencv.core.Core;
 import org.opencv.core.Mat;
 import org.opencv.imgproc.Imgproc;
 import org.openpnp.vision.pipeline.CvPipeline;
 import org.openpnp.vision.pipeline.CvStage;
+import org.openpnp.vision.pipeline.Property;
+import org.openpnp.vision.pipeline.Stage;
+import org.openpnp.vision.pipeline.stages.ThresholdAdaptive.AdaptiveMethod;
+import org.simpleframework.xml.Attribute;
 import org.simpleframework.xml.Root;
 
 @Root
+@Stage(description="Applies histogram equalization to the selected channels of the image.  For gray scale images this will increase the image contrast.  For color images, the results will vary depending on the image format and channels selected for equalization.  Generally applying histogram equalization to a color image will result in a false color image; however, contrast enhancement can be achieved on HSV formats by applying equalization to only the third channel (V).")
 public class HistogramEqualize extends CvStage {
+
+    public enum ChannelsToEqualize {
+        First(1),
+        Second(2),
+        Third(4),
+        FirstAndSecond(1+2),
+        FirstAndThird(1+4),
+        SecondAndThird(2+4),
+        All(1+2+4);
+        
+        private int code;
+
+        ChannelsToEqualize(int code) {
+            this.code = code;
+        }
+
+        public int getCode() {
+            return code;
+        }
+    }
+    
+    @Attribute(required=false)
+    @Property(description="Selects which channel(s) of the image to equalize.  This setting has no effect on single channel (gray scale) images.")
+    private ChannelsToEqualize channelsToEqualize = ChannelsToEqualize.All;
+    
+    public ChannelsToEqualize getChannelsToEqualize() {
+        return channelsToEqualize;
+    }
+
+    public void setChannelsToEqualize(ChannelsToEqualize channelsToEqualize) {
+        this.channelsToEqualize = channelsToEqualize;
+    }
+
     @Override
     public Result process(CvPipeline pipeline) throws Exception {
         Mat mat = pipeline.getWorkingImage();
-        Imgproc.equalizeHist(mat, mat);
+        int nChannels = mat.channels();
+        Mat workingMat = new Mat();
+        for (int i=0; i<nChannels; i++) {
+            if ((nChannels == 1) || ((channelsToEqualize.getCode()>>i) % 2 == 1)) {
+                Core.extractChannel(mat, workingMat, i);
+                Imgproc.equalizeHist(workingMat, workingMat);
+                Core.insertChannel(workingMat, mat, i);
+            };
+        };
         return null;
     }
 }


### PR DESCRIPTION
**# Description**
This change allows the HistogramEqualize stage to be applied to color images.  For grayscale images there is no change in functionality.

**# Justification**
This change provides additional capability to manipulate images that can potentially improve object recognition.

**# Instructions for Use**
For grayscale images the intensity histogram of the image is stretched in an attempt to ensure every intensity level occurs in the new image thereby increasing its contrast.  For color images, the channelsToEqualize parameter selects which channel(s) of the image to equalize (defaults to all channels).  If applied to an intensity only channel (such as the third channel (V) of an HSV image), the image will have its contrast enhanced but there will be no change in its color appearance.  If applied to non-intensity channels (such as the H and/or S channels of an HSV image or to any channels of a BGR image) the result will be not only be a change in contrast but also an alteration of the colors in the image.

**# Implementation Details**
**1. How did you test the change?** Tested on my machine with both grayscale and color images and observed the results.
**2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)?**  Yes.
**3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing.**  No changes were made in either of these packages.
**4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted.**  Maven tests were run and passed.
