### PR TITLE
LengthUnits Mouse Coordinates display in Pipeline Editor

### DIFF
--- a/src/main/java/org/openpnp/vision/pipeline/CvStage.java
+++ b/src/main/java/org/openpnp/vision/pipeline/CvStage.java
@@ -9,6 +9,7 @@ import java.beans.MethodDescriptor;
 import java.beans.PropertyDescriptor;
 
 import org.opencv.core.Mat;
+import org.openpnp.model.LengthUnit;
 import org.simpleframework.xml.Attribute;
 
 /**
@@ -84,6 +85,12 @@ public abstract class CvStage {
         catch (Exception e) {
             return null;
         }
+    }
+
+    // a stage may optionally define a length unit which is handled in the pipeline editor's 
+    // ResultsPanel.matView
+    public LengthUnit getLengthUnit() {
+        return null;
     }
 
     public BeanInfo getBeanInfo() {

--- a/src/main/java/org/openpnp/vision/pipeline/ui/MatView.java
+++ b/src/main/java/org/openpnp/vision/pipeline/ui/MatView.java
@@ -29,6 +29,10 @@ public class MatView extends JComponent {
         repaint();
     }
 
+    public BufferedImage getImage() {
+        return image;
+    }
+
     public Point scalePoint(Point p) {
         if (image == null) {
             return new Point(0, 0);


### PR DESCRIPTION
# Description
This adds the ability for a CvStage to expose a LengthUnit and subsequent display of mouse coordinates in the status line of the ResultsPanel MatView.

# Justification
For pipelines to remain stable between different camera models, resolutions, lenses, focal distances etc., all dimensions relating to physical objects should be expressed as proper length units rather than pixels. 

This PR prepares the ability for a CvStage to override the `getLengthUnit()` method and expose the LengthUnits in which the stage will express and store such dimensional properties. 

For the user to be able to specify such dimensional properties in a stage, the mouse coordinates are now also displayed as offsets from the camera center, in said LengthUnits, and oriented as Machine coordinates (i.e. Y pointing up rather than down).

This is used in the upcoming AffineWarp stage. 

# Instructions for Use
The end user use will be documented for the AffineWarp stage.

# Implementation Details
1. I tested the changes in #977 and broke the changes out here.
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. Successful `mvn test` before submitting the Pull Request. 
