### PR TITLE
Add a setting that allows max vision retries to be changed.

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/ReferencePnpJobProcessor.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferencePnpJobProcessor.java
@@ -73,6 +73,9 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
     @Attribute(required = false)
     protected JobOrderHint jobOrder = JobOrderHint.PartHeight;
 
+    @Attribute(required = false)
+    protected int maxVisionRetries = 3;
+
     @Element(required = false)
     public PnpJobPlanner planner = new SimplePnpJobPlanner();
 
@@ -680,8 +683,7 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
             final Part part = placement.getPart();
 
             Exception lastException = null;
-            // TODO make retry count configurable.
-            for (int i = 0; i < 3; i++) {
+            for (int i = 0; i < ReferencePnpJobProcessor.this.getMaxVisionRetries(); i++) {
                 fireTextStatus("Aligning %s for %s.", part.getId(), placement.getId());
                 try {
                     plannedPlacement.alignmentOffsets = VisionUtils.findPartAlignmentOffsets(
@@ -1033,6 +1035,14 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
     public void setJobOrder(JobOrderHint newJobOrder) {
         this.jobOrder = newJobOrder;
     }    
+
+    public int getMaxVisionRetries() {
+        return maxVisionRetries;
+    }
+
+    public void setMaxVisionRetries(int maxVisionRetries) {
+        this.maxVisionRetries = maxVisionRetries;
+    }
 
     protected abstract class PlannedPlacementStep implements Step {
         protected final List<PlannedPlacement> plannedPlacements;

--- a/src/main/java/org/openpnp/machine/reference/wizards/ReferencePnpJobProcessorConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/wizards/ReferencePnpJobProcessorConfigurationWizard.java
@@ -23,10 +23,13 @@ import javax.swing.BoxLayout;
 import javax.swing.JComboBox;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
+import javax.swing.JTextField;
 import javax.swing.border.TitledBorder;
 
 import org.openpnp.Translations;
+import org.openpnp.gui.components.ComponentDecorators;
 import org.openpnp.gui.support.AbstractConfigurationWizard;
+import org.openpnp.gui.support.IntegerConverter;
 import org.openpnp.machine.reference.ReferencePnpJobProcessor;
 import org.openpnp.machine.reference.ReferencePnpJobProcessor.JobOrderHint;
 
@@ -39,6 +42,7 @@ import com.jgoodies.forms.layout.RowSpec;
 public class ReferencePnpJobProcessorConfigurationWizard extends AbstractConfigurationWizard {
     private final ReferencePnpJobProcessor jobProcessor;
     private JComboBox comboBoxJobOrder;
+    private JTextField maxVisionRetriesTextField;
 
     public ReferencePnpJobProcessorConfigurationWizard(ReferencePnpJobProcessor jobProcessor) {
         this.jobProcessor = jobProcessor;
@@ -55,6 +59,7 @@ public class ReferencePnpJobProcessorConfigurationWizard extends AbstractConfigu
                 FormSpecs.DEFAULT_COLSPEC,},
             new RowSpec[] {
                 FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
                 FormSpecs.DEFAULT_ROWSPEC,}));
 
         JLabel lblJobOrder = new JLabel(Translations.getString("MachineSetup.JobProcessors.ReferencePnpJobProcessor.Label.JobOrder"));
@@ -62,10 +67,22 @@ public class ReferencePnpJobProcessorConfigurationWizard extends AbstractConfigu
 
         comboBoxJobOrder = new JComboBox(JobOrderHint.values());
         panelGeneral.add(comboBoxJobOrder, "4, 2");
+
+        JLabel lblMaxVisionRetries = new JLabel(Translations.getString("MachineSetup.JobProcessors.ReferencePnpJobProcessor.Label.MaxVisionRetries"));
+        panelGeneral.add(lblMaxVisionRetries, "2, 3, right, default");
+
+        maxVisionRetriesTextField = new JTextField();
+        panelGeneral.add(maxVisionRetriesTextField, "4, 3");
+        maxVisionRetriesTextField.setColumns(10);
     }
 
     @Override
     public void createBindings() {
+        IntegerConverter intConverter = new IntegerConverter();
+
         addWrappedBinding(jobProcessor, "jobOrder", comboBoxJobOrder, "selectedItem");
+        addWrappedBinding(jobProcessor, "maxVisionRetries", maxVisionRetriesTextField, "text", intConverter);
+
+        ComponentDecorators.decorateWithAutoSelect(maxVisionRetriesTextField);
     }
 }

--- a/src/main/resources/org/openpnp/translations.properties
+++ b/src/main/resources/org/openpnp/translations.properties
@@ -76,6 +76,7 @@ MachineControls.Action.Start=Start
 MachineControls.Action.Stop=Stop
 MachineControls.Label=Machine Controls
 MachineSetup.JobProcessors.ReferencePnpJobProcessor.Label.JobOrder=Job order
+MachineSetup.JobProcessors.ReferencePnpJobProcessor.Label.MaxVisionRetries=Max Vision Retries
 Menu.Edit=Edit
 Menu.Edit.Undo=Undo
 Menu.Edit.Redo=Redo


### PR DESCRIPTION
# Description
Currently the job processor has a hardcoded vision retry. Added a new property and corresponding UI element.

# Implementation Details
Test via mvn test, and with both clean and existing openpnp configs.
