### PR TITLE
Sort 'PartHeight' jobs by id as a secondary field.

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/ReferencePnpJobProcessor.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferencePnpJobProcessor.java
@@ -409,7 +409,9 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
             else {
                 // Get the list of unfinished placements and sort them by part height.
                     jobPlacements = getPendingJobPlacements().stream()
-                            .sorted(Comparator.comparing(JobPlacement::getPartHeight))
+                            .sorted(Comparator
+                                .comparing(JobPlacement::getPartHeight)
+                                .thenComparing(JobPlacement::getPartId))
                             .collect(Collectors.toList());
             }
 


### PR DESCRIPTION
# Description
Currently the 'PartHeight' job order sorts only based on height. When placing many different parts with the same height the actual order is not defined: it may place 603-10k -> 603-1k -> 603-10k.

This change uses the part id as a secondary sort option. Parts will be placed in order of height, and when multiple parts are the same height they will be grouped together: 603-1k -> 603-10k -> 603-10k.

# Justification
Current height based placement is impossible to predict when multiple parts have the same height. This is a big time sink when manually feeding (or dealing with problem feeders).

# Implementation Details
Tested with mvn test, and by running jobs various jobs.