### PR TITLE
Handling of KiCad bottom part rotation

### DIFF
--- a/src/main/java/org/openpnp/gui/importer/KicadPosImporter.java
+++ b/src/main/java/org/openpnp/gui/importer/KicadPosImporter.java
@@ -108,6 +108,19 @@ public class KicadPosImporter implements BoardImporter {
             double placementRotation = Double.parseDouble(matcher.group(6));
             String placementLayer = matcher.group(7);
 
+            if (placementLayer.contains("bottom")) {
+            	/* With the board origin set to the lower left, KiCad exports the position
+            	 * for the bottom parts with negative X position. The negative number is the distance from the
+            	 * 'right border' if the board is turned around with the original origin now on the right lower side.
+            	 * In order to work with the 'new' bottom coordinate and origin system, the X value has to be inverted.
+            	 * See https://github.com/openpnp/openpnp/wiki/Board-Locations
+            	 * */
+            	placementX = -placementX;
+            }
+            if (placementRotation==-0.0) { /* KiCad might report the rotation as -0.0 which does not make much sense, fixing this */
+            	placementRotation = 0.0;
+            }
+
             Placement placement = new Placement(placementId);
             placement.setLocation(new Location(LengthUnit.Millimeters, placementX, placementY, 0,
                     placementRotation));

--- a/src/main/java/org/openpnp/gui/importer/KicadPosImporter.java
+++ b/src/main/java/org/openpnp/gui/importer/KicadPosImporter.java
@@ -116,6 +116,10 @@ public class KicadPosImporter implements BoardImporter {
             	 * See https://github.com/openpnp/openpnp/wiki/Board-Locations
             	 * */
             	placementX = -placementX;
+            	/* Bottom parts need to be rotated, KiCad exports the rotation of the part as 'looking through the board' 
+            	 * If the part is at 45 degrees, it needs to be mirrored for the bottom side on the 90 degree axis
+            	 */
+            	placementRotation = 180-placementRotation;
             }
             if (placementRotation==-0.0) { /* KiCad might report the rotation as -0.0 which does not make much sense, fixing this */
             	placementRotation = 0.0;


### PR DESCRIPTION
# Description
The fix is for handling placement for bottom parts, imported from KiCad pos files. The bottom parts need to be mirrored at the 90°/180° axis.

# Justification
The fix enables importing KiCad bottom part placement/position files for populating boards.

# Instructions for Use
n/a, simply import KiCad files. Bottom part position and orientation will be updated so parts can be placed with OpenPnP

# Implementation Details
1. How did you test the change? Be descriptive. Untested code will not be accepted.
Tested with with a PCB having parts on the bottom (capacitors, SOT-23 parts) in different orientation (90/180/0/45/135/270 degrees). They all worked fine with the change/fix.

2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)?
yes.

3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing.
no.

4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted.
yes, tests passed.