### PR TITLE
Bugfix/Pump Actuation

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/ReferenceNozzle.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceNozzle.java
@@ -690,24 +690,24 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
     }
     
     protected void actuateVacuumValve(boolean on) throws Exception {
-        actuatePump(true);
+        if (on) {
+            actuatePump(true);
+        }
 
         getVacuumActuator().actuate(on);
 
-        actuatePump(false);
+        if (! on) {
+            actuatePump(false);
+        }
     }
 
     protected void actuateVacuumValve(double value) throws Exception {
         actuatePump(true);
 
         getVacuumActuator().actuate(value);
-
-        actuatePump(false);
     }
 
     protected void actuateBlowValve(double value) throws Exception {
-        actuatePump(true);
-
         getBlowOffActuator().actuate(value);
 
         actuatePump(false);


### PR DESCRIPTION
# Description
Fixes a small logic error in Revision: bd3a78a5f2890aa430858fed540963a5797cc93e which leads to the pump constantly being switched on and off. Observed this in the log while testing something else (my machine does not actually actuate the pump, it runs on a hysteresis instead).

The pump must only be enabled before the valve switches on and only be disabled after the valve switches off. Same for the value setting variant with blow off. 

See the past change:
https://github.com/openpnp/openpnp/commit/bd3a78a5f2890aa430858fed540963a5797cc93e#diff-b380475a49f8df054452d2236b8bb376

# Justification
Obvious.

# Instructions for Use
Look into the log with tracing level. Do a small job. 

# Implementation Details
1. Tested on machine. Observed log. My machine does not actually actuate the pump. 
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. Did run `mvn test` before submitting the Pull Request.
