### PR TITLE
Various small additions to utils, one bugfix

### DIFF
--- a/src/main/java/org/openpnp/model/Length.java
+++ b/src/main/java/org/openpnp/model/Length.java
@@ -71,6 +71,16 @@ public class Length {
         return new Length(value * d, units);
     }
 
+    public double divide(Length length) {
+        length = length.convertToUnits(units);
+        return value / length.getValue();
+    }
+
+    public Length modulo(Length length) {
+        length = length.convertToUnits(units);
+        return new Length(value % length.getValue(), units);
+    }
+
     public double getValue() {
         return value;
     }

--- a/src/main/java/org/openpnp/model/Location.java
+++ b/src/main/java/org/openpnp/model/Location.java
@@ -288,7 +288,7 @@ public class Location {
      * value from this object instead of the second location.
      * 
      * This is intended as a utility method, useful for creating new Locations based on two existing
-     * ones with one or more values substituded.
+     * ones with one or more values substituted.
      * 
      * @param location
      * @param x

--- a/src/main/java/org/openpnp/model/Location.java
+++ b/src/main/java/org/openpnp/model/Location.java
@@ -283,6 +283,30 @@ public class Location {
     }
 
     /**
+     * Returns a new Location with the same units as this one but with values updated from 
+     * a second Location. If a specified boolean is false, the new Location will contain the
+     * value from this object instead of the second location.
+     * 
+     * This is intended as a utility method, useful for creating new Locations based on two existing
+     * ones with one or more values substituded.
+     * 
+     * @param location
+     * @param x
+     * @param y
+     * @param z
+     * @param rotation
+     * @return
+     */
+    public Location derive(Location location, boolean x, boolean y, boolean z, boolean rotation) {
+        location = location.convertToUnits(this.getUnits());
+        return new Location(units, 
+                x ? location.x : this.x, 
+                        y ? location.y : this.y,
+                                z ? location.z : this.z, 
+                                        rotation ? location.rotation : this.rotation);
+    }
+
+    /**
      * Returns a new Location with this Location's X and Y rotated by angle. Z and Rotation are
      * unchanged.
      * 

--- a/src/main/java/org/openpnp/vision/Ransac.java
+++ b/src/main/java/org/openpnp/vision/Ransac.java
@@ -192,14 +192,15 @@ public class Ransac {
         }
 
         // Discard this line if any index is missing
-        Integer minIndex = indicesOnLine.first();
-        Integer maxIndex = indicesOnLine.last();
-        for (Integer idx=minIndex + 1; idx<maxIndex; idx++) {
-            if (!indicesOnLine.contains(idx)) {
-                return new ArrayList<>();
+        if (indicesOnLine.size() > 0) {
+            Integer minIndex = indicesOnLine.first();
+            Integer maxIndex = indicesOnLine.last();
+            for (Integer idx=minIndex + 1; idx<maxIndex; idx++) {
+                if (!indicesOnLine.contains(idx)) {
+                    return new ArrayList<>();
+                }
             }
         }
-
         return spacedInliers;
     }
 


### PR DESCRIPTION
# Description
In order to ease merging an upcoming large feeder PR, I'd like to break these small additions out:
* divide and modulo of Lengths
* derive and unit-adapt one (partial) Location to another
* bugfix in Ransac if the indicesOnLine turns out empty

# Justification
Division and Modulo of Lengths is just a logical extension of the present methods. Doing it outside the class is very ugly (and units are often forgotten). Used multiple times in the upcoming PR. 

Even in my past PRs, the need to derive (partially) from one Location and unit-adapt to another Location was ever-present. This typically resulted in hard-to-read, easy-to-bungle, lengthy statements. In the new feeder it was turning ugly. I finally wrapped this into a safe method.

The bug in Ransac occured when I tried to solve one vision problem. I later used another method but thought it still useful to fix the bug. 

# Instructions for Use
Please see the methods.

# Implementation Details
1. These are(were) tested and used extensively in the upcoming PR. 
2. I did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. I did make changes in `org.openpnp.model` packages: Length and Location.
4. Did run `mvn test` before submitting.
