### PR TITLE
Feature/auto feeder move before feed

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/feeder/ReferenceAutoFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/ReferenceAutoFeeder.java
@@ -29,6 +29,7 @@ import org.openpnp.model.Location;
 import org.openpnp.spi.Actuator;
 import org.openpnp.spi.Nozzle;
 import org.openpnp.spi.PropertySheetHolder;
+import org.openpnp.util.MovableUtils;
 import org.pmw.tinylog.Logger;
 import org.simpleframework.xml.Attribute;
 
@@ -55,6 +56,9 @@ public class ReferenceAutoFeeder extends ReferenceFeeder {
     
     @Attribute(required=false)
     protected double postPickActuatorValue;
+    
+    @Attribute(required=false)
+    protected boolean moveBeforeFeed;
 
     @Override
     public Location getPickLocation() throws Exception {
@@ -73,6 +77,9 @@ public class ReferenceAutoFeeder extends ReferenceFeeder {
         }
         if (actuator == null) {
             throw new Exception("Feed failed. Unable to find an actuator named " + actuatorName);
+        }
+        if (isMoveBeforeFeed()) {
+            MovableUtils.moveToLocationAtSafeZ(nozzle, getPickLocation().derive(null, null, Double.NaN, null));
         }
         if (actuatorType == ActuatorType.Boolean) {
             actuator.actuate(actuatorValue != 0);
@@ -150,7 +157,15 @@ public class ReferenceAutoFeeder extends ReferenceFeeder {
         this.postPickActuatorValue = postPickActuatorValue;
     }
 
-    @Override
+    public boolean isMoveBeforeFeed() {
+		return moveBeforeFeed;
+	}
+
+	public void setMoveBeforeFeed(boolean moveBeforeFeed) {
+		this.moveBeforeFeed = moveBeforeFeed;
+	}
+
+	@Override
     public Wizard getConfigurationWizard() {
         return new ReferenceAutoFeederConfigurationWizard(this);
     }

--- a/src/main/java/org/openpnp/machine/reference/feeder/wizards/ReferenceAutoFeederConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/wizards/ReferenceAutoFeederConfigurationWizard.java
@@ -25,6 +25,7 @@ import java.awt.event.ActionEvent;
 import javax.swing.AbstractAction;
 import javax.swing.Action;
 import javax.swing.JButton;
+import javax.swing.JCheckBox;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JTextField;
@@ -58,6 +59,8 @@ public class ReferenceAutoFeederConfigurationWizard
     private JComboBox postPickActuatorType;
     private JButton btnTestFeedActuator;
     private JButton btnTestPostPickActuator;
+    private JCheckBox ckBoxMoveBeforeFeed;
+    
 
     public ReferenceAutoFeederConfigurationWizard(ReferenceAutoFeeder feeder) {
         super(feeder);
@@ -81,6 +84,8 @@ public class ReferenceAutoFeederConfigurationWizard
                 FormSpecs.RELATED_GAP_COLSPEC,
                 FormSpecs.DEFAULT_COLSPEC,},
             new RowSpec[] {
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
                 FormSpecs.RELATED_GAP_ROWSPEC,
                 FormSpecs.DEFAULT_ROWSPEC,
                 FormSpecs.RELATED_GAP_ROWSPEC,
@@ -136,6 +141,13 @@ public class ReferenceAutoFeederConfigurationWizard
 
         btnTestPostPickActuator = new JButton(testPostPickActuatorAction);
         panelActuator.add(btnTestPostPickActuator, "12, 6");
+
+        JLabel lblMoveBeforeFeed = new JLabel("Move before feed");
+        panelActuator.add(lblMoveBeforeFeed, "2, 8, right, default");
+        lblMoveBeforeFeed.setToolTipText("Move nozzle to pick location before actuating feed actuator");
+        
+        ckBoxMoveBeforeFeed = new JCheckBox();
+        panelActuator.add(ckBoxMoveBeforeFeed, "4, 8, left, default");
     }
 
     @Override
@@ -152,6 +164,8 @@ public class ReferenceAutoFeederConfigurationWizard
         addWrappedBinding(feeder, "postPickActuatorName", comboBoxPostPickActuator, "selectedItem");
         addWrappedBinding(feeder, "postPickActuatorType", postPickActuatorType, "selectedItem");
         addWrappedBinding(feeder, "postPickActuatorValue", postPickActuatorValue, "text", doubleConverter);
+        
+        addWrappedBinding(feeder, "moveBeforeFeed", ckBoxMoveBeforeFeed, "selected");
         
         ComponentDecorators.decorateWithAutoSelect(actuatorValue);
         ComponentDecorators.decorateWithAutoSelect(postPickActuatorValue);

--- a/src/main/java/org/openpnp/machine/reference/feeder/wizards/ReferenceSlotAutoFeederConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/wizards/ReferenceSlotAutoFeederConfigurationWizard.java
@@ -26,6 +26,7 @@ import javax.swing.AbstractAction;
 import javax.swing.Action;
 import javax.swing.BoxLayout;
 import javax.swing.JButton;
+import javax.swing.JCheckBox;
 import javax.swing.JComboBox;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
@@ -74,6 +75,7 @@ public class ReferenceSlotAutoFeederConfigurationWizard
     private JComboBox postPickActuatorType;
     private JTextField feederNameTf;
     private JTextField bankNameTf;
+    private JCheckBox ckBoxMoveBeforeFeed;
 
     public ReferenceSlotAutoFeederConfigurationWizard(ReferenceSlotAutoFeeder feeder) {
         this.feeder = feeder;
@@ -247,6 +249,8 @@ public class ReferenceSlotAutoFeederConfigurationWizard
                 FormSpecs.RELATED_GAP_ROWSPEC,
                 FormSpecs.DEFAULT_ROWSPEC,
                 FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
                 FormSpecs.DEFAULT_ROWSPEC,}));
 
         JLabel lblActuatorName = new JLabel("Actuator Name");
@@ -291,6 +295,14 @@ public class ReferenceSlotAutoFeederConfigurationWizard
         
         JLabel lblForBoolean_1 = new JLabel("For Boolean: 1 = True, 0 = False");
         panelActuator.add(lblForBoolean_1, "10, 6");
+        
+        JLabel lblMoveBeforeFeed = new JLabel("Move before feed");
+        panelActuator.add(lblMoveBeforeFeed, "2, 8, right, default");
+        lblMoveBeforeFeed.setToolTipText("Move nozzle to pick location before actuating feed actuator");
+        
+        ckBoxMoveBeforeFeed = new JCheckBox();
+        panelActuator.add(ckBoxMoveBeforeFeed, "4, 8, left, default");
+
         try {
         }
         catch (Throwable t) {
@@ -380,6 +392,7 @@ public class ReferenceSlotAutoFeederConfigurationWizard
         addWrappedBinding(feeder, "postPickActuatorType", postPickActuatorType, "selectedItem");
         addWrappedBinding(feeder, "postPickActuatorValue", postPickActuatorValue, "text", doubleConverter);
         
+        addWrappedBinding(feeder, "moveBeforeFeed", ckBoxMoveBeforeFeed, "selected");
         
         addWrappedBinding(feeder, "feedRetryCount", retryCountTf, "text", intConverter);
         addWrappedBinding(feeder, "pickRetryCount", pickRetryCount, "text", intConverter);


### PR DESCRIPTION
# Description
Adds a check box to the ReferenceAutoFeeder and ReferenceSlotAutoFeeder to move the head to the pick location before actuating the feed actuator.  Default is disabled.

# Justification
I have come across a couple of different feeders that could use the Auto Feeder, but require the head to be over the pick position before actuating the feed actuator.

# Instructions for Use
If you want to use the feature, check the check box in the feeder configuration.

# Implementation Details
1. How did you test the change? Tested on my machine.
2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)? Yes.
3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing. N/A
4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted.  All tests run and passed.
