### PR TITLE
Prevent setWizardContainer from creating bindings more than once

### DIFF
--- a/src/main/java/org/openpnp/gui/support/AbstractConfigurationWizard.java
+++ b/src/main/java/org/openpnp/gui/support/AbstractConfigurationWizard.java
@@ -151,11 +151,13 @@ public abstract class AbstractConfigurationWizard extends JPanel implements Wiza
     @Override
     public void setWizardContainer(WizardContainer wizardContainer) {
         this.wizardContainer = wizardContainer;
-        scrollPane.getVerticalScrollBar()
-                .setUnitIncrement(Configuration.get().getVerticalScrollUnitIncrement());
-        listener = new ApplyResetBindingListener(applyAction, resetAction);
-        createBindings();
-        loadFromModel();
+        if (listener == null) { //only allow bindings to be created the first time
+            scrollPane.getVerticalScrollBar()
+                    .setUnitIncrement(Configuration.get().getVerticalScrollUnitIncrement());
+            listener = new ApplyResetBindingListener(applyAction, resetAction);
+            createBindings();
+            loadFromModel();
+        }
     }
 
     @Override


### PR DESCRIPTION
# Description
The setWizardContainer method was changed to prevent it from creating bindings more than once.  This fixes a bug introduced/uncovered by PR 934.  That PR added a call to a feeder wizard's setWizardContainer  method to set the container to the feeders panel.  Unfortunately, the setWizardContainer method also called the wizard's createBindings method which resulted in bindings being created twice.  This caused noticeable problems with the reference slot auto feeder wizard - probably due to the unique way it set-up bindings.  The other feeder wizards didn't seem to display the same issue although their bindings were also being created twice.

# Justification
Makes the reference slot auto feeder wizard work correctly.

# Instructions for Use
No special instructions needed.

# Implementation Details
**1. How did you test the change?** Duplicated the problem with the develop branch and verified that with this change the wizard behaves as expected.
**2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)?** Yes.
**3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing.**  No changes were made to either package.
**4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted.**  Maven tests were run and passed.
