### PR TITLE
Update GcodeDriver.java

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/driver/GcodeDriver.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/GcodeDriver.java
@@ -67,6 +67,7 @@ public class GcodeDriver extends AbstractReferenceDriver implements Named, Runna
         PUMP_ON_COMMAND,
         PUMP_OFF_COMMAND,
         MOVE_TO_COMMAND(true, "Id", "Name", "FeedRate", "X", "Y", "Z", "Rotation"),
+        MOVE_TO_COMPLETE_COMMAND(true),
         MOVE_TO_COMPLETE_REGEX(true),
         PICK_COMMAND(true, "Id", "Name", "VacuumLevelPartOn", "VacuumLevelPartOff"),
         PLACE_COMMAND(true, "Id", "Name"),
@@ -220,7 +221,8 @@ public class GcodeDriver extends AbstractReferenceDriver implements Named, Runna
         commands.add(new Command(null, CommandType.COMMAND_CONFIRM_REGEX, "^ok.*"));
         commands.add(new Command(null, CommandType.CONNECT_COMMAND, "G21 ; Set millimeters mode\nG90 ; Set absolute positioning mode\nM82 ; Set absolute mode for extruder"));
         commands.add(new Command(null, CommandType.HOME_COMMAND, "G28 ; Home all axes"));
-        commands.add(new Command(null, CommandType.MOVE_TO_COMMAND, "G0 {X:X%.4f} {Y:Y%.4f} {Z:Z%.4f} {Rotation:E%.4f} F{FeedRate:%.0f} ; Send standard Gcode move\nM400 ; Wait for moves to complete before returning"));
+        commands.add(new Command(null, CommandType.MOVE_TO_COMMAND, "G0 {X:X%.4f} {Y:Y%.4f} {Z:Z%.4f} {Rotation:E%.4f} F{FeedRate:%.0f} ; Send standard Gcode move"));
+        commands.add(new Command(null, CommandType.MOVE_TO_COMPLETE_COMMAND, "M400 ; Wait for moves to complete before returning"));
     }
 
     public synchronized void connect() throws Exception {
@@ -568,6 +570,9 @@ public class GcodeDriver extends AbstractReferenceDriver implements Named, Runna
             rotation = rotationAxis.getTransform().toRaw(rotationAxis, hm, rotation);
         }
 
+        // remember if moved
+        boolean hasMoved = false;
+        
         // Only do something if there at least one axis included in the move
         if (xAxis != null || yAxis != null || zAxis != null || rotationAxis != null) {
 
@@ -719,6 +724,8 @@ public class GcodeDriver extends AbstractReferenceDriver implements Named, Runna
                 if (rotationAxis != null) {
                     rotationAxis.setCoordinate(rotation);
                 }
+                
+                hasMoved = true;
 
             } // there is a move
 
@@ -727,6 +734,17 @@ public class GcodeDriver extends AbstractReferenceDriver implements Named, Runna
         // regardless of any action above the subdriver needs its actions based on original input
         for (ReferenceDriver driver : subDrivers) {
             driver.moveTo(hm, locationOriginal, speed);
+        }
+
+        // if there was a move
+        if (hasMoved) {
+            /*
+             * If moveToCompleteCommand is specified, send it
+             */
+            command = getCommand(hm, CommandType.MOVE_TO_COMPLETE_COMMAND);
+            if (command != null) {
+                    sendGcode(command);
+            }
         }
 
     }


### PR DESCRIPTION
Add MOVE_TO_COMPLETE_COMMAND to separate the move command from the wait for completion command.  Allows simultaneous moves across multiple drivers.

-----------------------------------------------------------------------

# Description
Separates the "wait for completion" part of the MOVE_TO_COMMAND to a MOVE_TO_COMPLETION_COMMAND.

# Justification
This allows moves to be sent to multiple controllers simultaneously and can then wait for them to complete individually.

# Instructions for Use
To use the feature, remove M400 from the MOVE_TO_COMMAND and add M400 to the MOVE_TO_COMPLETE_COMMAND.  Use of this feature is optional.  If there is nothing in the MOVE_TO_COMPLETE_COMMAND it will be ignored.

This is documentation for a user, not for a developer.

# Implementation Details
1. Tested on a machine with two controllers.  The main controller has Z, C1, and C2.  The sub controller has X, Y.  Sending the instruction "moveTo((163.280000, 209.530000, 0.000000, -180.000000 mm), 1.0)" sends the following to the controllers:
GcodeDriver TRACE: [serial://COM4] >> T0
GcodeDriver TRACE: [serial://COM4] << echo:Active Extruder: 0
GcodeDriver TRACE: [serial://COM4] << ok
GcodeDriver TRACE: [serial://COM4] >> G0  E-180.0000 F50000 ; Send standard Gcode move
GcodeDriver TRACE: [serial://COM4] << ok
GcodeDriver TRACE: [serial://COM5] >> G1 X177.2349 Y259.1500 F30000
GcodeDriver TRACE: [serial://COM5] << ok
GcodeDriver TRACE: [serial://COM5] >> G1 X177.7349 Y259.6500   F3000
GcodeDriver TRACE: [serial://COM5] << ok
GcodeDriver TRACE: [serial://COM5] >> M400; wait for completion (sub)
GcodeDriver TRACE: [serial://COM5] << ok
GcodeDriver TRACE: [serial://COM4] >> M400 ; Wait for completion (main)
GcodeDriver TRACE: [serial://COM4] << ok

2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)?  Yes
3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing.  N/A
4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted.  No failures.
