### PR TITLE
Handling import of KiCad PCB bottom position information: KiCad uses …

### DIFF
--- a/src/main/java/org/openpnp/gui/importer/KicadPosImporter.java
+++ b/src/main/java/org/openpnp/gui/importer/KicadPosImporter.java
@@ -108,6 +108,19 @@ public class KicadPosImporter implements BoardImporter {
             double placementRotation = Double.parseDouble(matcher.group(6));
             String placementLayer = matcher.group(7);
 
+            if (placementLayer.contains("bottom")) {
+            	/* With the board origin set to the lower left, KiCad exports the position
+            	 * for the bottom parts with negative X position. The negative number is the distance from the
+            	 * 'right border' if the board is turned around with the original origin now on the right lower side.
+            	 * In order to work with the 'new' bottom coordinate and origin system, the X value has to be inverted.
+            	 * See https://github.com/openpnp/openpnp/wiki/Board-Locations
+            	 * */
+            	placementX = -placementX;
+            }
+            if (placementRotation==-0.0) { /* KiCad might report the rotation as -0.0 which does not make much sense, fixing this */
+            	placementRotation = 0.0;
+            }
+
             Placement placement = new Placement(placementId);
             placement.setLocation(new Location(LengthUnit.Millimeters, placementX, placementY, 0,
                     placementRotation));


### PR DESCRIPTION
# Description
This fix is for dealing with KiCad bottom side import to work with the new model described in https://github.com/openpnp/openpnp/wiki/Board-Locations
The fix includes negating the bottom X coordinates, plus a more cosmetic fix for -0.0 rotation valuse.

# Justification
Necessary for bottom placements to work with KiCad position files, using the new model in https://github.com/openpnp/openpnp/wiki/Board-Locations

# Instructions for Use
n/a

# Implementation Details
1. How did you test the change? Be descriptive. Untested code will not be accepted.
Tested with bottom KiCad position files, with the board flipped on the Y axis and having the board origin on the left lower edge.

2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)?
yes

3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing.
n/a

4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted.
done: Tests run: 20, Failures: 0, Errors: 0, Skipped: 0