### PR TITLE
Added pipeline stage to write actuators

### DIFF
--- a/src/main/java/org/openpnp/vision/pipeline/stages/ActuatorWrite.java
+++ b/src/main/java/org/openpnp/vision/pipeline/stages/ActuatorWrite.java
@@ -1,0 +1,91 @@
+package org.openpnp.vision.pipeline.stages;
+
+
+import org.openpnp.model.Configuration;
+import org.openpnp.spi.Actuator;
+import org.openpnp.spi.Head;
+import org.openpnp.vision.pipeline.CvPipeline;
+import org.openpnp.vision.pipeline.CvStage;
+import org.openpnp.vision.pipeline.Stage;
+import org.pmw.tinylog.Logger;
+import org.simpleframework.xml.Attribute;
+
+@Stage(description="Performs simple actuator write. Machine must be connected, otherwise error is thrown.")
+public class ActuatorWrite extends CvStage {
+	
+	public enum ActuatorType {
+	        Double,
+	        Boolean
+	}
+	    
+	@Attribute(required=false)
+	protected String actuatorName;
+	    
+	@Attribute(required=false)
+	protected ActuatorType actuatorType = ActuatorType.Double;
+	    
+	@Attribute(required=false)
+	protected double actuatorValue;
+
+	public String getActuatorName() {
+	     return actuatorName;
+	}
+
+	public void setActuatorName(String actuatorName) {
+	     this.actuatorName = actuatorName;
+	}
+
+	public ActuatorType getActuatorType() {
+	     return actuatorType;
+	}
+
+	public void setActuatorType(ActuatorType actuatorType) {
+	     this.actuatorType = actuatorType;
+	}
+	
+	public double getActuatorValue() {
+	     return actuatorValue;
+	}
+
+	public void setActuatorValue(double actuatorValue) {
+	     this.actuatorValue = actuatorValue;
+	}
+    
+
+    @Override
+    public Result process(CvPipeline pipeline) throws Exception {
+
+    	if (actuatorName == null || actuatorName.equals("")) {
+            Logger.warn("No actuator name specified for pipeline {}.", getName());
+        }
+    	else{
+    		
+	        Actuator actuator =  Configuration.get().getMachine().getActuatorByName(actuatorName);
+	        	        
+	        if (actuator == null) {	        	
+	            for (final Head head : Configuration.get().getMachine().getHeads()) {
+	            	actuator = head.getActuatorByName(actuatorName);
+	            	if(  actuator != null){
+	            		break;
+	                }
+	            }		        		            
+	        }
+	        
+	        if (actuator == null)
+	        {
+	        	throw new Exception("Actuator writing (CvStage operation) failed. Unable to find an actuator named " + actuatorName);
+	        }
+	        else{
+	        		        
+		        if (actuatorType == ActuatorType.Boolean) {
+		            actuator.actuate(actuatorValue != 0);
+		        }
+		        else {
+		            actuator.actuate(actuatorValue);
+		        }
+	        }
+    	}	
+        
+        return null;
+    }
+}

--- a/src/main/java/org/openpnp/vision/pipeline/ui/CvPipelineEditor.java
+++ b/src/main/java/org/openpnp/vision/pipeline/ui/CvPipelineEditor.java
@@ -65,6 +65,7 @@ import org.openpnp.vision.pipeline.stages.SimpleBlobDetector;
 import org.openpnp.vision.pipeline.stages.Threshold;
 import org.openpnp.vision.pipeline.stages.ThresholdAdaptive;
 import org.openpnp.vision.pipeline.stages.WritePartTemplateImage;
+import org.openpnp.vision.pipeline.stages.ActuatorWrite;
 
 /**
  * A JPanel based component for editing a CvPipeline. Allows the user to add and remove stages,
@@ -134,6 +135,8 @@ public class CvPipelineEditor extends JPanel {
         registerStageClass(Threshold.class);
         registerStageClass(ThresholdAdaptive.class);
         registerStageClass(WritePartTemplateImage.class);
+        registerStageClass(ActuatorWrite.class);
+        
     }
 
     private final static Set<Class<? extends CvStage>> stageClasses;


### PR DESCRIPTION


# Description
I have added Cv pipeline stage which allows writing to actuators. 

# Justification
This allows controlling actuators directly from Cv pipeline, without using external scripts ( there is a Cv pipeline stage which can execute such script). It helps e.g. to control light intensity directly (if you have such actuator - it is quite common case) 
 
# Instructions for Use
Setup actuator name, value and type ( double of boolean) - in similar way as all other parameters for any stage.

This is documentation for a user, not for a developer.

# Implementation Details
This code was copied mainly from part controlling feeder actuators, it was just formatted to follow Cv stage classes implementation
Tested for positive (proper actuator) and negative cases ( wrong actuator name).
It supports all actuators ( machine and head based)

