### PR TITLE
Feature/Show fiducial locator pipeline image in camera view

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/vision/ReferenceFiducialLocator.java
+++ b/src/main/java/org/openpnp/machine/reference/vision/ReferenceFiducialLocator.java
@@ -16,13 +16,13 @@ import javax.swing.Icon;
 import org.apache.commons.io.IOUtils;
 import org.opencv.core.KeyPoint;
 import org.openpnp.gui.MainFrame;
-import org.openpnp.gui.support.MessageBoxes;
+import org.openpnp.gui.components.CameraView;
 import org.openpnp.gui.support.PropertySheetWizardAdapter;
 import org.openpnp.gui.support.Wizard;
-import org.openpnp.machine.reference.feeder.BlindsFeeder;
 import org.openpnp.machine.reference.vision.wizards.ReferenceFiducialLocatorConfigurationWizard;
 import org.openpnp.machine.reference.vision.wizards.ReferenceFiducialLocatorPartConfigurationWizard;
 import org.openpnp.model.Board;
+import org.openpnp.model.Board.Side;
 import org.openpnp.model.BoardLocation;
 import org.openpnp.model.Configuration;
 import org.openpnp.model.Footprint;
@@ -33,12 +33,12 @@ import org.openpnp.model.Part;
 import org.openpnp.model.Placement;
 import org.openpnp.model.Placement.Type;
 import org.openpnp.model.Point;
-import org.openpnp.model.Board.Side;
 import org.openpnp.spi.Camera;
 import org.openpnp.spi.FiducialLocator;
 import org.openpnp.spi.PropertySheetHolder;
 import org.openpnp.util.IdentifiableList;
 import org.openpnp.util.MovableUtils;
+import org.openpnp.util.OpenCvUtils;
 import org.openpnp.util.QuickHull;
 import org.openpnp.util.TravellingSalesman;
 import org.openpnp.util.Utils2D;
@@ -371,7 +371,17 @@ public class ReferenceFiducialLocator implements FiducialLocator {
                 
                 // And use the closest result
                 location = locations.get(0);
-                
+
+                MainFrame frame = MainFrame.get(); 
+                if (frame != null) {
+                    CameraView cameraView = frame.getCameraViews().getCameraView(camera);
+                    if (cameraView != null) {    
+                        cameraView.showFilteredImage(OpenCvUtils.toBufferedImage(pipeline.getWorkingImage()), 
+                                location.getX()+", "+location.getY()+" "+location.getUnits().getShortName(),
+                                1500);
+                    }
+                }
+
                 Logger.debug("{} located at {}", part.getId(), location);
                 // Move to where we actually found the fid
                 camera.moveTo(location);

--- a/src/main/java/org/openpnp/machine/reference/vision/ReferenceFiducialLocator.java
+++ b/src/main/java/org/openpnp/machine/reference/vision/ReferenceFiducialLocator.java
@@ -17,6 +17,7 @@ import org.apache.commons.io.IOUtils;
 import org.opencv.core.KeyPoint;
 import org.openpnp.gui.MainFrame;
 import org.openpnp.gui.components.CameraView;
+import org.openpnp.gui.support.LengthConverter;
 import org.openpnp.gui.support.PropertySheetWizardAdapter;
 import org.openpnp.gui.support.Wizard;
 import org.openpnp.machine.reference.vision.wizards.ReferenceFiducialLocatorConfigurationWizard;
@@ -376,8 +377,11 @@ public class ReferenceFiducialLocator implements FiducialLocator {
                 if (frame != null) {
                     CameraView cameraView = frame.getCameraViews().getCameraView(camera);
                     if (cameraView != null) {    
+                        LengthConverter lengthConverter = new LengthConverter();
                         cameraView.showFilteredImage(OpenCvUtils.toBufferedImage(pipeline.getWorkingImage()), 
-                                location.getX()+", "+location.getY()+" "+location.getUnits().getShortName(),
+                                lengthConverter.convertForward(location.getLengthX())+", "
+                                        +lengthConverter.convertForward(location.getLengthY())+" "
+                                        +location.getUnits().getShortName(),
                                 1500);
                     }
                 }


### PR DESCRIPTION
# Description
After processing the fiducial locator pipeline, the resulting working image is shown in camera view for a moment (same as in bottom vision), also showing the location coordinates in the top left corner.

# Justification
It's just nice for this to show its result and work the same way as bottom vision. 

Also cleaned up some superfluous imports from before.

# Instructions for Use
Use visual homing on the machine.

![fidloc](https://user-images.githubusercontent.com/9963310/79338623-efb09280-7f27-11ea-892a-aed7c1915149.jpg)

# Implementation Details
1. The change was extensively tested in #977, now broken out and tested solo.
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. Successful `mvn test` before submitting the Pull Request. 

