### PR TITLE
Add support for Siemens Schultz feeders

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/ReferenceMachine.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceMachine.java
@@ -50,6 +50,8 @@ import org.openpnp.machine.reference.feeder.ReferenceSlotAutoFeeder;
 import org.openpnp.machine.reference.feeder.ReferenceStripFeeder;
 import org.openpnp.machine.reference.feeder.ReferenceTrayFeeder;
 import org.openpnp.machine.reference.feeder.ReferenceTubeFeeder;
+import org.openpnp.machine.reference.feeder.SchultzFeeder;
+import org.openpnp.machine.reference.feeder.SlotSchultzFeeder;
 import org.openpnp.machine.reference.psh.ActuatorsPropertySheetHolder;
 import org.openpnp.machine.reference.psh.CamerasPropertySheetHolder;
 import org.openpnp.machine.reference.psh.NozzleTipsPropertySheetHolder;
@@ -222,6 +224,8 @@ public class ReferenceMachine extends AbstractMachine {
         l.add(ReferenceLoosePartFeeder.class);
         l.add(AdvancedLoosePartFeeder.class);
         l.add(BlindsFeeder.class);
+        l.add(SchultzFeeder.class);
+        l.add(SlotSchultzFeeder.class);
         l.addAll(registeredFeederClasses);
         return l;
     }

--- a/src/main/java/org/openpnp/machine/reference/feeder/SchultzFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/SchultzFeeder.java
@@ -1,0 +1,309 @@
+/*
+ * Copyright (C) 2011 Jason von Nieda <jason@vonnieda.org>
+ * 
+ * This file is part of OpenPnP.
+ * 
+ * OpenPnP is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * OpenPnP is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License along with OpenPnP. If not, see
+ * <http://www.gnu.org/licenses/>.
+ * 
+ * For more information about OpenPnP visit http://openpnp.org
+ */
+
+package org.openpnp.machine.reference.feeder;
+
+import javax.swing.Action;
+
+import org.openpnp.gui.support.Wizard;
+import org.openpnp.machine.reference.ReferenceFeeder;
+import org.openpnp.machine.reference.feeder.wizards.SchultzFeederConfigurationWizard;
+import org.openpnp.model.Configuration;
+import org.openpnp.model.Location;
+import org.openpnp.model.Part;
+import org.openpnp.spi.Actuator;
+import org.openpnp.spi.Nozzle;
+import org.openpnp.spi.PropertySheetHolder;
+import org.openpnp.util.MovableUtils;
+import org.pmw.tinylog.Logger;
+import org.simpleframework.xml.Attribute;
+
+public class SchultzFeeder extends ReferenceFeeder {
+    public enum ActuatorType {
+        Double,
+        Boolean
+    }
+    
+    @Attribute(required=false)
+    protected String actuatorName;
+    
+    @Attribute(required=false)
+    protected ActuatorType actuatorType = ActuatorType.Double;
+    
+    @Attribute(required=false)
+    protected double actuatorValue;
+
+    @Attribute(required=false)
+    protected String postPickActuatorName;
+    
+    @Attribute(required=false)
+    protected ActuatorType postPickActuatorType = ActuatorType.Double;
+    
+    @Attribute(required=false)
+    protected String feedCountActuatorName;
+    
+    @Attribute(required=false)
+    protected ActuatorType feedCountActuatorType = ActuatorType.Double;
+    
+    @Attribute(required=false)
+    protected String clearCountActuatorName;
+    
+    @Attribute(required=false)
+    protected ActuatorType clearCountActuatorType = ActuatorType.Double;
+    
+    @Attribute(required=false)
+    protected String pitchActuatorName;
+    
+    @Attribute(required=false)
+    protected ActuatorType pitchActuatorType = ActuatorType.Double;
+    
+    @Attribute(required=false)
+    protected String togglePitchActuatorName;
+    
+    @Attribute(required=false)
+    protected ActuatorType togglePitchActuatorType = ActuatorType.Double;
+    
+    @Attribute(required=false)
+    protected String statusActuatorName;
+    
+    @Attribute(required=false)
+    protected ActuatorType statusActuatorType = ActuatorType.Double;
+    
+    @Attribute(required=false)
+    protected String idActuatorName;
+    
+    @Attribute(required=false)
+    protected ActuatorType idActuatorType = ActuatorType.Double;
+    
+    @Attribute(required=false)
+    protected String fiducialPart;
+    
+    @Override
+    public Location getPickLocation() throws Exception {
+        return location;
+    }
+
+    @Override
+    public void feed(Nozzle nozzle) throws Exception {
+        if (actuatorName == null || actuatorName.equals("")) {
+            Logger.warn("No actuatorName specified for feeder {}.", getName());
+            return;
+        }
+        Actuator actuator = nozzle.getHead().getActuatorByName(actuatorName);
+        if (actuator == null) {
+            actuator = Configuration.get().getMachine().getActuatorByName(actuatorName);
+        }
+        if (actuator == null) {
+            throw new Exception("Feed failed. Unable to find an actuator named " + actuatorName);
+        }
+        MovableUtils.moveToLocationAtSafeZ(nozzle, getPickLocation().derive(null, null, Double.NaN, null));
+        if (actuatorType == ActuatorType.Boolean) {
+            actuator.actuate(actuatorValue != 0);
+        }
+        else {
+            actuator.actuate(actuatorValue);
+        }
+    }
+    
+    @Override
+    public void postPick(Nozzle nozzle) throws Exception {
+        if (postPickActuatorName == null || postPickActuatorName.equals("")) {
+            return;
+        }
+        Actuator actuator = nozzle.getHead().getActuatorByName(postPickActuatorName);
+        if (actuator == null) {
+            actuator = Configuration.get().getMachine().getActuatorByName(postPickActuatorName);
+        }
+        if (actuator == null) {
+            throw new Exception("Post pick failed. Unable to find an actuator named " + postPickActuatorName);
+        }
+        // TODO: check status before feed?
+        
+        if (postPickActuatorType == ActuatorType.Boolean) {
+            actuator.actuate(actuatorValue != 0);
+        }
+        else {
+            actuator.actuate(actuatorValue);
+        }
+    }
+    
+    public String getActuatorName() {
+        return actuatorName;
+    }
+
+    public void setActuatorName(String actuatorName) {
+        this.actuatorName = actuatorName;
+    }
+
+    public ActuatorType getActuatorType() {
+        return actuatorType;
+    }
+
+    public void setActuatorType(ActuatorType actuatorType) {
+        this.actuatorType = actuatorType;
+    }
+
+    public double getActuatorValue() {
+        return actuatorValue;
+    }
+
+    public void setActuatorValue(double actuatorValue) {
+        this.actuatorValue = actuatorValue;
+    }
+
+    public String getPostPickActuatorName() {
+        return postPickActuatorName;
+    }
+
+    public void setPostPickActuatorName(String postPickActuatorName) {
+        this.postPickActuatorName = postPickActuatorName;
+    }
+
+    public ActuatorType getPostPickActuatorType() {
+        return postPickActuatorType;
+    }
+
+    public void setPostPickActuatorType(ActuatorType postPickActuatorType) {
+        this.postPickActuatorType = postPickActuatorType;
+    }
+
+    public String getFeedCountActuatorName() {
+        return feedCountActuatorName;
+    }
+
+    public void setFeedCountActuatorName(String feedCountActuatorName) {
+        this.feedCountActuatorName = feedCountActuatorName;
+    }
+
+    public ActuatorType getFeedCountActuatorType() {
+        return feedCountActuatorType;
+    }
+
+    public void setFeedCountActuatorType(ActuatorType feedCountActuatorType) {
+        this.feedCountActuatorType = feedCountActuatorType;
+    }
+
+    public String getClearCountActuatorName() {
+        return clearCountActuatorName;
+    }
+
+    public void setClearCountActuatorName(String clearCountActuatorName) {
+        this.clearCountActuatorName = clearCountActuatorName;
+    }
+
+    public ActuatorType getClearCountActuatorType() {
+        return clearCountActuatorType;
+    }
+
+    public void setClearCountActuatorType(ActuatorType clearCountActuatorType) {
+        this.clearCountActuatorType = clearCountActuatorType;
+    }
+
+    public String getPitchActuatorName() {
+        return pitchActuatorName;
+    }
+
+    public void setPitchActuatorName(String pitchActuatorName) {
+        this.pitchActuatorName = pitchActuatorName;
+    }
+
+    public ActuatorType getPitchActuatorType() {
+        return pitchActuatorType;
+    }
+
+    public void setPitchActuatorType(ActuatorType pitchActuatorType) {
+        this.pitchActuatorType = pitchActuatorType;
+    }
+
+    public String getTogglePitchActuatorName() {
+        return togglePitchActuatorName;
+    }
+
+    public void setTogglePitchActuatorName(String togglePitchActuatorName) {
+        this.togglePitchActuatorName = togglePitchActuatorName;
+    }
+
+    public ActuatorType getTogglePitchActuatorType() {
+        return togglePitchActuatorType;
+    }
+
+    public void setTogglePitchActuatorType(ActuatorType togglePitchActuatorType) {
+        this.togglePitchActuatorType = togglePitchActuatorType;
+    }
+
+    public String getStatusActuatorName() {
+        return statusActuatorName;
+    }
+
+    public void setStatusActuatorName(String statusActuatorName) {
+        this.statusActuatorName = statusActuatorName;
+    }
+
+    public ActuatorType getStatusActuatorType() {
+        return statusActuatorType;
+    }
+
+    public void setStatusActuatorType(ActuatorType statusActuatorType) {
+        this.statusActuatorType = statusActuatorType;
+    }
+
+    public String getIdActuatorName() {
+        return idActuatorName;
+    }
+
+    public void setIdActuatorName(String idActuatorName) {
+        this.idActuatorName = idActuatorName;
+    }
+
+    public ActuatorType getIdActuatorType() {
+        return idActuatorType;
+    }
+
+    public void setIdActuatorType(ActuatorType idActuatorType) {
+        this.idActuatorType = idActuatorType;
+    }
+
+    public void setFiducialPart(String part) {
+        fiducialPart = part;
+    }
+
+    public String getFiducialPart() {
+		return fiducialPart;
+    }
+
+	@Override
+    public Wizard getConfigurationWizard() {
+        return new SchultzFeederConfigurationWizard(this);
+    }
+
+    @Override
+    public String getPropertySheetHolderTitle() {
+        return getClass().getSimpleName() + " " + getName();
+    }
+
+    @Override
+    public PropertySheetHolder[] getChildPropertySheetHolders() {
+        return null;
+    }
+
+    @Override
+    public Action[] getPropertySheetHolderActions() {
+        return null;
+    }
+}

--- a/src/main/java/org/openpnp/machine/reference/feeder/SlotSchultzFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/SlotSchultzFeeder.java
@@ -1,0 +1,358 @@
+package org.openpnp.machine.reference.feeder;
+
+import java.util.List;
+
+import org.openpnp.ConfigurationListener;
+import org.openpnp.gui.support.Wizard;
+import org.openpnp.machine.reference.feeder.wizards.SlotSchultzFeederConfigurationWizard;
+import org.openpnp.model.AbstractModelObject;
+import org.openpnp.model.Configuration;
+import org.openpnp.model.Identifiable;
+import org.openpnp.model.LengthUnit;
+import org.openpnp.model.Location;
+import org.openpnp.model.Named;
+import org.openpnp.model.Part;
+import org.openpnp.spi.Nozzle;
+import org.openpnp.util.IdentifiableList;
+import org.simpleframework.xml.Attribute;
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.ElementList;
+import org.simpleframework.xml.Root;
+import org.simpleframework.xml.core.Commit;
+import org.simpleframework.xml.core.Persist;
+
+import com.google.common.collect.BiMap;
+import com.google.common.collect.HashBiMap;
+
+public class SlotSchultzFeeder extends SchultzFeeder {
+    @Attribute(required = false)
+    private String bankId;
+
+    @Attribute(required = false)
+    private String feederId;
+
+    private Bank bank;
+    
+    public SlotSchultzFeeder() {
+        this.id = Configuration.createId("SLOT-");
+        this.name = this.id;
+        // partId is required in AbstractFeeder to save the config. We don't use it so we just
+        // set it to an empty string to make the serializer happy.
+        partId = "";
+    }
+    
+    @Commit
+    public void commit() {
+        Configuration.get().addListener(new ConfigurationListener() {
+            @Override
+            public void configurationLoaded(Configuration configuration) throws Exception {
+            }
+            
+            @Override
+            public void configurationComplete(Configuration configuration) throws Exception {
+                setBank(getBanks().get(bankId));
+                setFeeder(getBank().getFeeder(feederId));
+            }
+        });
+    }
+
+    @Persist
+    public void persist() {
+        bankId = getBank().getId();
+        feederId = getFeeder() == null ? null : getFeeder().getId();
+    }
+
+    @Override
+    public Location getPickLocation() throws Exception {
+        if (getFeeder() == null) {
+            return location;
+        }
+        
+        // Start with the slot's location.
+        Location pickLocation = getLocation();
+        // Rotate the feeder's offsets by the slot's rotation making the offsets
+        // normal to the slot's orientation.
+        Location offsets = getFeeder().getOffsets().rotateXy(pickLocation.getRotation());
+        // Add the rotated offsets to the pickLocation to get the final pickLocation. We add
+        // with rotation since we need to pick with the combined rotation of the slot and the
+        // offsets.
+        pickLocation = pickLocation.addWithRotation(offsets);
+        return pickLocation;
+    }
+
+    @Override
+    public void feed(Nozzle nozzle) throws Exception {
+        if (getFeeder() == null) {
+            throw new Exception("No feeder loaded in slot.");
+        }
+        super.feed(nozzle);
+    }
+
+    @Override
+    public void postPick(Nozzle nozzle) throws Exception {
+        if (getFeeder() == null) {
+            throw new Exception("No feeder loaded in slot.");
+        }
+        super.postPick(nozzle);
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return super.isEnabled() && getFeeder() != null && getFeeder().getPart() != null;
+    }
+
+    @Override
+    public void setPart(Part part) {
+        if (getFeeder() == null) {
+            return;
+        }
+        getFeeder().setPart(part);
+    }
+
+    @Override
+    public Part getPart() {
+        if (getFeeder() == null) {
+            return null;
+        }
+        return getFeeder().getPart();
+    }
+
+    public Bank getBank() {
+        if (bank == null) {
+            bank = getBanks().get(getBanks().size() - 1);
+        }
+        return bank;
+    }
+
+    public void setBank(Bank bank) throws Exception {
+        if (bank == null) {
+            throw new Exception("Bank is required.");
+        }
+        this.bank = bank;
+    }
+
+    public Feeder getFeeder() {
+        return getBank().getFeeder(this);
+    }
+
+    public void setFeeder(Feeder feeder) throws Exception {
+        if (feeder != null) {
+          // Make sure the feeder is in our bank.
+          if (getBank().getFeeder(feeder.getId()) == null) {
+              throw new Exception("Can't set feeder from another bank.");
+          }
+        }
+        getBank().setFeeder(this, feeder);
+    }
+    
+    public static synchronized IdentifiableList<Bank> getBanks() {
+        BanksProperty bp = (BanksProperty) Configuration.get().getMachine().getProperty("SchultzFeederSlot.banks");
+        if (bp == null) {
+            bp = new BanksProperty();
+            Bank bank = new Bank();
+            bank.setName("Default");
+            bp.banks.add(bank);
+            Configuration.get().getMachine().setProperty("SchultzFeederSlot.banks", bp);
+        }
+        return bp.banks;
+    }
+    
+    @Override
+    public String getName() {
+        return String.format("%s (%s)", name, getFeeder() == null ? "None" : getFeeder().getName());
+    }
+    
+    @Override
+    public void setName(String name) {
+        /**
+         * This is kind of an ugly hack to avoid the bug in:
+         * https://github.com/openpnp/openpnp/issues/427.
+         * It removes any instance of the additional info we show in the name when a feeder is
+         * attached.
+         */
+        name = name.replace(String.format("(%s)", getFeeder() == null ? "None" : getFeeder().getName()), "").trim();
+        super.setName(name);
+    }
+    
+    @Override
+    public Wizard getConfigurationWizard() {
+        return new SlotSchultzFeederConfigurationWizard(this);
+    }
+
+    @Root
+    public static class Bank extends AbstractModelObject implements Identifiable, Named {
+        @ElementList
+        private IdentifiableList<SlotSchultzFeeder.Feeder> feeders = new IdentifiableList<>();
+
+        @Attribute(name = "id")
+        final private String id;
+
+        @Attribute
+        private String name;
+        
+        BiMap<Feeder, SlotSchultzFeeder> assignments = HashBiMap.create();
+        
+        public Bank() {
+            this(Configuration.createId("BANK-"));
+        }
+
+        public Bank(@Attribute(name = "id") String id) {
+            if (id == null) {
+                throw new Error("Id is required.");
+            }
+            this.id = id;
+            this.name = id;
+        }
+
+        public String getId() {
+            return id;
+        }
+
+        Feeder getFeeder(String id) {
+            return feeders.get(id);
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            Object oldValue = this.name;
+            this.name = name;
+            firePropertyChange("name", oldValue, name);
+        }
+        
+        @Override
+        public String toString() {
+            return name;
+        }
+        
+        public List<Feeder> getFeeders() {
+            return feeders;
+        }
+        
+        public void setFeeder(SlotSchultzFeeder slot, Feeder feeder) throws Exception {
+            assignments.forcePut(feeder, slot);
+        }
+        
+        public Feeder getFeeder(SlotSchultzFeeder slot) {
+            return assignments.inverse().get(slot);
+        }
+    }
+    
+    /**
+     * This class is just a delegate wrapper around a list. 
+     */
+    @Root
+    public static class BanksProperty {
+        @ElementList
+        IdentifiableList<Bank> banks = new IdentifiableList<>();
+    }
+
+    @Root
+    public static class Feeder extends AbstractModelObject implements Identifiable, Named {
+        @Attribute(name = "id")
+        final private String id;
+
+        @Attribute
+        private String name;
+
+        @Attribute(required = false)
+        private String partId;
+
+        @Element
+        private Location offsets = new Location(LengthUnit.Millimeters);
+
+        private Part part;
+        
+        private SlotSchultzFeeder owner = null;
+
+        public Feeder() {
+            this(Configuration.createId("SLOTFDR-"));
+        }
+
+        public Feeder(@Attribute(name = "id") String id) {
+            this.id = id;
+            this.name = id;
+            Configuration.get().addListener(new ConfigurationListener.Adapter() {
+                @Override
+                public void configurationLoaded(Configuration configuration) throws Exception {
+                    part = configuration.getPart(partId);
+                }
+            });
+        }
+        
+        public void setOwner(SlotSchultzFeeder owner) throws Exception {
+            if (this.owner == owner) {
+                return;
+            }
+            if (this.owner != null) {
+                System.out.println(String.format("Remove owner of %s from %s", this, owner));
+                this.owner.setFeeder(null);
+            }
+            System.out.println(String.format("Set owner of %s to %s", this, owner));
+            this.owner = owner;
+        }
+
+        @Persist
+        public void persist() {
+            partId = part == null ? null : part.getId();
+        }
+
+        public String getId() {
+            return id;
+        }
+
+        public void setPart(Part part) {
+            Object oldValue = this.part;
+            this.part = part;
+            firePropertyChange("part", oldValue, part);
+        }
+
+        public Part getPart() {
+            return part;
+        }
+
+        public void setOffsets(Location offsets) {
+            Object oldValue = this.offsets;
+            this.offsets = offsets;
+            firePropertyChange("offsets", oldValue, offsets);
+        }
+
+        public Location getOffsets() {
+            return offsets;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            Object oldValue = this.name;
+            this.name = name;
+            firePropertyChange("name", oldValue, name);
+        }
+        
+        @Override
+        public String toString() {
+            return name;
+        }
+    }
+
+	public Location getFiducialLocation(Location location, String part) {
+		Location fiducialLocation = null;
+		Part fiducialPart = Configuration.get().getPart(part);
+		if (fiducialPart != null) {
+	        try {
+				fiducialLocation = Configuration.get().getMachine().getFiducialLocator()
+				.getHomeFiducialLocation(location, fiducialPart);
+			} catch (Exception e) {
+				// TODO Auto-generated catch block
+				//e.printStackTrace();
+			}
+		}
+		
+        return fiducialLocation;
+	}
+
+}

--- a/src/main/java/org/openpnp/machine/reference/feeder/wizards/SchultzFeederConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/wizards/SchultzFeederConfigurationWizard.java
@@ -1,0 +1,492 @@
+/*
+ * Copyright (C) 2011 Jason von Nieda <jason@vonnieda.org>
+ * 
+ * This file is part of OpenPnP.
+ * 
+ * OpenPnP is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * OpenPnP is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License along with OpenPnP. If not, see
+ * <http://www.gnu.org/licenses/>.
+ * 
+ * For more information about OpenPnP visit http://openpnp.org
+ */
+
+package org.openpnp.machine.reference.feeder.wizards;
+
+import java.awt.Color;
+import java.awt.event.ActionEvent;
+
+import javax.swing.AbstractAction;
+import javax.swing.Action;
+import javax.swing.JButton;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JTextField;
+import javax.swing.border.EtchedBorder;
+import javax.swing.border.TitledBorder;
+
+import org.openpnp.gui.components.ComponentDecorators;
+import org.openpnp.gui.support.ActuatorsComboBoxModel;
+import org.openpnp.gui.support.DoubleConverter;
+import org.openpnp.machine.reference.feeder.SchultzFeeder;
+import org.openpnp.machine.reference.feeder.SchultzFeeder.ActuatorType;
+import org.openpnp.model.Configuration;
+import org.openpnp.spi.Actuator;
+import org.openpnp.util.UiUtils;
+import org.pmw.tinylog.Logger;
+
+import com.jgoodies.forms.layout.ColumnSpec;
+import com.jgoodies.forms.layout.FormLayout;
+import com.jgoodies.forms.layout.FormSpecs;
+import com.jgoodies.forms.layout.RowSpec;
+import javax.swing.JComboBox;
+
+@SuppressWarnings("serial")
+public class SchultzFeederConfigurationWizard
+        extends AbstractReferenceFeederConfigurationWizard {
+    private final SchultzFeeder feeder;
+    
+	private JComboBox comboBoxFeedActuator;
+    private JTextField actuatorValue;
+
+    private JComboBox comboBoxPostPickActuator;
+    private JTextField postPickActuatorValue;
+    private JComboBox actuatorType;
+    private JComboBox postPickActuatorType;
+
+    private JButton btnTestFeedActuator;
+    private JButton btnTestPostPickActuator;
+
+    private JComboBox comboBoxFeedCountActuator;
+    private JTextField feedCountActuatorValue;
+    private JComboBox feedCountActuatorType;
+    private JButton btnGetFeedCountActuator;
+    private JTextField feedCountValue;
+
+    private JComboBox comboBoxClearCountActuator;
+    private JTextField clearCountActuatorValue;
+    private JComboBox clearCountActuatorType;
+    private JButton btnClearCountActuator;
+
+    private JComboBox comboBoxPitchActuator;
+    private JTextField pitchActuatorValue;
+    private JComboBox pitchActuatorType;
+    private JButton btnPitchActuator;
+    private JTextField pitchValue;
+
+    private JComboBox comboBoxTogglePitchActuator;
+    private JTextField togglePitchActuatorValue;
+    private JComboBox togglePitchActuatorType;
+    private JButton btnTogglePitchActuator;
+
+    private JComboBox comboBoxStatusActuator;
+    private JTextField statusActuatorValue;
+    private JComboBox statusActuatorType;
+    private JButton btnStatusActuator;
+    private JTextField statusText;
+
+    private JComboBox comboBoxIdActuator;
+    private JTextField idActuatorValue;
+    private JComboBox idActuatorType;
+    private JButton btnIdActuator;
+    private JTextField idText;
+
+    public SchultzFeederConfigurationWizard(SchultzFeeder feeder) {
+        super(feeder);
+        this.feeder = feeder;
+
+        JPanel panelActuator = new JPanel();
+        panelActuator.setBorder(new TitledBorder(new EtchedBorder(EtchedBorder.LOWERED, null, null),
+                "Actuators", TitledBorder.LEADING, TitledBorder.TOP, null, new Color(0, 0, 0)));
+        contentPanel.add(panelActuator);
+        panelActuator.setLayout(new FormLayout(new ColumnSpec[] {
+                FormSpecs.RELATED_GAP_COLSPEC,
+                FormSpecs.DEFAULT_COLSPEC,
+                FormSpecs.RELATED_GAP_COLSPEC,
+                ColumnSpec.decode("default:grow"),
+                FormSpecs.RELATED_GAP_COLSPEC,
+                FormSpecs.DEFAULT_COLSPEC,
+                FormSpecs.RELATED_GAP_COLSPEC,
+                FormSpecs.DEFAULT_COLSPEC,
+                FormSpecs.RELATED_GAP_COLSPEC,
+                FormSpecs.DEFAULT_COLSPEC,
+                FormSpecs.RELATED_GAP_COLSPEC,
+                FormSpecs.DEFAULT_COLSPEC,},
+            new RowSpec[] {
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,}));
+
+        JLabel lblActuatorValue = new JLabel("Feeder Number:");
+        panelActuator.add(lblActuatorValue, "4, 2, right, default");
+
+        actuatorValue = new JTextField();
+        panelActuator.add(actuatorValue, "6, 2");
+        actuatorValue.setColumns(6);
+
+        JLabel lblActuator = new JLabel("Actuator");
+        panelActuator.add(lblActuator, "4, 4, left, default");
+
+        JLabel lblGetID = new JLabel("Get ID");
+        panelActuator.add(lblGetID, "2, 6, right, default");
+        
+        comboBoxIdActuator = new JComboBox();
+        comboBoxIdActuator.setModel(new ActuatorsComboBoxModel(Configuration.get().getMachine()));
+        panelActuator.add(comboBoxIdActuator, "4, 6, fill, default");
+        
+        btnIdActuator = new JButton(getIdActuatorAction);
+        panelActuator.add(btnIdActuator, "6, 6");
+
+        idText = new JTextField();
+        idText.setColumns(10);
+        panelActuator.add(idText, "8, 6");
+        
+        JLabel lblFeed = new JLabel("Pre Pick");
+        panelActuator.add(lblFeed, "2, 8, right, default");
+        
+        comboBoxFeedActuator = new JComboBox();
+        comboBoxFeedActuator.setModel(new ActuatorsComboBoxModel(Configuration.get().getMachine()));
+        panelActuator.add(comboBoxFeedActuator, "4, 8, fill, default");
+        
+        btnTestFeedActuator = new JButton(testFeedActuatorAction);
+        panelActuator.add(btnTestFeedActuator, "6, 8");
+
+        JLabel lblPostPick = new JLabel("Post Pick");
+        panelActuator.add(lblPostPick, "2, 10, right, default");
+        
+        comboBoxPostPickActuator = new JComboBox();
+        comboBoxPostPickActuator.setModel(new ActuatorsComboBoxModel(Configuration.get().getMachine()));
+        panelActuator.add(comboBoxPostPickActuator, "4, 10, fill, default");
+        
+        btnTestPostPickActuator = new JButton(testPostPickActuatorAction);
+        panelActuator.add(btnTestPostPickActuator, "6, 10");
+
+        JLabel lblFeedCount = new JLabel("Get Feed Count");
+        panelActuator.add(lblFeedCount, "2, 12, right, default");
+        
+        comboBoxFeedCountActuator = new JComboBox();
+        comboBoxFeedCountActuator.setModel(new ActuatorsComboBoxModel(Configuration.get().getMachine()));
+        panelActuator.add(comboBoxFeedCountActuator, "4, 12, fill, default");
+        
+        btnGetFeedCountActuator = new JButton(getFeedCountActuatorAction);
+        panelActuator.add(btnGetFeedCountActuator, "6, 12");
+
+        feedCountValue = new JTextField();
+        feedCountValue.setColumns(8);
+        panelActuator.add(feedCountValue, "8, 12");
+        
+        JLabel lblClearCount = new JLabel("Clear Feed Count");
+        panelActuator.add(lblClearCount, "2, 14, right, default");
+        
+        comboBoxClearCountActuator = new JComboBox();
+        comboBoxClearCountActuator.setModel(new ActuatorsComboBoxModel(Configuration.get().getMachine()));
+        panelActuator.add(comboBoxClearCountActuator, "4, 14, fill, default");
+        
+        btnClearCountActuator = new JButton(clearCountActuatorAction);
+        panelActuator.add(btnClearCountActuator, "6, 14");
+
+        JLabel lblGetPitch = new JLabel("Get Pitch");
+        panelActuator.add(lblGetPitch, "2, 16, right, default");
+        
+        comboBoxPitchActuator = new JComboBox();
+        comboBoxPitchActuator.setModel(new ActuatorsComboBoxModel(Configuration.get().getMachine()));
+        panelActuator.add(comboBoxPitchActuator, "4, 16, fill, default");
+        
+        btnPitchActuator = new JButton(pitchActuatorAction);
+        panelActuator.add(btnPitchActuator, "6, 16");
+
+        pitchValue = new JTextField();
+        pitchValue.setColumns(8);
+        panelActuator.add(pitchValue, "8, 16");
+        
+        JLabel lblTogglePitch = new JLabel("Toggle Pitch");
+        panelActuator.add(lblTogglePitch, "2, 18, right, default");
+        
+        comboBoxTogglePitchActuator = new JComboBox();
+        comboBoxTogglePitchActuator.setModel(new ActuatorsComboBoxModel(Configuration.get().getMachine()));
+        panelActuator.add(comboBoxTogglePitchActuator, "4, 18, fill, default");
+        
+        btnTogglePitchActuator = new JButton(togglePitchActuatorAction);
+        panelActuator.add(btnTogglePitchActuator, "6, 18");
+
+        JLabel lblTogglePitchDesc = new JLabel("Toggle between 2 MM and 4 MM");
+        panelActuator.add(lblTogglePitchDesc, "8, 18, left, default");
+        
+        JLabel lblGetStatus = new JLabel("Get Status");
+        panelActuator.add(lblGetStatus, "2, 20, right, default");
+        
+        comboBoxStatusActuator = new JComboBox();
+        comboBoxStatusActuator.setModel(new ActuatorsComboBoxModel(Configuration.get().getMachine()));
+        panelActuator.add(comboBoxStatusActuator, "4, 20, fill, default");
+        
+        btnStatusActuator = new JButton(statusActuatorAction);
+        panelActuator.add(btnStatusActuator, "6, 20");
+
+        statusText = new JTextField();
+        statusText.setColumns(50);
+        panelActuator.add(statusText, "8, 20");
+        
+		if(Configuration.get().getMachine().isEnabled()){
+			getIdActuatorAction.actionPerformed(null);
+			getFeedCountActuatorAction.actionPerformed(null);
+			pitchActuatorAction.actionPerformed(null);
+			statusActuatorAction.actionPerformed(null);
+	    }
+        
+    }
+
+    @Override
+    public void createBindings() {
+        super.createBindings();
+
+        DoubleConverter doubleConverter =
+                new DoubleConverter(Configuration.get().getLengthDisplayFormat());
+
+        addWrappedBinding(feeder, "actuatorName", comboBoxFeedActuator, "selectedItem");
+        addWrappedBinding(feeder, "actuatorType", actuatorType, "selectedItem");
+        addWrappedBinding(feeder, "actuatorValue", actuatorValue, "text", doubleConverter);
+        
+        addWrappedBinding(feeder, "postPickActuatorName", comboBoxPostPickActuator, "selectedItem");
+        addWrappedBinding(feeder, "postPickActuatorType", postPickActuatorType, "selectedItem");
+        
+        addWrappedBinding(feeder, "feedCountActuatorName", comboBoxFeedCountActuator, "selectedItem");
+        addWrappedBinding(feeder, "feedCountActuatorType", feedCountActuatorType, "selectedItem");
+        
+        addWrappedBinding(feeder, "clearCountActuatorName", comboBoxClearCountActuator, "selectedItem");
+        addWrappedBinding(feeder, "clearCountActuatorType", clearCountActuatorType, "selectedItem");
+        
+        addWrappedBinding(feeder, "pitchActuatorName", comboBoxPitchActuator, "selectedItem");
+        addWrappedBinding(feeder, "pitchActuatorType", pitchActuatorType, "selectedItem");
+        
+        addWrappedBinding(feeder, "togglePitchActuatorName", comboBoxTogglePitchActuator, "selectedItem");
+        addWrappedBinding(feeder, "togglePitchActuatorType", togglePitchActuatorType, "selectedItem");
+        
+        addWrappedBinding(feeder, "statusActuatorName", comboBoxStatusActuator, "selectedItem");
+        addWrappedBinding(feeder, "statusActuatorType", statusActuatorType, "selectedItem");
+        
+        addWrappedBinding(feeder, "idActuatorName", comboBoxIdActuator, "selectedItem");
+        addWrappedBinding(feeder, "idActuatorType", idActuatorType, "selectedItem");
+        
+        ComponentDecorators.decorateWithAutoSelect(actuatorValue);
+    }
+
+    private Action getIdActuatorAction = new AbstractAction("Get ID") {
+		@Override
+		public void actionPerformed(ActionEvent arg0) {
+			UiUtils.messageBoxOnException(() -> {
+				if (!(Configuration.get().getMachine().isEnabled())) {
+					throw new Exception ("Start machine first.");
+				}
+				if (feeder.getIdActuatorName() == null || feeder.getIdActuatorName().equals("")) {
+					Logger.warn("No getIdActuatorName specified for feeder {}.", feeder.getName());
+					return;
+				}
+				Actuator actuator = Configuration.get().getMachine()
+						.getActuatorByName(feeder.getIdActuatorName());
+
+				if (actuator == null) {
+					throw new Exception(
+							"Failed, unable to find an actuator named " + feeder.getIdActuatorName());
+				}
+                String s = actuator.read(feeder.getActuatorValue());
+                idText.setText(s == null ? "" : s);
+			});
+		}
+    };
+
+    private Action testFeedActuatorAction = new AbstractAction("Test pre pick") {
+		@Override
+		public void actionPerformed(ActionEvent arg0) {
+			UiUtils.messageBoxOnException(() -> {
+				if (!(Configuration.get().getMachine().isEnabled())) {
+					throw new Exception ("Start machine first.");
+				}
+				if (feeder.getActuatorName() == null || feeder.getActuatorName().equals("")) {
+					Logger.warn("No actuatorName specified for feeder {}.", feeder.getName());
+					return;
+				}
+				Actuator actuator = Configuration.get().getMachine().getActuatorByName(feeder.getActuatorName());
+
+				if (actuator == null) {
+					throw new Exception("Feed failed. Unable to find an actuator named " + feeder.getActuatorName());
+				}
+				if (feeder.getActuatorType() == ActuatorType.Boolean) {
+					actuator.actuate(feeder.getActuatorValue() != 0);
+				} else {
+					actuator.actuate(feeder.getActuatorValue());
+				}
+			});
+		}
+    };
+
+    private Action testPostPickActuatorAction = new AbstractAction("Test post pick") {
+		@Override
+		public void actionPerformed(ActionEvent arg0) {
+			UiUtils.messageBoxOnException(() -> {
+				if (!(Configuration.get().getMachine().isEnabled())) {
+					throw new Exception ("Start machine first.");
+				}
+				if (feeder.getPostPickActuatorName() == null || feeder.getPostPickActuatorName().equals("")) {
+					Logger.warn("No postPickActuatorName specified for feeder {}.", feeder.getName());
+					return;
+				}
+				Actuator actuator = Configuration.get().getMachine()
+						.getActuatorByName(feeder.getPostPickActuatorName());
+
+				if (actuator == null) {
+					throw new Exception(
+							"Feed failed. Unable to find an actuator named " + feeder.getPostPickActuatorName());
+				}
+				actuator.actuate(feeder.getActuatorValue());
+				getFeedCountActuatorAction.actionPerformed(null);
+			});
+		}
+    };
+
+    private Action getFeedCountActuatorAction = new AbstractAction("Get feed count") {
+		@Override
+		public void actionPerformed(ActionEvent arg0) {
+			UiUtils.messageBoxOnException(() -> {
+				if (!(Configuration.get().getMachine().isEnabled())) {
+					throw new Exception ("Start machine first.");
+				}
+				if (feeder.getFeedCountActuatorName() == null || feeder.getFeedCountActuatorName().equals("")) {
+					Logger.warn("No feedCountActuatorName specified for feeder {}.", feeder.getName());
+					return;
+				}
+				Actuator actuator = Configuration.get().getMachine()
+						.getActuatorByName(feeder.getFeedCountActuatorName());
+
+				if (actuator == null) {
+					throw new Exception(
+							"Failed, unable to find an actuator named " + feeder.getFeedCountActuatorName());
+				}
+                String s = actuator.read(feeder.getActuatorValue());
+                feedCountValue.setText(s == null ? "" : s);
+			});
+		}
+    };
+
+    private Action clearCountActuatorAction = new AbstractAction("Clear feed count") {
+		@Override
+		public void actionPerformed(ActionEvent arg0) {
+			UiUtils.messageBoxOnException(() -> {
+				if (!(Configuration.get().getMachine().isEnabled())) {
+					throw new Exception ("Start machine first.");
+				}
+				if (feeder.getClearCountActuatorName() == null || feeder.getClearCountActuatorName().equals("")) {
+					Logger.warn("No clearCountActuatorName specified for feeder {}.", feeder.getName());
+					return;
+				}
+				Actuator actuator = Configuration.get().getMachine()
+						.getActuatorByName(feeder.getClearCountActuatorName());
+
+				if (actuator == null) {
+					throw new Exception(
+							"Failed, unable to find an actuator named " + feeder.getClearCountActuatorName());
+				}
+				if (feeder.getClearCountActuatorType() == ActuatorType.Boolean) {
+					actuator.actuate(feeder.getActuatorValue() != 0);
+				} else {
+					actuator.actuate(feeder.getActuatorValue());
+				}
+				feedCountValue.setText("");
+			});
+		}
+    };
+
+    private Action pitchActuatorAction = new AbstractAction("Get pitch") {
+		@Override
+		public void actionPerformed(ActionEvent arg0) {
+			UiUtils.messageBoxOnException(() -> {
+				if (!(Configuration.get().getMachine().isEnabled())) {
+					throw new Exception ("Start machine first.");
+				}
+				if (feeder.getPitchActuatorName() == null || feeder.getPitchActuatorName().equals("")) {
+					Logger.warn("No pitchActuatorName specified for feeder {}.", feeder.getName());
+					return;
+				}
+				Actuator actuator = Configuration.get().getMachine()
+						.getActuatorByName(feeder.getPitchActuatorName());
+
+				if (actuator == null) {
+					throw new Exception(
+							"Failed, unable to find an actuator named " + feeder.getPitchActuatorName());
+				}
+                String s = actuator.read(feeder.getActuatorValue());
+                pitchValue.setText(s == null ? "" : s);
+			});
+		}
+    };
+
+    private Action togglePitchActuatorAction = new AbstractAction("Toggle pitch") {
+		@Override
+		public void actionPerformed(ActionEvent arg0) {
+			UiUtils.messageBoxOnException(() -> {
+				if (!(Configuration.get().getMachine().isEnabled())) {
+					throw new Exception ("Start machine first.");
+				}
+				if (feeder.getTogglePitchActuatorName() == null || feeder.getTogglePitchActuatorName().equals("")) {
+					Logger.warn("No togglePitchActuatorName specified for feeder {}.", feeder.getName());
+					return;
+				}
+				Actuator actuator = Configuration.get().getMachine()
+						.getActuatorByName(feeder.getTogglePitchActuatorName());
+
+				if (actuator == null) {
+					throw new Exception(
+							"Failed, unable to find an actuator named " + feeder.getTogglePitchActuatorName());
+				}
+                actuator.actuate(feeder.getActuatorValue());
+                pitchActuatorAction.actionPerformed(null);
+			});
+		}
+    };
+
+    private Action statusActuatorAction = new AbstractAction("Get status") {
+		@Override
+		public void actionPerformed(ActionEvent arg0) {
+			UiUtils.messageBoxOnException(() -> {
+				if (!(Configuration.get().getMachine().isEnabled())) {
+					throw new Exception ("Start machine first.");
+				}
+				if (feeder.getStatusActuatorName() == null || feeder.getStatusActuatorName().equals("")) {
+					Logger.warn("No statusActuatorName specified for feeder {}.", feeder.getName());
+					return;
+				}
+				Actuator actuator = Configuration.get().getMachine()
+						.getActuatorByName(feeder.getStatusActuatorName());
+
+				if (actuator == null) {
+					throw new Exception(
+							"Failed, unable to find an actuator named " + feeder.getStatusActuatorName());
+				}
+                String s = actuator.read(feeder.getActuatorValue());
+                statusText.setText(s == null ? "" : s);
+			});
+		}
+    };
+}

--- a/src/main/java/org/openpnp/machine/reference/feeder/wizards/SlotSchultzFeederConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/wizards/SlotSchultzFeederConfigurationWizard.java
@@ -1,0 +1,926 @@
+/*
+ * Copyright (C) 2011 Jason von Nieda <jason@vonnieda.org>
+ * 
+ * This file is part of OpenPnP.
+ * 
+ * OpenPnP is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * OpenPnP is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License along with OpenPnP. If not, see
+ * <http://www.gnu.org/licenses/>.
+ * 
+ * For more information about OpenPnP visit http://openpnp.org
+ */
+
+package org.openpnp.machine.reference.feeder.wizards;
+
+import java.awt.Color;
+import java.awt.event.ActionEvent;
+import java.util.Collections;
+
+import javax.swing.AbstractAction;
+import javax.swing.Action;
+import javax.swing.BoxLayout;
+import javax.swing.JButton;
+import javax.swing.JComboBox;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JTextField;
+import javax.swing.SwingUtilities;
+import javax.swing.border.EtchedBorder;
+import javax.swing.border.TitledBorder;
+
+import org.jdesktop.beansbinding.AbstractBindingListener;
+import org.jdesktop.beansbinding.AutoBinding;
+import org.jdesktop.beansbinding.AutoBinding.UpdateStrategy;
+import org.jdesktop.beansbinding.Binding;
+import org.jdesktop.beansbinding.BindingListener;
+import org.openpnp.gui.components.ComponentDecorators;
+import org.openpnp.gui.components.LocationButtonsPanel;
+import org.openpnp.gui.support.AbstractConfigurationWizard;
+import org.openpnp.gui.support.ActuatorsComboBoxModel;
+import org.openpnp.gui.support.DoubleConverter;
+import org.openpnp.gui.support.Icons;
+import org.openpnp.gui.support.IdentifiableListCellRenderer;
+import org.openpnp.gui.support.IntegerConverter;
+import org.openpnp.gui.support.JBindings.Wrapper;
+import org.openpnp.gui.support.LengthConverter;
+import org.openpnp.gui.support.MessageBoxes;
+import org.openpnp.gui.support.MutableLocationProxy;
+import org.openpnp.gui.support.PartsComboBoxModel;
+import org.openpnp.machine.reference.feeder.SchultzFeeder.ActuatorType;
+import org.openpnp.machine.reference.feeder.SlotSchultzFeeder;
+import org.openpnp.machine.reference.feeder.SlotSchultzFeeder.Bank;
+import org.openpnp.machine.reference.feeder.SlotSchultzFeeder.Feeder;
+import org.openpnp.model.Configuration;
+import org.openpnp.model.Location;
+import org.openpnp.model.Part;
+import org.openpnp.spi.Actuator;
+import org.openpnp.util.UiUtils;
+import org.pmw.tinylog.Logger;
+
+import com.jgoodies.forms.layout.ColumnSpec;
+import com.jgoodies.forms.layout.FormLayout;
+import com.jgoodies.forms.layout.FormSpecs;
+import com.jgoodies.forms.layout.RowSpec;
+import java.awt.FlowLayout;
+
+public class SlotSchultzFeederConfigurationWizard
+        extends AbstractConfigurationWizard {
+    private final SlotSchultzFeeder feeder;
+    private JTextField actuatorName;
+    private JTextField postPickActuatorName;
+    private JTextField feedCountActuatorName;
+    private JTextField clearCountActuatorName;
+    private JTextField pitchActuatorName;
+    private JTextField statusActuatorName;
+    private JTextField idActuatorName;
+
+	private JComboBox comboBoxFeedActuator;
+    private JTextField actuatorValue;
+
+    private JComboBox comboBoxPostPickActuator;
+    private JTextField postPickActuatorValue;
+    private JComboBox actuatorType;
+    private JComboBox postPickActuatorType;
+
+    private JButton btnTestFeedActuator;
+    private JButton btnTestPostPickActuator;
+
+    private JComboBox comboBoxFeedCountActuator;
+    private JTextField feedCountActuatorValue;
+    private JComboBox feedCountActuatorType;
+    private JButton btnGetFeedCountActuator;
+    private JTextField feedCountValue;
+
+    private JComboBox comboBoxClearCountActuator;
+    private JTextField clearCountActuatorValue;
+    private JComboBox clearCountActuatorType;
+    private JButton btnClearCountActuator;
+
+    private JComboBox comboBoxPitchActuator;
+    private JTextField pitchActuatorValue;
+    private JComboBox pitchActuatorType;
+    private JButton btnPitchActuator;
+    private JTextField pitchValue;
+
+    private JComboBox comboBoxTogglePitchActuator;
+    private JTextField togglePitchActuatorValue;
+    private JComboBox togglePitchActuatorType;
+    private JButton btnTogglePitchActuator;
+
+    private JComboBox comboBoxStatusActuator;
+    private JTextField statusActuatorValue;
+    private JComboBox statusActuatorType;
+    private JButton btnStatusActuator;
+    private JTextField statusText;
+
+    private JComboBox comboBoxIdActuator;
+    private JTextField idActuatorValue;
+    private JComboBox idActuatorType;
+    private JButton btnIdActuator;
+    private JTextField idText;
+    
+    
+    private JTextField feederNameTf;
+    private JTextField bankNameTf;
+
+    
+    public SlotSchultzFeederConfigurationWizard(SlotSchultzFeeder feeder) {
+        this.feeder = feeder;
+        
+        JPanel slotPanel = new JPanel();
+        slotPanel.setBorder(new TitledBorder(null, "Slot", TitledBorder.LEADING, TitledBorder.TOP, null, null));
+        contentPanel.add(slotPanel);
+        slotPanel.setLayout(new BoxLayout(slotPanel, BoxLayout.Y_AXIS));
+        
+        JPanel whateverPanel = new JPanel();
+        slotPanel.add(whateverPanel);
+        FormLayout fl_whateverPanel = new FormLayout(new ColumnSpec[] {
+                FormSpecs.RELATED_GAP_COLSPEC,
+                FormSpecs.DEFAULT_COLSPEC,
+                FormSpecs.RELATED_GAP_COLSPEC,
+                FormSpecs.DEFAULT_COLSPEC,
+                FormSpecs.RELATED_GAP_COLSPEC,
+                FormSpecs.DEFAULT_COLSPEC,
+                FormSpecs.RELATED_GAP_COLSPEC,
+                FormSpecs.DEFAULT_COLSPEC,
+                FormSpecs.RELATED_GAP_COLSPEC,
+                FormSpecs.DEFAULT_COLSPEC,
+                FormSpecs.RELATED_GAP_COLSPEC,
+                FormSpecs.DEFAULT_COLSPEC,
+                FormSpecs.RELATED_GAP_COLSPEC,
+                FormSpecs.DEFAULT_COLSPEC,},
+            new RowSpec[] {
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,});
+        fl_whateverPanel.setColumnGroups(new int[][]{new int[]{4, 6, 8, 10}});
+        whateverPanel.setLayout(fl_whateverPanel);
+        
+        feederNameTf = new JTextField();
+        whateverPanel.add(feederNameTf, "8, 2, 3, 1");
+        feederNameTf.setColumns(10);
+        
+        JPanel panel_1 = new JPanel();
+        FlowLayout flowLayout_1 = (FlowLayout) panel_1.getLayout();
+        flowLayout_1.setAlignment(FlowLayout.LEFT);
+        whateverPanel.add(panel_1, "12, 2");
+        
+        JButton newFeederBtn = new JButton(newFeederAction);
+        panel_1.add(newFeederBtn);
+        
+        JButton deleteFeederBtn = new JButton(deleteFeederAction);
+        panel_1.add(deleteFeederBtn);
+        
+        JLabel lblPickRetryCount = new JLabel("Pick Retry Count");
+        whateverPanel.add(lblPickRetryCount, "2, 12, right, default");
+        
+        pickRetryCount = new JTextField();
+        pickRetryCount.setColumns(10);
+        whateverPanel.add(pickRetryCount, "4, 12, fill, default");
+        
+        JLabel lblBank = new JLabel("Bank");
+        whateverPanel.add(lblBank, "2, 14, right, default");
+        
+        bankCb = new JComboBox();
+        whateverPanel.add(bankCb, "4, 14, 3, 1");
+        bankCb.addActionListener(e -> {
+            feederCb.removeAllItems();
+            Bank bank = (Bank) bankCb.getSelectedItem();
+            feederCb.addItem(null);
+            if (bank != null) {
+                for (Feeder f : bank.getFeeders()) {
+                    feederCb.addItem(f);
+                }
+            }
+        });
+        
+        JLabel lblFeeder = new JLabel("Feeder");
+        whateverPanel.add(lblFeeder, "2, 2, right, default");
+        
+        feederCb = new JComboBox();
+        whateverPanel.add(feederCb, "4, 2, 3, 1");
+        
+        JPanel feederPanel = new JPanel();
+        feederPanel.setBorder(new TitledBorder(new EtchedBorder(EtchedBorder.LOWERED, null, null), "Feeder", TitledBorder.LEADING, TitledBorder.TOP, null, new Color(0, 0, 0)));
+        contentPanel.add(feederPanel);
+        FormLayout fl_feederPanel = new FormLayout(new ColumnSpec[] {
+                FormSpecs.RELATED_GAP_COLSPEC,
+                FormSpecs.DEFAULT_COLSPEC,
+                FormSpecs.RELATED_GAP_COLSPEC,
+                FormSpecs.DEFAULT_COLSPEC,
+                FormSpecs.RELATED_GAP_COLSPEC,
+                FormSpecs.DEFAULT_COLSPEC,
+                FormSpecs.RELATED_GAP_COLSPEC,
+                FormSpecs.DEFAULT_COLSPEC,
+                FormSpecs.RELATED_GAP_COLSPEC,
+                FormSpecs.DEFAULT_COLSPEC,
+                FormSpecs.RELATED_GAP_COLSPEC,
+                FormSpecs.DEFAULT_COLSPEC,},
+            new RowSpec[] {
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,});
+        fl_feederPanel.setColumnGroups(new int[][]{new int[]{4, 6, 8, 10}});
+        feederPanel.setLayout(fl_feederPanel);
+        
+        JLabel lblX_1 = new JLabel("X");
+        feederPanel.add(lblX_1, "4, 2");
+        
+        JLabel lblY_1 = new JLabel("Y");
+        feederPanel.add(lblY_1, "6, 2");
+        
+        JLabel lblZ_1 = new JLabel("Z");
+        feederPanel.add(lblZ_1, "8, 2");
+        
+        JLabel lblRotation_1 = new JLabel("Rotation");
+        feederPanel.add(lblRotation_1, "10, 2");
+        
+        JLabel lblOffsets = new JLabel("Offsets");
+        feederPanel.add(lblOffsets, "2, 4");
+        
+        xOffsetTf = new JTextField();
+        feederPanel.add(xOffsetTf, "4, 4");
+        xOffsetTf.setColumns(10);
+        
+        yOffsetTf = new JTextField();
+        feederPanel.add(yOffsetTf, "6, 4");
+        yOffsetTf.setColumns(10);
+        
+        zOffsetTf = new JTextField();
+        feederPanel.add(zOffsetTf, "8, 4");
+        zOffsetTf.setColumns(10);
+        
+        rotOffsetTf = new JTextField();
+        feederPanel.add(rotOffsetTf, "10, 4");
+        rotOffsetTf.setColumns(10);
+        
+//        offsetLocButtons = new LocationButtonsPanel(xOffsetTf, yOffsetTf, zOffsetTf, rotOffsetTf);
+        offsetLocButtons = new LocationButtonsPanel(xOffsetTf, yOffsetTf, zOffsetTf, null);
+        feederPanel.add(offsetLocButtons, "12, 4");
+        
+        JLabel lblPart = new JLabel("Part");
+        feederPanel.add(lblPart, "2, 6, right, default");
+        
+        feederPartCb = new JComboBox();
+        feederPanel.add(feederPartCb, "4, 6, 3, 1");
+        feederPartCb.setModel(new PartsComboBoxModel());
+        feederPartCb.setRenderer(new IdentifiableListCellRenderer<Part>());
+
+        JPanel panelActuator = new JPanel();
+        panelActuator.setBorder(new TitledBorder(new EtchedBorder(EtchedBorder.LOWERED, null, null),
+                "Actuators", TitledBorder.LEADING, TitledBorder.TOP, null, new Color(0, 0, 0)));
+        contentPanel.add(panelActuator);
+        panelActuator.setLayout(new FormLayout(new ColumnSpec[] {
+                FormSpecs.RELATED_GAP_COLSPEC,
+                FormSpecs.DEFAULT_COLSPEC,
+                FormSpecs.RELATED_GAP_COLSPEC,
+                FormSpecs.DEFAULT_COLSPEC,
+                FormSpecs.RELATED_GAP_COLSPEC,
+                FormSpecs.DEFAULT_COLSPEC,
+                FormSpecs.RELATED_GAP_COLSPEC,
+                FormSpecs.DEFAULT_COLSPEC,
+                FormSpecs.RELATED_GAP_COLSPEC,
+                FormSpecs.DEFAULT_COLSPEC,},
+            new RowSpec[] {
+                    FormSpecs.RELATED_GAP_ROWSPEC,
+                    FormSpecs.DEFAULT_ROWSPEC,
+                    FormSpecs.RELATED_GAP_ROWSPEC,
+                    FormSpecs.DEFAULT_ROWSPEC,
+                    FormSpecs.RELATED_GAP_ROWSPEC,
+                    FormSpecs.DEFAULT_ROWSPEC,
+                    FormSpecs.RELATED_GAP_ROWSPEC,
+                    FormSpecs.DEFAULT_ROWSPEC,
+                    FormSpecs.RELATED_GAP_ROWSPEC,
+                    FormSpecs.DEFAULT_ROWSPEC,
+                    FormSpecs.RELATED_GAP_ROWSPEC,
+                    FormSpecs.DEFAULT_ROWSPEC,
+                    FormSpecs.RELATED_GAP_ROWSPEC,
+                    FormSpecs.DEFAULT_ROWSPEC,
+                    FormSpecs.RELATED_GAP_ROWSPEC,
+                    FormSpecs.DEFAULT_ROWSPEC,
+                    FormSpecs.RELATED_GAP_ROWSPEC,
+                    FormSpecs.DEFAULT_ROWSPEC,
+                    FormSpecs.RELATED_GAP_ROWSPEC,
+                    FormSpecs.DEFAULT_ROWSPEC,}));
+
+        JLabel lblActuatorValue = new JLabel("Feeder Number:");
+        panelActuator.add(lblActuatorValue, "4, 2, right, default");
+
+        actuatorValue = new JTextField();
+        panelActuator.add(actuatorValue, "6, 2");
+        actuatorValue.setColumns(6);
+
+        JLabel lblActuator = new JLabel("Actuator");
+        panelActuator.add(lblActuator, "4, 4, left, default");
+
+        JLabel lblGetID = new JLabel("Get ID");
+        panelActuator.add(lblGetID, "2, 6, right, default");
+        
+        comboBoxIdActuator = new JComboBox();
+        comboBoxIdActuator.setModel(new ActuatorsComboBoxModel(Configuration.get().getMachine()));
+        panelActuator.add(comboBoxIdActuator, "4, 6, fill, default");
+        
+        btnIdActuator = new JButton(getIdActuatorAction);
+        panelActuator.add(btnIdActuator, "6, 6");
+
+        idText = new JTextField();
+        idText.setColumns(10);
+        panelActuator.add(idText, "8, 6");
+        
+        JLabel lblFeed = new JLabel("Pre Pick");
+        panelActuator.add(lblFeed, "2, 8, right, default");
+        
+        comboBoxFeedActuator = new JComboBox();
+        comboBoxFeedActuator.setModel(new ActuatorsComboBoxModel(Configuration.get().getMachine()));
+        panelActuator.add(comboBoxFeedActuator, "4, 8, fill, default");
+        
+        btnTestFeedActuator = new JButton(testFeedActuatorAction);
+        panelActuator.add(btnTestFeedActuator, "6, 8");
+
+        JLabel lblPostPick = new JLabel("Post Pick");
+        panelActuator.add(lblPostPick, "2, 10, right, default");
+        
+        comboBoxPostPickActuator = new JComboBox();
+        comboBoxPostPickActuator.setModel(new ActuatorsComboBoxModel(Configuration.get().getMachine()));
+        panelActuator.add(comboBoxPostPickActuator, "4, 10, fill, default");
+        
+        btnTestPostPickActuator = new JButton(testPostPickActuatorAction);
+        panelActuator.add(btnTestPostPickActuator, "6, 10");
+
+        JLabel lblFeedCount = new JLabel("Get Feed Count");
+        panelActuator.add(lblFeedCount, "2, 12, right, default");
+        
+        comboBoxFeedCountActuator = new JComboBox();
+        comboBoxFeedCountActuator.setModel(new ActuatorsComboBoxModel(Configuration.get().getMachine()));
+        panelActuator.add(comboBoxFeedCountActuator, "4, 12, fill, default");
+        
+        btnGetFeedCountActuator = new JButton(getFeedCountActuatorAction);
+        panelActuator.add(btnGetFeedCountActuator, "6, 12");
+
+        feedCountValue = new JTextField();
+        feedCountValue.setColumns(8);
+        panelActuator.add(feedCountValue, "8, 12");
+        
+        JLabel lblClearCount = new JLabel("Clear Feed Count");
+        panelActuator.add(lblClearCount, "2, 14, right, default");
+        
+        comboBoxClearCountActuator = new JComboBox();
+        comboBoxClearCountActuator.setModel(new ActuatorsComboBoxModel(Configuration.get().getMachine()));
+        panelActuator.add(comboBoxClearCountActuator, "4, 14, fill, default");
+        
+        btnClearCountActuator = new JButton(clearCountActuatorAction);
+        panelActuator.add(btnClearCountActuator, "6, 14");
+
+        JLabel lblGetPitch = new JLabel("Get Pitch");
+        panelActuator.add(lblGetPitch, "2, 16, right, default");
+        
+        comboBoxPitchActuator = new JComboBox();
+        comboBoxPitchActuator.setModel(new ActuatorsComboBoxModel(Configuration.get().getMachine()));
+        panelActuator.add(comboBoxPitchActuator, "4, 16, fill, default");
+        
+        btnPitchActuator = new JButton(pitchActuatorAction);
+        panelActuator.add(btnPitchActuator, "6, 16");
+
+        pitchValue = new JTextField();
+        pitchValue.setColumns(8);
+        panelActuator.add(pitchValue, "8, 16");
+        
+        JLabel lblTogglePitch = new JLabel("Toggle Pitch");
+        panelActuator.add(lblTogglePitch, "2, 18, right, default");
+        
+        comboBoxTogglePitchActuator = new JComboBox();
+        comboBoxTogglePitchActuator.setModel(new ActuatorsComboBoxModel(Configuration.get().getMachine()));
+        panelActuator.add(comboBoxTogglePitchActuator, "4, 18, fill, default");
+        
+        btnTogglePitchActuator = new JButton(togglePitchActuatorAction);
+        panelActuator.add(btnTogglePitchActuator, "6, 18");
+
+        JLabel lblTogglePitchDesc = new JLabel("Toggle between 2 MM and 4 MM");
+        panelActuator.add(lblTogglePitchDesc, "8, 18, left, default");
+        
+        JLabel lblGetStatus = new JLabel("Get Status");
+        panelActuator.add(lblGetStatus, "2, 20, right, default");
+        
+        comboBoxStatusActuator = new JComboBox();
+        comboBoxStatusActuator.setModel(new ActuatorsComboBoxModel(Configuration.get().getMachine()));
+        panelActuator.add(comboBoxStatusActuator, "4, 20, fill, default");
+        
+        btnStatusActuator = new JButton(statusActuatorAction);
+        panelActuator.add(btnStatusActuator, "6, 20");
+
+        statusText = new JTextField();
+        statusText.setColumns(50);
+        panelActuator.add(statusText, "8, 20");
+        
+		if(Configuration.get().getMachine().isEnabled()){
+			getIdActuatorAction.actionPerformed(null);
+			getFeedCountActuatorAction.actionPerformed(null);
+			pitchActuatorAction.actionPerformed(null);
+			statusActuatorAction.actionPerformed(null);
+	    }
+        
+        for (Bank bank : SlotSchultzFeeder.getBanks()) {
+            bankCb.addItem(bank);
+        }
+        feederCb.addItem(null);
+        
+        JLabel lblX = new JLabel("X");
+        whateverPanel.add(lblX, "4, 4, center, default");
+        
+        JLabel lblY = new JLabel("Y");
+        whateverPanel.add(lblY, "6, 4, center, default");
+        
+        JLabel lblZ = new JLabel("Z");
+        whateverPanel.add(lblZ, "8, 4, center, default");
+        
+        JLabel lblRotation = new JLabel("Rotation");
+        whateverPanel.add(lblRotation, "10, 4, center, default");
+        
+        JLabel lblPickLocation = new JLabel("Location");
+        whateverPanel.add(lblPickLocation, "2, 6, right, default");
+        
+        xPickLocTf = new JTextField();
+        whateverPanel.add(xPickLocTf, "4, 6");
+        xPickLocTf.setColumns(10);
+        
+        yPickLocTf = new JTextField();
+        whateverPanel.add(yPickLocTf, "6, 6");
+        yPickLocTf.setColumns(10);
+        
+        zPickLocTf = new JTextField();
+        whateverPanel.add(zPickLocTf, "8, 6");
+        zPickLocTf.setColumns(10);
+        
+        pickLocButtons = new LocationButtonsPanel(xPickLocTf, yPickLocTf, zPickLocTf, rotPickLocTf);
+        
+        rotPickLocTf = new JTextField();
+        whateverPanel.add(rotPickLocTf, "10, 6");
+        rotPickLocTf.setColumns(10);
+        whateverPanel.add(pickLocButtons, "12, 6");
+        
+        JButton fiducialAlign = new JButton(updateLocationAction);
+        whateverPanel.add(fiducialAlign, "14, 6");
+        fiducialAlign.setIcon(Icons.fiducialCheck);
+        fiducialAlign.setToolTipText("Update feeder location based on fiducial");
+        
+        JLabel lblFiducialPart = new JLabel("Fiducial Part");
+        whateverPanel.add(lblFiducialPart, "2, 8, right, default");
+        
+        fiducialPartTf = new JTextField();
+        whateverPanel.add(fiducialPartTf, "4, 8, 3, 1");
+        fiducialPartTf.addActionListener(e -> {
+        	feeder.setFiducialPart(fiducialPartTf.getText());
+        });
+        
+        JLabel lblFeedRetryCount = new JLabel("Feed Retry Count");
+        whateverPanel.add(lblFeedRetryCount, "2, 10, right, default");
+        
+        feedRetryCount = new JTextField();
+        whateverPanel.add(feedRetryCount, "4, 10");
+        feedRetryCount.setColumns(10);
+        
+        bankNameTf = new JTextField();
+        whateverPanel.add(bankNameTf, "8, 14, 3, 1");
+        bankNameTf.setColumns(10);
+        
+        JPanel panel = new JPanel();
+        FlowLayout flowLayout = (FlowLayout) panel.getLayout();
+        flowLayout.setAlignment(FlowLayout.LEFT);
+        whateverPanel.add(panel, "12, 14");
+        
+        JButton newBankBtn = new JButton(newBankAction);
+        panel.add(newBankBtn);
+        
+        JButton deleteBankBtn = new JButton(deleteBankAction);
+        panel.add(deleteBankBtn);
+        if (feeder.getBank() != null) {
+            for (Feeder f : feeder.getBank().getFeeders()) {
+                feederCb.addItem(f);
+            }
+        }
+    }
+
+    @Override
+    public void createBindings() {
+        LengthConverter lengthConverter = new LengthConverter();
+        IntegerConverter intConverter = new IntegerConverter();
+        DoubleConverter doubleConverter =
+                new DoubleConverter(Configuration.get().getLengthDisplayFormat());
+
+        addWrappedBinding(feeder, "fiducialPart", fiducialPartTf, "text");
+        addWrappedBinding(feeder, "feedRetryCount", feedRetryCount, "text", intConverter);
+        addWrappedBinding(feeder, "pickRetryCount", pickRetryCount, "text", intConverter);
+
+        addWrappedBinding(feeder, "actuatorName", comboBoxFeedActuator, "selectedItem");
+        addWrappedBinding(feeder, "actuatorType", actuatorType, "selectedItem");
+        addWrappedBinding(feeder, "actuatorValue", actuatorValue, "text", doubleConverter);
+        
+        addWrappedBinding(feeder, "postPickActuatorName", comboBoxPostPickActuator, "selectedItem");
+        addWrappedBinding(feeder, "postPickActuatorType", postPickActuatorType, "selectedItem");
+        
+        addWrappedBinding(feeder, "feedCountActuatorName", comboBoxFeedCountActuator, "selectedItem");
+        addWrappedBinding(feeder, "feedCountActuatorType", feedCountActuatorType, "selectedItem");
+        
+        addWrappedBinding(feeder, "clearCountActuatorName", comboBoxClearCountActuator, "selectedItem");
+        addWrappedBinding(feeder, "clearCountActuatorType", clearCountActuatorType, "selectedItem");
+        
+        addWrappedBinding(feeder, "pitchActuatorName", comboBoxPitchActuator, "selectedItem");
+        addWrappedBinding(feeder, "pitchActuatorType", pitchActuatorType, "selectedItem");
+        
+        addWrappedBinding(feeder, "togglePitchActuatorName", comboBoxTogglePitchActuator, "selectedItem");
+        addWrappedBinding(feeder, "togglePitchActuatorType", togglePitchActuatorType, "selectedItem");
+        
+        addWrappedBinding(feeder, "statusActuatorName", comboBoxStatusActuator, "selectedItem");
+        addWrappedBinding(feeder, "statusActuatorType", statusActuatorType, "selectedItem");
+        
+        addWrappedBinding(feeder, "idActuatorName", comboBoxIdActuator, "selectedItem");
+        addWrappedBinding(feeder, "idActuatorType", idActuatorType, "selectedItem");
+
+        /**
+         * Note that we set up the bindings here differently than everywhere else. In most
+         * wizards the fields are bound with wrapped bindings and the proxy is bound with a hard
+         * binding. Here we do the opposite so that when the user captures a new location
+         * it is set on the proxy immediately. This allows the offsets to update immediately.
+         * I'm not actually sure why we do it the other way everywhere else, since this seems
+         * to work fine. Might not matter in most other cases. 
+         */
+        MutableLocationProxy pickLocation = new MutableLocationProxy();
+        addWrappedBinding(feeder, "location", pickLocation, "location");
+        bind(UpdateStrategy.READ_WRITE, pickLocation, "lengthX", xPickLocTf, "text", lengthConverter);
+        bind(UpdateStrategy.READ_WRITE, pickLocation, "lengthY", yPickLocTf, "text", lengthConverter);
+        bind(UpdateStrategy.READ_WRITE, pickLocation, "lengthZ", zPickLocTf, "text", lengthConverter);
+        bind(UpdateStrategy.READ_WRITE, pickLocation, "rotation", rotPickLocTf, "text", doubleConverter);
+        bind(UpdateStrategy.READ, pickLocation, "location", offsetLocButtons, "baseLocation");
+        
+        /**
+         * The strategy for the bank and feeder properties are a little complex:
+         * We create an observable wrapper for bank and feeder. We add wrapped bindings
+         * for these against the source feeder, so if they are changed, then upon hitting
+         * Apply they will be changed on the source.
+         * In addition we add non-wrapped bindings from the bank and feeder wrappers to their
+         * instance properties such as name and part. Thus they will be updated immediately.
+         */
+        Wrapper<Bank> bankWrapper = new Wrapper<>();
+        Wrapper<Feeder> feederWrapper = new Wrapper<>();
+        
+        addWrappedBinding(feeder, "bank", bankWrapper, "value");
+        addWrappedBinding(feeder, "feeder", feederWrapper, "value");
+        
+        bind(UpdateStrategy.READ_WRITE, bankWrapper, "value", bankCb, "selectedItem");
+        bind(UpdateStrategy.READ_WRITE, bankWrapper, "value.name", bankNameTf, "text")
+            .addBindingListener(new AbstractBindingListener() {
+                @Override
+                public void synced(Binding binding) {
+                    SwingUtilities.invokeLater(() -> bankCb.repaint());
+                }
+            });
+        bind(UpdateStrategy.READ_WRITE, feederWrapper, "value", feederCb, "selectedItem");
+        bind(UpdateStrategy.READ_WRITE, feederWrapper, "value.name", feederNameTf, "text")
+            .addBindingListener(new AbstractBindingListener() {
+                @Override
+                public void synced(Binding binding) {
+                    SwingUtilities.invokeLater(() -> feederCb.repaint());
+                }
+            });
+        bind(UpdateStrategy.READ_WRITE, feederWrapper, "value.part", feederPartCb, "selectedItem");
+
+        MutableLocationProxy offsets = new MutableLocationProxy();
+        bind(UpdateStrategy.READ_WRITE, feederWrapper, "value.offsets", offsets, "location");
+        bind(UpdateStrategy.READ_WRITE, offsets, "lengthX", xOffsetTf, "text", lengthConverter);
+        bind(UpdateStrategy.READ_WRITE, offsets, "lengthY", yOffsetTf, "text", lengthConverter);
+        bind(UpdateStrategy.READ_WRITE, offsets, "lengthZ", zOffsetTf, "text", lengthConverter);
+        bind(UpdateStrategy.READ_WRITE, offsets, "rotation", rotOffsetTf, "text", doubleConverter);
+
+        //ComponentDecorators.decorateWithAutoSelect(actuatorName);
+        //ComponentDecorators.decorateWithAutoSelect(actuatorValue);
+        //ComponentDecorators.decorateWithAutoSelect(postPickActuatorName);
+        //ComponentDecorators.decorateWithAutoSelect(feedCountActuatorName);
+        //ComponentDecorators.decorateWithAutoSelect(clearCountActuatorName);
+        //ComponentDecorators.decorateWithAutoSelect(pitchActuatorName);
+        //ComponentDecorators.decorateWithAutoSelect(statusActuatorName);
+
+        ComponentDecorators.decorateWithAutoSelect(feederNameTf);
+        ComponentDecorators.decorateWithAutoSelect(bankNameTf);
+        
+        ComponentDecorators.decorateWithAutoSelectAndLengthConversion(xPickLocTf);
+        ComponentDecorators.decorateWithAutoSelectAndLengthConversion(yPickLocTf);
+        ComponentDecorators.decorateWithAutoSelectAndLengthConversion(zPickLocTf);
+        ComponentDecorators.decorateWithAutoSelect(rotPickLocTf);
+
+        ComponentDecorators.decorateWithAutoSelectAndLengthConversion(xOffsetTf);
+        ComponentDecorators.decorateWithAutoSelectAndLengthConversion(yOffsetTf);
+        ComponentDecorators.decorateWithAutoSelectAndLengthConversion(zOffsetTf);
+        ComponentDecorators.decorateWithAutoSelect(rotOffsetTf);
+
+        ComponentDecorators.decorateWithAutoSelect(fiducialPartTf);
+
+        ComponentDecorators.decorateWithAutoSelect(feedRetryCount);
+        ComponentDecorators.decorateWithAutoSelect(pickRetryCount);
+        
+        feederPartCb.addActionListener(e -> {
+            notifyChange();
+        });
+
+    }
+    
+    private Action newFeederAction = new AbstractAction("New") {
+        @Override
+        public void actionPerformed(ActionEvent e) {
+            Bank bank = (Bank) bankCb.getSelectedItem();
+            Feeder f = new Feeder(idText.getText());
+            bank.getFeeders().add(f);
+            feederCb.addItem(f);
+            feederCb.setSelectedItem(f);
+        }
+    };
+
+    private Action deleteFeederAction = new AbstractAction("Delete") {
+        @Override
+        public void actionPerformed(ActionEvent e) {
+            Feeder feeder = (Feeder) feederCb.getSelectedItem();
+            Bank bank = (Bank) bankCb.getSelectedItem();
+            bank.getFeeders().remove(feeder);
+            feederCb.removeItem(feeder);
+        }
+    };
+
+    private Action newBankAction = new AbstractAction("New") {
+        @Override
+        public void actionPerformed(ActionEvent e) {
+            Bank bank = new Bank();
+            SlotSchultzFeeder.getBanks().add(bank);
+            bankCb.addItem(bank);
+            bankCb.setSelectedItem(bank);
+        }
+    };
+    
+    private Action deleteBankAction = new AbstractAction("Delete") {
+        @Override
+        public void actionPerformed(ActionEvent e) {
+            Bank bank = (Bank) bankCb.getSelectedItem();
+            if (SlotSchultzFeeder.getBanks().size() < 2) {
+                MessageBoxes.errorBox(getTopLevelAncestor(), "Error", "Can't delete the only bank. There must always be one bank defined.");
+                return;
+            }
+            SlotSchultzFeeder.getBanks().remove(bank);
+            bankCb.removeItem(bank);
+        }
+    };
+
+    private Action getIdActuatorAction = new AbstractAction("Get ID") {
+		@Override
+		public void actionPerformed(ActionEvent arg0) {
+			UiUtils.messageBoxOnException(() -> {
+				if (!(Configuration.get().getMachine().isEnabled())) {
+					throw new Exception ("Start machine first.");
+				}
+				if (feeder.getIdActuatorName() == null || feeder.getIdActuatorName().equals("")) {
+					Logger.warn("No getIdActuatorName specified for feeder {}.", feeder.getName());
+					return;
+				}
+				Actuator actuator = Configuration.get().getMachine()
+						.getActuatorByName(feeder.getIdActuatorName());
+
+				if (actuator == null) {
+					throw new Exception(
+							"Failed, unable to find an actuator named " + feeder.getIdActuatorName());
+				}
+                String s = actuator.read(feeder.getActuatorValue());
+                idText.setText(s == null ? "" : s);
+			});
+		}
+    };
+
+    private Action testFeedActuatorAction = new AbstractAction("Test pre pick") {
+		@Override
+		public void actionPerformed(ActionEvent arg0) {
+			UiUtils.messageBoxOnException(() -> {
+				if (!(Configuration.get().getMachine().isEnabled())) {
+					throw new Exception ("Start machine first.");
+				}
+				if (feeder.getActuatorName() == null || feeder.getActuatorName().equals("")) {
+					Logger.warn("No actuatorName specified for feeder {}.", feeder.getName());
+					return;
+				}
+				Actuator actuator = Configuration.get().getMachine().getActuatorByName(feeder.getActuatorName());
+
+				if (actuator == null) {
+					throw new Exception("Feed failed. Unable to find an actuator named " + feeder.getActuatorName());
+				}
+				if (feeder.getActuatorType() == ActuatorType.Boolean) {
+					actuator.actuate(feeder.getActuatorValue() != 0);
+				} else {
+					actuator.actuate(feeder.getActuatorValue());
+				}
+			});
+		}
+    };
+
+    private Action testPostPickActuatorAction = new AbstractAction("Test post pick") {
+		@Override
+		public void actionPerformed(ActionEvent arg0) {
+			UiUtils.messageBoxOnException(() -> {
+				if (!(Configuration.get().getMachine().isEnabled())) {
+					throw new Exception ("Start machine first.");
+				}
+				if (feeder.getPostPickActuatorName() == null || feeder.getPostPickActuatorName().equals("")) {
+					Logger.warn("No postPickActuatorName specified for feeder {}.", feeder.getName());
+					return;
+				}
+				Actuator actuator = Configuration.get().getMachine()
+						.getActuatorByName(feeder.getPostPickActuatorName());
+
+				if (actuator == null) {
+					throw new Exception(
+							"Feed failed. Unable to find an actuator named " + feeder.getPostPickActuatorName());
+				}
+				if (feeder.getPostPickActuatorType() == ActuatorType.Boolean) {
+					actuator.actuate(feeder.getActuatorValue() != 0);
+				} else {
+					actuator.actuate(feeder.getActuatorValue());
+				}
+			});
+		}
+    };
+
+    private Action getFeedCountActuatorAction = new AbstractAction("Get feed count") {
+		@Override
+		public void actionPerformed(ActionEvent arg0) {
+			UiUtils.messageBoxOnException(() -> {
+				if (!(Configuration.get().getMachine().isEnabled())) {
+					throw new Exception ("Start machine first.");
+				}
+				if (feeder.getFeedCountActuatorName() == null || feeder.getFeedCountActuatorName().equals("")) {
+					Logger.warn("No feedCountActuatorName specified for feeder {}.", feeder.getName());
+					return;
+				}
+				Actuator actuator = Configuration.get().getMachine()
+						.getActuatorByName(feeder.getFeedCountActuatorName());
+
+				if (actuator == null) {
+					throw new Exception(
+							"Failed, unable to find an actuator named " + feeder.getFeedCountActuatorName());
+				}
+                String s = actuator.read(feeder.getActuatorValue());
+                feedCountValue.setText(s == null ? "" : s);
+			});
+		}
+    };
+
+    private Action clearCountActuatorAction = new AbstractAction("Clear feed count") {
+		@Override
+		public void actionPerformed(ActionEvent arg0) {
+			UiUtils.messageBoxOnException(() -> {
+				if (!(Configuration.get().getMachine().isEnabled())) {
+					throw new Exception ("Start machine first.");
+				}
+				if (feeder.getClearCountActuatorName() == null || feeder.getClearCountActuatorName().equals("")) {
+					Logger.warn("No clearCountActuatorName specified for feeder {}.", feeder.getName());
+					return;
+				}
+				Actuator actuator = Configuration.get().getMachine()
+						.getActuatorByName(feeder.getClearCountActuatorName());
+
+				if (actuator == null) {
+					throw new Exception(
+							"Failed, unable to find an actuator named " + feeder.getClearCountActuatorName());
+				}
+				if (feeder.getClearCountActuatorType() == ActuatorType.Boolean) {
+					actuator.actuate(feeder.getActuatorValue() != 0);
+				} else {
+					actuator.actuate(feeder.getActuatorValue());
+				}
+				feedCountValue.setText("");
+			});
+		}
+    };
+
+    private Action pitchActuatorAction = new AbstractAction("Get pitch") {
+		@Override
+		public void actionPerformed(ActionEvent arg0) {
+			UiUtils.messageBoxOnException(() -> {
+				if (!(Configuration.get().getMachine().isEnabled())) {
+					throw new Exception ("Start machine first.");
+				}
+				if (feeder.getPitchActuatorName() == null || feeder.getPitchActuatorName().equals("")) {
+					Logger.warn("No feedCountActuatorName specified for feeder {}.", feeder.getName());
+					return;
+				}
+				Actuator actuator = Configuration.get().getMachine()
+						.getActuatorByName(feeder.getPitchActuatorName());
+
+				if (actuator == null) {
+					throw new Exception(
+							"Failed, unable to find an actuator named " + feeder.getPitchActuatorName());
+				}
+                String s = actuator.read(feeder.getActuatorValue());
+                pitchValue.setText(s == null ? "" : s);
+			});
+		}
+    };
+
+    private Action togglePitchActuatorAction = new AbstractAction("Toggle pitch") {
+		@Override
+		public void actionPerformed(ActionEvent arg0) {
+			UiUtils.messageBoxOnException(() -> {
+				if (!(Configuration.get().getMachine().isEnabled())) {
+					throw new Exception ("Start machine first.");
+				}
+				if (feeder.getTogglePitchActuatorName() == null || feeder.getTogglePitchActuatorName().equals("")) {
+					Logger.warn("No togglePitchActuatorName specified for feeder {}.", feeder.getName());
+					return;
+				}
+				Actuator actuator = Configuration.get().getMachine()
+						.getActuatorByName(feeder.getTogglePitchActuatorName());
+
+				if (actuator == null) {
+					throw new Exception(
+							"Failed, unable to find an actuator named " + feeder.getTogglePitchActuatorName());
+				}
+                actuator.actuate(feeder.getActuatorValue());
+                pitchActuatorAction.actionPerformed(null);
+			});
+		}
+    };
+
+    private Action statusActuatorAction =  new AbstractAction("Get status") {
+		@Override
+		public void actionPerformed(ActionEvent arg0) {
+			UiUtils.messageBoxOnException(() -> {
+				if (!(Configuration.get().getMachine().isEnabled())) {
+					throw new Exception ("Start machine first.");
+				}
+				if (feeder.getStatusActuatorName() == null || feeder.getStatusActuatorName().equals("")) {
+					Logger.warn("No statusActuatorName specified for feeder {}.", feeder.getName());
+					return;
+				}
+				Actuator actuator = Configuration.get().getMachine()
+						.getActuatorByName(feeder.getStatusActuatorName());
+
+				if (actuator == null) {
+					throw new Exception(
+							"Failed, unable to find an actuator named " + feeder.getStatusActuatorName());
+				}
+                String s = actuator.read(feeder.getActuatorValue());
+                statusText.setText(s == null ? "" : s);
+			});
+		}
+    };
+
+    private Action updateLocationAction = new AbstractAction() {
+    	@Override
+    	public void actionPerformed(ActionEvent arg0) {
+			UiUtils.messageBoxOnException(() -> {
+				// make sure machine is powered on
+				if(Configuration.get().getMachine().isEnabled()) {
+					if (feeder.getFiducialPart() == null) {
+						Logger.warn("No fiducial defined for feeder {}.", feeder.getName());
+						return;
+					}
+					Location newLocation = feeder.getFiducialLocation(feeder.getLocation(), feeder.getFiducialPart());
+					xPickLocTf.setText(newLocation.getLengthX().toString());
+					yPickLocTf.setText(newLocation.getLengthY().toString());
+				}
+			});
+    	}
+    	
+    };
+    
+    private JComboBox feederCb;
+    private JComboBox bankCb;    
+    private JComboBox feederPartCb;
+    private JTextField fiducialPartTf;
+    private JTextField xOffsetTf;
+    private JTextField yOffsetTf;
+    private JTextField zOffsetTf;
+    private JTextField rotOffsetTf;
+    private JTextField xPickLocTf;
+    private JTextField yPickLocTf;
+    private JTextField zPickLocTf;
+    private JTextField rotPickLocTf;
+    private LocationButtonsPanel offsetLocButtons;
+    private LocationButtonsPanel pickLocButtons;
+    private JTextField feedRetryCount;
+    private JTextField pickRetryCount;
+}


### PR DESCRIPTION
# Description
Adds a regular feeder and slot feeder.  The slot feeder version makes use of the ID in the feeder EEPROM to know which feeder is in the slot.

# Justification
Adds new functionality which many users will find useful.

# Instructions for Use
Open the Feeders tab and add a new feeder.  Select SchultzFeeder or SlotSchultzFeeder and use the wizard to set it up.  I will add a section to the wiki after this is merged.  In the meantime, there are some instructions on my github [wiki](https://github.com/bilsef/SchultzController/wiki).  I have scripts to help with setting up the slots.  These feeders have a fiducial, so I make use of it and added a button to the SlotSchultzFeeder wizard to precisely set the feeder location based on the fiducial.  There is a script to automate that as well, when feeders are swapped out.

# Implementation Details
1. How did you test the change? I have been testing the feeders for the last two weeks on my machine.
2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)? Yes.
3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing. N/A
4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted.  All tests passed.
