### PR TITLE
Bugfix/select next placement

### DIFF
--- a/src/main/java/org/openpnp/gui/JobPlacementsPanel.java
+++ b/src/main/java/org/openpnp/gui/JobPlacementsPanel.java
@@ -498,7 +498,7 @@ public class JobPlacementsPanel extends JPanel {
                 // used after the initial click. Otherwise, button focus is lost
                 // when table is updated
                	Component comp = MainFrame.get().getFocusOwner();
-               	Helpers.selectNextTableRow(table);
+               	Helpers.selectNextTableRow(table, boardLocation.getSide());
                 comp.requestFocus();
                	Location location = Utils2D.calculateBoardPlacementLocation(boardLocation,
                         getSelection().getLocation());

--- a/src/main/java/org/openpnp/gui/support/Helpers.java
+++ b/src/main/java/org/openpnp/gui/support/Helpers.java
@@ -29,6 +29,7 @@ import javax.swing.JTextField;
 import org.jdesktop.beansbinding.BeanProperty;
 import org.openpnp.model.Configuration;
 import org.openpnp.model.Location;
+import org.openpnp.model.Board.Side;
 
 public class Helpers {
     public static void copyLocationIntoTextFields(Location l, JTextField x, JTextField y,
@@ -84,6 +85,29 @@ public class Helpers {
          table.addRowSelectionInterval(index, index);   
     }
     
+    public static void selectNextTableRow(JTable table, Side side){
+    	int index = table.getSelectedRow();
+
+    	if (index == -1){
+			index = 0;
+    	}
+    	 
+        table.clearSelection();
+		
+    	int counter = 0;
+    	for (int i = 0; i < table.getModel().getRowCount(); i++ ) {
+    		if (table.getModel().getValueAt(i, 3) == side) {
+    			counter++;
+    		}
+    	}
+
+    	if (++index > counter - 1) {
+    		index = 0;
+    	}
+
+    	table.addRowSelectionInterval(index, index);   
+	}
+
     public static void selectFirstTableRow(JTable table) {
         table.clearSelection();
         int index = 0;


### PR DESCRIPTION
# Fix for bug #909
The method selectNextTableRow in gui/support/Helpers.java calls getRowCount, but this returns the total number of placements on the board.  We need the count of placements on the currently selected side of the board.  I created a overload method for selectNextTableRow that counts the placements on the selected side.

# Justification
Bug fix.

# Instructions for Use
load a job
click on any board
click on any placement
step through the placements with the icon "Position the camera at the next placements location"
step over the end of the list
It will wrap back to the first placement.

# Implementation Details
1. How did you test the change? Tested with the pnp-test job.
2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)? Yes.
3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing. N/A
4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted.
Tests run: 20, Failures: 0, Errors: 0, Skipped: 0
