### PR TITLE
Fixed null pointer and class cast exceptions in AdvancedLoosePartFeeder

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/feeder/AdvancedLoosePartFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/AdvancedLoosePartFeeder.java
@@ -78,7 +78,7 @@ public class AdvancedLoosePartFeeder extends ReferenceFeeder {
             pipeline.process();
             // Grab the results
             List<RotatedRect> results = (List<RotatedRect>) pipeline.getResult(VisionUtils.PIPELINE_RESULTS_NAME).model;
-            if (results.isEmpty()) {
+            if ((results == null) || results.isEmpty()) {
                 throw new Exception("Feeder " + getName() + ": No parts found.");
             }
             // Find the closest result

--- a/src/main/java/org/openpnp/vision/pipeline/stages/ClosestModel.java
+++ b/src/main/java/org/openpnp/vision/pipeline/stages/ClosestModel.java
@@ -171,12 +171,11 @@ public class ClosestModel extends CvStage {
             }
         }
         if (model instanceof RotatedRect) {
-
             multi.add(model);
 
 
         }
-        else if (model instanceof List<?> && ((List<?>) model).get(0) instanceof RotatedRect) {
+        else if (model instanceof List<?> && !((List) model).isEmpty() && ((List<?>) model).get(0) instanceof RotatedRect) {
 
             multi = (ArrayList) model;
 


### PR DESCRIPTION
# Description
The AdvancedLoosePartFeeder sometimes fails with a Null Pointer Exception or sometimes with a Class Cast Exception.  This change fixes those so that the feeder correctly reports "No parts found." instead.  

# Justification
Makes it easier for the user to understand what is going wrong.

# Instructions for Use
No special instructions needed.

# Implementation Details
1. Had a setup on my machine which could reliably cause the two previously stated exceptions.  After making the change, re-ran and the feeder correctly reported "No parts found."
2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)?  Yes.
3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing.  No changes were made to either of these packages.
4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted.  Maven tests were run and passed.
