### PR TITLE
Feature/A More Job Like Manual Pick (Repeat)

### DIFF
--- a/src/main/java/org/openpnp/gui/FeedersPanel.java
+++ b/src/main/java/org/openpnp/gui/FeedersPanel.java
@@ -77,6 +77,8 @@ import org.openpnp.model.Part;
 import org.openpnp.spi.Camera;
 import org.openpnp.spi.Feeder;
 import org.openpnp.spi.Nozzle;
+import org.openpnp.spi.NozzleTip;
+import org.openpnp.spi.JobProcessor.JobProcessorException;
 import org.openpnp.spi.PropertySheetHolder.PropertySheet;
 import org.openpnp.util.MovableUtils;
 import org.openpnp.util.UiUtils;
@@ -506,14 +508,58 @@ public class FeedersPanel extends JPanel implements WizardContainer {
         public void actionPerformed(ActionEvent arg0) {
             UiUtils.submitUiMachineTask(() -> {
                 Feeder feeder = getSelection();
-                Nozzle nozzle = MainFrame.get().getMachineControls().getSelectedNozzle();
 
+                // Simulate a "one feeder" job, prepare the feeder.
+                List<Feeder> feedersToPrepare = new ArrayList<>();
+                feedersToPrepare.add(feeder);
+                feeder.prepareForJob(feedersToPrepare);
+
+                // Check the nozzle tip package compatibility.
+                Nozzle nozzle = MainFrame.get().getMachineControls().getSelectedNozzle();
+                org.openpnp.model.Package packag = feeder.getPart().getPackage();
+                if (nozzle.getNozzleTip() == null || 
+                        !packag.getCompatibleNozzleTips().contains(nozzle.getNozzleTip())) {
+                    // Wrong nozzle tip, try find one that works.
+                    boolean resolved = false;
+                    if (nozzle.isNozzleTipChangedOnManualFeed()) {
+                        for (NozzleTip nozzleTip : packag.getCompatibleNozzleTips()) {
+                            if (nozzle.getCompatibleNozzleTips().contains(nozzleTip)) {
+                                // Found a compatible one.
+                                nozzle.loadNozzleTip(nozzleTip);
+                                resolved = true;
+                                break;
+                            }
+                        }
+                    }
+                    if (nozzle.getNozzleTip() == null) {
+                        throw new Exception("Can't pick, no nozzle tip loaded on nozzle "+nozzle.getName()+". "
+                                +"You may want to enable automatic nozzle tip change on manual feed on the Nozzle / Tool Changer.");
+                    }
+                    else if (! resolved) {
+                        throw new Exception("Can't pick, loaded nozzle tip "+
+                                nozzle.getNozzleTip().getName()+" is not compatible with package "+packag.getId()+". "
+                                +"You may want to enable automatic nozzle tip change on manual feed on the Nozzle / Tool Changer.");
+                    }
+                }
+
+                // Perform the feed.
                 nozzle.moveToSafeZ();
                 feeder.feed(nozzle);
+
+                // Go to the pick location and pick.
                 Location pickLocation = feeder.getPickLocation();
                 MovableUtils.moveToLocationAtSafeZ(nozzle, pickLocation);
                 nozzle.pick(feeder.getPart());
                 nozzle.moveToSafeZ();
+
+                // Perform the vacuum check, if enabled.
+                if (nozzle.isPartOnEnabled()) {
+                    if(!nozzle.isPartOn()) {
+                        throw new JobProcessorException(nozzle, "No part detected.");
+                    }
+                }
+
+                // Anything else? 
                 feeder.postPick(nozzle);
             });
         }

--- a/src/main/java/org/openpnp/machine/reference/ReferenceNozzle.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceNozzle.java
@@ -52,6 +52,9 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
     @Attribute(required = false)
     private boolean changerEnabled = false;
 
+    @Attribute(required = false)
+    private boolean nozzleTipChangedOnManualFeed = false;
+
     @Element(required = false)
     protected Length safeZ = new Length(0, LengthUnit.Millimeters);
 
@@ -146,6 +149,15 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
     @Override
     public ReferenceNozzleTip getNozzleTip() {
         return nozzleTip;
+    }
+
+    @Override
+    public boolean isNozzleTipChangedOnManualFeed() {
+        return nozzleTipChangedOnManualFeed;
+    }
+
+    public void setNozzleTipChangedOnManualFeed(boolean nozzleTipChangedOnManualFeed) {
+        this.nozzleTipChangedOnManualFeed = nozzleTipChangedOnManualFeed;
     }
 
     @Override

--- a/src/main/java/org/openpnp/machine/reference/wizards/ReferenceNozzleToolChangerWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/wizards/ReferenceNozzleToolChangerWizard.java
@@ -40,6 +40,8 @@ public class ReferenceNozzleToolChangerWizard extends AbstractConfigurationWizar
     private JPanel panelChanger;
     private JCheckBox chckbxChangerEnabled;
     private JLabel lblChangerEnabled;
+    private JLabel lblChangeOnManual;
+    private JCheckBox chckbxChangeOnManualFeed;
 
     public ReferenceNozzleToolChangerWizard(ReferenceNozzle nozzle) {
         this.nozzle = nozzle;
@@ -62,6 +64,8 @@ public class ReferenceNozzleToolChangerWizard extends AbstractConfigurationWizar
                 ColumnSpec.decode("default:grow"),},
             new RowSpec[] {
                 FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
                 FormSpecs.DEFAULT_ROWSPEC,}));
                 
         lblChangerEnabled = new JLabel("Automatic Tool Changer Enabled?");
@@ -69,6 +73,12 @@ public class ReferenceNozzleToolChangerWizard extends AbstractConfigurationWizar
 
         chckbxChangerEnabled = new JCheckBox("");
         panelChanger.add(chckbxChangerEnabled, "4, 2");
+        
+        lblChangeOnManual = new JLabel("Change On Manual Feed?");
+        panelChanger.add(lblChangeOnManual, "2, 4, right, default");
+        
+        chckbxChangeOnManualFeed = new JCheckBox("");
+        panelChanger.add(chckbxChangeOnManualFeed, "4, 4");
         
         CellConstraints cc = new CellConstraints();
     }
@@ -79,5 +89,6 @@ public class ReferenceNozzleToolChangerWizard extends AbstractConfigurationWizar
         IntegerConverter intConverter = new IntegerConverter();
 
         addWrappedBinding(nozzle, "changerEnabled", chckbxChangerEnabled, "selected");
+        addWrappedBinding(nozzle, "nozzleTipChangedOnManualFeed", chckbxChangeOnManualFeed, "selected");
     }
 }

--- a/src/main/java/org/openpnp/spi/Nozzle.java
+++ b/src/main/java/org/openpnp/spi/Nozzle.java
@@ -111,6 +111,8 @@ public interface Nozzle
     
     public void removeCompatibleNozzleTip(NozzleTip nt);
     
+    boolean isNozzleTipChangedOnManualFeed();
+
     public void calibrate() throws Exception;
     public boolean isCalibrated();
 }


### PR DESCRIPTION
Note, this is a repeat of what the #939 was intended to be. The changes were reverted in the merge, due to a git misunderstanding on my side.

---

# Description

A pick in the Feeder Panel does not behave like one would in a Job. So this PR aims to implement a more "job like" behavior for the manual pick operation:

- The selected feeder is prepared (like all of them would in a Job).
- This results in the desired behaviour with the BlindsFeeder, otherwise it would sometimes end up in a ridiculous NozzleTip changing frenzy.
- You can now switch on automatic NozzleTip change on manual feed in the "Tool Changer" wizard of the Nozzle.
- If enabled, the NozzleTip is automatically changed for one that is compatible with the package in the feeder.
- If disabled, the pick is aborted if the NozzleTip is incompatible (of course, this is up for discussion, like everything).
- The vacuum check is also done.

# Justification
The user can better experiment with picks, if the behavior is more like in a Job. Most importantly the vacuum setup (vacuum ranges, dwell times) can now be tested outside a job. 

# Instructions for Use
Switch on the "Change On Manual Feed?" Checkbox in the "Changer Tool" WIzard of the Nozzle. 
![grafik](https://user-images.githubusercontent.com/9963310/72916709-caeeb980-3d42-11ea-8c77-6c5a1efccbea.png)

Then use the pick button in the Feeder Panel:
![grafik](https://user-images.githubusercontent.com/9963310/72917467-2cfbee80-3d44-11ea-8a4c-06c53a5af99b.png)

# Implementation Details
1. Tested it with the BlindsFeeder, most specifically by forcing it to change the nozzle tip for cover opening. While testing, I had some pick issues and only noticed then (after some frustration), that the vacuum check is not currently performed in the manual pick. 
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. Added the  `org.openpnp.spi.Nozzle.isNozzleTipChangedOnManualFeed()` method.
4. Did run `mvn test` before submitting the Pull Request. 
