### PR TITLE
Feature/Actuator No-Safe-Z button for the LocationButtonsPanel

### DIFF
--- a/src/main/java/org/openpnp/gui/components/LocationButtonsPanel.java
+++ b/src/main/java/org/openpnp/gui/components/LocationButtonsPanel.java
@@ -123,10 +123,12 @@ public class LocationButtonsPanel extends JPanel {
         if (actuatorName == null || actuatorName.trim().length() == 0) {
             buttonCaptureTool.setAction(captureToolCoordinatesAction);
             buttonCenterTool.setAction(positionToolAction);
+            buttonCenterToolNoSafeZ.setAction(positionToolNoSafeZAction);
         }
         else {
             buttonCaptureTool.setAction(captureActuatorCoordinatesAction);
             buttonCenterTool.setAction(positionActuatorAction);
+            buttonCenterToolNoSafeZ.setAction(positionActuatorNoSafeZAction);
         }
     }
 
@@ -351,6 +353,26 @@ public class LocationButtonsPanel extends JPanel {
                             location = location.addWithRotation(baseLocation);
                         }
                         MovableUtils.moveToLocationAtSafeZ(actuator, location);
+                    });
+                }
+            };
+    private Action positionActuatorNoSafeZAction =
+            new AbstractAction("Position Actuator (Without Safe Z)", Icons.centerPinNoSafeZ) {
+                {
+                    putValue(Action.SHORT_DESCRIPTION,
+                            "Position the actuator over the center of the location without first moving to Safe Z.");
+                }
+
+                @Override
+                public void actionPerformed(ActionEvent arg0) {
+                    UiUtils.submitUiMachineTask(() -> {
+                        Actuator actuator = getActuator();
+                        Location location = getParsedLocation();
+                        if (baseLocation != null) {
+                            location = location.rotateXy(baseLocation.getRotation());
+                            location = location.addWithRotation(baseLocation);
+                        }
+                        actuator.moveTo(location);
                     });
                 }
             };

--- a/src/main/java/org/openpnp/gui/support/Icons.java
+++ b/src/main/java/org/openpnp/gui/support/Icons.java
@@ -28,6 +28,7 @@ public class Icons {
     public static Icon centerTool = getIcon("/icons/position-nozzle.svg");
     public static Icon centerToolNoSafeZ = getIcon("/icons/position-nozzle-no-safe-z.svg");
     public static Icon centerPin = getIcon("/icons/position-actuator.svg");
+    public static Icon centerPinNoSafeZ = getIcon("/icons/position-actuator-no-safe-z.svg");
     public static Icon centerCameraOnFeeder = getIcon("/icons/position-camera-on-feeder.svg");
     public static Icon centerNozzleOnFeeder = getIcon("/icons/position-nozzle-on-feeder.svg");
 

--- a/src/main/resources/icons/position-actuator-no-safe-z.svg
+++ b/src/main/resources/icons/position-actuator-no-safe-z.svg
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:sketch="http://www.bohemiancoding.com/sketch/ns"
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24px"
+   height="24px"
+   viewBox="0 0 24 24"
+   version="1.1"
+   id="svg11"
+   sodipodi:docname="position-actuator-no-safe-z.svg"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)">
+  <metadata
+     id="metadata15">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2341"
+     inkscape:window-height="1608"
+     id="namedview13"
+     showgrid="false"
+     inkscape:zoom="27.812867"
+     inkscape:cx="1.7442045"
+     inkscape:cy="8.893301"
+     inkscape:window-x="0"
+     inkscape:window-y="238"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg11"
+     inkscape:snap-to-guides="false" />
+  <!-- Generator: Sketch 3.2.2 (9983) - http://www.bohemiancoding.com/sketch -->
+  <title
+     id="title2">position-actuator</title>
+  <desc
+     id="desc4">Created with Sketch.</desc>
+  <defs
+     id="defs6">
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker6551"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Send">
+      <path
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#005bdc;fill-opacity:0.99215686;fill-rule:evenodd;stroke:#005bdc;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:0.99215686"
+         id="path6553"
+         inkscape:connector-curvature="0" />
+    </marker>
+  </defs>
+  <g
+     id="Page-1"
+     sketch:type="MSPage"
+     style="fill:none;fill-rule:evenodd;stroke:none;stroke-width:1">
+    <g
+       id="position-actuator"
+       sketch:type="MSLayerGroup"
+       style="fill:#bd0404">
+      <path
+         d="m 12,8 c -2.21,0 -4,1.79 -4,4 0,2.21 1.79,4 4,4 2.21,0 4,-1.79 4,-4 0,-2.21 -1.79,-4 -4,-4 z"
+         id="Shape"
+         sketch:type="MSShapeGroup"
+         inkscape:connector-curvature="0" />
+    </g>
+  </g>
+  <path
+     inkscape:connector-curvature="0"
+     id="path4327-2"
+     d="M 4,4 H 20"
+     style="fill:none;fill-opacity:0;fill-rule:evenodd;stroke:#005bd9;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.99215686"
+     sodipodi:nodetypes="cc" />
+</svg>


### PR DESCRIPTION
# Description
The LocationButtonsPanel already has an option to display a No-Safe-Z button for the selected tool mode. This PR adds the same for the Actuator mode. 

# Justification
Need to move the actuator with no Safe Z when definition the lever actuation for the `ReferencePushPullFeeder` in #977 .

Without the PR the panel will use the tool instead:

![grafik](https://user-images.githubusercontent.com/9963310/79342451-7451df80-7f2d-11ea-9382-272383f815b6.png)

# Instructions for Use
Use the button with the blue line above the red dot instead of the one with the red dot.

![actuator-no-safe-z](https://user-images.githubusercontent.com/9963310/79341508-37391d80-7f2c-11ea-882b-81b32f86aa0d.png)

# Implementation Details
1. This was tested inside #977 and is now broken out (so it cannot be tested).
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. Sucessful `mvn test` before submitting the Pull Request.
