### PR TITLE
Method to determine if a location is inside soft-limits.

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/ReferenceHead.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceHead.java
@@ -31,6 +31,7 @@ import org.openpnp.machine.reference.psh.NozzlesPropertySheetHolder;
 import org.openpnp.machine.reference.wizards.ReferenceHeadConfigurationWizard;
 import org.openpnp.model.Configuration;
 import org.openpnp.model.Location;
+import org.openpnp.spi.HeadMountable;
 import org.openpnp.spi.PropertySheetHolder;
 import org.openpnp.spi.base.AbstractHead;
 import org.pmw.tinylog.Logger;
@@ -78,22 +79,32 @@ public class ReferenceHead extends AbstractHead {
         Logger.debug("{}.moveToSafeZ({})", getName(), speed);
         super.moveToSafeZ(speed);
     }
-    
-    public void moveTo(ReferenceHeadMountable hm, Location location, double speed) throws Exception {
+
+    @Override 
+    public boolean isInsideSoftLimits(HeadMountable hm, Location location)  throws Exception {
         if (isSoftLimitsEnabled()) {
             /**
              * Since minLocation and maxLocation are captured with the Camera's coordinates, we need
              * to know where the Camera will land, not the HeadMountable.
              */
-            Location cameraLocation = location.subtract(hm.getHeadOffsets());
-            cameraLocation = cameraLocation.add(((ReferenceCamera) getDefaultCamera()).getHeadOffsets());
-            Location minLocation = this.minLocation.convertToUnits(cameraLocation.getUnits());
-            Location maxLocation = this.maxLocation.convertToUnits(cameraLocation.getUnits());
-            if (cameraLocation.getX() < minLocation.getX() || cameraLocation.getX() > maxLocation.getX() ||
-                    cameraLocation.getY() < minLocation.getY() || cameraLocation.getY() > maxLocation.getY()) {
-                throw new Exception(String.format("Can't move %s to %s, outside of soft limits on head %s.",
-                        hm.getName(), location, getName()));
+            if (hm instanceof ReferenceHeadMountable) {
+                Location cameraLocation = location.subtract(((ReferenceHeadMountable)hm).getHeadOffsets());
+                cameraLocation = cameraLocation.add(((ReferenceCamera) getDefaultCamera()).getHeadOffsets());
+                Location minLocation = this.minLocation.convertToUnits(cameraLocation.getUnits());
+                Location maxLocation = this.maxLocation.convertToUnits(cameraLocation.getUnits());
+                if (cameraLocation.getX() < minLocation.getX() || cameraLocation.getX() > maxLocation.getX() ||
+                        cameraLocation.getY() < minLocation.getY() || cameraLocation.getY() > maxLocation.getY()) {
+                    return false;
+                }
             }
+        }
+        return true;
+    }
+
+    public void moveTo(ReferenceHeadMountable hm, Location location, double speed) throws Exception {
+        if (! isInsideSoftLimits(hm, location)) {
+            throw new Exception(String.format("Can't move %s to %s, outside of soft limits on head %s.",
+                    hm.getName(), location, getName()));
         }
         getDriver().moveTo(hm, location, speed);
         getMachine().fireMachineHeadActivity(this);

--- a/src/main/java/org/openpnp/spi/Head.java
+++ b/src/main/java/org/openpnp/spi/Head.java
@@ -135,4 +135,12 @@ public interface Head extends Identifiable, Named, WizardConfigurable, PropertyS
     public Actuator getZProbe(); 
     
     public Actuator getPump(); 
+
+    /**
+     * Returns true if the given HeadMountable can go to the specified location within soft-limits.
+     * @param hm
+     * @param location
+     * @return
+     */
+    public boolean isInsideSoftLimits(HeadMountable hm, Location location) throws Exception;
 }


### PR DESCRIPTION
# Description
A method on the Head can be called to determine whether a HeadMountable can go to the specified location within the soft-limits. 

# Justification
The soft-limits check is currently only implemented inside ReferenceHead.moveTo(). In order to proactively check whether a location is within soft-limits, the check is refactored into a separate method.

The method is used in my upcoming feeder to check the eligibility of fiducials on the feeder. 

# Instructions for Use
Use `head.isInsideSoftLimits(hm, location)` to check if the HeadMountable `hm` can go to `location`.

# Implementation Details
1. The refactored soft-limit checking on moveTo() was successfully tested on purpose. It was also very useful in developing, when things went wrong. The new method was also successfully used for the feeder I'm developing, to select eligible fiducials for feeders that are on the edge of the machine.  
2. I did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. The method is in `org.openpnp.spi`.
4. Successful `mvn test` before submitting.
