### PR TITLE
Feature/camera zoom mouse wheel sensitivity

### DIFF
--- a/src/main/java/org/openpnp/gui/components/CameraView.java
+++ b/src/main/java/org/openpnp/gui/components/CameraView.java
@@ -76,6 +76,7 @@ import org.pmw.tinylog.Logger;
 @SuppressWarnings("serial")
 public class CameraView extends JComponent implements CameraListener {
     private static final String PREF_RETICLE = "CamerView.reticle";
+    private static final String PREF_ZOOM_INCREMENT = "CamerView.zoomIncrement";
 
     private static final String DEFAULT_RETICLE_KEY = "DEFAULT_RETICLE_KEY";
 
@@ -189,6 +190,7 @@ public class CameraView extends JComponent implements CameraListener {
     private boolean showName = false;
     
     private double zoom = 1d;
+    private double zoomIncPerMouseWheelTick = 0.01;
     
     private boolean dragJogging = false;
     
@@ -201,6 +203,7 @@ public class CameraView extends JComponent implements CameraListener {
     long lastFrameReceivedTime = 0;
     MovingAverage fpsAverage = new MovingAverage(24);
     double fps = 0;
+    
     
     public CameraView() {
         setBackground(Color.black);
@@ -232,6 +235,10 @@ public class CameraView extends JComponent implements CameraListener {
     
     private String getReticlePrefKey() {
         return PREF_RETICLE + "." + camera.getId();
+    }
+
+    private String getZoomIncrementPrefKey() {
+        return PREF_ZOOM_INCREMENT + "." + camera.getId();
     }
 
     public void addActionListener(CameraViewActionListener listener) {
@@ -271,6 +278,9 @@ public class CameraView extends JComponent implements CameraListener {
                 Logger.debug("No reticle preference found.");
             }
         }
+
+        // load the zoom increment pref, if any
+        zoomIncPerMouseWheelTick = prefs.getDouble(getZoomIncrementPrefKey(), 0.01);
 
     }
 
@@ -335,6 +345,15 @@ public class CameraView extends JComponent implements CameraListener {
         this.text = text;
     }
 
+    public double getZoomIncPerMouseWheelTick() {
+        return zoomIncPerMouseWheelTick;
+    }
+
+    public void setZoomIncPerMouseWheelTick(double zoomIncPerMouseWheelTick) {
+        prefs.putDouble(getZoomIncrementPrefKey(), zoomIncPerMouseWheelTick);
+        this.zoomIncPerMouseWheelTick = zoomIncPerMouseWheelTick;
+    }
+    
     /**
      * Causes a short flash in the CameraView to get the user's attention.
      */
@@ -1517,7 +1536,7 @@ public class CameraView extends JComponent implements CameraListener {
     private MouseWheelListener mouseWheelListener = new MouseWheelListener() {
         @Override
         public void mouseWheelMoved(MouseWheelEvent e) {
-            zoom -= e.getPreciseWheelRotation() * 0.01d;
+            zoom -= e.getPreciseWheelRotation() * zoomIncPerMouseWheelTick;
             zoom = Math.max(zoom, 1.0d);
             zoom = Math.min(zoom, 100d);
             calculateScalingData();

--- a/src/main/java/org/openpnp/gui/components/CameraView.java
+++ b/src/main/java/org/openpnp/gui/components/CameraView.java
@@ -77,6 +77,7 @@ import org.pmw.tinylog.Logger;
 public class CameraView extends JComponent implements CameraListener {
     private static final String PREF_RETICLE = "CamerView.reticle";
     private static final String PREF_ZOOM_INCREMENT = "CamerView.zoomIncrement";
+    private static final double DEFAULT_ZOOM_INCREMENT = 0.01;
 
     private static final String DEFAULT_RETICLE_KEY = "DEFAULT_RETICLE_KEY";
 
@@ -190,7 +191,7 @@ public class CameraView extends JComponent implements CameraListener {
     private boolean showName = false;
     
     private double zoom = 1d;
-    private double zoomIncPerMouseWheelTick = 0.01;
+    private double zoomIncPerMouseWheelTick = DEFAULT_ZOOM_INCREMENT;
     
     private boolean dragJogging = false;
     
@@ -203,7 +204,6 @@ public class CameraView extends JComponent implements CameraListener {
     long lastFrameReceivedTime = 0;
     MovingAverage fpsAverage = new MovingAverage(24);
     double fps = 0;
-    
     
     public CameraView() {
         setBackground(Color.black);
@@ -280,7 +280,7 @@ public class CameraView extends JComponent implements CameraListener {
         }
 
         // load the zoom increment pref, if any
-        zoomIncPerMouseWheelTick = prefs.getDouble(getZoomIncrementPrefKey(), 0.01);
+        zoomIncPerMouseWheelTick = prefs.getDouble(getZoomIncrementPrefKey(), DEFAULT_ZOOM_INCREMENT);
 
     }
 

--- a/src/main/java/org/openpnp/gui/components/CameraViewPopupMenu.java
+++ b/src/main/java/org/openpnp/gui/components/CameraViewPopupMenu.java
@@ -44,11 +44,16 @@ import org.openpnp.model.LengthUnit;
 @SuppressWarnings("serial")
 public class CameraViewPopupMenu extends JPopupMenu {
     private CameraView cameraView;
+    private JMenu zoomIncMenu;
     private JMenu reticleMenu;
     private JMenu reticleOptionsMenu;
 
     public CameraViewPopupMenu(CameraView cameraView) {
         this.cameraView = cameraView;
+
+        zoomIncMenu = createZoomIncMenu();
+
+        add(zoomIncMenu);
 
         reticleMenu = createReticleMenu();
 
@@ -75,6 +80,73 @@ public class CameraViewPopupMenu extends JPopupMenu {
         }
     }
 
+    private JMenu createZoomIncMenu() {
+        JMenu subMenu = new JMenu("Zoom Increment Per Mouse Wheel Tick");
+        ButtonGroup buttonGroup = new ButtonGroup();
+        JRadioButtonMenuItem menuItem = new JRadioButtonMenuItem("10.0");
+        buttonGroup.add(menuItem);
+        if (cameraView.getZoomIncPerMouseWheelTick() == 10.0) {
+            menuItem.setSelected(true);
+        }
+        menuItem.addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                cameraView.setZoomIncPerMouseWheelTick(10.0);
+            }
+        });
+        subMenu.add(menuItem);
+        menuItem = new JRadioButtonMenuItem("1.0");
+        buttonGroup.add(menuItem);
+        if (cameraView.getZoomIncPerMouseWheelTick() == 1.0) {
+            menuItem.setSelected(true);
+        }
+        menuItem.addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                cameraView.setZoomIncPerMouseWheelTick(1.0);
+            }
+        });
+        subMenu.add(menuItem);
+        menuItem = new JRadioButtonMenuItem("0.1");
+        buttonGroup.add(menuItem);
+        if (cameraView.getZoomIncPerMouseWheelTick() == 0.1) {
+            menuItem.setSelected(true);
+        }
+        menuItem.addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                cameraView.setZoomIncPerMouseWheelTick(0.1);
+            }
+        });
+        subMenu.add(menuItem);
+        menuItem = new JRadioButtonMenuItem("0.01");
+        buttonGroup.add(menuItem);
+        if (cameraView.getZoomIncPerMouseWheelTick() == 0.01) {
+            menuItem.setSelected(true);
+        }
+        menuItem.addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                cameraView.setZoomIncPerMouseWheelTick(0.01);
+            }
+        });
+        subMenu.add(menuItem);
+        menuItem = new JRadioButtonMenuItem("0.001");
+        buttonGroup.add(menuItem);
+        if (cameraView.getZoomIncPerMouseWheelTick() == 0.001) {
+            menuItem.setSelected(true);
+        }
+        menuItem.addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                cameraView.setZoomIncPerMouseWheelTick(0.001);
+            }
+        });
+        subMenu.add(menuItem);
+        
+        return subMenu;
+    }
+    
     private JMenu createReticleMenu() {
         JMenu menu = new JMenu("Reticle");
 


### PR DESCRIPTION
# Description
This change allows the user to change the camera zoom sensitivty to make it more (or less) responsive to mouse wheel movement.

# Justification
Some find the current sensitivity of the mouse wheel to be too low which requires a great deal of "spinning" of the mouse wheel in order to get to the desired zoom level.  This change allow the user to select the sensitivity they desire.

# Instructions for Use
In a camera view, menu (right) click and use the "Zoom Increment Per Mouse Wheel Tick" option to select the desired zoom increment.  Larger numbers make zooming in/out more responsive to each mouse wheel tick.  Each camera view has its own independent setting and the selected setting is remembered between program start-ups.

# Implementation Details
**1. How did you test the change?** Ran on my machine and observed the responsiveness of the mouse wheel when zooming in the camera views at various different settings.  Also tested shutting-down and restarting the program to verify the settings were remembered.
**2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)?**  Yes.
**3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing.**  No changes where made to either of these packages.
**4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted.**  Maven tests were run an passed.
