### PR TITLE
Add scripting event when using the "Position the Camera" button.

### DIFF
--- a/src/main/java/org/openpnp/gui/JobPanel.java
+++ b/src/main/java/org/openpnp/gui/JobPanel.java
@@ -35,7 +35,9 @@ import java.beans.PropertyChangeListener;
 import java.io.File;
 import java.io.FilenameFilter;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.prefs.Preferences;
 
 import javax.swing.AbstractAction;
@@ -95,6 +97,7 @@ import org.openpnp.spi.Machine;
 import org.openpnp.spi.MachineListener;
 import org.openpnp.util.MovableUtils;
 import org.openpnp.util.UiUtils;
+import org.pmw.tinylog.Logger;
 
 import com.google.common.eventbus.Subscribe;
 
@@ -1254,6 +1257,14 @@ public class JobPanel extends JPanel {
                         MainFrame.get().getCameraViews().ensureCameraVisible(camera);
                         Location location = getSelection().getLocation();
                         MovableUtils.moveToLocationAtSafeZ(camera, location);
+                        try {
+                            Map<String, Object> globals = new HashMap<>();
+                            globals.put("camera", this);
+                            Configuration.get().getScripting().on("Camera.AfterPosition", globals);
+                        }
+                        catch (Exception e) {
+                            Logger.warn(e);
+                        }
                     });
                 }
             };
@@ -1282,6 +1293,14 @@ public class JobPanel extends JPanel {
                         
                         MovableUtils.moveToLocationAtSafeZ(camera, location);
                        
+                        try {
+                            Map<String, Object> globals = new HashMap<>();
+                            globals.put("camera", this);
+                            Configuration.get().getScripting().on("Camera.AfterPosition", globals);
+                        }
+                        catch (Exception e) {
+                            Logger.warn(e);
+                        }
                     });
                 }
             };

--- a/src/main/java/org/openpnp/gui/JobPanel.java
+++ b/src/main/java/org/openpnp/gui/JobPanel.java
@@ -1259,7 +1259,7 @@ public class JobPanel extends JPanel {
                         MovableUtils.moveToLocationAtSafeZ(camera, location);
                         try {
                             Map<String, Object> globals = new HashMap<>();
-                            globals.put("camera", this);
+                            globals.put("camera", camera);
                             Configuration.get().getScripting().on("Camera.AfterPosition", globals);
                         }
                         catch (Exception e) {
@@ -1295,7 +1295,7 @@ public class JobPanel extends JPanel {
                        
                         try {
                             Map<String, Object> globals = new HashMap<>();
-                            globals.put("camera", this);
+                            globals.put("camera", camera);
                             Configuration.get().getScripting().on("Camera.AfterPosition", globals);
                         }
                         catch (Exception e) {

--- a/src/main/java/org/openpnp/gui/JobPlacementsPanel.java
+++ b/src/main/java/org/openpnp/gui/JobPlacementsPanel.java
@@ -485,7 +485,7 @@ public class JobPlacementsPanel extends JPanel {
                 MovableUtils.moveToLocationAtSafeZ(camera, location);
                 try {
                     Map<String, Object> globals = new HashMap<>();
-                    globals.put("camera", this);
+                    globals.put("camera", camera);
                     Configuration.get().getScripting().on("Camera.AfterPosition", globals);
                 }
                 catch (Exception e) {
@@ -519,7 +519,7 @@ public class JobPlacementsPanel extends JPanel {
                 
                 try {
                     Map<String, Object> globals = new HashMap<>();
-                    globals.put("camera", this);
+                    globals.put("camera", camera);
                     Configuration.get().getScripting().on("Camera.AfterPosition", globals);
                 }
                 catch (Exception e) {

--- a/src/main/java/org/openpnp/gui/JobPlacementsPanel.java
+++ b/src/main/java/org/openpnp/gui/JobPlacementsPanel.java
@@ -11,7 +11,9 @@ import java.awt.event.KeyEvent;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.regex.PatternSyntaxException;
 
 import javax.swing.AbstractAction;
@@ -65,6 +67,7 @@ import org.openpnp.spi.Nozzle;
 import org.openpnp.util.MovableUtils;
 import org.openpnp.util.UiUtils;
 import org.openpnp.util.Utils2D;
+import org.pmw.tinylog.Logger;
 
 public class JobPlacementsPanel extends JPanel {
     private JTable table;
@@ -480,6 +483,14 @@ public class JobPlacementsPanel extends JPanel {
                 Camera camera = MainFrame.get().getMachineControls().getSelectedTool().getHead()
                         .getDefaultCamera();
                 MovableUtils.moveToLocationAtSafeZ(camera, location);
+                try {
+                    Map<String, Object> globals = new HashMap<>();
+                    globals.put("camera", this);
+                    Configuration.get().getScripting().on("Camera.AfterPosition", globals);
+                }
+                catch (Exception e) {
+                    Logger.warn(e);
+                }
             });
         }
     };
@@ -506,6 +517,14 @@ public class JobPlacementsPanel extends JPanel {
                         .getDefaultCamera();
                 MovableUtils.moveToLocationAtSafeZ(camera, location);
                 
+                try {
+                    Map<String, Object> globals = new HashMap<>();
+                    globals.put("camera", this);
+                    Configuration.get().getScripting().on("Camera.AfterPosition", globals);
+                }
+                catch (Exception e) {
+                    Logger.warn(e);
+                }
             });
         };
     };

--- a/src/main/java/org/openpnp/gui/components/LocationButtonsPanel.java
+++ b/src/main/java/org/openpnp/gui/components/LocationButtonsPanel.java
@@ -275,7 +275,7 @@ public class LocationButtonsPanel extends JPanel {
                         MovableUtils.moveToLocationAtSafeZ(camera, location);
                         try {
                             Map<String, Object> globals = new HashMap<>();
-                            globals.put("camera", this);
+                            globals.put("camera", camera);
                             Configuration.get().getScripting().on("Camera.AfterPosition", globals);
                         }
                         catch (Exception e) {

--- a/src/main/java/org/openpnp/gui/components/LocationButtonsPanel.java
+++ b/src/main/java/org/openpnp/gui/components/LocationButtonsPanel.java
@@ -22,6 +22,9 @@ package org.openpnp.gui.components;
 import java.awt.FlowLayout;
 import java.awt.event.ActionEvent;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import javax.swing.AbstractAction;
 import javax.swing.Action;
 import javax.swing.JButton;
@@ -44,6 +47,7 @@ import org.openpnp.spi.HeadMountable;
 import org.openpnp.util.Cycles;
 import org.openpnp.util.MovableUtils;
 import org.openpnp.util.UiUtils;
+import org.pmw.tinylog.Logger;
 
 /**
  * A JPanel of 4 small buttons that assist in setting locations. The buttons are Capture Camera
@@ -269,6 +273,14 @@ public class LocationButtonsPanel extends JPanel {
                             location = location.addWithRotation(baseLocation);
                         }
                         MovableUtils.moveToLocationAtSafeZ(camera, location);
+                        try {
+                            Map<String, Object> globals = new HashMap<>();
+                            globals.put("camera", this);
+                            Configuration.get().getScripting().on("Camera.AfterPosition", globals);
+                        }
+                        catch (Exception e) {
+                            Logger.warn(e);
+                        }
                     });
                 }
             };


### PR DESCRIPTION
Add scripting event after camera move to position.

# Description
Add a scripting event after moving the camera to position by pressing the Position the Camera Icon.

# Justification
Most of the time when pressing the Position the Camera Icon, I want to look at something, so I have to turn on the down light.  I thought it would be nice if the light could be turned on automatically so I added this scripting event.

# Instructions for Use
Put a Camera.AfterPosition script in the scripts/Events directory.  For example:
Camera.AfterPosition.js
> /**
>     Controls lighting for the down camera 
>  */
>  var downCamLights = machine.getActuatorByName("DownCamLights");
>  downCamLights.actuate(true);

# Implementation Details
1. How did you test the change?  Added above script and verified light was turned on when using the Position the Camera Icon.
2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)? Yes
3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing.  N/A
4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted.  Tests run: 20, Failures: 0, Errors: 0, Skipped: 0
