### PR TITLE
Fix bottom side panel fiducial check

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/vision/ReferenceFiducialLocator.java
+++ b/src/main/java/org/openpnp/machine/reference/vision/ReferenceFiducialLocator.java
@@ -74,10 +74,14 @@ public class ReferenceFiducialLocator implements FiducialLocator {
     public Location locateBoard(BoardLocation boardLocation, boolean checkPanel) throws Exception {
         List<Placement> fiducials;
 
+        Side boardSide = boardLocation.getSide();  // save for later
+       
         if (checkPanel) {
             Panel panel = MainFrame.get().getJobTab().getJob().getPanels()
                     .get(boardLocation.getPanelId());
             fiducials = panel.getFiducials();
+            // If we are looking for panel fiducials, we need to treat the board as top side
+            boardLocation.setSide(Side.Top);
         }
         else {
             fiducials = getFiducials(boardLocation);
@@ -184,6 +188,9 @@ public class ReferenceFiducialLocator implements FiducialLocator {
         Location result = Utils2D.calculateBoardPlacementLocation(boardLocation, new Location(LengthUnit.Millimeters));
         result = result.convertToUnits(boardLocation.getLocation().getUnits());
         result = result.derive(null, null, boardLocation.getLocation().getZ(), null);
+        if (checkPanel) {
+            boardLocation.setSide(boardSide);	// restore side
+        }
         return result;
     }
     


### PR DESCRIPTION
# Description
Fixes panel bottom fiducial detection.

# Justification
Bugfix #905 fixed the board bottom fiducial detection, but the panel fiducials were still incorrect.  This is because the panel must always be treated as top side for the purpose of fiducial detection.  This will update the origin of each board in the panel to the lower left corner of the boards.

# Instructions for Use
Set up the panel the same as for the top side.  If the fiducial locations are different, set them also.  Fiducials are referenced to the lower left corner of the lower left board (board 0 origin).

# Implementation Details
1. How did you test the change? I created a 2 x 3 panelized version of the pnp-test board with top and bottom panels.  Panel and board fiducials were properly located for top and bottom.  Components appeared in the correct positions.  I also tested on a live system with a panelized board.
2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)? Yes.
3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing. N/A
4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted.  All tests passed
