### PR TITLE
Feature/Better Process Instructions Visibility

### DIFF
--- a/src/main/java/org/openpnp/gui/support/Icons.java
+++ b/src/main/java/org/openpnp/gui/support/Icons.java
@@ -83,6 +83,8 @@ public class Icons {
     public static Icon lockQuestion = getIcon("/icons/lock-question.svg");
 
     public static Icon openSCadIcon = getIcon("/icons/openscad-icon.svg");
+    public static Icon processActivity1Icon = getIcon("/icons/process-activity-1.svg");
+    public static Icon processActivity2Icon = getIcon("/icons/process-activity-2.svg");
 
     public static Icon getIcon(String resourceName, int width, int height) {
         if (resourceName.endsWith(".svg")) {

--- a/src/main/resources/icons/process-activity-1.svg
+++ b/src/main/resources/icons/process-activity-1.svg
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   x="0"
+   y="0"
+   width="64"
+   height="64"
+   viewBox="0, 0, 64, 64"
+   id="svg7"
+   sodipodi:docname="process_activity_1.svg"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)">
+  <metadata
+     id="metadata13">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs11" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2376"
+     inkscape:window-height="1808"
+     id="namedview9"
+     showgrid="false"
+     inkscape:zoom="3.6875"
+     inkscape:cx="-14.237288"
+     inkscape:cy="42.847458"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg7" />
+  <g
+     aria-label="&gt;"
+     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;line-height:1.25;font-family:'Swis721 Blk BT';-inkscape-font-specification:'Swis721 Blk BT, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#ca0000;fill-opacity:1;stroke:none"
+     id="text4531"
+     transform="matrix(2.1731748,0,0,2.2438248,-37.208223,-51.338768)">
+    <path
+       d="m 43.350504,34.397247 v 5.488282 l -23.007813,9.511718 v -5.839843 l 15.644532,-6.386719 -15.644532,-6.40625 v -5.878906 z"
+       id="path4533"
+       inkscape:connector-curvature="0"
+       style="fill:#ca0000;fill-opacity:1" />
+  </g>
+</svg>

--- a/src/main/resources/icons/process-activity-2.svg
+++ b/src/main/resources/icons/process-activity-2.svg
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   x="0"
+   y="0"
+   width="64"
+   height="64"
+   viewBox="0, 0, 64, 64"
+   id="svg7"
+   sodipodi:docname="process_activity_2.svg"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)">
+  <metadata
+     id="metadata13">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs11" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2376"
+     inkscape:window-height="1808"
+     id="namedview9"
+     showgrid="false"
+     inkscape:zoom="3.6875"
+     inkscape:cx="32"
+     inkscape:cy="42.847458"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg7" />
+  <g
+     aria-label="&gt;"
+     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;line-height:1.25;font-family:'Swis721 Blk BT';-inkscape-font-specification:'Swis721 Blk BT, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#eaeaea;fill-opacity:1;stroke:none"
+     id="text4531"
+     transform="matrix(2.1731748,0,0,2.2438248,-37.208223,-51.338768)">
+    <path
+       d="m 43.350504,34.397247 v 5.488282 l -23.007813,9.511718 v -5.839843 l 15.644532,-6.386719 -15.644532,-6.40625 v -5.878906 z"
+       id="path4533"
+       inkscape:connector-curvature="0"
+       style="fill:#eaeaea;fill-opacity:1" />
+  </g>
+</svg>


### PR DESCRIPTION
# Description
OpenPNP provides a special instructions panel, that pops up underneath the camera views to guide you through setup processes, step-by-step. 

This panel is currently used by the multiple location board location setup process:

![grafik](https://user-images.githubusercontent.com/9963310/79329895-dd7b2800-7f18-11ea-8c44-4b4059b65d8f.png)

If you press the button, "nothing" seems to happen, as the showing of the instructions is quite subtle and all the other user interface elements remain fully active. It is easy to start the process and never finish it. 

![grafik](https://user-images.githubusercontent.com/9963310/79330031-1915f200-7f19-11ea-9f0d-1e5a310c5c27.png)

This PR adds a blinking icon to the process instructions to attract the users' attention. 

![grafik](https://user-images.githubusercontent.com/9963310/79330201-68f4b900-7f19-11ea-8467-d56f4f5ce768.png)

The red icon will blink on and off and the instructions are now hard to ignore. 

The PR also makes sure that the standard dialog font is used, instead of the out-of-place serifed HTML default font.

# Justification
The process instruction will be used with #977 to setup a region of interest for OCR.

[Watch the video section](https://youtu.be/5QcJ2ziIJ14?t=43)

# Instructions for Use
Just use any of the guided setup processes. 

# Implementation Details
1. Tested with the multiple location board location setup process.
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. Succesful `mvn test` before submitting the Pull Request.
