### PR TITLE
getting rid of toolchanger config backward compatibility due to issue #913

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/ReferenceNozzleTip.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceNozzleTip.java
@@ -24,7 +24,6 @@ import org.openpnp.spi.base.AbstractNozzleTip;
 import org.openpnp.util.UiUtils;
 import org.simpleframework.xml.Attribute;
 import org.simpleframework.xml.Element;
-import org.simpleframework.xml.core.Commit;
 
 public class ReferenceNozzleTip extends AbstractNozzleTip {
     @Attribute(required = false)
@@ -46,7 +45,7 @@ public class ReferenceNozzleTip extends AbstractNozzleTip {
     private double changerMidToMid2Speed = 1D;
     
     @Element(required = false)
-    private Location changerMidLocation2;
+    private Location changerMidLocation2 = new Location(LengthUnit.Millimeters);
     
     @Element(required = false)
     private double changerMid2ToEndSpeed = 1D;
@@ -73,20 +72,6 @@ public class ReferenceNozzleTip extends AbstractNozzleTip {
     public ReferenceNozzleTip() {
     }
 
-    @Commit
-    public void commit() {
-        /*
-         * Backwards compatibility. Since this field is being added after the fact, if
-         * the field is not specified in the config then we just make a copy of the
-         * other mid location. The result is that if a user already has a changer
-         * configured they will not suddenly have a move to 0,0,0,0 which would break
-         * everything.
-         */
-        if (changerMidLocation2 == null) {
-            changerMidLocation2 = changerMidLocation.derive(null, null, null, null);
-        }
-    }
-    
     @Override
     public String toString() {
         return getName() + " " + getId();

--- a/src/test/resources/config/BasicJobTest/machine.xml
+++ b/src/test/resources/config/BasicJobTest/machine.xml
@@ -52,6 +52,8 @@
 				x="50.0" y="0.0" z="0.0" rotation="0.0" />
 			<changer-mid-location units="Millimeters"
 				x="50.0" y="0.0" z="0.0" rotation="0.0" />
+			<changer-mid-location-2 units="Millimeters"
+				x="50.0" y="0.0" z="0.0" rotation="0.0" />
 			<changer-end-location units="Millimeters"
 				x="50.0" y="0.0" z="0.0" rotation="0.0" />
 		</nozzle-tip>
@@ -60,6 +62,8 @@
 			<changer-start-location units="Millimeters"
 				x="70.0" y="0.0" z="0.0" rotation="0.0" />
 			<changer-mid-location units="Millimeters"
+				x="70.0" y="0.0" z="0.0" rotation="0.0" />
+			<changer-mid-location-2 units="Millimeters"
 				x="70.0" y="0.0" z="0.0" rotation="0.0" />
 			<changer-end-location units="Millimeters"
 				x="70.0" y="0.0" z="0.0" rotation="0.0" />


### PR DESCRIPTION
Solves Issue #913

# Description
Removing backward compatibilty stuff from the 
src\main\java\org\openpnp\machine\reference\ReferenceNozzleTip.java
and added missing middle 2 positions to 
src\test\resources\config\BasicJobTest\machine.xml
to fulfill the automatic tests 

# Justification
it solves issue #913 

# Implementation Details
1. How did you test the change? Be descriptive. Untested code will not be accepted.
used it and added new nozzle tip and the problem of missing line and not able to write the machine.xml is gone. now it starts with 0.000.

2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)?
AFAIK just copy and pasted the new constructor...
3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing.
4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted.
done. it says Build Success.
