### PR TITLE
New ReferenceLeverFeeder

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/ReferenceMachine.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceMachine.java
@@ -41,6 +41,7 @@ import org.openpnp.machine.reference.driver.NullDriver;
 import org.openpnp.machine.reference.feeder.AdvancedLoosePartFeeder;
 import org.openpnp.machine.reference.feeder.ReferenceAutoFeeder;
 import org.openpnp.machine.reference.feeder.ReferenceDragFeeder;
+import org.openpnp.machine.reference.feeder.ReferenceLeverFeeder;
 import org.openpnp.machine.reference.feeder.ReferenceLoosePartFeeder;
 import org.openpnp.machine.reference.feeder.ReferenceRotatedTrayFeeder;
 import org.openpnp.machine.reference.feeder.ReferenceSlotAutoFeeder;
@@ -212,6 +213,7 @@ public class ReferenceMachine extends AbstractMachine {
         l.add(ReferenceTrayFeeder.class);
         l.add(ReferenceRotatedTrayFeeder.class);
         l.add(ReferenceDragFeeder.class);
+        l.add(ReferenceLeverFeeder.class);
         l.add(ReferenceTubeFeeder.class);
         l.add(ReferenceAutoFeeder.class);
         l.add(ReferenceSlotAutoFeeder.class);

--- a/src/main/java/org/openpnp/machine/reference/feeder/ReferenceLeverFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/ReferenceLeverFeeder.java
@@ -1,0 +1,492 @@
+/*
+ * Copyright (C) 2011 Jason von Nieda <jason@vonnieda.org>
+ * 
+ * This file is part of OpenPnP.
+ * 
+ * OpenPnP is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * OpenPnP is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License along with OpenPnP. If not, see
+ * <http://www.gnu.org/licenses/>.
+ * 
+ * For more information about OpenPnP visit http://openpnp.org
+ */
+
+package org.openpnp.machine.reference.feeder;
+
+import java.awt.Point;
+import java.awt.image.BufferedImage;
+import java.beans.PropertyChangeListener;
+import java.beans.PropertyChangeSupport;
+import java.io.File;
+import java.io.IOException;
+
+import javax.imageio.ImageIO;
+import javax.swing.Action;
+
+import org.openpnp.ConfigurationListener;
+import org.openpnp.gui.support.Wizard;
+import org.openpnp.machine.reference.ReferenceFeeder;
+import org.openpnp.machine.reference.feeder.wizards.ReferenceLeverFeederConfigurationWizard;
+import org.openpnp.model.Configuration;
+import org.openpnp.model.Length;
+import org.openpnp.model.LengthUnit;
+import org.openpnp.model.Location;
+import org.openpnp.model.Rectangle;
+import org.openpnp.spi.Actuator;
+import org.openpnp.spi.Camera;
+import org.openpnp.spi.Head;
+import org.openpnp.spi.Nozzle;
+import org.openpnp.spi.PropertySheetHolder;
+import org.openpnp.spi.VisionProvider;
+import org.openpnp.util.Utils2D;
+import org.pmw.tinylog.Logger;
+import org.simpleframework.xml.Attribute;
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.core.Persist;
+
+/**
+ * Vision System Description
+ * 
+ * The Vision Operation is defined as moving the Camera to the defined Pick Location, performing a
+ * template match against the Template Image bound by the Area of Interest and then storing the
+ * offsets from the Pick Location to the matched image as Vision Offsets.
+ * 
+ * The feed operation consists of: 1. Move to start location.  2. Move to end location at specified speed.
+ * 3. Move to start location at normal speed. 4. Move the cameera to pick location.
+ * 
+ */
+public class ReferenceLeverFeeder extends ReferenceFeeder {
+
+
+    private final PropertyChangeSupport propertyChangeSupport = new PropertyChangeSupport(this);
+
+    @Element
+    protected Location feedStartLocation = new Location(LengthUnit.Millimeters);
+    @Element
+    protected Location feedEndLocation = new Location(LengthUnit.Millimeters);
+    @Element(required = false)
+    private Length partPitch = new Length(4, LengthUnit.Millimeters);
+    @Element(required = false)
+    protected double feedSpeed = 1.0;
+    @Attribute(required = false)
+    protected String actuatorName;
+    @Attribute(required = false)
+    protected String peelOffActuatorName;
+    @Element(required = false)
+    protected Vision vision = new Vision();
+
+    protected Location pickLocation;
+
+    private double feededCount = 0;
+    private double partsPitchX = -2; //-2mm for 2 mm part pitch (2 parts per feed)
+    private double partsPitchY = 0;
+	
+    /*
+     * visionOffset contains the difference between where the part was expected to be and where it
+     * is. Subtracting these offsets from the pickLocation produces the correct pick location.
+     */
+    protected Location visionOffset;
+    protected Location partPick;
+
+    @Override
+    public Location getPickLocation() throws Exception {
+        if (pickLocation == null) {
+            pickLocation = location;
+        }
+
+        if (vision.isEnabled() && visionOffset != null) {
+			if (partPitch.convertToUnits(LengthUnit.Millimeters).getValue() == 2 && partPick != null) {
+				return pickLocation.subtract(visionOffset).add(partPick);
+			}
+			else {
+				return pickLocation.subtract(visionOffset);
+			}
+        }
+
+        return pickLocation;
+    }
+
+    @Override
+    public void feed(Nozzle nozzle) throws Exception {
+        Logger.debug("feed({})", nozzle);
+
+        if (actuatorName == null) {
+            throw new Exception("No actuator name set.");
+        }
+
+
+        Head head = nozzle.getHead();
+
+        Actuator actuator = head.getActuatorByName(actuatorName);
+
+        if (actuator == null) {
+            throw new Exception(String.format("No Actuator found with name %s on feed Head %s",
+                    actuatorName, head.getName()));
+        }
+
+		Actuator peelOffActuator = null;
+
+		if (peelOffActuatorName != null) {
+			peelOffActuator = head.getActuatorByName(peelOffActuatorName);
+		}
+
+        head.moveToSafeZ();
+
+        pickLocation = this.location;
+
+        if (feededCount == 0) {
+            Location feedStartLocation = this.feedStartLocation;
+            Location feedEndLocation = this.feedEndLocation;
+
+		    for (double i = partPitch.convertToUnits(LengthUnit.Millimeters).getValue(); i > 0; i=i-4) {  // perform multiple feeds if required
+		    
+	            // Move the actuator to the feed start location.
+	            actuator.moveTo(feedStartLocation.derive(null, null, Double.NaN, Double.NaN));
+		    
+	            // enable actuator (may do nothing)
+		    	actuator.actuate(true);
+		    
+	            // Push the lever
+	            actuator.moveTo(feedEndLocation, feedSpeed * actuator.getHead().getMachine().getSpeed());
+		    
+			    // Start the take up actuator
+		    	if (peelOffActuator != null) {
+		    		peelOffActuator.actuate(true);
+		    	}
+	            // Now move back to the start location to move the tape.
+	            actuator.moveTo(feedStartLocation.derive(null, null, Double.NaN, Double.NaN));
+		    
+			    // Stop the take up actuator
+		    	if (peelOffActuator != null) {
+		    		peelOffActuator.actuate(false);
+		    	}
+		    
+	            // disable actuator
+		    	actuator.actuate(false);
+			}
+
+	        if (partPitch.convertToUnits(LengthUnit.Millimeters).getValue() == 2) {
+				feededCount = 2;
+	        }
+        } 
+        else {
+			Logger.debug("Multi parts Lever feeder: skipping feed " + feededCount);
+        }
+
+
+        head.moveToSafeZ();
+
+		if (feededCount > 0) {
+			feededCount--;
+			if (feededCount > 0) {
+				partPick = new Location(LengthUnit.Millimeters, partsPitchX * feededCount,
+						partsPitchY * feededCount, 0, 0);
+			} 
+			else {
+				partPick = null;
+			}
+		}
+
+        if (vision.isEnabled()) {
+            visionOffset = getVisionOffsets(head, location);
+
+            Logger.debug("final visionOffsets " + visionOffset);
+
+            Logger.debug("Modified pickLocation {}", pickLocation.subtract(visionOffset));
+        }
+    }
+
+    // TODO: Throw an Exception if vision fails.
+    private Location getVisionOffsets(Head head, Location pickLocation) throws Exception {
+        Logger.debug("getVisionOffsets({}, {})", head.getName(), pickLocation);
+        // Find the Camera to be used for vision
+        Camera camera = null;
+        for (Camera c : head.getCameras()) {
+            if (c.getVisionProvider() != null) {
+                camera = c;
+            }
+        }
+
+        if (camera == null) {
+            throw new Exception("No vision capable camera found on head.");
+        }
+        
+        if (vision.getTemplateImage() == null) {
+            throw new Exception("Template image is required when vision is enabled.");
+        }
+        
+        if (vision.getAreaOfInterest().getWidth() == 0 || vision.getAreaOfInterest().getHeight() == 0) {
+            throw new Exception("Area of Interest is required when vision is enabled.");
+        }
+
+        head.moveToSafeZ();
+
+        // Position the camera over the pick location.
+        Logger.debug("Move camera to pick location.");
+        camera.moveTo(pickLocation);
+
+        // Move the camera to be in focus over the pick location.
+        // head.moveTo(head.getX(), head.getY(), z, head.getC());
+
+        // Settle the camera
+        Thread.sleep(camera.getSettleTimeMs());
+
+        VisionProvider visionProvider = camera.getVisionProvider();
+
+        Rectangle aoi = getVision().getAreaOfInterest();
+
+        // Perform the template match
+        Logger.debug("Perform template match.");
+        Point[] matchingPoints = visionProvider.locateTemplateMatches(aoi.getX(), aoi.getY(),
+                aoi.getWidth(), aoi.getHeight(), 0, 0, vision.getTemplateImage());
+
+        // Get the best match from the array
+        Point match = matchingPoints[0];
+
+        // match now contains the position, in pixels, from the top left corner
+        // of the image to the top left corner of the match. We are interested in
+        // knowing how far from the center of the image the center of the match is.
+        double imageWidth = camera.getWidth();
+        double imageHeight = camera.getHeight();
+        double templateWidth = vision.getTemplateImage().getWidth();
+        double templateHeight = vision.getTemplateImage().getHeight();
+        double matchX = match.x;
+        double matchY = match.y;
+
+        Logger.debug("matchX {}, matchY {}", matchX, matchY);
+
+        // Adjust the match x and y to be at the center of the match instead of
+        // the top left corner.
+        matchX += (templateWidth / 2);
+        matchY += (templateHeight / 2);
+
+        Logger.debug("centered matchX {}, matchY {}", matchX, matchY);
+
+        // Calculate the difference between the center of the image to the
+        // center of the match.
+        double offsetX = (imageWidth / 2) - matchX;
+        double offsetY = (imageHeight / 2) - matchY;
+
+        Logger.debug("offsetX {}, offsetY {}", offsetX, offsetY);
+
+        // Invert the Y offset because images count top to bottom and the Y
+        // axis of the machine counts bottom to top.
+        offsetY *= -1;
+
+        Logger.debug("negated offsetX {}, offsetY {}", offsetX, offsetY);
+
+        // And convert pixels to units
+        Location unitsPerPixel = camera.getUnitsPerPixel();
+        offsetX *= unitsPerPixel.getX();
+        offsetY *= unitsPerPixel.getY();
+
+        Logger.debug("final, in camera units offsetX {}, offsetY {}", offsetX, offsetY);
+
+        return new Location(unitsPerPixel.getUnits(), offsetX, offsetY, 0, 0);
+    }
+
+    @Override
+    public String toString() {
+        return String.format("ReferenceTapeFeeder id %s", id);
+    }
+
+	public void resetVisionOffsets() {
+		if (visionOffset != null) {
+			visionOffset = null;
+			Logger.debug("resetVisionOffsets " + visionOffset);
+		}
+
+		partPick = null;
+	}
+
+    public Location getFeedStartLocation() {
+        return feedStartLocation;
+    }
+
+    public void setFeedStartLocation(Location feedStartLocation) {
+        this.feedStartLocation = feedStartLocation;
+    }
+
+    public Location getFeedEndLocation() {
+        return feedEndLocation;
+    }
+
+    public void setFeedEndLocation(Location feedEndLocation) {
+        this.feedEndLocation = feedEndLocation;
+    }
+
+    public Length getPartPitch() {
+        return partPitch;
+    }
+
+    public void setPartPitch(Length partPitch) {
+        this.partPitch = partPitch;
+    }
+
+    public Double getFeedSpeed() {
+        return feedSpeed;
+    }
+
+    public void setFeedSpeed(Double feedSpeed) {
+        this.feedSpeed = feedSpeed;
+    }
+
+    public String getActuatorName() {
+        return actuatorName;
+    }
+
+    public void setActuatorName(String actuatorName) {
+        String oldValue = this.actuatorName;
+        this.actuatorName = actuatorName;
+        propertyChangeSupport.firePropertyChange("actuatorName", oldValue, actuatorName);
+    }
+
+    public String getPeelOffActuatorName() {
+        return peelOffActuatorName;
+    }
+
+    public void setPeelOffActuatorName(String actuatorName) {
+        String oldValue = this.peelOffActuatorName;
+        this.peelOffActuatorName = actuatorName;
+        propertyChangeSupport.firePropertyChange("actuatorName", oldValue, actuatorName);
+    }
+
+    public Vision getVision() {
+        return vision;
+    }
+
+    public void setVision(Vision vision) {
+        this.vision = vision;
+    }
+
+    public void addPropertyChangeListener(PropertyChangeListener listener) {
+        propertyChangeSupport.addPropertyChangeListener(listener);
+    }
+
+    public void addPropertyChangeListener(String propertyName, PropertyChangeListener listener) {
+        propertyChangeSupport.addPropertyChangeListener(propertyName, listener);
+    }
+
+    public void removePropertyChangeListener(PropertyChangeListener listener) {
+        propertyChangeSupport.removePropertyChangeListener(listener);
+    }
+
+    public void removePropertyChangeListener(String propertyName, PropertyChangeListener listener) {
+        propertyChangeSupport.removePropertyChangeListener(propertyName, listener);
+    }
+
+    @Override
+    public Wizard getConfigurationWizard() {
+        return new ReferenceLeverFeederConfigurationWizard(this);
+    }
+
+    @Override
+    public String getPropertySheetHolderTitle() {
+        return getClass().getSimpleName() + " " + getName();
+    }
+
+    @Override
+    public PropertySheetHolder[] getChildPropertySheetHolders() {
+        return null;
+    }
+
+    @Override
+    public Action[] getPropertySheetHolderActions() {
+        return null;
+    }
+
+    public static class Vision {
+        @Attribute(required = false)
+        private boolean enabled;
+        @Attribute(required = false)
+        private String templateImageName;
+        @Element(required = false)
+        private Rectangle areaOfInterest = new Rectangle();
+        @Element(required = false)
+        private Location templateImageTopLeft = new Location(LengthUnit.Millimeters);
+        @Element(required = false)
+        private Location templateImageBottomRight = new Location(LengthUnit.Millimeters);
+
+        private BufferedImage templateImage;
+        private boolean templateImageDirty;
+
+        public Vision() {
+            Configuration.get().addListener(new ConfigurationListener.Adapter() {
+                @Override
+                public void configurationComplete(Configuration configuration) throws Exception {
+                    if (templateImageName != null) {
+                        File file = configuration.getResourceFile(Vision.this.getClass(),
+                                templateImageName);
+                        templateImage = ImageIO.read(file);
+                    }
+                }
+            });
+        }
+
+        @SuppressWarnings("unused")
+        @Persist
+        private void persist() throws IOException {
+            if (templateImageDirty) {
+                File file = null;
+                if (templateImageName != null) {
+                    file = Configuration.get().getResourceFile(this.getClass(), templateImageName);
+                }
+                else {
+                    file = Configuration.get().createResourceFile(this.getClass(), "tmpl_", ".png");
+                    templateImageName = file.getName();
+                }
+                ImageIO.write(templateImage, "png", file);
+                templateImageDirty = false;
+            }
+        }
+
+        public boolean isEnabled() {
+            return enabled;
+        }
+
+        public void setEnabled(boolean enabled) {
+            this.enabled = enabled;
+        }
+
+        public BufferedImage getTemplateImage() {
+            return templateImage;
+        }
+
+        public void setTemplateImage(BufferedImage templateImage) {
+            if (templateImage != this.templateImage) {
+                this.templateImage = templateImage;
+                templateImageDirty = true;
+            }
+        }
+
+        public Rectangle getAreaOfInterest() {
+            return areaOfInterest;
+        }
+
+        public void setAreaOfInterest(Rectangle areaOfInterest) {
+            this.areaOfInterest = areaOfInterest;
+        }
+
+        public Location getTemplateImageTopLeft() {
+            return templateImageTopLeft;
+        }
+
+        public void setTemplateImageTopLeft(Location templateImageTopLeft) {
+            this.templateImageTopLeft = templateImageTopLeft;
+        }
+
+        public Location getTemplateImageBottomRight() {
+            return templateImageBottomRight;
+        }
+
+        public void setTemplateImageBottomRight(Location templateImageBottomRight) {
+            this.templateImageBottomRight = templateImageBottomRight;
+        }
+    }
+}

--- a/src/main/java/org/openpnp/machine/reference/feeder/wizards/ReferenceLeverFeederConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/wizards/ReferenceLeverFeederConfigurationWizard.java
@@ -1,0 +1,562 @@
+/*
+ * Copyright (C) 2011 Jason von Nieda <jason@vonnieda.org>
+ * 
+ * This file is part of OpenPnP.
+ * 
+ * OpenPnP is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * OpenPnP is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License along with OpenPnP. If not, see
+ * <http://www.gnu.org/licenses/>.
+ * 
+ * For more information about OpenPnP visit http://openpnp.org
+ */
+
+package org.openpnp.machine.reference.feeder.wizards;
+
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.Dimension;
+import java.awt.FlowLayout;
+import java.awt.Rectangle;
+import java.awt.event.ActionEvent;
+import java.awt.image.BufferedImage;
+
+import javax.swing.AbstractAction;
+import javax.swing.Action;
+import javax.swing.BoxLayout;
+import javax.swing.ImageIcon;
+import javax.swing.JButton;
+import javax.swing.JCheckBox;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JSeparator;
+import javax.swing.JTextField;
+import javax.swing.SwingConstants;
+import javax.swing.SwingUtilities;
+import javax.swing.border.BevelBorder;
+import javax.swing.border.EtchedBorder;
+import javax.swing.border.TitledBorder;
+
+import org.jdesktop.beansbinding.AutoBinding.UpdateStrategy;
+import org.jdesktop.beansbinding.BeanProperty;
+import org.jdesktop.beansbinding.Bindings;
+import org.openpnp.gui.MainFrame;
+import org.openpnp.gui.components.CameraView;
+import org.openpnp.gui.components.ComponentDecorators;
+import org.openpnp.gui.components.LocationButtonsPanel;
+import org.openpnp.gui.support.BufferedImageIconConverter;
+import org.openpnp.gui.support.DoubleConverter;
+import org.openpnp.gui.support.IntegerConverter;
+import org.openpnp.gui.support.LengthConverter;
+import org.openpnp.gui.support.MessageBoxes;
+import org.openpnp.gui.support.MutableLocationProxy;
+import org.openpnp.gui.support.PercentConverter;
+import org.openpnp.machine.reference.feeder.ReferenceLeverFeeder;
+import org.openpnp.model.Configuration;
+import org.openpnp.spi.Camera;
+import org.openpnp.util.UiUtils;
+
+import com.jgoodies.forms.layout.ColumnSpec;
+import com.jgoodies.forms.layout.FormLayout;
+import com.jgoodies.forms.layout.FormSpecs;
+import com.jgoodies.forms.layout.RowSpec;
+
+@SuppressWarnings("serial")
+public class ReferenceLeverFeederConfigurationWizard
+        extends AbstractReferenceFeederConfigurationWizard {
+    private final ReferenceLeverFeeder feeder;
+
+    private JTextField textFieldFeedStartX;
+    private JTextField textFieldFeedStartY;
+    private JTextField textFieldFeedStartZ;
+    private JTextField textFieldFeedEndX;
+    private JTextField textFieldFeedEndY;
+    private JTextField textFieldFeedEndZ;
+    private JTextField textFieldFeedRate;
+    private JLabel lblPartPitch;
+    private JTextField textFieldPartPitch;
+	private JLabel lblFeedRate;
+    private JLabel lblActuatorId;
+    private JLabel lblPeelOffActuatorId;
+    private JTextField textFieldActuatorId;
+    private JTextField textFieldPeelOffActuatorId;
+    private JPanel panelGeneral;
+    private JPanel panelVision;
+    private JPanel panelLocations;
+    private JCheckBox chckbxVisionEnabled;
+    private JPanel panelVisionEnabled;
+    private JPanel panelTemplate;
+    private JLabel labelTemplateImage;
+    private JButton btnChangeTemplateImage;
+    private JSeparator separator;
+    private JPanel panelVisionTemplateAndAoe;
+    private JPanel panelAoE;
+    private JLabel lblX_1;
+    private JLabel lblY_1;
+    private JTextField textFieldAoiX;
+    private JTextField textFieldAoiY;
+    private JTextField textFieldAoiWidth;
+    private JTextField textFieldAoiHeight;
+    private LocationButtonsPanel locationButtonsPanelFeedStart;
+    private LocationButtonsPanel locationButtonsPanelFeedEnd;
+    private JLabel lblWidth;
+    private JLabel lblHeight;
+    private JButton btnChangeAoi;
+    private JButton btnCancelChangeAoi;
+    private JPanel panel;
+    private JButton btnCancelChangeTemplateImage;
+    private JButton btnResetVisionOffsets;
+
+    public ReferenceLeverFeederConfigurationWizard(ReferenceLeverFeeder feeder) {
+        super(feeder);
+        this.feeder = feeder;
+
+        JPanel panelFields = new JPanel();
+        panelFields.setLayout(new BoxLayout(panelFields, BoxLayout.Y_AXIS));
+
+        panelGeneral = new JPanel();
+        panelGeneral.setBorder(new TitledBorder(null, "General Settings", TitledBorder.LEADING,
+                TitledBorder.TOP, null, null));
+
+        panelFields.add(panelGeneral);
+        panelGeneral.setLayout(new FormLayout(
+                new ColumnSpec[] {FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,
+                        FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,
+                        FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,
+                        FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,},
+                new RowSpec[] {FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,}));
+
+        lblPartPitch = new JLabel("Part Pitch");
+        panelGeneral.add(lblPartPitch, "2, 2, right, default");
+
+        textFieldPartPitch = new JTextField();
+        panelGeneral.add(textFieldPartPitch, "4, 2");
+        textFieldPartPitch.setColumns(5);
+
+        lblFeedRate = new JLabel("Feed Speed %");
+        panelGeneral.add(lblFeedRate, "2, 4");
+
+        textFieldFeedRate = new JTextField();
+        panelGeneral.add(textFieldFeedRate, "4, 4");
+        textFieldFeedRate.setColumns(5);
+
+        lblActuatorId = new JLabel("Actuator Name");
+        panelGeneral.add(lblActuatorId, "2, 6, right, default");
+
+        textFieldActuatorId = new JTextField();
+        panelGeneral.add(textFieldActuatorId, "4, 6");
+        textFieldActuatorId.setColumns(5);
+
+        lblPeelOffActuatorId = new JLabel("Peel Off Actuator Name");
+        panelGeneral.add(lblPeelOffActuatorId, "6, 6, right, default");
+
+        textFieldPeelOffActuatorId = new JTextField();
+        panelGeneral.add(textFieldPeelOffActuatorId, "8, 6");
+        textFieldPeelOffActuatorId.setColumns(5);
+
+        panelLocations = new JPanel();
+        panelFields.add(panelLocations);
+        panelLocations.setBorder(new TitledBorder(null, "Locations", TitledBorder.LEADING,
+                TitledBorder.TOP, null, null));
+        panelLocations.setLayout(new FormLayout(new ColumnSpec[] {
+                FormSpecs.RELATED_GAP_COLSPEC,
+                FormSpecs.DEFAULT_COLSPEC,
+                FormSpecs.RELATED_GAP_COLSPEC,
+                FormSpecs.DEFAULT_COLSPEC,
+                FormSpecs.RELATED_GAP_COLSPEC,
+                FormSpecs.DEFAULT_COLSPEC,
+                FormSpecs.RELATED_GAP_COLSPEC,
+                FormSpecs.DEFAULT_COLSPEC,
+                FormSpecs.RELATED_GAP_COLSPEC,
+                ColumnSpec.decode("left:default:grow"),},
+            new RowSpec[] {
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,}));
+
+        JLabel lblX = new JLabel("X");
+        panelLocations.add(lblX, "4, 4");
+
+        JLabel lblY = new JLabel("Y");
+        panelLocations.add(lblY, "6, 4");
+
+        JLabel lblZ = new JLabel("Z");
+        panelLocations.add(lblZ, "8, 4");
+
+        JLabel lblFeedStartLocation = new JLabel("Feed Start Location");
+        panelLocations.add(lblFeedStartLocation, "2, 6, right, default");
+
+        textFieldFeedStartX = new JTextField();
+        panelLocations.add(textFieldFeedStartX, "4, 6");
+        textFieldFeedStartX.setColumns(8);
+
+        textFieldFeedStartY = new JTextField();
+        panelLocations.add(textFieldFeedStartY, "6, 6");
+        textFieldFeedStartY.setColumns(8);
+
+        textFieldFeedStartZ = new JTextField();
+        panelLocations.add(textFieldFeedStartZ, "8, 6");
+        textFieldFeedStartZ.setColumns(8);
+
+        locationButtonsPanelFeedStart = new LocationButtonsPanel(textFieldFeedStartX,
+                textFieldFeedStartY, textFieldFeedStartZ, null);
+        panelLocations.add(locationButtonsPanelFeedStart, "10, 6");
+
+        JLabel lblFeedEndLocation = new JLabel("Feed End Location");
+        panelLocations.add(lblFeedEndLocation, "2, 8, right, default");
+
+        textFieldFeedEndX = new JTextField();
+        panelLocations.add(textFieldFeedEndX, "4, 8");
+        textFieldFeedEndX.setColumns(8);
+
+        textFieldFeedEndY = new JTextField();
+        panelLocations.add(textFieldFeedEndY, "6, 8");
+        textFieldFeedEndY.setColumns(8);
+
+        textFieldFeedEndZ = new JTextField();
+        panelLocations.add(textFieldFeedEndZ, "8, 8");
+        textFieldFeedEndZ.setColumns(8);
+
+        locationButtonsPanelFeedEnd = new LocationButtonsPanel(textFieldFeedEndX, textFieldFeedEndY,
+                textFieldFeedEndZ, null);
+        panelLocations.add(locationButtonsPanelFeedEnd, "10, 8");
+        
+        //
+        panelVision = new JPanel();
+        panelVision.setBorder(new TitledBorder(null, "Vision", TitledBorder.LEADING,
+                TitledBorder.TOP, null, null));
+        panelFields.add(panelVision);
+        panelVision.setLayout(new BoxLayout(panelVision, BoxLayout.Y_AXIS));
+
+        panelVisionEnabled = new JPanel();
+        FlowLayout fl_panelVisionEnabled = (FlowLayout) panelVisionEnabled.getLayout();
+        fl_panelVisionEnabled.setAlignment(FlowLayout.LEFT);
+        panelVision.add(panelVisionEnabled);
+
+        chckbxVisionEnabled = new JCheckBox("Vision Enabled?");
+        panelVisionEnabled.add(chckbxVisionEnabled);
+
+        separator = new JSeparator();
+        panelVision.add(separator);
+
+        panelVisionTemplateAndAoe = new JPanel();
+        panelVision.add(panelVisionTemplateAndAoe);
+        panelVisionTemplateAndAoe.setLayout(new FormLayout(
+                new ColumnSpec[] {FormSpecs.LABEL_COMPONENT_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,
+                        FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,},
+                new RowSpec[] {FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,}));
+
+        panelTemplate = new JPanel();
+        panelTemplate.setBorder(new TitledBorder(new EtchedBorder(EtchedBorder.LOWERED, null, null),
+                "Template Image", TitledBorder.LEADING, TitledBorder.TOP, null,
+                new Color(0, 0, 0)));
+        panelVisionTemplateAndAoe.add(panelTemplate, "2, 2, center, fill");
+        panelTemplate.setLayout(new BoxLayout(panelTemplate, BoxLayout.Y_AXIS));
+
+        labelTemplateImage = new JLabel("");
+        labelTemplateImage.setAlignmentX(Component.CENTER_ALIGNMENT);
+        panelTemplate.add(labelTemplateImage);
+        labelTemplateImage.setBorder(new BevelBorder(BevelBorder.LOWERED, null, null, null, null));
+        labelTemplateImage.setMinimumSize(new Dimension(150, 150));
+        labelTemplateImage.setMaximumSize(new Dimension(150, 150));
+        labelTemplateImage.setHorizontalAlignment(SwingConstants.CENTER);
+        labelTemplateImage.setSize(new Dimension(150, 150));
+        labelTemplateImage.setPreferredSize(new Dimension(150, 150));
+
+        panel = new JPanel();
+        panelTemplate.add(panel);
+
+        btnChangeTemplateImage = new JButton(selectTemplateImageAction);
+        panel.add(btnChangeTemplateImage);
+        btnChangeTemplateImage.setAlignmentX(Component.CENTER_ALIGNMENT);
+
+        btnCancelChangeTemplateImage = new JButton(cancelSelectTemplateImageAction);
+        panel.add(btnCancelChangeTemplateImage);
+
+        panelAoE = new JPanel();
+        panelAoE.setBorder(new TitledBorder(null, "Area of Interest", TitledBorder.LEADING,
+                TitledBorder.TOP, null, null));
+        panelVisionTemplateAndAoe.add(panelAoE, "4, 2, fill, fill");
+        panelAoE.setLayout(new FormLayout(
+                new ColumnSpec[] {FormSpecs.RELATED_GAP_COLSPEC, ColumnSpec.decode("default:grow"),
+                        FormSpecs.RELATED_GAP_COLSPEC, ColumnSpec.decode("default:grow"),
+                        FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,
+                        FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,
+                        FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,
+                        FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,},
+                new RowSpec[] {
+						FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
+                        }));
+
+        lblX_1 = new JLabel("X");
+        panelAoE.add(lblX_1, "2, 2");
+
+        lblY_1 = new JLabel("Y");
+        panelAoE.add(lblY_1, "4, 2");
+
+        lblWidth = new JLabel("Width");
+        panelAoE.add(lblWidth, "6, 2");
+
+        lblHeight = new JLabel("Height");
+        panelAoE.add(lblHeight, "8, 2");
+
+        textFieldAoiX = new JTextField();
+        panelAoE.add(textFieldAoiX, "2, 4, fill, default");
+        textFieldAoiX.setColumns(5);
+
+        textFieldAoiY = new JTextField();
+        panelAoE.add(textFieldAoiY, "4, 4, fill, default");
+        textFieldAoiY.setColumns(5);
+
+        textFieldAoiWidth = new JTextField();
+        panelAoE.add(textFieldAoiWidth, "6, 4, fill, default");
+        textFieldAoiWidth.setColumns(5);
+
+        textFieldAoiHeight = new JTextField();
+        panelAoE.add(textFieldAoiHeight, "8, 4, fill, default");
+        textFieldAoiHeight.setColumns(5);
+
+        btnChangeAoi = new JButton("Change");
+        btnChangeAoi.setAction(selectAoiAction);
+        panelAoE.add(btnChangeAoi, "10, 4");
+
+        btnCancelChangeAoi = new JButton("Cancel");
+        btnCancelChangeAoi.setAction(cancelSelectAoiAction);
+        panelAoE.add(btnCancelChangeAoi, "12, 4");
+
+        cancelSelectTemplateImageAction.setEnabled(false);
+        cancelSelectAoiAction.setEnabled(false);
+
+        btnResetVisionOffsets = new JButton("Reset offsets");
+        btnResetVisionOffsets.setAction(resetVisionOffsets);
+        panelAoE.add(btnResetVisionOffsets, "12, 10");
+
+        contentPanel.add(panelFields);
+    }
+
+    @Override
+    public void createBindings() {
+        super.createBindings();
+        LengthConverter lengthConverter = new LengthConverter();
+        IntegerConverter intConverter = new IntegerConverter();
+        DoubleConverter doubleConverter =
+                new DoubleConverter(Configuration.get().getLengthDisplayFormat());
+        BufferedImageIconConverter imageConverter = new BufferedImageIconConverter();
+        PercentConverter percentConverter = new PercentConverter();
+
+        addWrappedBinding(feeder, "partPitch", textFieldPartPitch, "text", lengthConverter);
+        addWrappedBinding(feeder, "feedSpeed", textFieldFeedRate, "text", percentConverter);
+        addWrappedBinding(feeder, "actuatorName", textFieldActuatorId, "text");
+        addWrappedBinding(feeder, "peelOffActuatorName", textFieldPeelOffActuatorId, "text");
+
+        MutableLocationProxy feedStartLocation = new MutableLocationProxy();
+        bind(UpdateStrategy.READ_WRITE, feeder, "feedStartLocation", feedStartLocation, "location");
+        addWrappedBinding(feedStartLocation, "lengthX", textFieldFeedStartX, "text",
+                lengthConverter);
+        addWrappedBinding(feedStartLocation, "lengthY", textFieldFeedStartY, "text",
+                lengthConverter);
+        addWrappedBinding(feedStartLocation, "lengthZ", textFieldFeedStartZ, "text",
+                lengthConverter);
+
+        MutableLocationProxy feedEndLocation = new MutableLocationProxy();
+        bind(UpdateStrategy.READ_WRITE, feeder, "feedEndLocation", feedEndLocation, "location");
+        addWrappedBinding(feedEndLocation, "lengthX", textFieldFeedEndX, "text", lengthConverter);
+        addWrappedBinding(feedEndLocation, "lengthY", textFieldFeedEndY, "text", lengthConverter);
+        addWrappedBinding(feedEndLocation, "lengthZ", textFieldFeedEndZ, "text", lengthConverter);
+
+        addWrappedBinding(feeder, "vision.enabled", chckbxVisionEnabled, "selected");
+        addWrappedBinding(feeder, "vision.templateImage", labelTemplateImage, "icon",
+                imageConverter);
+
+        addWrappedBinding(feeder, "vision.areaOfInterest.x", textFieldAoiX, "text", intConverter);
+        addWrappedBinding(feeder, "vision.areaOfInterest.y", textFieldAoiY, "text", intConverter);
+
+        addWrappedBinding(feeder, "vision.areaOfInterest.width", textFieldAoiWidth, "text",
+                intConverter);
+        addWrappedBinding(feeder, "vision.areaOfInterest.height", textFieldAoiHeight, "text",
+                intConverter);
+        
+        ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldPartPitch);
+        ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldFeedRate);
+        ComponentDecorators.decorateWithAutoSelect(textFieldActuatorId);
+        ComponentDecorators.decorateWithAutoSelect(textFieldPeelOffActuatorId);
+        ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldFeedStartX);
+        ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldFeedStartY);
+        ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldFeedStartZ);
+        ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldFeedEndX);
+        ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldFeedEndY);
+        ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldFeedEndZ);
+        ComponentDecorators.decorateWithAutoSelect(textFieldAoiX);
+        ComponentDecorators.decorateWithAutoSelect(textFieldAoiY);
+        ComponentDecorators.decorateWithAutoSelect(textFieldAoiWidth);
+        ComponentDecorators.decorateWithAutoSelect(textFieldAoiHeight);
+
+        bind(UpdateStrategy.READ, feeder, "actuatorName", locationButtonsPanelFeedStart, "actuatorName");
+        bind(UpdateStrategy.READ, feeder, "actuatorName", locationButtonsPanelFeedEnd, "actuatorName");
+    }
+
+    @SuppressWarnings("serial")
+    private Action selectTemplateImageAction = new AbstractAction("Select") {
+        @Override
+        public void actionPerformed(ActionEvent arg0) {
+            UiUtils.messageBoxOnException(() -> {
+                Camera camera = MainFrame.get().getMachineControls().getSelectedTool().getHead()
+                        .getDefaultCamera();
+                CameraView cameraView = MainFrame.get().getCameraViews().setSelectedCamera(camera);
+
+                cameraView.setSelectionEnabled(true);
+                // org.openpnp.model.Rectangle r =
+                // feeder.getVision().getTemplateImageCoordinates();
+                org.openpnp.model.Rectangle r = null;
+                if (r == null || r.getWidth() == 0 || r.getHeight() == 0) {
+                    cameraView.setSelection(0, 0, 100, 100);
+                }
+                else {
+                    // cameraView.setSelection(r.getLeft(), r.getTop(),
+                    // r.getWidth(), r.getHeight());
+                }
+                btnChangeTemplateImage.setAction(confirmSelectTemplateImageAction);
+                cancelSelectTemplateImageAction.setEnabled(true);
+            });
+        }
+    };
+
+    @SuppressWarnings("serial")
+    private Action confirmSelectTemplateImageAction = new AbstractAction("Confirm") {
+        @Override
+        public void actionPerformed(ActionEvent arg0) {
+            UiUtils.messageBoxOnException(() -> {
+                Camera camera = MainFrame.get().getMachineControls().getSelectedTool().getHead()
+                        .getDefaultCamera();
+                CameraView cameraView = MainFrame.get().getCameraViews().setSelectedCamera(camera);
+
+                BufferedImage image = cameraView.captureSelectionImage();
+                if (image == null) {
+                    MessageBoxes.errorBox(ReferenceLeverFeederConfigurationWizard.this,
+                            "No Image Selected",
+                            "Please select an area of the camera image using the mouse.");
+                }
+                else {
+                    labelTemplateImage.setIcon(new ImageIcon(image));
+                }
+                cameraView.setSelectionEnabled(false);
+                btnChangeTemplateImage.setAction(selectTemplateImageAction);
+                cancelSelectTemplateImageAction.setEnabled(false);
+            });
+        }
+    };
+
+    @SuppressWarnings("serial")
+    private Action cancelSelectTemplateImageAction = new AbstractAction("Cancel") {
+        @Override
+        public void actionPerformed(ActionEvent arg0) {
+            UiUtils.messageBoxOnException(() -> {
+                Camera camera = MainFrame.get().getMachineControls().getSelectedTool().getHead()
+                        .getDefaultCamera();
+                CameraView cameraView = MainFrame.get().getCameraViews().setSelectedCamera(camera);
+
+                btnChangeTemplateImage.setAction(selectTemplateImageAction);
+                cancelSelectTemplateImageAction.setEnabled(false);
+                cameraView.setSelectionEnabled(false);
+            });
+        }
+    };
+
+    @SuppressWarnings("serial")
+    private Action selectAoiAction = new AbstractAction("Select") {
+        @Override
+        public void actionPerformed(ActionEvent arg0) {
+            UiUtils.messageBoxOnException(() -> {
+                Camera camera = MainFrame.get().getMachineControls().getSelectedTool().getHead()
+                        .getDefaultCamera();
+                CameraView cameraView = MainFrame.get().getCameraViews().setSelectedCamera(camera);
+
+                btnChangeAoi.setAction(confirmSelectAoiAction);
+                cancelSelectAoiAction.setEnabled(true);
+
+                cameraView.setSelectionEnabled(true);
+                org.openpnp.model.Rectangle r = feeder.getVision().getAreaOfInterest();
+                if (r == null || r.getWidth() == 0 || r.getHeight() == 0) {
+                    cameraView.setSelection(0, 0, 100, 100);
+                }
+                else {
+                    cameraView.setSelection(r.getX(), r.getY(), r.getWidth(), r.getHeight());
+                }
+            });
+        }
+    };
+
+    @SuppressWarnings("serial")
+    private Action confirmSelectAoiAction = new AbstractAction("Confirm") {
+        @Override
+        public void actionPerformed(ActionEvent arg0) {
+            UiUtils.messageBoxOnException(() -> {
+                Camera camera = MainFrame.get().getMachineControls().getSelectedTool().getHead()
+                        .getDefaultCamera();
+                CameraView cameraView = MainFrame.get().getCameraViews().setSelectedCamera(camera);
+
+                btnChangeAoi.setAction(selectAoiAction);
+                cancelSelectAoiAction.setEnabled(false);
+
+                cameraView.setSelectionEnabled(false);
+                final Rectangle rect = cameraView.getSelection();
+                SwingUtilities.invokeLater(new Runnable() {
+                    public void run() {
+                        textFieldAoiX.setText(Integer.toString(rect.x));
+                        textFieldAoiY.setText(Integer.toString(rect.y));
+                        textFieldAoiWidth.setText(Integer.toString(rect.width));
+                        textFieldAoiHeight.setText(Integer.toString(rect.height));
+                    }
+                });
+            });
+        }
+    };
+
+    @SuppressWarnings("serial")
+    private Action cancelSelectAoiAction = new AbstractAction("Cancel") {
+        @Override
+        public void actionPerformed(ActionEvent arg0) {
+            UiUtils.messageBoxOnException(() -> {
+                Camera camera = MainFrame.get().getMachineControls().getSelectedTool().getHead()
+                        .getDefaultCamera();
+                CameraView cameraView = MainFrame.get().getCameraViews().setSelectedCamera(camera);
+
+                btnChangeAoi.setAction(selectAoiAction);
+                cancelSelectAoiAction.setEnabled(false);
+                btnChangeAoi.setAction(selectAoiAction);
+                cancelSelectAoiAction.setEnabled(false);
+                cameraView.setSelectionEnabled(false);
+            });
+        }
+    };
+
+    @SuppressWarnings("serial")
+    private Action resetVisionOffsets = new AbstractAction("Reset vision offsets") {
+        @Override
+        public void actionPerformed(ActionEvent arg0) {
+            UiUtils.messageBoxOnException(() -> {
+				feeder.resetVisionOffsets();
+            });
+        }
+    };
+}


### PR DESCRIPTION
# Description
ReferenceLeverFeeder supports feeders where a lever is pushed one or more times to feed the parts (such as Alex Feeder).  Made from ReferenceDragFeeder.

# Justification
While the ReferenceDragFeeder can be used for this type of feeder, it has some issues.  It doesn't support part pitch greater than 4 and the feed operation is not optimal.

# Instructions for Use
You will need a Head Mountable Actuator defined.  It doesn't have to do anything for this feeder.  You can also define a cover take-up actuator if needed.  Add a new ReferenceLeverFeeder and use the wizard to set it up.  Setting the part pitch to 2mm will pick 2 parts per feed.  If the pitch is greater than 4mm, the appropriate number of feeds will be performed for each pick.

# Implementation Details
1. How did you test the change? I tested it on my machine set up with 15 feeders of various sizes.
2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)? Yes.
3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing. N/A
4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted.  All tests passed.
