### PR TITLE
Fix/LocationButtonsPanel invokeAndWait usage

### DIFF
--- a/src/main/java/org/openpnp/gui/components/LocationButtonsPanel.java
+++ b/src/main/java/org/openpnp/gui/components/LocationButtonsPanel.java
@@ -220,7 +220,7 @@ public class LocationButtonsPanel extends JPanel {
 
                 @Override
                 public void actionPerformed(ActionEvent arg0) {
-                    UiUtils.messageBoxOnException(() -> {
+                    UiUtils.submitUiMachineTask(() -> {
                         Location l = getTool().getLocation();
                         if (baseLocation != null) {
                             l = l.subtractWithRotation(baseLocation);
@@ -244,7 +244,7 @@ public class LocationButtonsPanel extends JPanel {
 
                 @Override
                 public void actionPerformed(ActionEvent arg0) {
-                    UiUtils.messageBoxOnException(() -> {
+                    UiUtils.submitUiMachineTask(() -> {
                         Actuator actuator = getActuator();
                         if (actuator == null) {
                             return;


### PR DESCRIPTION
# Description
Due to
https://github.com/openpnp/openpnp/commit/61ef27ebd64fe358291034cb84338e029e0c8574
there are exceptions, when pressing the tool capture button. No message box is displayed, it just silently fails.

```
Exception in thread "AWT-EventQueue-0" java.lang.Error: Cannot call invokeAndWait from the event dispatcher thread
at java.awt.EventQueue.invokeAndWait(EventQueue.java:1331)
at java.awt.EventQueue.invokeAndWait(EventQueue.java:1324)
at javax.swing.SwingUtilities.invokeAndWait(SwingUtilities.java:1353)
at org.openpnp.gui.components.LocationButtonsPanel$2.lambda$0(LocationButtonsPanel.java:230)
at org.openpnp.util.UiUtils.messageBoxOnException(UiUtils.java:97)
at org.openpnp.gui.components.LocationButtonsPanel$2.actionPerformed(LocationButtonsPanel.java:223)
```

The camera capture works, because it is inside a `UiUtils.submitUiMachineTask()` for possible Z-Probing.

The `UiUtils.submitUiMachineTask()` was implemented for all the remaining capture buttons.

# Justification
It seems logical to always capture coordinates inside a machine tasks. Otherwise, the machine might theoretically be in the middle of a `driver.moveTo()` when you press the button and you could get only half updated axes (OK, that's theory).

Therefore, all buttons were changed over to `UiUtils.submitUiMachineTask()`.

# Instructions for Use
Use a tool or actuator capture button.

# Implementation Details
1. Just tested with a NullDriver.
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. Did run `mvn test` before submitting the Pull Request. 
