### PR TITLE
Removed type cast error in machine controls "nozzles" change listener.

### DIFF
--- a/src/main/java/org/openpnp/gui/MachineControlsPanel.java
+++ b/src/main/java/org/openpnp/gui/MachineControlsPanel.java
@@ -423,8 +423,8 @@ public class MachineControlsPanel extends JPanel {
                     }
                     else if (e.getOldValue() != null && e.getNewValue() == null) {
                         for (int i = 0; i < comboBoxHeadMountable.getItemCount(); i++) {
-                            NozzleItem item = (NozzleItem) comboBoxHeadMountable.getItemAt(i);
-                            if (item.getNozzle() == e.getOldValue()) {
+                            HeadMountableItem item = (HeadMountableItem) comboBoxHeadMountable.getItemAt(i);
+                            if (item.getItem() == e.getOldValue()) {
                                 comboBoxHeadMountable.removeItemAt(i);
                             }
                         }


### PR DESCRIPTION
# Description
Just a small bugfix for a type cast error that pops up from time to time. I believe it was introduced when Actuators were allowed as selected tool in the machine controls.

# Justification
The comboBox no longer contains `NozzleItem`s but `HeadMountableItem`s. See the "cameras" change listener following for symmetry. 

The change is also part of #859 and merging this would simplify the code review there.

# Instructions for Use
Bugfix. 

# Implementation Details
1. I have run `mvn test` before submitting the Pull Request. 
