### PR TITLE
Remove duplicated vision offset correction

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/feeder/ReferenceStripFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/ReferenceStripFeeder.java
@@ -189,11 +189,6 @@ public class ReferenceStripFeeder extends ReferenceFeeder {
         // so that the part is picked at the right angle
         l = l.derive(null, null, null, angle + getLocation().getRotation());
 
-        // and if vision was performed, add the offsets
-        if (visionEnabled && visionOffsets != null) {
-            l = l.add(visionOffsets);
-        }
-
         return l;
     }
 


### PR DESCRIPTION
# Description
getPickLocation() is using visionLocation value to calculate pick location. visionLocation already contains value that was previously corrected in updateVisionOffsets().

l value (pick location) is calculated from lineLocations, which may be calculated using visionLocation in getIdealLineLocations().

# Justification
Vision offset was added twice and pick location error was increasing with feed count so much, that it was almost impossible to use strips longer than ~20-30 parts.
