### PR TITLE
Feature/ReferencePushPullFeeder (Reinstated)

### DIFF
--- a/src/main/java/org/openpnp/gui/FeedersPanel.java
+++ b/src/main/java/org/openpnp/gui/FeedersPanel.java
@@ -510,9 +510,10 @@ public class FeedersPanel extends JPanel implements WizardContainer {
                 Feeder feeder = getSelection();
 
                 // Simulate a "one feeder" job, prepare the feeder.
-                List<Feeder> feedersToPrepare = new ArrayList<>();
-                feedersToPrepare.add(feeder);
-                feeder.prepareForJob(feedersToPrepare);
+                if (feeder.getJobPreparationLocation() != null) {
+                    feeder.prepareForJob(true);
+                }
+                feeder.prepareForJob(false);
 
                 // Check the nozzle tip package compatibility.
                 Nozzle nozzle = MainFrame.get().getMachineControls().getSelectedNozzle();

--- a/src/main/java/org/openpnp/gui/components/CameraView.java
+++ b/src/main/java/org/openpnp/gui/components/CameraView.java
@@ -1280,10 +1280,7 @@ public class CameraView extends JComponent implements CameraListener {
         }
     }
 
-    private void moveToClick(MouseEvent e) {
-        int x = e.getX();
-        int y = e.getY();
-
+    public Location getCameraViewCenterOffsetsFromXy(int x, int y) {
         // Find the difference in X and Y from the center of the image
         // to the mouse click.
         double offsetX = (scaledWidth / 2.0D) - (x - imageX);
@@ -1297,12 +1294,17 @@ public class CameraView extends JComponent implements CameraListener {
         offsetX *= scaledUnitsPerPixelX;
         offsetY *= scaledUnitsPerPixelY;
 
-        // The offsets now represent the distance to move the camera
-        // in the Camera's units per pixel's units.
+        // The offsets now represent the distance in the Camera's units per pixel's units.
 
         // Create a location in the Camera's units per pixel's units
         // and with the values of the offsets.
         Location offsets = camera.getUnitsPerPixel().derive(offsetX, offsetY, 0.0, 0.0);
+        return offsets;
+    }
+
+    private void moveToClick(MouseEvent e) {
+        // Get the offset from the Camera view center in Camera's units.
+        Location offsets = getCameraViewCenterOffsetsFromXy(e.getX(), e.getY());
         // And move there.
         UiUtils.submitUiMachineTask(() -> {
             if (camera.getHead() == null) {

--- a/src/main/java/org/openpnp/gui/processes/RegionOfInterestProcess.java
+++ b/src/main/java/org/openpnp/gui/processes/RegionOfInterestProcess.java
@@ -1,0 +1,261 @@
+/*
+ * Copyright (C) 2020 <mark@makr.zone>
+ * inspired by TwoPlacementBoardLocationProcess by
+ * Copyright (C) 2011 Jason von Nieda <jason@vonnieda.org>
+ * 
+ * This file is part of OpenPnP.
+ * 
+ * OpenPnP is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * OpenPnP is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License along with OpenPnP. If not, see
+ * <http://www.gnu.org/licenses/>.
+ * 
+ * For more information about OpenPnP visit http://openpnp.org
+ */
+
+package org.openpnp.gui.processes;
+
+import java.awt.BasicStroke;
+import java.awt.Color;
+import java.awt.Graphics2D;
+import java.awt.Point;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.swing.SwingUtilities;
+
+import org.openpnp.gui.MainFrame;
+import org.openpnp.gui.components.CameraView;
+import org.openpnp.gui.components.reticle.Reticle;
+import org.openpnp.model.LengthUnit;
+import org.openpnp.model.RegionOfInterest;
+import org.openpnp.spi.Camera;
+import org.openpnp.util.UiUtils;
+
+/**
+ * Guides the user through the three point region of interest operation using step by step instructions.
+ */
+public class RegionOfInterestProcess {
+    private final MainFrame mainFrame;
+    private String processTitle;
+    private final Camera camera;
+    private final CameraView cameraView; 
+
+    private int step = -1;
+    private String[] instructions = new String[] {
+            "<html><body>Click on what will become the upper left corner of your region of interest. Click again to reset and retry. Click Next to continue.</body></html>",
+            "<html><body>Now, click on what will become the upper right corner of your region of interest. Click again to reset and retry. Click Next to continue.</body></html>",
+            "<html><body>Next, click on what will become the lower left corner of your region of interest. Click again to reset and retry. Click Next to continue.</body></html>",
+            "<html><body>Finally, click to toggle beween a rectangular and parallelogrammatic region. Click Next to continue.</body></html>",
+            "<html><body>The region of interest has been defined. Click Finish to accept it, or Cancel to quit.</body></html>",};
+
+    private Map<Integer, Point> regionStakeout = new HashMap<>();
+    private boolean rectify = false;
+    private Point mouseLastPos = null;
+    private int mouseClickCount = 0;
+
+    private static final String PROCESS_RETICLE_KEY = "PROCESS_RETICLE_KEY";
+
+    RegionOfInterest regionOfInterest = null;
+
+    public RegionOfInterestProcess(MainFrame mainFrame, Camera camera, String processTitle)
+            throws Exception {
+        this.mainFrame = mainFrame;
+        this.processTitle = processTitle;
+        // setup the process
+        this.camera = camera;
+        SwingUtilities.invokeLater(() -> {
+            MainFrame.get().getCameraViews().ensureCameraVisible(camera);
+        });
+        this.cameraView = MainFrame.get()
+                .getCameraViews()
+                .getCameraView(this.camera);
+        this.cameraView.addMouseListener(locationClickedListener);
+        this.cameraView.addMouseMotionListener(locationClickedListener);
+        this.cameraView.flash();
+
+        this.cameraView.setReticle(PROCESS_RETICLE_KEY, new Reticle() {
+
+            @Override
+            public void draw(Graphics2D g2d, LengthUnit cameraUnitsPerPixelUnits,
+                    double cameraUnitsPerPixelX, double cameraUnitsPerPixelY, double viewPortCenterX,
+                    double viewPortCenterY, int viewPortWidth, int viewPortHeight, double rotation) {
+                if (mouseLastPos != null) {
+                    g2d.setColor(Color.orange);
+                    g2d.setStroke(new BasicStroke(1.0f));
+                    if (step ==  0) {
+                        // draw cross hairs moving with the mouse, for the moment we're assuming a 90° aligned region of interest
+                        // so these help to align with content. 
+                        // TODO: perhaps rotate that with the Reticle 
+                        g2d.drawLine(0, mouseLastPos.y, viewPortWidth-1, mouseLastPos.y);
+                        g2d.drawLine(mouseLastPos.x, viewPortHeight-1, mouseLastPos.x, 0);
+                    }
+                    else if (step == 1) {
+                        // draw cross hairs anchored at point 0, rotating with the mouse
+                        g2d.drawLine(regionStakeout.get(0).x, regionStakeout.get(0).y, mouseLastPos.x, mouseLastPos.y);
+                        int dx = mouseLastPos.x - regionStakeout.get(0).x;
+                        int dy = mouseLastPos.y - regionStakeout.get(0).y;
+                        // draw normal on both sides
+                        g2d.drawLine(regionStakeout.get(0).x-dy, regionStakeout.get(0).y+dx, regionStakeout.get(0).x+dy, regionStakeout.get(0).y-dx);
+                        // draw normal on both sides
+                        g2d.drawLine(mouseLastPos.x-dy, mouseLastPos.y+dx, mouseLastPos.x+dy, mouseLastPos.y-dx);
+                    }
+                    else if (step ==  2) {
+                        // draw width of ROI and height both normalized and not 
+                        int dx = regionStakeout.get(1).x - regionStakeout.get(0).x;
+                        int dy = regionStakeout.get(1).y - regionStakeout.get(0).y;
+                        // draw parallelogram
+                        g2d.drawLine(regionStakeout.get(0).x, regionStakeout.get(0).y, regionStakeout.get(1).x, regionStakeout.get(1).y);
+                        g2d.drawLine(mouseLastPos.x, mouseLastPos.y, mouseLastPos.x+dx, mouseLastPos.y+dy);
+                        g2d.drawLine(mouseLastPos.x, mouseLastPos.y, regionStakeout.get(0).x, regionStakeout.get(0).y);
+                        g2d.drawLine(mouseLastPos.x+dx, mouseLastPos.y+dy, regionStakeout.get(1).x, regionStakeout.get(1).y);
+                        // also draw the normal as a guide
+                        g2d.setColor(Color.red);
+                        g2d.drawLine(regionStakeout.get(0).x-dy, regionStakeout.get(0).y+dx, regionStakeout.get(0).x+dy, regionStakeout.get(0).y-dx);
+                    }
+                    else if (step ==  3) {
+                        rectify = (mouseClickCount % 2) == 1; 
+                        drawRegion(g2d);
+                    }
+                    else {
+                        drawRegion(g2d);
+                    }
+                }
+                g2d.setColor(Color.yellow);
+                g2d.setStroke(new BasicStroke(2));
+                for (Point p : regionStakeout.values()) {
+                    g2d.drawOval(p.x-3, p.y-3, 6, 6);
+                }
+            }
+
+            protected void drawRegion(Graphics2D g2d) {
+                if (rectify) {
+                    // calculate rectified region
+                    int dx1 = regionStakeout.get(1).x - regionStakeout.get(0).x;
+                    int dy1 = regionStakeout.get(1).y - regionStakeout.get(0).y;
+                    int dx2 = regionStakeout.get(2).x - regionStakeout.get(0).x;
+                    int dy2 = regionStakeout.get(2).y - regionStakeout.get(0).y;
+                    double d = Math.sqrt((double)(dx1*dx1+dy1*dy1));
+                    // normal unit vector (90° clockwise, as Y points downwards) 
+                    double nx = -dy1/d;
+                    double ny = dx1/d;
+                    // dot product is height
+                    double h = nx*dx2 + ny*dy2;
+                    int x2 = (int)Math.round(regionStakeout.get(0).x + h*nx);
+                    int y2 = (int)Math.round(regionStakeout.get(0).y + h*ny);
+                    // draw rectangle
+                    g2d.setColor(Color.red);
+                    g2d.drawLine(regionStakeout.get(0).x, regionStakeout.get(0).y, regionStakeout.get(1).x, regionStakeout.get(1).y);
+                    g2d.drawLine(regionStakeout.get(0).x, regionStakeout.get(0).y, x2, y2);
+                    g2d.drawLine(x2, y2, x2+dx1, y2+dy1);
+                    g2d.drawLine(x2+dx1, y2+dy1, regionStakeout.get(1).x, regionStakeout.get(1).y);
+                    g2d.drawArc(x2-20, y2-20, 40, 40, (int)Math.round(Math.atan2(dy2, -dx2)*180/Math.PI), -90);
+                }
+                else {
+                    // draw parallelogram
+                    int dx = regionStakeout.get(1).x - regionStakeout.get(0).x;
+                    int dy = regionStakeout.get(1).y - regionStakeout.get(0).y;
+                    g2d.drawLine(regionStakeout.get(0).x, regionStakeout.get(0).y, regionStakeout.get(1).x, regionStakeout.get(1).y);
+                    g2d.drawLine(regionStakeout.get(0).x, regionStakeout.get(0).y, regionStakeout.get(2).x, regionStakeout.get(2).y);
+                    g2d.drawLine(regionStakeout.get(2).x, regionStakeout.get(2).y, regionStakeout.get(2).x+dx, regionStakeout.get(2).y+dy);
+                    g2d.drawLine(regionStakeout.get(2).x+dx, regionStakeout.get(2).y+dy, regionStakeout.get(1).x, regionStakeout.get(1).y);
+                }
+            }
+        });
+
+        advance();
+    }
+
+    private MouseAdapter locationClickedListener = new MouseAdapter() {
+        @Override
+        public void mousePressed(final MouseEvent e) {
+            if (step < 3) {
+                if (mouseClickCount % 2 == 0) { 
+                    regionStakeout.put(step, e.getPoint());
+                }
+                else {
+                    regionStakeout.remove(step);
+                }
+            }
+            cameraView.flash();
+            mouseClickCount++;
+            cameraView.repaint();
+        }
+        @Override
+        public void mouseMoved(MouseEvent e) {
+            if (mouseClickCount % 2 == 0) { 
+                mouseLastPos = e.getPoint();
+            }
+            cameraView.repaint();
+        }
+    };
+
+    private void cleanup() {
+        mainFrame.hideInstructions();
+        cameraView.removeMouseListener(locationClickedListener);
+        cameraView.removeMouseMotionListener(locationClickedListener);
+        cameraView.removeReticle(PROCESS_RETICLE_KEY);
+    }
+
+    private void advance() {
+        boolean stepResult = true;
+        mouseClickCount = 0;
+        step++;
+        if (step == 5) {
+            saveResults();
+            cleanup();
+        }
+        else {
+            String title = String.format("%s (%d / 5)", processTitle, step + 1);
+            mainFrame.showInstructions(title, instructions[step], true, true,
+                    step == 4 ? "Finish" : "Next", cancelActionListener, proceedActionListener);
+        }
+    }
+
+    private boolean saveResults() {
+        // calculate the Locations from pixels
+        regionOfInterest = new RegionOfInterest(
+                cameraView.getCameraViewCenterOffsetsFromXy(regionStakeout.get(0).x, regionStakeout.get(0).y),
+                cameraView.getCameraViewCenterOffsetsFromXy(regionStakeout.get(1).x, regionStakeout.get(1).y),
+                cameraView.getCameraViewCenterOffsetsFromXy(regionStakeout.get(2).x, regionStakeout.get(2).y),
+                rectify);
+        UiUtils.messageBoxOnException(() -> {
+            setResult(regionOfInterest);
+        });
+        return true;
+    }
+
+    private void cancel() {
+        cleanup();
+    }
+
+    private final ActionListener proceedActionListener = new ActionListener() {
+        @Override
+        public void actionPerformed(ActionEvent e) {
+            advance();
+        }
+    };
+
+    private final ActionListener cancelActionListener = new ActionListener() {
+        @Override
+        public void actionPerformed(ActionEvent e) {
+            cancel();
+        }
+    };
+
+    public void setResult(RegionOfInterest roi) {
+    }
+    public RegionOfInterest getRegionOfInterest() {
+        return regionOfInterest;
+    }
+}

--- a/src/main/java/org/openpnp/gui/tablemodel/PackagesTableModel.java
+++ b/src/main/java/org/openpnp/gui/tablemodel/PackagesTableModel.java
@@ -34,8 +34,8 @@ import org.openpnp.model.Package;
 public class PackagesTableModel extends AbstractTableModel implements PropertyChangeListener {
     final private Configuration configuration;
 
-    private String[] columnNames = new String[] {"ID", "Description"};
-    private Class[] columnTypes = new Class[] {String.class, String.class,};
+    private String[] columnNames = new String[] {"ID", "Description", "Tape Specification"};
+    private Class[] columnTypes = new Class[] {String.class, String.class, String.class};
     private List<Package> packages;
 
     public PackagesTableModel(Configuration configuration) {
@@ -65,7 +65,7 @@ public class PackagesTableModel extends AbstractTableModel implements PropertyCh
 
     @Override
     public boolean isCellEditable(int rowIndex, int columnIndex) {
-        return columnIndex == 1;
+        return columnIndex == 1 || columnIndex == 2;
     }
 
     public Package getPackage(int index) {
@@ -78,6 +78,9 @@ public class PackagesTableModel extends AbstractTableModel implements PropertyCh
             Package this_package = packages.get(rowIndex);
             if (columnIndex == 1) {
                 this_package.setDescription((String) aValue);
+            }
+            else if (columnIndex == 2) {
+                this_package.setTapeSpecification((String) aValue);
             }
         }
         catch (Exception e) {
@@ -92,6 +95,8 @@ public class PackagesTableModel extends AbstractTableModel implements PropertyCh
                 return this_package.getId();
             case 1:
                 return this_package.getDescription();
+            case 2:
+                return this_package.getTapeSpecification();
             default:
                 return null;
         }

--- a/src/main/java/org/openpnp/machine/reference/ReferenceFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceFeeder.java
@@ -23,7 +23,13 @@ public abstract class ReferenceFeeder extends AbstractFeeder {
     }
 
     @Override
-    public void prepareForJob(List<Feeder> feedersToPrepare) throws Exception {
+    public Location getJobPreparationLocation()  {
+        // the default RefrenceFeeder has no prep. location
+        return null;
+    }
+    
+    @Override
+    public void prepareForJob(boolean visit) throws Exception {
         // the default RefrenceFeeder needs no prep.
     }
 }

--- a/src/main/java/org/openpnp/machine/reference/ReferenceMachine.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceMachine.java
@@ -43,6 +43,7 @@ import org.openpnp.machine.reference.feeder.AdvancedLoosePartFeeder;
 import org.openpnp.machine.reference.feeder.BlindsFeeder;
 import org.openpnp.machine.reference.feeder.ReferenceAutoFeeder;
 import org.openpnp.machine.reference.feeder.ReferenceDragFeeder;
+import org.openpnp.machine.reference.feeder.ReferencePushPullFeeder;
 import org.openpnp.machine.reference.feeder.ReferenceLeverFeeder;
 import org.openpnp.machine.reference.feeder.ReferenceLoosePartFeeder;
 import org.openpnp.machine.reference.feeder.ReferenceRotatedTrayFeeder;
@@ -218,6 +219,7 @@ public class ReferenceMachine extends AbstractMachine {
         l.add(ReferenceRotatedTrayFeeder.class);
         l.add(ReferenceDragFeeder.class);
         l.add(ReferenceLeverFeeder.class);
+        l.add(ReferencePushPullFeeder.class);
         l.add(ReferenceTubeFeeder.class);
         l.add(ReferenceAutoFeeder.class);
         l.add(ReferenceSlotAutoFeeder.class);

--- a/src/main/java/org/openpnp/machine/reference/feeder/BlindsFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/BlindsFeeder.java
@@ -1058,24 +1058,24 @@ public class BlindsFeeder extends ReferenceFeeder {
         return feederList;
     }
 
-    public static void actuateAllFeederCovers(boolean openState) throws Exception  {
+    public static void actuateAllFeederCovers(Nozzle preferredNozzle, boolean openState) throws Exception  {
         List<BlindsFeeder> feederList = getFeedersWithCoverToActuate(Configuration.get().getMachine().getFeeders(), 
                 new CoverActuation [] { CoverActuation.Manual, CoverActuation.CheckOpen, CoverActuation.OpenOnFirstUse, CoverActuation.OpenOnJobStart }, 
                 openState); 
         if (feederList.size() == 0) {
             throw new Exception("[BlindsFeeder] No feeders found to "+(openState ? "open." : "close."));
         }
-        actuateListedFeederCovers(feederList, openState, false);
+        actuateListedFeederCovers(preferredNozzle, feederList, openState, false);
     }
 
-    public static void actuateListedFeederCovers(List<BlindsFeeder> feederList, boolean openState, boolean restoreNozzleTip) throws Exception  {
+    public static void actuateListedFeederCovers(Nozzle preferredNozzle, List<BlindsFeeder> feederList, boolean openState, boolean restoreNozzleTip) throws Exception  {
         if (feederList.size() == 0) {
             // nothing to do, avoid changing the nozzle tip for nothing.
             return;
         }
 
         // Get the push nozzle for the current position. This will also throw if none is allowed.
-        NozzleAndTipForPushing nozzleAndTipForPushing = BlindsFeeder.getNozzleAndTipForPushing(null, true);
+        NozzleAndTipForPushing nozzleAndTipForPushing = BlindsFeeder.getNozzleAndTipForPushing(preferredNozzle, true);
 
         // Use a Travelling Salesman algorithm to optimize the path to actuate all the feeder covers.
         TravellingSalesman<BlindsFeeder> tsm = new TravellingSalesman<>(

--- a/src/main/java/org/openpnp/machine/reference/feeder/BlindsFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/BlindsFeeder.java
@@ -1174,7 +1174,7 @@ public class BlindsFeeder extends ReferenceFeeder {
                 NozzleTip nozzleTip = preferredNozzle.getNozzleTip();
                 if (nozzleTip.isPushAndDragAllowed()) {
                     // Return the nozzle and nozzle tip.
-                    return new NozzleAndTipForPushing(preferredNozzle, nozzleTip);
+                    return new NozzleAndTipForPushing(preferredNozzle, nozzleTip, false);
                 }
             }
         }
@@ -1261,7 +1261,7 @@ public class BlindsFeeder extends ReferenceFeeder {
         }
     }
 
-    public void actuateCover(boolean openState) throws Exception {
+    public void actuateCover(Nozzle preferredNozzle, boolean openState) throws Exception {
         // If needed, load a NozzleTip that allows pushing but do not restore the previously loaded NozzleTip. 
         actuateCover(preferredNozzle, openState, true, false);
     }

--- a/src/main/java/org/openpnp/machine/reference/feeder/ReferencePushPullFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/ReferencePushPullFeeder.java
@@ -1,0 +1,2355 @@
+/*
+ * Copyright (C) 2020 <mark@makr.zone>
+ * based on the ReferenceLeverFeeder 
+ * Copyright (C) 2011 Jason von Nieda <jason@vonnieda.org>
+ * 
+ * This file is part of OpenPnP.
+ * 
+ * OpenPnP is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * OpenPnP is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License along with OpenPnP. If not, see
+ * <http://www.gnu.org/licenses/>.
+ * 
+ * For more information about OpenPnP visit http://openpnp.org
+ */
+
+package org.openpnp.machine.reference.feeder;
+
+import java.awt.Color;
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import javax.swing.Action;
+import javax.swing.JOptionPane;
+
+import org.apache.commons.io.IOUtils;
+import org.opencv.core.Core;
+import org.opencv.core.KeyPoint;
+import org.opencv.core.Mat;
+import org.opencv.core.Point;
+import org.opencv.core.RotatedRect;
+import org.opencv.core.Size;
+import org.opencv.imgcodecs.Imgcodecs;
+import org.opencv.imgproc.Imgproc;
+import org.openpnp.ConfigurationListener;
+import org.openpnp.gui.MainFrame;
+import org.openpnp.gui.support.PropertySheetWizardAdapter;
+import org.openpnp.gui.support.Wizard;
+import org.openpnp.machine.reference.ReferenceFeeder;
+import org.openpnp.machine.reference.feeder.wizards.ReferencePushPullFeederConfigurationWizard;
+import org.openpnp.machine.reference.feeder.wizards.ReferencePushPullMotionConfigurationWizard;
+import org.openpnp.model.Configuration;
+import org.openpnp.model.Length;
+import org.openpnp.model.LengthUnit;
+import org.openpnp.model.Location;
+import org.openpnp.model.Part;
+import org.openpnp.model.RegionOfInterest;
+import org.openpnp.spi.Actuator;
+import org.openpnp.spi.Camera;
+import org.openpnp.spi.Feeder;
+import org.openpnp.spi.Head;
+import org.openpnp.spi.Machine;
+import org.openpnp.spi.MachineListener;
+import org.openpnp.spi.Nozzle;
+import org.openpnp.spi.PropertySheetHolder;
+import org.openpnp.util.MovableUtils;
+import org.openpnp.util.OpenCvUtils;
+import org.openpnp.util.TravellingSalesman;
+import org.openpnp.util.VisionUtils;
+import org.openpnp.vision.FluentCv;
+import org.openpnp.vision.Ransac;
+import org.openpnp.vision.Ransac.Line;
+import org.openpnp.vision.pipeline.CvPipeline;
+import org.openpnp.vision.pipeline.CvStage;
+import org.openpnp.vision.pipeline.CvStage.Result;
+import org.openpnp.vision.pipeline.stages.SimpleOcr;
+import org.pmw.tinylog.Logger;
+import org.simpleframework.xml.Attribute;
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.core.Commit;
+
+public class ReferencePushPullFeeder extends ReferenceFeeder {
+
+    // Rotation of the part within the feeder (i.e. within the tape)
+    // This is compatible with tonyluken's pending PR #943 or a similar solution.
+    // Conversely, feeder.location.rotation contains the orientation of the feeder itself
+    // and it defines the local feeder coordinate system. The rotationInFeeder here can be removed
+    // once it is inherited. 
+    @Attribute(required=false)
+    protected Double rotationInFeeder = new Double(0.0);
+
+    @Attribute(required = false)
+    protected boolean normalizePickLocation = true;
+
+    @Attribute(required = false)
+    protected boolean snapToAxis = true;
+
+    @Element(required = false)
+    protected Location hole1Location = new Location(LengthUnit.Millimeters);
+    @Element(required = false)
+    protected Location hole2Location = new Location(LengthUnit.Millimeters);
+
+    @Attribute(required = false)
+    protected boolean usedAsTemplate = false; 
+
+    @Element
+    protected Location feedStartLocation = new Location(LengthUnit.Millimeters);
+    @Element(required = false)
+    protected Location feedMid1Location = new Location(LengthUnit.Millimeters);
+    @Element(required = false)
+    protected Location feedMid2Location = new Location(LengthUnit.Millimeters);
+    @Element(required = false)
+    protected Location feedMid3Location = new Location(LengthUnit.Millimeters);
+    @Element
+    protected Location feedEndLocation = new Location(LengthUnit.Millimeters);
+    @Element(required = false)
+    private Length partPitch = new Length(4, LengthUnit.Millimeters);
+    @Element(required = false)
+    private Length feedPitch = new Length(4, LengthUnit.Millimeters);
+    @Attribute(required = false)
+    private long feedMultiplier= 1;
+
+    @Element(required = false)
+    protected double feedSpeedPush1 = 1.0; 
+    @Attribute(required = false)
+    protected double feedSpeedPush2 = 1.0; 
+    @Attribute(required = false)
+    protected double feedSpeedPush3 = 1.0; 
+    @Attribute(required = false)
+    protected double feedSpeedPushEnd = 1.0;
+    @Attribute(required = false)
+    protected double feedSpeedPull3 = 1.0;
+    @Attribute(required = false)
+    protected double feedSpeedPull2 = 1.0;
+    @Attribute(required = false)
+    protected double feedSpeedPull1 = 1.0;
+    @Attribute(required = false)
+    protected double feedSpeedPull0 = 1.0;
+
+    @Attribute(required = false)
+    protected boolean includedPush1 = false; 
+    @Attribute(required = false)
+    protected boolean includedPush2 = false; 
+    @Attribute(required = false)
+    protected boolean includedPush3 = false; 
+    @Attribute(required = false)
+    protected boolean includedPushEnd = true; 
+
+    @Attribute(required = false)
+    protected boolean includedMulti0 = true; 
+    @Attribute(required = false)
+    protected boolean includedMulti1 = false; 
+    @Attribute(required = false)
+    protected boolean includedMulti2 = false; 
+    @Attribute(required = false)
+    protected boolean includedMulti3 = false; 
+    @Attribute(required = false)
+    protected boolean includedMultiEnd = true; 
+
+    @Attribute(required = false)
+    protected boolean includedPull0 = true; 
+    @Attribute(required = false)
+    protected boolean includedPull1 = false; 
+    @Attribute(required = false)
+    protected boolean includedPull2 = false; 
+    @Attribute(required = false)
+    protected boolean includedPull3 = false; 
+
+    @Attribute(required = false)
+    protected String actuatorName;
+    @Attribute(required = false)
+    protected String peelOffActuatorName;
+
+    @Attribute(required = false)
+    private long feedCount = 0;
+
+    @Element(required = false)
+    private CvPipeline pipeline = createDefaultPipeline();
+
+    @Attribute(required = false)
+    protected String ocrFontName = "Liberation Mono";
+    @Attribute(required = false)
+    protected double ocrFontSizePt = 7.0;
+    @Element(required = false)
+    protected RegionOfInterest ocrRegion = null; 
+
+    public enum OcrWrongPartAction {
+        None,
+        SwapFeeders,
+        SwapOrCreate,
+        ChangePart,
+        ChangePartAndClone
+    }
+
+    @Attribute(required = false)
+    protected OcrWrongPartAction ocrWrongPartAction = OcrWrongPartAction.SwapOrCreate;
+    @Attribute(required = false)
+    protected boolean ocrDiscoverOnJobStart = true;
+    @Attribute(required = false)
+    protected boolean ocrStopAfterWrongPart = false;
+
+    @Element(required = false)
+    private Length precisionWanted = new Length(0.1, LengthUnit.Millimeters);
+
+    @Attribute(required = false)
+    private int calibrationCount = 0;
+    @Element(required = false)
+    private Length sumOfErrors = new Length(0, LengthUnit.Millimeters);
+    @Element(required = false)
+    private Length sumOfErrorSquares = new Length(0, LengthUnit.Millimeters);
+
+
+    // These are not on the GUI but can be tweaked in the machine.xml /////////////////
+
+    // initial calibration tolerance, i.e. how much the feeder can be shifted physically 
+    @Attribute(required = false)
+    private double calibrationToleranceMm = 1.95;
+    // vision and comparison sprocket hole tolerance (in size, position)
+    @Attribute(required = false)
+    private double sprocketHoleToleranceMm = 0.3;
+    // for rows of feeders, the tolerance in X, Y
+    @Attribute(required = false)
+    private double rowLocationToleranceMm = 4.0; 
+    // for rows of feeders, the tolerance in Z
+    @Attribute(required = false)
+    private double rowZLocationToleranceMm = 1.0; 
+
+    @Attribute(required = false)
+    private int calibrateMaxPasses = 3; 
+    // how close the camera has to be to prevent one more pass
+    @Attribute(required = false)
+    private double calibrateToleranceMm = 0.3; 
+    @Attribute(required = false)
+    private int calibrateMinStatistic = 2; 
+
+    /*
+     * visionOffset contains the difference between where the part was expected to be and where it
+     * is. Subtracting these offsets from the pickLocation produces the correct pick location.
+     */
+    protected Location visionOffset;
+
+    public static final Location nullLocation = new Location(LengthUnit.Millimeters);
+
+    private void checkHomedState(Machine machine) {
+        if (!machine.isHomed()) {
+            this.resetCalibration();
+        }
+    }
+
+    public ReferencePushPullFeeder() {
+        // Listen to the machine become unhomed to invalidate feeder calibration. 
+        // Note that home()  first switches the machine isHomed() state off, then on again, 
+        // so we also catch re-homing. 
+        Configuration.get().addListener(new ConfigurationListener.Adapter() {
+            @Override
+            public void configurationComplete(Configuration configuration) throws Exception {
+                Configuration.get().getMachine().addListener(new MachineListener.Adapter() {
+
+                    @Override
+                    public void machineHeadActivity(Machine machine, Head head) {
+                        checkHomedState(machine);
+                    }
+
+                    @Override
+                    public void machineEnabled(Machine machine) {
+                        checkHomedState(machine);
+                    }
+                });
+            }
+        });
+    }
+
+    @Commit
+    public void commit() {
+    }
+
+    public Camera getCamera() throws Exception {
+        return  Configuration.get()
+                .getMachine()
+                .getDefaultHead()
+                .getDefaultCamera();
+    }
+
+
+    public enum CalibrationTrigger {
+        None,
+        OnFirstUse,
+        UntilConfident,
+        OnEachTapeFeed
+    }
+
+    @Attribute(required = false)
+    protected CalibrationTrigger calibrationTrigger = CalibrationTrigger.UntilConfident;
+
+    public void assertCalibrated(boolean tapeFeed) throws Exception {
+        if ((visionOffset == null && calibrationTrigger != CalibrationTrigger.None)
+                || (tapeFeed && calibrationTrigger == CalibrationTrigger.UntilConfident && !isPrecisionSufficient())
+                || (tapeFeed && calibrationTrigger == CalibrationTrigger.OnEachTapeFeed)) {
+            // not yet calibrated (enough)
+            obtainCalibratedVisionOffset();
+            if (visionOffset == null) {
+                // no lock obtained
+                throw new Exception(String.format("Vision failed on feeder %s.", getName()));
+            }
+        }
+    }
+
+    public boolean isPrecisionSufficient() {
+        if (calibrationCount < calibrateMinStatistic) {
+            return false;
+        }
+        else if (getPrecisionConfidenceLimit().divide(getPrecisionWanted()) > 1.0) {
+            return false;
+        }
+        return true;
+    }
+
+    public boolean isVisionEnabled() {
+        return calibrationTrigger != CalibrationTrigger.None;
+    }
+
+    @Override
+    public Location getPickLocation() throws Exception {
+        assertCalibrated(false);
+        // Numbers are 1-based (a feed is needed before the very first part can be picked),
+        // therefore the modulo calculation is a bit gnarly.
+        // The 1-based approach has the benefit, that at feed count 0 (reset) the part closest to the reel 
+        // is the pick location which is the last part in a multi-part feed cycle, which is the one we want for setup.  
+        long partInCycle = ((getFeedCount()+getPartsPerFeedCycle()-1) % getPartsPerFeedCycle())+1;
+        return getPickLocation(partInCycle, visionOffset);
+    }
+
+    @Override
+    public void feed(Nozzle nozzle) throws Exception {
+        Logger.debug("feed({})", nozzle);
+
+        if (actuatorName == null || actuatorName.isEmpty()) {
+            throw new Exception(String.format("No actuator name set on feeder %s.", getName()));
+        }
+
+
+        Head head = nozzle.getHead();
+        Actuator actuator = head.getActuatorByName(actuatorName);
+        if (actuator == null) {
+            throw new Exception(String.format("No Actuator found with name %s on feed Head %s",
+                    actuatorName, head.getName()));
+        }
+
+        Actuator peelOffActuator = head.getActuatorByName(peelOffActuatorName);
+
+        if (getFeedCount() % getPartsPerFeedCycle() == 0) {
+            // Modulo of feed count is zero - no more parts there to pick, must feed 
+
+            // Make sure we're calibrated
+            assertCalibrated(false);
+
+            // Create the effective feed locations, keeping the Rotation intact and applying the vision offset.
+            Location feedStartLocation = getFeedStartLocation()
+                    .derive(actuator.getLocation(), false, false, false, true)
+                    .subtractWithRotation(getVisionOffset());
+            Location feedMid1Location = getFeedMid1Location()
+                    .derive(actuator.getLocation(), false, false, false, true)
+                    .subtractWithRotation(getVisionOffset());
+            Location feedMid2Location = getFeedMid2Location()
+                    .derive(actuator.getLocation(), false, false, false, true)
+                    .subtractWithRotation(getVisionOffset());
+            Location feedMid3Location = getFeedMid3Location()
+                    .derive(actuator.getLocation(), false, false, false, true)
+                    .subtractWithRotation(getVisionOffset());
+            Location feedEndLocation = getFeedEndLocation()
+                    .derive(actuator.getLocation(), false, false, false, true)
+                    .subtractWithRotation(getVisionOffset());
+
+            // Move to the Feed Start Location
+            MovableUtils.moveToLocationAtSafeZ(actuator, feedStartLocation);
+            double baseSpeed = actuator.getHead().getMachine().getSpeed();
+
+            long feedsPerPart = (long)Math.ceil(getPartPitch().divide(getFeedPitch()));
+            long n = getFeedMultiplier()*feedsPerPart;
+            for (long i = 0; i < n; i++) {  // perform multiple feeds if required
+
+                boolean isFirst = (i == 0); 
+                boolean isLast = (i == n-1); 
+
+                // enable actuator (may do nothing)
+                actuator.actuate(true);
+
+                // Push the lever by following the path of locations
+                if (includedPush1 && (isFirst || includedMulti1)) {
+                    actuator.moveTo(feedMid1Location, feedSpeedPush1*baseSpeed);
+                }
+                if (includedPush2 && (isFirst || includedMulti2)) {
+                    actuator.moveTo(feedMid2Location, feedSpeedPush2*baseSpeed);
+                }
+                if (includedPush3 && (isFirst || includedMulti3)) {
+                    actuator.moveTo(feedMid3Location, feedSpeedPush3*baseSpeed);
+                }
+                if (includedPushEnd && (isFirst || includedMultiEnd)) {
+                    actuator.moveTo(feedEndLocation, feedSpeedPushEnd*baseSpeed);
+                }
+
+                // Start the take up actuator
+                if (peelOffActuator != null) {
+                    peelOffActuator.actuate(true);
+                }
+
+                // Now move back to the start location to move the tape.
+                if (includedPull3 && (isLast || includedMulti3)) {
+                    actuator.moveTo(feedMid3Location, feedSpeedPull3 * baseSpeed);
+                }
+                if (includedPull2 && (isLast || includedMulti2)) {
+                    actuator.moveTo(feedMid2Location, feedSpeedPull2 * baseSpeed);
+                }
+                if (includedPull1 && (isLast || includedMulti1)) {
+                    actuator.moveTo(feedMid1Location, feedSpeedPull1*baseSpeed);
+                }
+                if (includedPull0 && (isLast || includedMulti0)) {
+                    actuator.moveTo(feedStartLocation, feedSpeedPull0*baseSpeed);
+                }
+
+                // Stop the take up actuator
+                if (peelOffActuator != null) {
+                    peelOffActuator.actuate(false);
+                }
+
+                // disable actuator
+                actuator.actuate(false);
+            }
+
+            head.moveToSafeZ();
+
+            // Make sure we're calibrated after type feed
+            assertCalibrated(true);
+        } 
+        else {
+            Logger.debug("Multi parts feed: skipping tape feed at feed count " + feedCount);
+        }
+
+        // increment feed count 
+        setFeedCount(getFeedCount()+1);
+    }
+
+    private void obtainCalibratedVisionOffset() throws Exception {
+        Camera camera = getCamera();
+        try (CvPipeline pipeline = getCvPipeline(camera, true, false)) {
+            OcrWrongPartAction ocrAction = OcrWrongPartAction.None;
+            boolean ocrStop = false;
+            if (visionOffset == null) {
+                // this is the very first calibration -> also detect OCR
+                ocrAction = getOcrWrongPartAction();
+                ocrStop = isOcrStopAfterWrongPart();
+            }
+            performVisionOperations(camera, pipeline, false, false, true, ocrAction, ocrStop, null);
+        }
+    }
+
+    @Override
+    public String toString() {
+        return String.format("%s id %s", getClass().getName(), id);
+    }
+
+    @Override
+    public void setLocation(Location location) {
+        super.setLocation(location);
+        resetCalibration();
+    }
+
+    public Double getRotationInFeeder() {
+        if (rotationInFeeder == null) {
+            rotationInFeeder = new Double(0.0);
+        }
+        return rotationInFeeder;
+    }
+
+    public void setRotationInFeeder(Double rotationInFeeder) {
+        Object oldValue = this.rotationInFeeder;
+        this.rotationInFeeder = rotationInFeeder;
+        firePropertyChange("rotationInFeeder", oldValue, rotationInFeeder);
+    }
+
+    public boolean isNormalizePickLocation() {
+        return normalizePickLocation;
+    }
+
+    public void setNormalizePickLocation(boolean normalizePickLocation) {
+        Object oldValue = this.normalizePickLocation;
+        this.normalizePickLocation = normalizePickLocation;
+        firePropertyChange("normalizePickLocation", oldValue, normalizePickLocation);
+    }
+
+    public boolean isSnapToAxis() {
+        return snapToAxis;
+    }
+
+    public void setSnapToAxis(boolean snapToAxis) {
+        Object oldValue = this.normalizePickLocation;
+        this.snapToAxis = snapToAxis;
+        firePropertyChange("snapToAxis", oldValue, snapToAxis);
+    }
+
+    public Location getHole1Location() {
+        return hole1Location;
+    }
+
+    public void setHole1Location(Location hole1Location) {
+        Object oldValue = this.hole1Location;
+        this.hole1Location = hole1Location;
+        firePropertyChange("hole1Location", oldValue, hole1Location);
+        resetCalibration();
+    }
+
+    public Location getHole2Location() {
+        return hole2Location;
+    }
+
+    public void setHole2Location(Location hole2Location) {
+        Object oldValue = this.hole2Location;
+        this.hole2Location = hole2Location;
+        firePropertyChange("hole2Location", oldValue, hole2Location);
+        resetCalibration();
+    }
+
+    public boolean isUsedAsTemplate() {
+        return usedAsTemplate;
+    }
+
+    public void setUsedAsTemplate(boolean usedAsTemplate) {
+        Object oldValue = this.usedAsTemplate;
+        this.usedAsTemplate = usedAsTemplate;
+        firePropertyChange("usedAsTemplate", oldValue, usedAsTemplate);
+        // this also changes the status implicitly 
+        firePropertyChange("cloneTemplateStatus", "", getCloneTemplateStatus());
+    }
+
+    public Location getFeedStartLocation() {
+        return feedStartLocation;
+    }
+
+    public void setFeedStartLocation(Location feedStartLocation) {
+        Object oldValue = this.feedStartLocation;
+        this.feedStartLocation = feedStartLocation;
+        firePropertyChange("feedStartLocation", oldValue, feedStartLocation);
+    }
+
+    public Location getFeedMid1Location() {
+        return feedMid1Location;
+    }
+
+    public void setFeedMid1Location(Location feedMid1Location) {
+        Object oldValue = this.feedMid1Location;
+        this.feedMid1Location = feedMid1Location;
+        firePropertyChange("feedMid1Location", oldValue, feedMid1Location);
+    }
+
+    public Location getFeedMid2Location() {
+        return feedMid2Location;
+    }
+
+    public void setFeedMid2Location(Location feedMid2Location) {
+        Object oldValue = this.feedMid2Location;
+        this.feedMid2Location = feedMid2Location;
+        firePropertyChange("feedMid2Location", oldValue, feedMid2Location);
+    }
+
+    public Location getFeedMid3Location() {
+        return feedMid3Location;
+    }
+
+    public void setFeedMid3Location(Location feedMid3Location) {
+        Object oldValue = this.feedMid3Location;
+        this.feedMid3Location = feedMid3Location;
+        firePropertyChange("feedMid3Location", oldValue, feedMid3Location);
+    }
+
+    public Location getFeedEndLocation() {
+        return feedEndLocation;
+    }
+
+    public void setFeedEndLocation(Location feedEndLocation) {
+        Object oldValue = this.feedEndLocation;
+        this.feedEndLocation = feedEndLocation;
+        firePropertyChange("feedEndLocation", oldValue, feedEndLocation);
+    }
+
+    public Length getPartPitch() {
+        return partPitch;
+    }
+
+    public void setPartPitch(Length partPitch) {
+        Object oldValue = this.partPitch;
+        this.partPitch = partPitch;
+        firePropertyChange("partPitch", oldValue, partPitch);
+    }
+
+    public Length getFeedPitch() {
+        return feedPitch;
+    }
+
+    public void setFeedPitch(Length feedPitch) {
+        Object oldValue = this.feedPitch;
+        this.feedPitch = feedPitch;
+        firePropertyChange("feedPitch", oldValue, feedPitch);
+    }
+
+    public double getFeedSpeedPush1() {
+        return feedSpeedPush1;
+    }
+
+    public void setFeedSpeedPush1(double feedSpeedPush1) {
+        Object oldValue = this.feedSpeedPush1;
+        this.feedSpeedPush1 = feedSpeedPush1;
+        firePropertyChange("feedSpeedPush1", oldValue, feedSpeedPush1);
+    }
+
+    public double getFeedSpeedPush2() {
+        return feedSpeedPush2;
+    }
+
+    public void setFeedSpeedPush2(double feedSpeedPush2) {
+        Object oldValue = this.feedSpeedPush2;
+        this.feedSpeedPush2 = feedSpeedPush2;
+        firePropertyChange("feedSpeedPush2", oldValue, feedSpeedPush2);
+    }
+
+    public double getFeedSpeedPush3() {
+        return feedSpeedPush3;
+    }
+
+    public void setFeedSpeedPush3(double feedSpeedPush3) {
+        Object oldValue = this.feedSpeedPush3;
+        this.feedSpeedPush3 = feedSpeedPush3;
+        firePropertyChange("feedSpeedPush3", oldValue, feedSpeedPush3);
+    }
+
+    public double getFeedSpeedPushEnd() {
+        return feedSpeedPushEnd;
+    }
+
+    public void setFeedSpeedPushEnd(double feedSpeedPushEnd) {
+        Object oldValue = this.feedSpeedPushEnd;
+        this.feedSpeedPushEnd = feedSpeedPushEnd;
+        firePropertyChange("feedSpeedPushEnd", oldValue, feedSpeedPushEnd);
+    }
+
+    public double getFeedSpeedPull3() {
+        return feedSpeedPull3;
+    }
+
+    public void setFeedSpeedPull3(double feedSpeedPull3) {
+        Object oldValue = this.feedSpeedPull3;
+        this.feedSpeedPull3 = feedSpeedPull3;
+        firePropertyChange("feedSpeedPull3", oldValue, feedSpeedPull3);
+    }
+
+    public double getFeedSpeedPull2() {
+        return feedSpeedPull2;
+    }
+
+    public void setFeedSpeedPull2(double feedSpeedPull2) {
+        Object oldValue = this.feedSpeedPull2;
+        this.feedSpeedPull2 = feedSpeedPull2;
+        firePropertyChange("feedSpeedPull2", oldValue, feedSpeedPull2);
+    }
+
+    public double getFeedSpeedPull1() {
+        return feedSpeedPull1;
+    }
+
+    public void setFeedSpeedPull1(double feedSpeedPull1) {
+        Object oldValue = this.feedSpeedPull1;
+        this.feedSpeedPull1 = feedSpeedPull1;
+        firePropertyChange("feedSpeedPull1", oldValue, feedSpeedPull1);
+    }
+
+    public double getFeedSpeedPull0() {
+        return feedSpeedPull0;
+    }
+
+    public void setFeedSpeedPull0(double feedSpeedPull0) {
+        Object oldValue = this.feedSpeedPull0;
+        this.feedSpeedPull0 = feedSpeedPull0;
+        firePropertyChange("feedSpeedPull0", oldValue, feedSpeedPull0);
+    }
+
+    public boolean isIncludedPush1() {
+        return includedPush1;
+    }
+
+    public void setIncludedPush1(boolean includedPush1) {
+        Object oldValue = this.includedPush1;
+        this.includedPush1 = includedPush1;
+        firePropertyChange("includedPush1", oldValue, includedPush1);
+    }
+
+    public boolean isIncludedPush2() {
+        return includedPush2;
+    }
+
+    public void setIncludedPush2(boolean includedPush2) {
+        Object oldValue = this.includedPush2;
+        this.includedPush2 = includedPush2;
+        firePropertyChange("includedPush2", oldValue, includedPush2);
+    }
+
+    public boolean isIncludedPush3() {
+        return includedPush3;
+    }
+
+    public void setIncludedPush3(boolean includedPush3) {
+        Object oldValue = this.includedPush3;
+        this.includedPush3 = includedPush3;
+        firePropertyChange("includedPush3", oldValue, includedPush3);
+    }
+
+    public boolean isIncludedPushEnd() {
+        return includedPushEnd;
+    }
+
+    public void setIncludedPushEnd(boolean includedPushEnd) {
+        Object oldValue = this.includedPushEnd;
+        this.includedPushEnd = includedPushEnd;
+        firePropertyChange("includedPushEnd", oldValue, includedPushEnd);
+    }
+
+    public boolean isIncludedMulti0() {
+        return includedMulti0;
+    }
+
+    public void setIncludedMulti0(boolean includedMulti0) {
+        Object oldValue = this.includedMulti0;
+        this.includedMulti0 = includedMulti0;
+        firePropertyChange("includedMulti0", oldValue, includedMulti0);
+    }
+
+    public boolean isIncludedMulti1() {
+        return includedMulti1;
+    }
+
+    public void setIncludedMulti1(boolean includedMulti1) {
+        Object oldValue = this.includedMulti1;
+        this.includedMulti1 = includedMulti1;
+        firePropertyChange("includedMulti1", oldValue, includedMulti1);
+    }
+
+    public boolean isIncludedMulti2() {
+        return includedMulti2;
+    }
+
+    public void setIncludedMulti2(boolean includedMulti2) {
+        Object oldValue = this.includedMulti2;
+        this.includedMulti2 = includedMulti2;
+        firePropertyChange("includedMulti2", oldValue, includedMulti2);
+    }
+
+    public boolean isIncludedMulti3() {
+        return includedMulti3;
+    }
+
+    public void setIncludedMulti3(boolean includedMulti3) {
+        Object oldValue = this.includedMulti3;
+        this.includedMulti3 = includedMulti3;
+        firePropertyChange("includedMulti3", oldValue, includedMulti3);
+    }
+
+    public boolean isIncludedMultiEnd() {
+        return includedMultiEnd;
+    }
+
+    public void setIncludedMultiEnd(boolean includedMultiEnd) {
+        Object oldValue = this.includedMultiEnd;
+        this.includedMultiEnd = includedMultiEnd;
+        firePropertyChange("includedMultiEnd", oldValue, includedMultiEnd);
+    }
+
+    public boolean isIncludedPull0() {
+        return includedPull0;
+    }
+
+    public void setIncludedPull0(boolean includedPull0) {
+        Object oldValue = this.includedPull0;
+        this.includedPull0 = includedPull0;
+        firePropertyChange("includedPull0", oldValue, includedPull0);
+    }
+
+    public boolean isIncludedPull1() {
+        return includedPull1;
+    }
+
+    public void setIncludedPull1(boolean includedPull1) {
+        Object oldValue = this.includedPull1;
+        this.includedPull1 = includedPull1;
+        firePropertyChange("includedPull1", oldValue, includedPull1);
+    }
+
+    public boolean isIncludedPull2() {
+        return includedPull2;
+    }
+
+    public void setIncludedPull2(boolean includedPull2) {
+        Object oldValue = this.includedPull2;
+        this.includedPull2 = includedPull2;
+        firePropertyChange("includedPull2", oldValue, includedPull2);
+    }
+
+    public boolean isIncludedPull3() {
+        return includedPull3;
+    }
+
+    public void setIncludedPull3(boolean includedPull3) {
+        Object oldValue = this.includedPull3;
+        this.includedPull3 = includedPull3;
+        firePropertyChange("includedPull3", oldValue, includedPull3);
+    }
+
+    public String getActuatorName() {
+        return actuatorName;
+    }
+
+    public void setActuatorName(String actuatorName) {
+        String oldValue = this.actuatorName;
+        this.actuatorName = actuatorName;
+        // Unfortunately, java.beans.PropertyChangeSupport.firePropertyChange(String, Object, Object)
+        // will always treat null property changes as "dirty" signal. So let's handle those as empty Strings. 
+        firePropertyChange("actuatorName", 
+                oldValue == null ? "" : oldValue, 
+                        actuatorName == null ? "" : actuatorName);
+    }
+
+    public String getPeelOffActuatorName() {
+        return peelOffActuatorName;
+    }
+
+    public void setPeelOffActuatorName(String actuatorName) {
+        String oldValue = this.peelOffActuatorName;
+        this.peelOffActuatorName = actuatorName;
+        // Unfortunately, java.beans.PropertyChangeSupport.firePropertyChange(String, Object, Object)
+        // will always treat null property changes as "dirty" signal. So let's handle those as empty Strings. 
+        firePropertyChange("peelOffActuatorName", 
+                oldValue == null ? "" : oldValue, 
+                        actuatorName == null ? "" : actuatorName);
+    }
+
+    public long getFeedCount() {
+        return feedCount;
+    }
+
+    public void setFeedCount(long feedCount) {
+        long oldValue = this.feedCount;
+        this.feedCount = feedCount;
+        firePropertyChange("feedCount", oldValue, feedCount);
+    }
+
+    public long getFeedMultiplier() {
+        return feedMultiplier;
+    }
+
+    public void setFeedMultiplier(long feedMultiplier) {
+        Object oldValue = this.feedMultiplier;
+        this.feedMultiplier = feedMultiplier;
+        firePropertyChange("feedMultiplier", oldValue, feedMultiplier);
+    }
+
+    public CalibrationTrigger getCalibrationTrigger() {
+        return calibrationTrigger;
+    }
+
+    public void setCalibrationTrigger(CalibrationTrigger calibrationTrigger) {
+        Object oldValue = this.calibrationTrigger;
+        this.calibrationTrigger = calibrationTrigger;
+        firePropertyChange("calibrationTrigger", oldValue, calibrationTrigger);
+    }
+
+    public String getOcrFontName() {
+        return ocrFontName;
+    }
+
+    public void setOcrFontName(String ocrFontName) {
+        Object oldValue = this.ocrFontName;
+        this.ocrFontName = ocrFontName;
+        firePropertyChange("ocrFontName", oldValue, ocrFontName);
+    }
+
+    public double getOcrFontSizePt() {
+        return ocrFontSizePt;
+    }
+
+    public void setOcrFontSizePt(double ocrFontSizePt) {
+        Object oldValue = this.ocrFontSizePt;
+        this.ocrFontSizePt = ocrFontSizePt;
+        firePropertyChange("ocrFontSizePt", oldValue, ocrFontSizePt);
+    }
+
+    public RegionOfInterest getOcrRegion() {
+        return ocrRegion;
+    }
+
+    public void setOcrRegion(RegionOfInterest ocrRegion) {
+        Object oldValue = this.ocrRegion;
+        this.ocrRegion = ocrRegion;
+        firePropertyChange("ocrRegion", oldValue, ocrRegion);
+    }
+
+    public OcrWrongPartAction getOcrWrongPartAction() {
+        return ocrWrongPartAction;
+    }
+
+    public void setOcrWrongPartAction(OcrWrongPartAction ocrWrongPartAction) {
+        Object oldValue = this.ocrWrongPartAction;
+        this.ocrWrongPartAction = ocrWrongPartAction;
+        firePropertyChange("ocrWrongPartAction", oldValue, ocrWrongPartAction);
+    }
+
+    public boolean isOcrDiscoverOnJobStart() {
+        return ocrDiscoverOnJobStart;
+    }
+
+    public void setOcrDiscoverOnJobStart(boolean ocrDiscoverOnJobStart) {
+        Object oldValue = this.ocrDiscoverOnJobStart;
+        this.ocrDiscoverOnJobStart = ocrDiscoverOnJobStart;
+        firePropertyChange("ocrDiscoverOnJobStart", oldValue, ocrDiscoverOnJobStart);
+    }
+
+    public boolean isOcrStopAfterWrongPart() {
+        return ocrStopAfterWrongPart;
+    }
+
+    public void setOcrStopAfterWrongPart(boolean ocrStopAfterWrongPart) {
+        Object oldValue = this.ocrStopAfterWrongPart;
+        this.ocrStopAfterWrongPart = ocrStopAfterWrongPart;
+        firePropertyChange("ocrStopAfterWrongPart", oldValue, ocrStopAfterWrongPart);
+    }
+
+    public Length getPrecisionWanted() {
+        return precisionWanted;
+    }
+
+    public void setPrecisionWanted(Length precisionWanted) {
+        Object oldValue = this.precisionWanted;
+        this.precisionWanted = precisionWanted;
+        firePropertyChange("precisionWanted", oldValue, precisionWanted);
+    }
+
+    public int getCalibrationCount() {
+        return calibrationCount;
+    }
+
+    public void setCalibrationCount(int calibrationCount) {
+        int oldValue = this.calibrationCount;
+        Length oldPrecision = getPrecisionAverage();
+        Length oldConfidence = getPrecisionConfidenceLimit();
+        this.calibrationCount = calibrationCount;
+        firePropertyChange("calibrationCount", oldValue, calibrationCount);
+        if (oldValue !=  calibrationCount) {
+            // this also implicitly changes the stats
+            firePropertyChange("precisionAverage", oldPrecision, getPrecisionAverage());
+            firePropertyChange("precisionConfidenceLimit", oldConfidence, getPrecisionConfidenceLimit());
+        }
+    }
+
+    public Length getSumOfErrors() {
+        return sumOfErrors;
+    }
+
+    public void addCalibrationError(Length error) {
+        sumOfErrors = sumOfErrors.add(error);
+        // this is a bit dodgy as the true unit is actually the length unit squared, but we'll use the square root of that later, so it will be fine.
+        error = error.convertToUnits(sumOfErrorSquares.getUnits());
+        sumOfErrorSquares = sumOfErrorSquares.add(error.multiply(error.getValue()));
+        setCalibrationCount(getCalibrationCount()+1); // will also fire average and confidence prop change
+    }
+
+    public Length getPrecisionAverage() {
+        return calibrationCount > 0 ? 
+                sumOfErrors.multiply(1.0/calibrationCount) 
+                : new Length(0, LengthUnit.Millimeters);
+    }
+
+    public void setPrecisionAverage(Length precisionAverage) {
+        // swallow this
+    }
+
+    public Length getPrecisionConfidenceLimit() {
+        if (calibrationCount >= 2) {
+            // Note, we don't take the average of the error, because the error is already a distance that is distributed 
+            // around the true sprocket holes center location i.e. distributed around zero i.e. zero is the mean 
+            // (this is limited math knowledge speaking).   
+            Length variance = sumOfErrorSquares.multiply(1.0/(calibrationCount-1));
+            Length scatter = new Length(Math.sqrt(variance.getValue()/Math.sqrt(calibrationCount)), variance.getUnits()); 
+            return scatter.multiply(1.64); // 95% confidence interval, normal distribution.
+        }
+        else {
+            return new Length(0, LengthUnit.Millimeters);
+        }
+    }
+
+    public void setPrecisionConfidenceLimit(Length precisionConfidenceLimit) {
+        // swallow this
+    }
+
+    public Length getPartsToSprocketHoleDistance() {
+        return new Length(getLocation().getLinearDistanceToLineSegment(getHole1Location(), getHole2Location()), 
+                getLocation().getUnits());
+    }
+
+    public long getPartsPerFeedCycle() {
+        long feedsPerPart = (long)Math.ceil(getPartPitch().divide(getFeedPitch()));
+        return Math.round(getFeedMultiplier()*Math.ceil(feedsPerPart*getFeedPitch().divide(getPartPitch())));
+    }
+
+    public void resetCalibrationStatistics() {
+        sumOfErrors = new Length(0, LengthUnit.Millimeters);
+        sumOfErrorSquares = new Length(0, LengthUnit.Millimeters);
+        setCalibrationCount(0);
+        resetCalibration();
+    }
+
+    public static Location forwardTransform(Location location, Location transform) {
+        return location.rotateXy(transform.getRotation()).addWithRotation(transform);
+    }
+
+    public static Location backwardTransform(Location location, Location transform) {
+        return location.subtractWithRotation(transform).rotateXy(-transform.getRotation());
+    }
+
+    protected Location getTransform(Location visionOffset) {
+        // Our local feeder coordinate system is relative to the EIA 481 standard tape orientation
+        // i.e. with the sprocket holes on top and the tape advancing to the right, which is our +X
+        // The pick location is on [0, 0] local, which corresponds to feeder.location global.
+        // The feeder.location.rotation contains the orientation of the tape on the machine.
+
+        // to make sure we get the right rotation, we update it from the sprocket holes
+        // instead of trusting the location.rotation. This might happen when the user fiddles 
+        // with the locations manually.
+
+        Location unitVector = getHole1Location().unitVectorTo(getHole2Location());
+        double rotationTape = Math.atan2(unitVector.getY(), unitVector.getX())*180.0/Math.PI;
+        Location transform = getLocation().derive(null, null, null, rotationTape);
+        if (Math.abs(rotationTape - getLocation().getRotation()) > 0.1) {
+            // HACK: something is not up-to-date -> refresh
+            setLocation(transform);
+        }
+
+        if (visionOffset != null) {
+            transform = transform.subtractWithRotation(visionOffset);
+        }
+        return transform;
+    }
+
+    protected Location transformFeederToMachineLocation(Location feederLocation, Location visionOffset) {
+        return forwardTransform(feederLocation, getTransform(visionOffset));
+    }
+
+    protected Location transformMachineToFeederLocation(Location machineLocation, Location visionOffset) {
+        return backwardTransform(machineLocation, getTransform(visionOffset));
+    }
+
+    public Location getPickLocation(long partInCycle, Location visionOffset)  {
+        // If the feeder is advancing more than one part per feed cycle (e.g. with 2mm pitch tape or if a multiplier is
+        // given), we need to cycle through multiple pick locations. partInCycle is 1-based and goes to getPartsPerFeedCycle().
+        long offsetPitches = (getPartsPerFeedCycle() - partInCycle) % getPartsPerFeedCycle();
+        Location feederLocation = new Location(partPitch.getUnits(), partPitch.multiply((double)offsetPitches).getValue(), 
+                0, 0, getRotationInFeeder());
+        Location machineLocation = transformFeederToMachineLocation(feederLocation, visionOffset);
+        return machineLocation;
+    } 
+
+
+    public CvPipeline getPipeline() {
+        return pipeline;
+    }
+
+    public void setPipeline(CvPipeline pipeline) {
+        this.pipeline = pipeline;
+    }
+
+    public Location getVisionOffset() {
+        if (isVisionEnabled() && visionOffset != null) {
+            return visionOffset;
+        }
+        else {
+            return nullLocation;
+        }
+    }
+
+    public void setVisionOffset(Location visionOffset) {
+        this.visionOffset = visionOffset;
+    }
+
+    public void resetCalibration() {
+        setVisionOffset(null);
+    }
+
+    public void resetPipeline() {
+        pipeline = createDefaultPipeline();
+    }
+
+    public Location getNominalVisionLocation() throws Exception {
+        if (hole1Location.equals(nullLocation) || hole2Location.equals(nullLocation)) {
+            // not yet initialized, just return the current camera location
+            return getCamera().getLocation();
+        }
+        else {
+            return getHole1Location().add(getHole2Location()).multiply(0.5, 0.5, 0.0, 0.0);
+        }
+    }
+
+    protected void setupOcr(Camera camera, CvPipeline pipeline, Location hole1, Location hole2, Location pickLocation) {
+        pipeline.setProperty("regionOfInterest", getOcrRegion());
+        pipeline.setProperty("fontName", getOcrFontName());
+        pipeline.setProperty("fontSizePt", getOcrFontSizePt());
+        pipeline.setProperty("alphabet", getConsolidatedOcrAlphabet(null));
+    }
+
+    protected void setupOcr(Camera camera, CvPipeline pipeline) {
+        setupOcr(camera, pipeline, getHole1Location(), getHole2Location(), getLocation());
+    }
+
+    protected void disableOcr(Camera camera, CvPipeline pipeline) {
+        pipeline.setProperty("regionOfInterest", null);
+        pipeline.setProperty("fontName", null);
+        pipeline.setProperty("fontSizePt", null);
+        pipeline.setProperty("alphabet", ""); // empty alphabet switches OCR off
+    }
+
+    public CvPipeline getCvPipeline(Camera camera, boolean clone, boolean performOcr) {
+        try {
+            CvPipeline pipeline = getPipeline();
+            if (clone) {
+                pipeline = pipeline.clone();
+            }
+            pipeline.setProperty("camera", camera);
+            pipeline.setProperty("feeder", this);
+            if (performOcr && getOcrRegion() != null) {
+                setupOcr(camera, pipeline);
+            }
+            else {
+                disableOcr(camera, pipeline);
+            }
+
+            return pipeline;
+        }
+        catch (CloneNotSupportedException e) {
+            throw new Error(e);
+        }
+    }
+
+    private static CvPipeline createDefaultPipeline() {
+        try {
+            String xml = IOUtils.toString(BlindsFeeder.class
+                    .getResource("ReferencePushPullFeeder-DefaultPipeline.xml"));
+            return new CvPipeline(xml);
+        }
+        catch (Exception e) {
+            throw new Error(e);
+        }
+    }
+
+    public enum FindFeaturesMode {
+        FromPickLocationGetHoles,
+        CalibrateHoles
+    }
+
+    protected String getConsolidatedOcrAlphabet(Part compatiblePart) {
+        // from all the compatible parts in the system, create the alphabet for OCR operation
+        Set<Character> characterSet = new HashSet<>(); 
+        for (Part part : Configuration.get().getParts()) {
+            if (compatiblePart == null || compatiblePartPackages(part, compatiblePart)) {
+                for (char ch : part.getId().toCharArray()) {
+                    characterSet.add(ch);
+                }
+            }
+        }
+        StringBuilder alphabet = new StringBuilder();
+        for (char ch : characterSet) {
+            if (ch != ' ') {
+                alphabet.append(ch);
+            }
+        }
+        return alphabet.toString();
+    }
+
+    public class FindFeatures {
+        private Camera camera;
+        private CvPipeline pipeline;
+        private long showResultMilliseconds;
+        private FindFeaturesMode autoSetupMode;
+        private Location calibratedVisionOffset;
+        private Location calibratedHole1Location;
+        private Location calibratedHole2Location;
+        private Location calibratedPickLocation;
+        private SimpleOcr.OcrModel detectedOcrModel;
+
+        // recognized stuff
+        private List<Result.Circle> holes;
+        private List<Line> lines;
+
+        public FindFeatures(Camera camera, CvPipeline pipeline, final long showResultMilliseconds, FindFeaturesMode autoSetupMode) {
+            this.camera = camera;
+            this.pipeline = pipeline;
+            this.showResultMilliseconds = showResultMilliseconds;
+            this.autoSetupMode = autoSetupMode;
+        }
+
+        public List<Result.Circle> getHoles() {
+            return holes;
+        }
+        public List<Line> getLines() {
+            return lines;
+        }
+
+        private void drawHoles(Mat mat, List<Result.Circle> features, Color color) {
+            if (features == null || features.isEmpty()) {
+                return;
+            }
+            for (Result.Circle circle : features) {
+                org.opencv.core.Point c =  new org.opencv.core.Point(circle.x, circle.y);
+                Imgproc.circle(mat, c, (int) (circle.diameter+0.5)/2, FluentCv.colorToScalar(color), 2);
+                Imgproc.circle(mat, c, 2, FluentCv.colorToScalar(color), 3);
+            }
+        }
+
+        private void drawLines(Mat mat, List<Line> lines, Color color) {
+            if (lines == null || lines.isEmpty()) {
+                return;
+            }
+            for (Line line : lines) {
+                Imgproc.line(mat, line.a, line.b, FluentCv.colorToScalar(color), 2);
+            }
+        }
+
+        private void drawOcrText(Mat mat, Color color) {
+            if (detectedOcrModel != null) {
+                Imgproc.putText(mat, detectedOcrModel.getText(), 
+                        new org.opencv.core.Point(20, mat.rows()-20), 
+                        Imgproc.FONT_HERSHEY_PLAIN, 
+                        3, 
+                        FluentCv.colorToScalar(Color.black), 6, 0, false);
+                Imgproc.putText(mat, detectedOcrModel.getText(), 
+                        new org.opencv.core.Point(20, mat.rows()-20), 
+                        Imgproc.FONT_HERSHEY_PLAIN, 
+                        3, 
+                        FluentCv.colorToScalar(color), 2, 0, false);
+            }
+        }
+        // number the parts in the pockets
+        private void drawPartNumbers(Mat mat, Color color) {
+            // make sure the numbers are not too dense
+            int [] baseLine = null;
+            double feederPocketPitchMm =  getPartPitch().convertToUnits(LengthUnit.Millimeters).getValue();
+            if (feederPocketPitchMm < 1.) {
+                // feeder not set up yet
+                return;
+            }
+
+            // calculate the diagonal text size
+            double fontScale = 1.0;
+            Size size = Imgproc.getTextSize(String.valueOf(getPartsPerFeedCycle()), 
+                    Imgproc.FONT_HERSHEY_PLAIN, fontScale, 2, baseLine);
+            Location textSizeMm = camera.getUnitsPerPixel().multiply(size.width, size.height, 0., 0.)
+                    .convertToUnits(LengthUnit.Millimeters);
+            if (textSizeMm.getY() < 0.0) {
+                textSizeMm = textSizeMm.multiply(1.0, -1.0, 0.0, 0.0);
+            }
+            final double minFontSizeMm = 0.6;
+            if (textSizeMm.getY() < minFontSizeMm) {
+                fontScale = minFontSizeMm / textSizeMm.getY();
+                textSizeMm = textSizeMm.multiply(fontScale, fontScale, 0.0, 0.0);
+            }
+            double textSizePitchCount = textSizeMm.getLinearDistanceTo(nullLocation)/feederPocketPitchMm;
+            int step;
+            if (textSizePitchCount < 0.75) {
+                step = 1;
+            }
+            else if (textSizePitchCount < 1.5) {
+                step = 2;
+            }
+            else if (textSizePitchCount < 4) {
+                step = 5;
+            }
+            else {
+                // something must be wrong - feeder probably not set up correctly (yet)
+                return;
+            }
+            // go through all the parts, step-wise 
+            for (int i = step; i <= getPartsPerFeedCycle(); i += step) {
+                String text = String.valueOf(i);
+                Size textSize = Imgproc.getTextSize(text, Imgproc.FONT_HERSHEY_PLAIN, fontScale, 2, baseLine);
+
+                Location partLocation = getPickLocation(i, calibratedVisionOffset)
+                        .convertToUnits(LengthUnit.Millimeters);
+                // TODO: go besides part
+                Location textLocation = transformMachineToFeederLocation(partLocation, calibratedVisionOffset);
+                textLocation = textLocation.add(new Location(LengthUnit.Millimeters, 0., -textSizeMm.getY()*0.25, 0., 0.));
+                textLocation = transformFeederToMachineLocation(textLocation, calibratedVisionOffset)
+                        .convertToUnits(LengthUnit.Millimeters);
+                org.openpnp.model.Point p = VisionUtils.getLocationPixels(camera, textLocation);
+                if (p.x > 0 && p.x < camera.getWidth() && p.y > 0 && p.y < camera.getHeight()) {
+                    // roughly in the visible range - draw it
+                    // determine the alignment based on where the text is located in relation to the pocket
+                    double dx = textLocation.getX() - partLocation.getX();
+                    double dy = textLocation.getY() - partLocation.getY();
+                    // the alignment, in relation to the lower left corner of the text
+                    double alignX, alignY;
+                    if (Math.abs(dx) > Math.abs(dy)) {
+                        // more horizontal displacement 
+                        if (dx < 0) {
+                            // to the left
+                            alignX = -textSize.width;
+                            alignY = textSize.height/2;
+                        }
+                        else {
+                            // to the right
+                            alignX = 0.;
+                            alignY = textSize.height/2;
+                        }
+                    }
+                    else {
+                        // more vertical displacement
+                        if (dy > 0) {
+                            // above
+                            alignX = -textSize.width/2;
+                            alignY = 0.0;
+                        }
+                        else {
+                            // below
+                            alignX = -textSize.width/2;
+                            alignY = textSize.height;
+                        }
+                    }
+                    Imgproc.putText(mat, text, 
+                            new org.opencv.core.Point(p.x + alignX, p.y + alignY), 
+                            Imgproc.FONT_HERSHEY_PLAIN, 
+                            fontScale, 
+                            FluentCv.colorToScalar(color), 2, 0, false);
+                }
+            }
+        }
+
+
+        public FindFeatures invoke() throws Exception {
+            List resultsList = null; 
+            try {
+                // in accordance with EIA-481 etc. we use all millimeters.
+                Location mmScale = camera.getUnitsPerPixel().convertToUnits(LengthUnit.Millimeters);
+                // reset the features
+                holes = new ArrayList<>();
+                lines = new ArrayList<>();
+
+                if (calibrationTrigger == CalibrationTrigger.None) {
+                    // No vision calibration wanted - just copy the pre-set locations
+                    calibratedHole1Location = getHole1Location();
+                    calibratedHole2Location = getHole2Location();
+                    calibratedPickLocation  = getLocation();
+                }
+                else {
+                    final double sprocketHoleDiameterMm = 1.5;
+                    final double sprocketHolePitchMm = 4;
+                    final double partPitchMinMm = 2;
+                    final double sprocketHoleToPartMinMm = 3.5; // sprocket hole to part @ 8mm
+                    final double sprocketHoleToPartGridMm = 2;  // +multiples of 2mm for wider tapes 
+                    final double sprocketHoleDiameterPx = sprocketHoleDiameterMm/mmScale.getX();
+                    final double sprocketHolePitchPx = sprocketHolePitchMm/mmScale.getX();
+                    final double sprocketHoleTolerancePx = sprocketHoleToleranceMm/mmScale.getX(); 
+                    // Grab the results
+                    resultsList = (List) pipeline.getResult(VisionUtils.PIPELINE_RESULTS_NAME).model;
+
+                    // Convert eligible results into circles
+                    List<CvStage.Result.Circle> results = new ArrayList<>();;
+                    for (Object result : resultsList) {
+                        if ((result) instanceof Result.Circle) {
+                            Result.Circle circle = ((Result.Circle) result);
+                            if (Math.abs(circle.diameter*mmScale.getX() - sprocketHoleDiameterMm) < sprocketHoleToleranceMm) {
+                                results.add(circle);
+                            }
+                        }
+                        else if ((result) instanceof RotatedRect) {
+                            RotatedRect rect = ((RotatedRect) result);
+                            double diameter = (rect.size.width+rect.size.height)/2.0;
+                            if (Math.abs(rect.size.width*mmScale.getX() - sprocketHoleDiameterMm) < sprocketHoleToleranceMm
+                                    && Math.abs(rect.size.height*mmScale.getX() - sprocketHoleDiameterMm) < sprocketHoleToleranceMm) {
+                                results.add(new Result.Circle(rect.center.x, rect.center.y, diameter));
+                            }
+                        }
+                        else if ((result) instanceof KeyPoint) {
+                            KeyPoint keyPoint = ((KeyPoint) result);
+                            results.add(new Result.Circle(keyPoint.pt.x, keyPoint.pt.y, sprocketHoleDiameterPx));
+                        }
+                    }
+
+
+
+                    // collect the circles into a list of points
+                    List<Point> points = new ArrayList<>();
+                    for (Result.Circle circle : results) {
+                        points.add(new Point(circle.x, circle.y));
+                    }
+                    List<Ransac.Line> ransacLines = Ransac.ransac(points, 100, sprocketHoleTolerancePx, sprocketHolePitchPx, sprocketHoleTolerancePx);
+                    // Get the best line within the calibration tolerance
+                    Ransac.Line bestLine = null;
+                    Location bestUnitVector = null;
+                    double bestDistanceMm = Double.MAX_VALUE;
+                    for (Ransac.Line line : ransacLines) {
+                        Point a = line.a;
+                        Point b = line.b;
+
+                        Location aLocation = VisionUtils.getPixelLocation(camera, a.x, a.y);
+                        Location bLocation = VisionUtils.getPixelLocation(camera, b.x, b.y);
+
+                        // Checks the distance to the line.
+                        double distanceMm = camera.getLocation().convertToUnits(LengthUnit.Millimeters).getLinearDistanceToLineSegment(aLocation, bLocation);
+                        if (distanceMm < (autoSetupMode == FindFeaturesMode.CalibrateHoles ? calibrationToleranceMm : bestDistanceMm)) {
+                            // Take the first line that is close enough, as the lines are ordered by length (descending).
+                            // In autoSetupMode take the closest line.
+                            bestLine = line;
+                            bestUnitVector = aLocation.unitVectorTo(bLocation);
+                            bestDistanceMm = distanceMm;
+                            lines.add(bestLine);
+                            break;
+                        }
+                    }
+
+                    if (autoSetupMode != null) {
+                        if (bestLine == null) {
+                            throw new Exception("No line of sprocket holes can be recognized"); 
+                        }
+                    }
+                    if (bestLine != null) {
+                        // Filter the circles by distance from the resulting line
+                        for (Result.Circle circle : results) {
+                            Point p = new Point(circle.x, circle.y);
+                            if (FluentCv.pointToLineDistance(bestLine.a, bestLine.b, p) <= sprocketHoleTolerancePx) {
+                                holes.add(circle);
+                            }
+                        }
+
+                        // Sort holes by distance from camera center.
+                        Collections.sort(holes, new Comparator<Result.Circle>() {
+                            @Override
+                            public int compare(Result.Circle o1, Result.Circle o2) {
+                                double d1 = VisionUtils.getPixelLocation(camera, o1.x, o1.y).getLinearDistanceTo(camera.getLocation());
+                                double d2 = VisionUtils.getPixelLocation(camera, o2.x, o2.y).getLinearDistanceTo(camera.getLocation());
+                                return Double.compare(d1, d2);
+                            }
+                        });
+
+                        if (autoSetupMode  == FindFeaturesMode.FromPickLocationGetHoles) {
+                            // because we sorted the holes by distance, the first two are our holes 1 and 2
+                            if (holes.size() < 2) {
+                                throw new Exception("At least two sprocket holes need to be recognized"); 
+                            }
+                            calibratedHole1Location = VisionUtils.getPixelLocation(camera, holes.get(0).x, holes.get(0).y)
+                                    .convertToUnits(LengthUnit.Millimeters);
+                            calibratedHole2Location = VisionUtils.getPixelLocation(camera, holes.get(1).x, holes.get(1).y)
+                                    .convertToUnits(LengthUnit.Millimeters);
+                            Location partLocation = camera.getLocation().convertToUnits(LengthUnit.Millimeters);
+                            double angle1 = Math.atan2(calibratedHole1Location.getY()-partLocation.getY(), calibratedHole1Location.getX()-partLocation.getX());
+                            double angle2 = Math.atan2(calibratedHole2Location.getY()-partLocation.getY(), calibratedHole2Location.getX()-partLocation.getX());
+                            double angleDiff = angleNorm180((angle2-angle1)*180/Math.PI);
+                            if (angleDiff > 0) {
+                                // The holes 1 and 2 must appear counter-clockwise from the part location, swap them! 
+                                Location swap = calibratedHole2Location;
+                                calibratedHole2Location = calibratedHole1Location;
+                                calibratedHole1Location = swap;
+                            }
+                            if (calibratedHole1Location.unitVectorTo(calibratedHole2Location)
+                                    .dotProduct(bestUnitVector).getValue() < 0.0) {
+                                // turn the unite vector around
+                                bestUnitVector = bestUnitVector.multiply(-1.0, -1.0, 0, 0);
+                            }
+                            // determine the correct transformation
+                            double angleTape = Math.atan2(bestUnitVector.getY(), bestUnitVector.getX())*180.0/Math.PI;
+                            // preliminary pick location
+                            calibratedPickLocation = camera.getLocation()
+                                    .derive(getLocation(), false, false, true, false) // previous Z
+                                    .derive(null,  null, null, angleTape); // preliminary feeeder orientation
+                        }
+                        else {
+                            // find the two holes matching 
+                            for (Result.Circle hole : holes) {
+                                Location l = VisionUtils.getPixelLocation(camera, hole.x, hole.y)
+                                        .convertToUnits(LengthUnit.Millimeters);
+                                double dist1Mm = l.getLinearDistanceTo(getHole1Location()); 
+                                double dist2Mm = l.getLinearDistanceTo(getHole2Location()); 
+                                if (dist1Mm < calibrationToleranceMm && dist1Mm < dist2Mm) {
+                                    calibratedHole1Location = l;
+                                }
+                                else if (dist2Mm < calibrationToleranceMm && dist2Mm < dist1Mm) {
+                                    calibratedHole2Location = l;
+                                }
+                            }
+                            if (calibratedHole1Location == null || calibratedHole2Location == null) {
+                                if (autoSetupMode  == FindFeaturesMode.CalibrateHoles) {
+                                    throw new Exception("The two reference sprocket holes cannot be recognized"); 
+                                }
+                            }
+                            else {
+                                if (calibratedHole1Location.unitVectorTo(calibratedHole2Location)
+                                        .dotProduct(bestUnitVector).getValue() < 0.0) {
+                                    // turn the unit vector around
+                                    bestUnitVector = bestUnitVector.multiply(-1.0, -1.0, 0, 0);
+                                }
+                                if (snapToAxis) {
+                                    if (Math.abs(bestUnitVector.getX()) > Math.abs(bestUnitVector.getY())*5) {
+                                        // close enough, snap to X
+                                        bestUnitVector = new Location(LengthUnit.Millimeters, Math.signum(bestUnitVector.getX()), 0, 0, 0);
+                                    }
+                                    else if (Math.abs(bestUnitVector.getY()) > Math.abs(bestUnitVector.getX())*5) {
+                                        // close enough, snap to Y
+                                        bestUnitVector = new Location(LengthUnit.Millimeters, 0, Math.signum(bestUnitVector.getY()), 0, 0);
+                                    }
+                                }
+                                // determine the correct transformation
+                                double angleTape = Math.atan2(bestUnitVector.getY(), bestUnitVector.getX())*180.0/Math.PI;
+                                // the new calibration target is really the mid-point
+                                Location midPoint = calibratedHole1Location.add(calibratedHole2Location).multiply(0.5, 0.5, 0, 0);
+                                // but let's project that back to the real hole positions with nominal pitch (undistorted by the camera lens and Z parallax)
+                                double distanceHolesMm = Math.round(calibratedHole1Location.getLinearDistanceTo(calibratedHole2Location)
+                                        /sprocketHolePitchMm)*sprocketHolePitchMm;
+                                calibratedHole1Location = midPoint.subtract(bestUnitVector.multiply(distanceHolesMm*0.5, distanceHolesMm*0.5, 0, 0));
+                                calibratedHole2Location = midPoint.add(bestUnitVector.multiply(distanceHolesMm*0.5, distanceHolesMm*0.5, 0, 0));
+                                Logger.trace("[ReferencePushPullFeeder] calibrated hole locations are: " + calibratedHole1Location + ", " +calibratedHole2Location);
+                                if (autoSetupMode  == FindFeaturesMode.CalibrateHoles) {
+                                    // get the current pick location relative to hole 1
+                                    Location pickLocation = getLocation().convertToUnits(LengthUnit.Millimeters);
+                                    Location relativePickLocation = pickLocation
+                                            .subtract(getHole1Location());
+                                    // rotate from old angle 
+                                    relativePickLocation =  relativePickLocation.rotateXy(-pickLocation.getRotation())
+                                            .derive(null, null, null, 0.0);
+                                    // normalize to a nominal local pick location according to EIA 481
+                                    if (normalizePickLocation) {
+                                        relativePickLocation = new Location(LengthUnit.Millimeters,
+                                                Math.round(relativePickLocation.getX()/partPitchMinMm)*partPitchMinMm,
+                                                -sprocketHoleToPartMinMm+Math.round((relativePickLocation.getY()+sprocketHoleToPartMinMm)/sprocketHoleToPartGridMm)*sprocketHoleToPartGridMm,
+                                                0, 0);
+                                    }
+                                    // calculate the new pick location with the new hole 1 location and tape angle 
+                                    calibratedPickLocation = calibratedHole1Location.add(relativePickLocation.rotateXy(angleTape))
+                                            .derive(null, null, pickLocation.getZ(), angleTape);
+                                }
+                            }
+                        }
+
+                        if (calibratedHole1Location != null && calibratedPickLocation != null) {
+                            // we have our calibrated locations
+                            // Get the calibrated vision offset (with Z always 0)
+                            calibratedVisionOffset = getLocation()
+                                    .subtractWithRotation(calibratedPickLocation)
+                                    .derive(null, null, 0.0, null);
+                            Logger.debug("[ReferencePushPullFeeder] calibrated vision offset is: " + calibratedVisionOffset + ", length is: "+calibratedVisionOffset.getLinearLengthTo(nullLocation));
+
+                            // Add tick marks for show
+                            if (calibratedPickLocation != null) {
+                                org.openpnp.model.Point a;
+                                org.openpnp.model.Point b;
+                                Location tick = new Location(LengthUnit.Millimeters, -bestUnitVector.getY(), bestUnitVector.getX(), 0, 0);
+                                a = VisionUtils.getLocationPixels(camera, calibratedPickLocation.subtract(tick));
+                                b = VisionUtils.getLocationPixels(camera, calibratedPickLocation.add(tick));
+                                lines.add(new Ransac.Line(new Point(a.x, a.y), new Point(b.x, b.y)));
+                                a = VisionUtils.getLocationPixels(camera, calibratedPickLocation.subtract(bestUnitVector));
+                                b = VisionUtils.getLocationPixels(camera, calibratedPickLocation.add(bestUnitVector));
+                                lines.add(new Ransac.Line(new Point(a.x, a.y), new Point(b.x, b.y)));
+                                Logger.debug("[ReferencePushPullFeeder] calibrated pick location is: " + calibratedPickLocation);
+                            }
+                        }
+                    }
+                }
+
+                Result ocrStageResult = pipeline.getResult("OCR"); 
+                if (ocrStageResult != null) {
+                    detectedOcrModel = (SimpleOcr.OcrModel) ocrStageResult.model;
+                }
+
+                if (showResultMilliseconds > 0) {
+                    // Draw the result onto the pipeline image.
+                    Mat resultMat = pipeline.getWorkingImage().clone();
+                    drawHoles(resultMat, getHoles(), Color.green);
+                    drawLines(resultMat, getLines(), new Color(0, 0, 255));
+                    drawPartNumbers(resultMat, Color.orange);
+                    drawOcrText(resultMat, Color.orange);
+
+                    if (Logger.getLevel() == org.pmw.tinylog.Level.DEBUG || Logger.getLevel() == org.pmw.tinylog.Level.TRACE) {
+                        File file = Configuration.get().createResourceFile(getClass(), "push-pull-feeder", ".png");
+                        Imgcodecs.imwrite(file.getAbsolutePath(), resultMat);
+                    }
+                    BufferedImage showResult = OpenCvUtils.toBufferedImage(resultMat);
+                    resultMat.release();
+                    MainFrame.get().getCameraViews().getCameraView(camera)
+                    .showFilteredImage(showResult, showResultMilliseconds);
+                }
+            }
+            catch (ClassCastException e) {
+                throw new Exception("Unrecognized result type (should be Result.Circle, RotatedRect, KeyPoint): " + resultsList);
+            }
+            return this;
+        }
+
+        private double angleNorm180(double angle) {
+            while (angle > 180) {
+                angle -= 360;
+            }
+            while (angle < -180) {
+                angle += 360;
+            }
+            return angle;
+        }
+    }
+
+    public void showFeatures() throws Exception {
+        Camera camera = getCamera();
+        try (CvPipeline pipeline = getCvPipeline(camera, true, true)) {
+
+            // Process vision and show feature without applying anything
+            pipeline.process();
+            new FindFeatures(camera, pipeline, 2000, null).invoke();
+        }
+    }
+
+    public void autoSetup() throws Exception {
+        Camera camera = getCamera();
+        // First preliminary smart clone to get a pipeline from the most suitable template.
+        if (getTemplateFeeder(null) != null) {
+            smartClone(null, false, false, false, true);
+        }
+        if (calibrationTrigger == CalibrationTrigger.None) {
+            // Just assume the user wants it now 
+            setCalibrationTrigger(CalibrationTrigger.UntilConfident);
+        }
+
+        try (CvPipeline pipeline = getCvPipeline(camera, true, true)) {
+            // Process vision and get some features 
+            pipeline.process();
+            FindFeatures feature = new FindFeatures(camera, pipeline, 2000, FindFeaturesMode.FromPickLocationGetHoles)
+                    .invoke();
+            // Store the initial vision based results
+            setLocation(feature.calibratedPickLocation);
+            setHole1Location(feature.calibratedHole1Location);
+            setHole2Location(feature.calibratedHole2Location);
+            // Second preliminary smart clone to get pipeline, OCR region etc. from a template, 
+            // this time with proper transformation. This may again be overwritten if
+            // OCR recognizes the proper part.
+            if (getTemplateFeeder(null) != null) {
+                smartClone(null, true, true, true, true);
+            }
+            // As we've changed all this -> reset any stats
+            resetCalibrationStatistics();
+            // Now run a sprocket hole calibration, make sure to change the part (not swap it)
+            performVisionOperations(camera, pipeline, true, true, false, OcrWrongPartAction.ChangePart, false, null);
+            // Move the camera back to the pick location
+            MovableUtils.moveToLocationAtSafeZ(camera, getLocation());
+        }
+    }
+
+    public List<ReferencePushPullFeeder> getPushPullFeedersFromPool(List<Feeder> pool) {
+        // Get all the feeders with the right type.
+        List<ReferencePushPullFeeder> list = new ArrayList<>();
+        for (Feeder feeder : pool) {
+            if (feeder instanceof ReferencePushPullFeeder) {
+                ReferencePushPullFeeder pushPullFeeder = (ReferencePushPullFeeder) feeder;
+                list.add(pushPullFeeder);
+            }
+        }
+        return list;
+    }
+
+    public List<ReferencePushPullFeeder> getAllPushPullFeeders() {
+        return getPushPullFeedersFromPool(Configuration.get().getMachine().getFeeders());
+    }
+
+    public Length getTapeWidth() {
+        // infer the tape width 
+        Location hole1Location = transformMachineToFeederLocation(getHole1Location(), null)
+                .convertToUnits(LengthUnit.Millimeters);
+        final double partToSprocketHoleHalfTapeWidthDiffMm = 0.5; // deducted from EIA-481
+        double tapeWidth = Math.round(hole1Location.getY()+partToSprocketHoleHalfTapeWidthDiffMm)*2;
+        return new Length(tapeWidth, LengthUnit.Millimeters);
+    }
+
+    protected org.openpnp.model.Package getPartPackage() {
+        if (getPart() != null) {
+            return getPart().getPackage();
+        }
+        return null;
+    }
+
+    protected boolean isOnSameRowLocation(ReferencePushPullFeeder feederTemplate) {
+        Location delta = getLocation()
+                .convertToUnits(LengthUnit.Millimeters)
+                .subtract(feederTemplate.getLocation());
+        if (Math.abs(delta.getZ()) < rowZLocationToleranceMm) {
+            if (Math.abs(delta.getX()) < rowLocationToleranceMm) {
+                return true;
+            }
+            if (Math.abs(delta.getY()) < rowLocationToleranceMm) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /*    protected boolean matchesTapeSettings(ReferencePushPullFeeder other) {
+        // the tape/feed geometry must match
+        if (!getFeedPitch().equals(other.getFeedPitch())) {
+            return false;
+        }
+        if (!getTapeWidth().equals(other.getTapeWidth())) {
+            return false;
+        }
+        if (!getPartPitch().equals(other.getPartPitch())) {
+            return false;
+        }
+        if (getFeedMultiplier() != other.getFeedMultiplier()) {
+            return false;
+        }
+        double hole1RelativeDistanceMm = transformMachineToFeederLocation(getHole1Location(), null).convertToUnits(LengthUnit.Millimeters)
+                .getLinearDistanceTo(other.transformMachineToFeederLocation(other.getHole1Location(), null));
+        if (hole1RelativeDistanceMm > sprocketHoleToleranceMm) {
+            return false;
+        }
+        return true;
+    }
+     */
+
+    static boolean compatiblePartPackages(Part part1, Part part2) {
+        if (part1 == null) {
+            return false;
+        }
+        if (part2 == null) {
+            return false;
+        }
+
+        org.openpnp.model.Package package1 = part1.getPackage();
+        org.openpnp.model.Package package2 = part2.getPackage();
+        if (package1 == package2) {
+            return true;
+        }
+        if ((package1.getTapeSpecification() != null && !package1.getTapeSpecification().isEmpty())
+                && package1.getTapeSpecification().equals(package2.getTapeSpecification())) {
+            return true;
+        }
+        return false;
+    }
+
+    public ReferencePushPullFeeder getTemplateFeeder(Part compatiblePart) {
+        List<ReferencePushPullFeeder> list = getAllPushPullFeeders();
+
+        Part comparePart = compatiblePart == null ? getPart() : compatiblePart;
+        // Rank the feeders by similarity.
+        Collections.sort(list, new Comparator<ReferencePushPullFeeder>() {
+            @Override
+            public int compare(ReferencePushPullFeeder feeder1, ReferencePushPullFeeder feeder2)  {
+                int diff; 
+                // compatible parts/packages favored
+                diff = (compatiblePartPackages(comparePart, feeder1.getPart())?0:1) - (compatiblePartPackages(comparePart, feeder2.getPart())?0:1);
+                if (diff != 0) {
+                    return diff;
+                }
+                // template is favored
+                diff = (feeder1.isUsedAsTemplate()?0:1) - (feeder2.isUsedAsTemplate()?0:1);
+                if (diff != 0) {
+                    return diff;
+                }
+                // same feed pitch is favored
+                diff = (getFeedPitch().equals(feeder1.getFeedPitch())?0:1) - (getFeedPitch().equals(feeder2.getFeedPitch())?0:1);
+                if (diff != 0) {
+                    return diff;
+                }
+                // same tape width is favored
+                diff = (getTapeWidth().equals(feeder1.getTapeWidth())?0:1) - (getTapeWidth().equals(feeder2.getTapeWidth())?0:1);
+                if (diff != 0) {
+                    return diff;
+                }
+                // same part pitch is favored
+                diff = (getPartPitch().equals(feeder1.getPartPitch())?0:1) - (getPartPitch().equals(getPartPitch())?0:1);
+                if (diff != 0) {
+                    return diff;
+                }
+                // same row is favored
+                diff = (isOnSameRowLocation(feeder1)?0:1) - (isOnSameRowLocation(feeder2)?0:1);
+                if (diff != 0) {
+                    return diff;
+                }
+                // enabled is favored
+                diff = (feeder1.isEnabled()?0:1) - (feeder2.isEnabled()?0:1);
+                if (diff != 0) {
+                    return diff;
+                }
+
+                // between equally good feeders, take the closer one
+                return new Double(feeder1.getLocation().convertToUnits(LengthUnit.Millimeters).getLinearDistanceTo(getLocation()))
+                        .compareTo(feeder2.getLocation().convertToUnits(LengthUnit.Millimeters).getLinearDistanceTo(getLocation()));
+            }
+        });
+
+        for (ReferencePushPullFeeder templateFeeder : list) {
+            if (templateFeeder != this) { 
+                if (compatiblePart == null || compatiblePartPackages(compatiblePart, templateFeeder.getPart())) {
+                    // the first ranking does it  
+                    return templateFeeder;
+                }
+            }
+        }
+        return null;
+    }
+
+    public List<ReferencePushPullFeeder> getCompatibleFeeders() {
+        List<ReferencePushPullFeeder> list = new ArrayList<>();
+        for (ReferencePushPullFeeder feeder : getAllPushPullFeeders()) {
+            if (feeder != this) { 
+                if (ReferencePushPullFeeder.compatiblePartPackages(getPart(), feeder.getPart())) {
+                    list.add(feeder);
+                }
+            }
+        }
+        return list;
+    }
+
+    public String getCloneTemplateStatus() {
+        Part part = getPart();
+        String status = "<span>";
+        if (isUsedAsTemplate()) {
+            status += "Clones to ";
+            int n = 0;
+            for (ReferencePushPullFeeder targetFeeder : getCompatibleFeeders()) {
+                if (n++ > 0) {
+                    status += ",<br/>";
+                }
+                status += targetFeeder.getName()+" "+targetFeeder.getPart().getId();
+            }
+            status += n == 0 ? "none." : " (Count: "+n+")";
+        }
+        else {
+            ReferencePushPullFeeder templateFeeder = getTemplateFeeder(null);
+            if (templateFeeder != null) {
+                status += "<strong>"+templateFeeder.getName()+"</strong>";
+                if (templateFeeder.getPart() != null) {
+                    status += " with part <strong>"+templateFeeder.getPart().getId()+"</strong>";
+                }
+                if (part != null 
+                        && compatiblePartPackages(part, templateFeeder.getPart())) { 
+                    org.openpnp.model.Package package1 = part.getPackage();
+                    if (package1 != null) {
+                        if (package1.getTapeSpecification() != null && !package1.getTapeSpecification().isEmpty()) {
+                            status += " selected by common tape & reel specification <strong>"+package1.getTapeSpecification()+"</strong>";
+                        }
+                        else {
+                            status += " selected by common package <strong>"+package1.getId()+"</strong>";
+                        }
+                    }
+                }
+                else {
+                    status += " selected as partial match.<br/>"
+                            + "<strong style=\"color:red\">Tape & reel specifications/packages are incompatible, settings must be reviewed.</strong>";
+                }
+            }
+            else {
+                status += "<strong>None found</strong>";
+            }
+        }
+        status += "</span>";
+        return status;
+    }
+
+    public void setCloneTemplateStatus(String cloneTemplateStatus) {
+        // does nothing
+        firePropertyChange("cloneTemplateStatus", cloneTemplateStatus, getCloneTemplateStatus());
+    }
+
+    public void smartClone(Part compatiblePart, 
+            boolean cloneLocationSettings, boolean cloneTapeSettings, boolean clonePushPullSettings, boolean cloneVisionSettings) throws Exception {
+        // get us the best template feeder
+        ReferencePushPullFeeder templateFeeder = getTemplateFeeder(compatiblePart);
+        if (templateFeeder == null) {
+            if (compatiblePart == null) {
+                throw new Exception("Feeder "+getName()+": No suitable template feeder found to clone."); 
+            }
+            else {
+                throw new Exception("Feeder "+getName()+": No template feeder found to clone for part "+compatiblePart.getId()+" compatibility.");
+            }
+        }
+        cloneFeederSettings(cloneLocationSettings, cloneTapeSettings, clonePushPullSettings, cloneVisionSettings,
+                templateFeeder);
+    }
+
+    public void cloneFeederSettings(boolean cloneLocationSettings, boolean cloneTapeSettings, boolean clonePushPullSettings,
+            boolean cloneVisionSettings, ReferencePushPullFeeder templateFeeder)
+                    throws CloneNotSupportedException {
+        if (cloneLocationSettings) {
+            // just the Z from the location
+            setLocation(getLocation().derive(templateFeeder.getLocation(), false, false, true, false));
+            // options
+            setNormalizePickLocation(templateFeeder.isNormalizePickLocation());
+            setSnapToAxis(templateFeeder.isSnapToAxis());
+        }
+        if (cloneTapeSettings) {
+            // Tape and feed spec
+            setPartPitch(templateFeeder.getPartPitch());
+            setRotationInFeeder(templateFeeder.getRotationInFeeder());
+            setFeedPitch(templateFeeder.getFeedPitch());
+            setFeedMultiplier(templateFeeder.getFeedMultiplier());
+            // reset
+            setFeedCount(0);
+        }
+        if (clonePushPullSettings) {
+            // clone the actuators
+            setActuatorName(templateFeeder.getActuatorName());
+            setPeelOffActuatorName(templateFeeder.getPeelOffActuatorName());
+            // clone all the speeds
+            setFeedSpeedPush1(templateFeeder.getFeedSpeedPush1());
+            setFeedSpeedPush2(templateFeeder.getFeedSpeedPush2());
+            setFeedSpeedPush3(templateFeeder.getFeedSpeedPush3());
+            setFeedSpeedPushEnd(templateFeeder.getFeedSpeedPushEnd());
+            setFeedSpeedPull3(templateFeeder.getFeedSpeedPull3());
+            setFeedSpeedPull2(templateFeeder.getFeedSpeedPull2());
+            setFeedSpeedPull1(templateFeeder.getFeedSpeedPull1());
+            setFeedSpeedPull0(templateFeeder.getFeedSpeedPull0());
+            // clone the switches
+            setIncludedPush1(templateFeeder.isIncludedPush1());
+            setIncludedPush2(templateFeeder.isIncludedPush2());
+            setIncludedPush3(templateFeeder.isIncludedPush3());
+            setIncludedPushEnd(templateFeeder.isIncludedPushEnd());
+            setIncludedPull3(templateFeeder.isIncludedPull3());
+            setIncludedPull2(templateFeeder.isIncludedPull2());
+            setIncludedPull1(templateFeeder.isIncludedPull1());
+            setIncludedPull0(templateFeeder.isIncludedPull0());
+            setIncludedMulti0(templateFeeder.isIncludedMulti0());
+            setIncludedMulti1(templateFeeder.isIncludedMulti1());
+            setIncludedMulti2(templateFeeder.isIncludedMulti2());
+            setIncludedMulti3(templateFeeder.isIncludedMulti3());
+            setIncludedMultiEnd(templateFeeder.isIncludedMultiEnd());
+        }
+        if (cloneVisionSettings) {
+            // other settings
+            setCalibrationTrigger(templateFeeder.getCalibrationTrigger());
+            setPrecisionWanted(templateFeeder.getPrecisionWanted());
+            setOcrFontName(templateFeeder.getOcrFontName());
+            setOcrFontSizePt(templateFeeder.getOcrFontSizePt());
+            setOcrWrongPartAction(templateFeeder.getOcrWrongPartAction());
+            setOcrDiscoverOnJobStart(templateFeeder.isOcrDiscoverOnJobStart());
+            setOcrStopAfterWrongPart(templateFeeder.isOcrStopAfterWrongPart());
+            // reset statistics
+            resetCalibration();
+            resetCalibrationStatistics();
+            setFeedCount(0);
+            // clone the pipeline
+            setPipeline(templateFeeder.getPipeline().clone());
+        }
+        // now transform over all the locations
+        setFeederLocation(getTransform(null), false, true, true, templateFeeder);
+    }
+
+    protected static Location relocatedLocation(Location location, Location oldTransform, Location newTransform) {
+        if (location.equals(nullLocation)) {
+            // a location with all zeroes is assumed as uninitialized 
+            return location;
+        }
+        else {
+            Location feederLocalLocation = backwardTransform(location, oldTransform);
+            location = forwardTransform(feederLocalLocation, newTransform);
+            return location;
+        }
+    }
+    protected static Location relocatedXyLocation(Location location, Location oldTransform, Location newTransform) {
+        // disregard Z and Rotation
+        return relocatedLocation(location.multiply(1.0, 1.0, 0.0, 0.0), oldTransform, newTransform);
+    }
+    protected static Location relocatedXyzLocation(Location location, Location oldTransform, Location newTransform) {
+        // disregard Rotation
+        return relocatedLocation(location.multiply(1.0, 1.0, 1.0, 0.0), oldTransform, newTransform);
+    }
+
+    protected void setFeederLocation(Location newTransform, 
+            boolean primary, boolean pushPull, boolean vision, 
+            ReferencePushPullFeeder templateFeeder) {
+        // Relocate the feeder to match the given new transformation.
+        Location oldTransform = templateFeeder.getTransform(null);
+        if (primary) {
+            setHole1Location(relocatedXyLocation(templateFeeder.getHole1Location(), oldTransform, newTransform));
+            setHole2Location(relocatedXyLocation(templateFeeder.getHole2Location(), oldTransform, newTransform));
+        }
+        if (pushPull) {
+            setFeedStartLocation(relocatedXyzLocation(templateFeeder.getFeedStartLocation(), oldTransform, newTransform));
+            setFeedMid1Location(relocatedXyzLocation(templateFeeder.getFeedMid1Location(), oldTransform, newTransform));
+            setFeedMid2Location(relocatedXyzLocation(templateFeeder.getFeedMid2Location(), oldTransform, newTransform));
+            setFeedMid3Location(relocatedXyzLocation(templateFeeder.getFeedMid3Location(), oldTransform, newTransform));
+            setFeedEndLocation(relocatedXyzLocation(templateFeeder.getFeedEndLocation(), oldTransform, newTransform));
+        }
+        if (vision) {
+            if (templateFeeder.getOcrRegion()!= null) {
+                setOcrRegion(templateFeeder.getOcrRegion()
+                        .rotateXy(newTransform.getRotation()-oldTransform.getRotation()));
+            }
+        }
+        if (primary) {
+            // finally and only now set the new pick location (in case some transformations happens in the getters/setters in the future)
+            setLocation(relocatedLocation(templateFeeder.getLocation(), oldTransform, newTransform));
+        }
+    }
+    protected void relocateFeeder(Location newTransform) {
+        // relocate from itself
+        setFeederLocation(newTransform, true, true, true, this);
+    }
+    protected void swapOutFeeders(ReferencePushPullFeeder other) {
+        // Swap out two feeders' locations.
+        Location transform1 = this.getTransform(null); 
+        Location transform2 = other.getTransform(null);
+        this.relocateFeeder(transform2);
+        other.relocateFeeder(transform1);
+    }
+
+    protected void triggerOcrAction(SimpleOcr.OcrModel ocrModel, OcrWrongPartAction ocrAction, boolean ocrStop,
+            StringBuilder report) throws Exception {
+        if (ocrAction == OcrWrongPartAction.None && ! ocrStop) {
+            return; 
+        }
+
+        // get first part of OCR Text as the part id
+        String ocrText = ocrModel.getText();
+        String partId = ocrText;
+        int pos = partId.indexOf('\n');
+        if (pos >= 0) {
+            partId = partId.substring(0, pos);
+        }                
+        pos = partId.indexOf(' ');
+        if (pos >= 0) {
+            partId = partId.substring(0, pos);
+        }
+        Configuration cfg = Configuration.get();
+        Part ocrPart = cfg.getPart(partId);
+        if (ocrPart == null) {
+            throw new Exception("OCR could not identify/find part id in feeder "+getName()
+            +", OCR detected part id "+partId+" (avg. score="+ocrModel.getAvgScore()+")");
+        }
+        Part currentPart = getPart();
+        if (currentPart == null) {
+            // No part set yet 
+            Logger.trace("[ReferencePushPullFeeder] OCR detected part in feeder "+getId()+", OCR part "+ocrPart.getId());
+            setOcrDetectedPart(ocrPart, true);
+        }
+        else if (ocrPart != null && ocrPart != currentPart) {
+            // Wrong part selected in feeder
+            Logger.trace("[ReferencePushPullFeeder] OCR detected wrong part in slot of feeder "+getName()
+            +", current part "+currentPart.getId()+" != OCR part "+ocrPart.getId());
+            ReferencePushPullFeeder otherFeeder = null;
+            for (ReferencePushPullFeeder feeder : getAllPushPullFeeders()) {
+                if (feeder.getPart() == ocrPart) {
+                    otherFeeder = feeder;
+                    Logger.trace("[ReferencePushPullFeeder] other feeder "+feeder.getName()
+                    +" has OCR detected part "+ocrPart.getId());
+                    break;
+                }
+            }
+            if (ocrAction == OcrWrongPartAction.SwapFeeders) {
+                if (otherFeeder == null) {
+                    throw new Exception("OCR detected part "+ocrPart.getId()+" in slot of feeder "+getName()
+                    +" is not present in any other feeder. Cannot swap out feeders.");
+                }
+                swapOutFeeders(otherFeeder);
+            }
+            if (ocrAction == OcrWrongPartAction.SwapOrCreate) {
+                if (otherFeeder == null) {
+                    // no other feeder has the OCR part -> create a new one
+                    Location newLocation =  getLocation();
+                    otherFeeder = createNewAtLocation(newLocation, ocrPart, this);
+                    if (compatiblePartPackages(ocrPart, currentPart)) {
+                        // compatible parts, clone settings from this one
+                        otherFeeder.cloneFeederSettings(true, true, true, true, this);
+                    }
+                    else {
+                        // incompatible parts, do a smart clone
+                        otherFeeder.smartClone(ocrPart, true, true, true, true);
+                    }
+                    // disable this one
+                    setEnabled(false);
+                    // TODO: the two feeders now sit on top of each other - move this one away?
+                }
+                else {
+                    swapOutFeeders(otherFeeder);
+                }
+            }
+            if (ocrAction == OcrWrongPartAction.ChangePart) {
+                setOcrDetectedPart(ocrPart, false);
+            }
+            else if (ocrAction == OcrWrongPartAction.ChangePartAndClone) {
+                setOcrDetectedPart(ocrPart, true);
+            }
+            if (ocrStop) {
+                throw new Exception("OCR detected different part in feeder "+getName()
+                +", current part "+currentPart.getId()+" vs. OCR part "+ocrPart.getId()+". Action performed: "+ocrAction.toString()+". Please review.");
+            }
+            else if (report != null) {
+                report.append("<p>Feeder "+getName()
+                        +": current part "+currentPart.getId()+", OCR part "+ocrPart.getId()+". Action performed: "+ocrAction.toString()+".</p>");
+            }
+        }
+    }
+
+    public ReferencePushPullFeeder createNewAtLocation(Location newLocation, Part part, ReferencePushPullFeeder templateFeeder)
+            throws Exception {
+        ReferencePushPullFeeder feeder;
+        feeder = new ReferencePushPullFeeder();
+        feeder.setPart(part != null ? part : Configuration.get().getParts().get(0));
+        feeder.setFeederLocation(newLocation, true, true, true, templateFeeder);
+        feeder.setEnabled(isEnabled());
+        // add to machine
+        Configuration.get().getMachine().addFeeder(feeder);
+        return feeder;
+    }
+
+    public ReferencePushPullFeeder createNewInRow()
+            throws Exception {
+        double bestDistanceMm = Double.MAX_VALUE;
+        ReferencePushPullFeeder closestFeeder = null;
+        for (ReferencePushPullFeeder feeder : getAllPushPullFeeders()) {
+            if (feeder != this && feeder.getPart() != null) {
+                double distanceMm = feeder.getLocation().convertToUnits(LengthUnit.Millimeters)
+                        .getLinearDistanceTo(this.getLocation());
+                if (closestFeeder == null 
+                        || distanceMm < bestDistanceMm) {
+                    bestDistanceMm = distanceMm;
+                    closestFeeder = feeder;
+                }
+            }
+        }
+        // the default row unit assumption is the 3D printed feeder that was developed together with this feeder class 
+        // adding +8mm to the tape width.  A clockwise around the table arrangement is assumed.
+        Location rowUnit = transformFeederToMachineLocation(new Location(LengthUnit.Millimeters, 
+                0, 
+                -getTapeWidth().convertToUnits(LengthUnit.Millimeters).getValue() - 8.0, // it is "down" in tape orientation
+                0, 0), null)
+                .subtract(getLocation());
+        // but if we have another feeder, the row unit is properly calculated
+        if (closestFeeder != null) {
+            rowUnit = getLocation().subtract(closestFeeder.getLocation()).convertToUnits(LengthUnit.Millimeters);
+            if (isSnapToAxis()) {
+                if (Math.abs(rowUnit.getX()) > rowLocationToleranceMm && Math.abs(rowUnit.getY()) <= rowLocationToleranceMm) {
+                    // row along X axis -> snap to it
+                    rowUnit = rowUnit.multiply(1.0, 0.0, 0.0, 0.0);
+                }
+                else if (Math.abs(rowUnit.getY()) > rowLocationToleranceMm && Math.abs(rowUnit.getX()) <= rowLocationToleranceMm) {
+                    // row along Y axis -> snap to it
+                    rowUnit = rowUnit.multiply(0.0, 1.0, 0.0, 0.0);
+                }
+                else {
+                    throw new Exception("Closest feeder "+closestFeeder.getName()+" "+closestFeeder.getPart().getId()+" does not form a row in X and Y");
+                }
+            }
+        }
+        Location newLocation = getLocation().add(rowUnit);
+        ReferencePushPullFeeder newFeeder = createNewAtLocation(newLocation, null, this);
+        newFeeder.cloneFeederSettings(true, true, true, true, this);
+        return newFeeder;
+    }
+
+
+    protected void setOcrDetectedPart(Part ocrPart, boolean clone) throws Exception {
+        if (isUsedAsTemplate()) {
+            if (!compatiblePartPackages(ocrPart, getPart())) {
+                throw new Exception("Feeder "+getName()+" is used as a template and can only be OCR-assigned parts with same tape specification or package.");
+            }
+            setPart(ocrPart);
+        }
+        else {
+            setPart(ocrPart);
+            if (clone) {
+                smartClone(ocrPart, true, true, true, true);
+            }
+        }
+    }
+
+    @Override
+    public Location getJobPreparationLocation() {
+        if (isOcrDiscoverOnJobStart() && visionOffset == null) {
+            return getPickLocation(0, null);
+        }
+        else {
+            return null;
+        }
+    }
+
+    @Override
+    public void prepareForJob(boolean visit) throws Exception {
+        super.prepareForJob(visit);
+        if (visit && isOcrDiscoverOnJobStart() && visionOffset == null) {
+            // Check the part in the feeder using OCR, this also calibrates the feeder.
+            // Note, we cannot change the parts at this point, it is too late in the Job Process, so we always stop.
+            performOcr(OcrWrongPartAction.None, true, null);
+        }
+    }
+
+    public void performOcrOnFeederList(List<ReferencePushPullFeeder> ocrFeederList, 
+            OcrWrongPartAction ocrAction, boolean ocrStop, StringBuilder report) throws Exception {
+        // Note, we want to be able to swap out feeders' locations while doing the OCR process, so we need 
+        // to plan the machine travel by locations rather than by the feeders themselves. We will later search 
+        // for the feeder by location.
+        List<Location> feederLocationList = new ArrayList<>();
+        for (ReferencePushPullFeeder feeder : ocrFeederList) {
+            feederLocationList.add(feeder.getPickLocation(0, null).convertToUnits(LengthUnit.Millimeters)); // Btw, convert to mm
+        }
+
+        // Use a Travelling Salesman algorithm to optimize the path to actuate all the feeder covers.
+        TravellingSalesman<Location> tsm = new TravellingSalesman<>(
+                feederLocationList, 
+                new TravellingSalesman.Locator<Location>() { 
+                    @Override
+                    public Location getLocation(Location locatable) {
+                        return locatable;
+                    }
+                }, 
+                // start from current location
+                getCamera().getLocation(), 
+                // no particular end location
+                null);
+
+        // Solve it (using the default heuristics).
+        tsm.solve();
+
+        // Finally perform the feeders OCR along the travel path.
+        for (Location location : tsm.getTravel()) {
+            // Search the feeder currently at this location (it might have been swapped out by the OCR)
+            for (ReferencePushPullFeeder ocrFeeder : ocrFeederList) {
+                if (location.getLinearDistanceTo(ocrFeeder.getPickLocation(0, null)) < calibrationToleranceMm) {
+                    ocrFeeder.performOcr(
+                            ocrAction != null ? ocrAction : ocrFeeder.getOcrWrongPartAction(),
+                                    ocrAction != null ? ocrStop : ocrFeeder.isOcrStopAfterWrongPart(),
+                                            report);
+                    break;
+                }
+            }
+        }
+    }
+
+    public void performOcrOnAllFeeders(OcrWrongPartAction ocrAction, boolean ocrStop, StringBuilder report) throws Exception { 
+        // Filter the feeders needing OCR
+        List<ReferencePushPullFeeder> ocrFeederList = new ArrayList<>(); 
+        for (ReferencePushPullFeeder feeder : getAllPushPullFeeders()) {
+            if (feeder.isEnabled() && (feeder.getOcrWrongPartAction() != OcrWrongPartAction.None || isOcrStopAfterWrongPart())) {
+                ocrFeederList.add(feeder);
+            }
+        }
+        if (ocrFeederList.size() == 0) {
+            throw new Exception("No enabled feeder with OCR found.");
+        }
+        // Now bulk-OCR. 
+        performOcrOnFeederList(ocrFeederList, ocrAction, ocrStop, report);
+    }
+
+
+    public void performOcr(OcrWrongPartAction ocrAction, boolean ocrStop, StringBuilder report) throws Exception {
+        if (getOcrRegion() == null) {
+            throw new Exception("Feeder "+getName()+" has no OCR region defined.");
+        }
+        Camera camera = getCamera();
+        try (CvPipeline pipeline = getCvPipeline(camera, true, true)) {
+            // run a sprocket hole calibration, including OCR
+            performVisionOperations(camera, pipeline, false, false, true, ocrAction, ocrStop, report); 
+        }
+    }
+
+    protected void performVisionOperations(Camera camera, CvPipeline pipeline, 
+            boolean storeHoles, boolean storePickLocation, boolean storeVisionOffset, OcrWrongPartAction ocrAction, boolean ocrStop,
+            StringBuilder report) throws Exception {
+        Location runningHole1Location = getHole1Location();
+        Location runningHole2Location = getHole2Location();
+        Location runningPickLocation = getLocation();
+        Location runningVisionOffset = getVisionOffset();
+        // Calibrate the exact hole locations by obtaining a mid-point lock on them,
+        // assuming that any camera lens and Z parallax distortion is symmetric.
+        for (int i = 0; i < calibrateMaxPasses; i++) {
+            // move the camera to the mid-point 
+            Location midPoint = runningHole1Location.add(runningHole2Location).multiply(0.5, 0.5, 0, 0)
+                    .derive(camera.getLocation(), false, false, true, false)
+                    .derive(null, null, null, runningPickLocation.getRotation()+getRotationInFeeder());
+            Logger.debug("[ReferencePushPullFeeder] calibrating sprocket holes pass "+ i+ " midPoint is "+midPoint);
+            MovableUtils.moveToLocationAtSafeZ(camera, midPoint);
+            // setup OCR if wanted
+            boolean ocrPass = (i == 0 && ocrAction != OcrWrongPartAction.None && getOcrRegion() != null);
+            if (ocrPass) { 
+                setupOcr(camera, pipeline, runningHole1Location, runningHole2Location, runningPickLocation);
+            }
+            else {
+                disableOcr(camera, pipeline);
+            }
+            // take a new shot
+            pipeline.process();
+            FindFeatures feature = new FindFeatures(camera, pipeline, 2000, FindFeaturesMode.CalibrateHoles)
+                    .invoke();
+            runningHole1Location = feature.calibratedHole1Location;
+            runningHole2Location = feature.calibratedHole2Location;
+            runningPickLocation = feature.calibratedPickLocation;
+            // calculate the worst pick location delta this gives, cycle part 1 is the worst as it is farthest away
+            Location uncalibratedPick1Location = getPickLocation(1, runningVisionOffset);
+            Location calibratedPick1Location = getPickLocation(1, feature.calibratedVisionOffset);
+            Length error = calibratedPick1Location.getLinearLengthTo(uncalibratedPick1Location);
+            Logger.trace("[ReferencePushPullFeeder] new vision offset "+feature.calibratedVisionOffset
+                    +" vs. previous vision offset "+runningVisionOffset+" results in error "+error+" at the (farthest) pick location");
+            // store data if requested
+            if (storeHoles) {
+                setHole1Location(runningHole1Location);
+                setHole2Location(runningHole2Location);
+            }
+            if (storePickLocation) {
+                setLocation(runningPickLocation);
+            }
+            if (storeVisionOffset) {
+                // update the stats
+                if (visionOffset != null) {
+                    // Only when a previous vision offset has been stored, should we store the error
+                    // because the feeder might have been moved physically. The user's actions are 
+                    // not part of the calibration error. :-)
+                    addCalibrationError(error);
+                }
+                setVisionOffset(feature.calibratedVisionOffset);
+            }
+            if (ocrPass) {
+                Logger.trace("[ReferencePushPullFeeder] got OCR text "+feature.detectedOcrModel.getText());
+                triggerOcrAction(feature.detectedOcrModel, ocrAction, ocrStop, report);
+            }
+            // is it good enough? Compare with running offset.
+            if (error.convertToUnits(LengthUnit.Millimeters).getValue() < calibrateToleranceMm) {
+                break;
+            }
+            runningVisionOffset = feature.calibratedVisionOffset;
+        }
+    }
+
+    @Override
+    public Wizard getConfigurationWizard() {
+        return new ReferencePushPullFeederConfigurationWizard(this);
+    }
+
+    @Override
+    public String getPropertySheetHolderTitle() {
+        return getClass().getSimpleName() + " " + getName();
+    }
+
+    @Override
+    public PropertySheet[] getPropertySheets() {
+        return new PropertySheet[] {
+                new PropertySheetWizardAdapter(getConfigurationWizard(), "Configuration"),
+                new PropertySheetWizardAdapter(new ReferencePushPullMotionConfigurationWizard(this), "Push-Pull Motion"),
+        };
+    }
+
+    @Override
+    public PropertySheetHolder[] getChildPropertySheetHolders() {
+        return null;
+    }
+
+    @Override
+    public Action[] getPropertySheetHolderActions() {
+        return null;
+    }
+}

--- a/src/main/java/org/openpnp/machine/reference/feeder/wizards/BlindsFeederConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/wizards/BlindsFeederConfigurationWizard.java
@@ -25,13 +25,11 @@ package org.openpnp.machine.reference.feeder.wizards;
 import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
 import java.io.File;
 import java.io.PrintWriter;
 
 import javax.swing.AbstractAction;
 import javax.swing.Action;
-import javax.swing.Icon;
 import javax.swing.JButton;
 import javax.swing.JCheckBox;
 import javax.swing.JComboBox;
@@ -149,13 +147,13 @@ public class BlindsFeederConfigurationWizard extends AbstractConfigurationWizard
                 ColumnSpec.decode("right:default:grow"),
                 FormSpecs.RELATED_GAP_COLSPEC,
                 FormSpecs.DEFAULT_COLSPEC,},
-            new RowSpec[] {
-                FormSpecs.RELATED_GAP_ROWSPEC,
-                FormSpecs.DEFAULT_ROWSPEC,
-                FormSpecs.RELATED_GAP_ROWSPEC,
-                FormSpecs.DEFAULT_ROWSPEC,
-                FormSpecs.RELATED_GAP_ROWSPEC,
-                FormSpecs.DEFAULT_ROWSPEC,}));
+                new RowSpec[] {
+                        FormSpecs.RELATED_GAP_ROWSPEC,
+                        FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC,
+                        FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC,
+                        FormSpecs.DEFAULT_ROWSPEC,}));
         try {
         }
         catch (Throwable t) {
@@ -918,7 +916,6 @@ public class BlindsFeederConfigurationWizard extends AbstractConfigurationWizard
     private JTextField textFieldEdgeClosingDistance;
     private JButton btnCalibrateEdges;
     private JButton btnShowInfo;
-    private JButton btnOpenAllButton;
     private JTextField textFieldFirstPocket;
     private JLabel lblFirstPocket;
     private JButton btnExtractOpenscadModel;
@@ -948,14 +945,6 @@ public class BlindsFeederConfigurationWizard extends AbstractConfigurationWizard
         feeder.setPipelineToAllFeeders();
     }
     protected void initDataBindings() {
-    }
-    private class SwingAction extends AbstractAction {
-        public SwingAction() {
-            putValue(NAME, "SwingAction");
-            putValue(SHORT_DESCRIPTION, "Some short description");
-        }
-        public void actionPerformed(ActionEvent e) {
-        }
     }
 }
 

--- a/src/main/java/org/openpnp/machine/reference/feeder/wizards/BlindsFeederConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/wizards/BlindsFeederConfigurationWizard.java
@@ -866,7 +866,7 @@ public class BlindsFeederConfigurationWizard extends AbstractConfigurationWizard
         public void actionPerformed(ActionEvent e) {
             applyAction.actionPerformed(e);
             UiUtils.submitUiMachineTask(() -> {
-                BlindsFeeder.actuateAllFeederCovers(true);
+                BlindsFeeder.actuateAllFeederCovers(MainFrame.get().getMachineControls().getSelectedNozzle(), true);
             });
         }
     };
@@ -881,7 +881,7 @@ public class BlindsFeederConfigurationWizard extends AbstractConfigurationWizard
         public void actionPerformed(ActionEvent e) {
             applyAction.actionPerformed(e);
             UiUtils.submitUiMachineTask(() -> {
-                BlindsFeeder.actuateAllFeederCovers(false);
+                BlindsFeeder.actuateAllFeederCovers(MainFrame.get().getMachineControls().getSelectedNozzle(), false);
             });
         }
     };

--- a/src/main/java/org/openpnp/machine/reference/feeder/wizards/ReferencePushPullFeederConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/wizards/ReferencePushPullFeederConfigurationWizard.java
@@ -1,0 +1,1044 @@
+/*
+ * Copyright (C) 2020 <mark@makr.zone>
+ * based on the ReferenceLeverFeeder 
+ * Copyright (C) 2011 Jason von Nieda <jason@vonnieda.org>
+ * 
+ * This file is part of OpenPnP.
+ * 
+ * OpenPnP is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * OpenPnP is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License along with OpenPnP. If not, see
+ * <http://www.gnu.org/licenses/>.
+ * 
+ * For more information about OpenPnP visit http://openpnp.org
+ */
+
+package org.openpnp.machine.reference.feeder.wizards;
+
+import java.awt.BorderLayout;
+import java.awt.Color;
+import java.awt.GraphicsEnvironment;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import javax.swing.AbstractAction;
+import javax.swing.Action;
+import javax.swing.BoxLayout;
+import javax.swing.JButton;
+import javax.swing.JCheckBox;
+import javax.swing.JComboBox;
+import javax.swing.JDialog;
+import javax.swing.JEditorPane;
+import javax.swing.JLabel;
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+import javax.swing.JTextField;
+import javax.swing.JTextPane;
+import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
+import javax.swing.border.TitledBorder;
+
+import org.jdesktop.beansbinding.AutoBinding.UpdateStrategy;
+import org.openpnp.events.FeederSelectedEvent;
+import org.openpnp.gui.MainFrame;
+import org.openpnp.gui.components.ComponentDecorators;
+import org.openpnp.gui.components.LocationButtonsPanel;
+import org.openpnp.gui.processes.RegionOfInterestProcess;
+import org.openpnp.gui.support.DoubleConverter;
+import org.openpnp.gui.support.Icons;
+import org.openpnp.gui.support.IntegerConverter;
+import org.openpnp.gui.support.LengthConverter;
+import org.openpnp.gui.support.LongConverter;
+import org.openpnp.gui.support.MutableLocationProxy;
+import org.openpnp.machine.reference.feeder.ReferencePushPullFeeder;
+import org.openpnp.machine.reference.feeder.ReferencePushPullFeeder.OcrWrongPartAction;
+import org.openpnp.model.Configuration;
+import org.openpnp.model.RegionOfInterest;
+import org.openpnp.spi.Camera;
+import org.openpnp.spi.Head;
+import org.openpnp.util.MovableUtils;
+import org.openpnp.util.UiUtils;
+import org.openpnp.vision.pipeline.CvPipeline;
+import org.openpnp.vision.pipeline.ui.CvPipelineEditor;
+import org.pmw.tinylog.Logger;
+
+import com.jgoodies.forms.layout.ColumnSpec;
+import com.jgoodies.forms.layout.FormLayout;
+import com.jgoodies.forms.layout.FormSpecs;
+import com.jgoodies.forms.layout.RowSpec;
+import java.awt.Dimension;
+
+@SuppressWarnings("serial")
+public class ReferencePushPullFeederConfigurationWizard
+extends AbstractReferenceFeederConfigurationWizard {
+    private final ReferencePushPullFeeder feeder;
+
+    public ReferencePushPullFeederConfigurationWizard(ReferencePushPullFeeder feeder) {
+        super(feeder, false);
+        this.feeder = feeder;
+
+        JPanel panelFields = new JPanel();
+        panelFields.setLayout(new BoxLayout(panelFields, BoxLayout.Y_AXIS));
+
+        panelLocations = new JPanel();
+        panelLocations.setBorder(new TitledBorder(null, "Locations", TitledBorder.LEADING,
+                TitledBorder.TOP, null, null));
+
+        panelFields.add(panelLocations);
+        panelLocations.setLayout(new FormLayout(new ColumnSpec[] {
+                FormSpecs.RELATED_GAP_COLSPEC,
+                ColumnSpec.decode("default:grow"),
+                FormSpecs.RELATED_GAP_COLSPEC,
+                ColumnSpec.decode("default:grow"),
+                FormSpecs.RELATED_GAP_COLSPEC,
+                ColumnSpec.decode("max(26dlu;default):grow"),
+                FormSpecs.RELATED_GAP_COLSPEC,
+                ColumnSpec.decode("default:grow"),
+                FormSpecs.RELATED_GAP_COLSPEC,
+                ColumnSpec.decode("right:max(180dlu;min)"),
+                FormSpecs.RELATED_GAP_COLSPEC,
+                FormSpecs.DEFAULT_COLSPEC,},
+                new RowSpec[] {
+                        FormSpecs.RELATED_GAP_ROWSPEC,
+                        FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC,
+                        FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC,
+                        FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC,
+                        FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC,
+                        FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC,
+                        FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC,
+                        FormSpecs.DEFAULT_ROWSPEC,}));
+
+        btnShowVisionFeatures = new JButton(showVisionFeaturesAction);
+        btnShowVisionFeatures.setToolTipText("Preview the features recognized by Computer Vision.");
+        btnShowVisionFeatures.setText("Preview Vision Features");
+        panelLocations.add(btnShowVisionFeatures, "2, 2, default, fill");
+
+        btnAutoSetup = new JButton(autoSetupAction);
+        panelLocations.add(btnAutoSetup, "4, 2, 7, 1");
+
+        button = new JButton(plusOneAction);
+        panelLocations.add(button, "12, 2");
+
+        lblX_1 = new JLabel("X");
+        panelLocations.add(lblX_1, "4, 4");
+
+        lblY_1 = new JLabel("Y");
+        panelLocations.add(lblY_1, "6, 4");
+
+        lblZ_1 = new JLabel("Z");
+        panelLocations.add(lblZ_1, "8, 4");
+
+        lblPickLocation = new JLabel("Pick Location");
+        lblPickLocation.setToolTipText("<html>Pick Location of the part. If multiple are produced by a feed operation<br/>\r\nthis must be the last one picked i.e. the one closest to the the tape reel.</html>");
+        panelLocations.add(lblPickLocation, "2, 6, right, default");
+
+        textFieldPickLocationX = new JTextField();
+        panelLocations.add(textFieldPickLocationX, "4, 6");
+        textFieldPickLocationX.setColumns(10);
+
+        textFieldPickLocationY = new JTextField();
+        panelLocations.add(textFieldPickLocationY, "6, 6");
+        textFieldPickLocationY.setColumns(10);
+
+        textFieldPickLocationZ = new JTextField();
+        panelLocations.add(textFieldPickLocationZ, "8, 6");
+        textFieldPickLocationZ.setColumns(10);
+
+        locationButtonsPanelFirstPick = new LocationButtonsPanel(textFieldPickLocationX, textFieldPickLocationY, textFieldPickLocationZ, null);
+        panelLocations.add(locationButtonsPanelFirstPick, "10, 6, 3, 1");
+
+        lblNormalizePickLocation = new JLabel("Normalize?");
+        lblNormalizePickLocation.setToolTipText("Normalize the pick location relative to the sprocket holes according to the EIA-481 standard.");
+        panelLocations.add(lblNormalizePickLocation, "2, 8, right, default");
+
+        checkBoxNormalizePickLocation = new JCheckBox("");
+        panelLocations.add(checkBoxNormalizePickLocation, "4, 8");
+        checkBoxNormalizePickLocation.setSelected(true);
+
+        lblHole1Location = new JLabel("Hole 1 Location");
+        lblHole1Location.setToolTipText("<html>Choose Hole 1 closer to the tape reel.<br/>\r\nIf possible choose two holes that bracket the part(s) to be picked.\r\n</html>");
+        panelLocations.add(lblHole1Location, "2, 10, right, default");
+
+        textFieldHole1LocationX = new JTextField();
+        panelLocations.add(textFieldHole1LocationX, "4, 10");
+        textFieldHole1LocationX.setColumns(10);
+
+        textFieldHole1LocationY = new JTextField();
+        panelLocations.add(textFieldHole1LocationY, "6, 10");
+        textFieldHole1LocationY.setColumns(10);
+
+        locationButtonsPanelHole1 = new LocationButtonsPanel(textFieldHole1LocationX, textFieldHole1LocationY, (JTextField) null, (JTextField) null);
+        panelLocations.add(locationButtonsPanelHole1, "10, 10, 3, 1");
+
+        lblHole2Location = new JLabel("Hole 2 Location");
+        lblHole2Location.setToolTipText("<html>Choose Hole 2 further away from the tape reel.<br/>\r\nIf possible choose two holes that bracket the part(s) to be picked.\r\n</html>");
+        panelLocations.add(lblHole2Location, "2, 12, right, default");
+
+        textFieldHole2LocationX = new JTextField();
+        panelLocations.add(textFieldHole2LocationX, "4, 12");
+        textFieldHole2LocationX.setColumns(10);
+
+        textFieldHole2LocationY = new JTextField();
+        panelLocations.add(textFieldHole2LocationY, "6, 12");
+        textFieldHole2LocationY.setColumns(10);
+
+        locationButtonsPanelHole2 = new LocationButtonsPanel(textFieldHole2LocationX, textFieldHole2LocationY, (JTextField) null, (JTextField) null);
+        panelLocations.add(locationButtonsPanelHole2, "10, 12, 3, 1");
+
+        lblSnapToAxis = new JLabel("Snap to Axis?");
+        lblSnapToAxis.setToolTipText("Snap rows of sprocket holes to the Axis parallel.");
+        panelLocations.add(lblSnapToAxis, "2, 14, right, default");
+
+        checkBoxSnapToAxis = new JCheckBox("");
+        checkBoxSnapToAxis.setToolTipText("Snap rows of sprocket holes to the Axis parallel.");
+        panelLocations.add(checkBoxSnapToAxis, "4, 14");
+        panelLocations = new JPanel();
+        panelLocations.setBorder(new TitledBorder(null, "Tape Settings", TitledBorder.LEADING,
+                TitledBorder.TOP, null, null));
+
+        panelTape = new JPanel();
+        panelFields.add(panelTape);
+        panelTape.setBorder(new TitledBorder(null, "Tape Settings", TitledBorder.LEADING, TitledBorder.TOP, null, new Color(0, 0, 0)));
+        panelTape.setLayout(new FormLayout(new ColumnSpec[] {
+                FormSpecs.RELATED_GAP_COLSPEC,
+                ColumnSpec.decode("default:grow"),
+                FormSpecs.RELATED_GAP_COLSPEC,
+                ColumnSpec.decode("default:grow"),
+                FormSpecs.RELATED_GAP_COLSPEC,
+                ColumnSpec.decode("max(26dlu;default):grow"),
+                FormSpecs.RELATED_GAP_COLSPEC,
+                ColumnSpec.decode("default:grow"),
+                FormSpecs.RELATED_GAP_COLSPEC,
+                ColumnSpec.decode("default:grow"),},
+                new RowSpec[] {
+                        FormSpecs.RELATED_GAP_ROWSPEC,
+                        FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC,
+                        FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC,
+                        FormSpecs.DEFAULT_ROWSPEC,}));
+
+        lblPartPitch = new JLabel("Part Pitch");
+        panelTape.add(lblPartPitch, "2, 2, right, default");
+        lblPartPitch.setToolTipText("Pitch of the parts in the tape (2mm, 4mm, 8mm, 12mm, etc.)");
+
+        textFieldPartPitch = new JTextField();
+        panelTape.add(textFieldPartPitch, "4, 2");
+        textFieldPartPitch.setToolTipText("Pitch of the parts in the tape (2mm, 4mm, 8mm, 12mm, etc.)");
+        textFieldPartPitch.setColumns(5);
+
+        lblRotation = new JLabel("Rotation in Tape");
+        panelTape.add(lblRotation, "6, 2, right, default");
+        lblRotation.setToolTipText("<html>Rotation of the part inside the tape as seen when the sprocket holes <br/>\r\nare on top. Your E-CAD part orientation is the reference.<br/>\r\nSee also: \r\n<ul>\r\n<li>EIA-481</li>\r\n<li>Component Zero Orientations for CAD Libraries</li>\r\n</ul>\r\n</html>");
+
+        textFieldRotationInTape = new JTextField();
+        panelTape.add(textFieldRotationInTape, "8, 2");
+        textFieldRotationInTape.setToolTipText("<html>Rotation of the part inside the tape as seen when the sprocket holes <br/>\r\nare on top. Your E-CAD part orientation is the reference.<br/>\r\nSee also: \r\n<ul>\r\n<li>EIA-481</li>\r\n<li>Component Zero Orientations for CAD Libraries</li>\r\n</ul>\r\n</html>");
+        textFieldRotationInTape.setColumns(10);
+
+        lblFeedPitch = new JLabel("Feed Pitch");
+        panelTape.add(lblFeedPitch, "2, 4, right, default");
+        lblFeedPitch.setToolTipText("How much the tape will be advanced by one lever actuation (usually multiples of 4mm)");
+
+        textFieldFeedPitch = new JTextField();
+        panelTape.add(textFieldFeedPitch, "4, 4");
+        textFieldFeedPitch.setToolTipText("How much the tape will be advanced by one lever actuation (usually multiples of 4mm)");
+        textFieldFeedPitch.setColumns(10);
+
+        lblMultiplier = new JLabel("Multiplier");
+        panelTape.add(lblMultiplier, "6, 4, right, default");
+        lblMultiplier.setToolTipText("To improve efficiency you can actuate the feeder multiple times to feed more parts per feed cycle.");
+
+        textFieldFeedMultiplier = new JTextField();
+        panelTape.add(textFieldFeedMultiplier, "8, 4");
+        textFieldFeedMultiplier.setToolTipText("To improve efficiency you can actuate the feeder multiple times to feed more parts per feed cycle.");
+        textFieldFeedMultiplier.setColumns(10);
+
+        btnDiscardParts = new JButton(discardPartsAction);
+        btnDiscardParts.setToolTipText("<html>Discard parts left over in the (multi-part) feed cycle.<br/>\r\nStarts with a fresh feed cycle including vision calibration (if enabled). \r\n</html>");
+        panelTape.add(btnDiscardParts, "10, 4");
+
+        lblFeedCount = new JLabel("Feed Count");
+        panelTape.add(lblFeedCount, "6, 6, right, default");
+        lblFeedCount.setToolTipText("Total feed count of the feeder.");
+
+        textFieldFeedCount = new JTextField();
+        panelTape.add(textFieldFeedCount, "8, 6");
+        textFieldFeedCount.setToolTipText("Total feed count of the feeder.");
+        textFieldFeedCount.setColumns(10);
+
+        btnReset = new JButton(resetFeedCountAction);
+        panelTape.add(btnReset, "10, 6");
+
+        Head head = null;
+        try {
+            head = Configuration.get().getMachine().getDefaultHead();
+        }
+        catch (Exception e) {
+            Logger.error(e, "Cannot determine default head of machine.");
+        }
+
+        //
+        panelVision = new JPanel();
+        panelVision.setBorder(new TitledBorder(null, "Vision", TitledBorder.LEADING,
+                TitledBorder.TOP, null, null));
+        panelFields.add(panelVision);
+        panelVision.setLayout(new BoxLayout(panelVision, BoxLayout.Y_AXIS));
+
+        panelVisionEnabled = new JPanel();
+        panelVision.add(panelVisionEnabled);
+        panelVisionEnabled.setLayout(new FormLayout(new ColumnSpec[] {
+                FormSpecs.LABEL_COMPONENT_GAP_COLSPEC,
+                ColumnSpec.decode("default:grow"),
+                FormSpecs.RELATED_GAP_COLSPEC,
+                ColumnSpec.decode("default:grow"),
+                FormSpecs.RELATED_GAP_COLSPEC,
+                ColumnSpec.decode("default:grow"),
+                FormSpecs.RELATED_GAP_COLSPEC,
+                ColumnSpec.decode("default:grow"),
+                FormSpecs.RELATED_GAP_COLSPEC,
+                ColumnSpec.decode("default:grow"),
+                FormSpecs.RELATED_GAP_COLSPEC,
+                ColumnSpec.decode("default:grow"),
+                FormSpecs.RELATED_GAP_COLSPEC,
+                ColumnSpec.decode("default:grow"),},
+                new RowSpec[] {
+                        FormSpecs.LINE_GAP_ROWSPEC,
+                        FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC,
+                        FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC,
+                        FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC,
+                        FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC,
+                        FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC,
+                        FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC,
+                        FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC,
+                        FormSpecs.DEFAULT_ROWSPEC,}));
+
+        lblCalibrationTrigger = new JLabel("Calibration Trigger");
+        panelVisionEnabled.add(lblCalibrationTrigger, "2, 2, right, default");
+
+        comboBoxCalibrationTrigger = new JComboBox(ReferencePushPullFeeder.CalibrationTrigger.values());
+        panelVisionEnabled.add(comboBoxCalibrationTrigger, "4, 2");
+
+        lblPrecisionAverage = new JLabel("Precision Average");
+        lblPrecisionAverage.setToolTipText("Obtained precision average i.e. offset of the pick location, as detected by the calibration");
+        panelVisionEnabled.add(lblPrecisionAverage, "8, 2, right, default");
+
+        textFieldPrecisionAverage = new JTextField();
+        textFieldPrecisionAverage.setToolTipText("Obtained precision average i.e. offset of the pick location, as detected by the calibration");
+        textFieldPrecisionAverage.setEditable(false);
+        panelVisionEnabled.add(textFieldPrecisionAverage, "10, 2");
+        textFieldPrecisionAverage.setColumns(10);
+
+        lblCalibrationCount = new JLabel("Calibration Count");
+        panelVisionEnabled.add(lblCalibrationCount, "12, 2, right, default");
+
+        textFieldCalibrationCount = new JTextField();
+        textFieldCalibrationCount.setEditable(false);
+        panelVisionEnabled.add(textFieldCalibrationCount, "14, 2");
+        textFieldCalibrationCount.setColumns(10);
+
+        lblPrecisionWanted = new JLabel("Precision wanted");
+        lblPrecisionWanted.setToolTipText("Precision wanted i.e. the tolerable pick location offset");
+        panelVisionEnabled.add(lblPrecisionWanted, "2, 4, right, default");
+
+        textFieldPrecisionWanted = new JTextField();
+        textFieldPrecisionWanted.setToolTipText("Precision wanted i.e. the tolerable pick location offset");
+        panelVisionEnabled.add(textFieldPrecisionWanted, "4, 4");
+        textFieldPrecisionWanted.setColumns(10);
+
+        lblPrecisionConfidenceLimit = new JLabel("Precision Confidence Limit");
+        lblPrecisionConfidenceLimit.setToolTipText("Precision obtained with 95% confidence (assuming normal distribution)");
+        panelVisionEnabled.add(lblPrecisionConfidenceLimit, "8, 4, right, default");
+
+        textFieldPrecisionConfidenceLimit = new JTextField();
+        textFieldPrecisionConfidenceLimit.setEditable(false);
+        panelVisionEnabled.add(textFieldPrecisionConfidenceLimit, "10, 4");
+        textFieldPrecisionConfidenceLimit.setColumns(10);
+
+        btnResetStatistics = new JButton(resetStatisticsAction);
+        panelVisionEnabled.add(btnResetStatistics, "12, 4, 3, 1");
+
+        lblOcrWrongPart = new JLabel("OCR Wrong Part Action");
+        lblOcrWrongPart.setToolTipText("<html>Determines what action should be taken when OCR detects the wrong Part ID in the feeder.<br/> \r\n<ul>\r\n<li><strong>None</strong>: no OCR is performed.</li>\r\n<li><strong>Stop</strong>: the error is indicated, the current process stopped.</li>\r\n<li><strong>Change Part & Stop</strong>: the part in the feeder is exchanged, error and stop.</li>\r\n<li><strong>Change Part & Continue</strong>: the part in the feeder is exchanged silently.</li>\r\n</ul>\r\n</html>\r\n");
+        panelVisionEnabled.add(lblOcrWrongPart, "2, 8, right, default");
+
+        comboBoxWrongPartAction = new JComboBox(ReferencePushPullFeeder.OcrWrongPartAction.values());
+        panelVisionEnabled.add(comboBoxWrongPartAction, "4, 8");
+
+        // Compose a font list of the system, the one currently selected, even if the system does not know it (yet), and the empty selection 
+        List<String> systemFontList = Arrays.asList(GraphicsEnvironment.getLocalGraphicsEnvironment()
+                .getAvailableFontFamilyNames()); 
+        List<String> fontList = new ArrayList<>();
+        if (!systemFontList.contains(feeder.getOcrFontName())) {
+            fontList.add(feeder.getOcrFontName());
+        }
+        fontList.add("");
+        fontList.addAll(systemFontList);
+
+        lblOcrFontName = new JLabel("OCR Font Name");
+        lblOcrFontName.setToolTipText("<html>Name of the OCR font to be recognized.<br/>\r\nMonospace fonts work much better, allow lower resolution and therefore faster <br/>\r\noperation. Use a font where all the used characters are easily distinguishable.<br/>\r\nFonts with clear separation between glyphs are much preferred.</html>");
+        panelVisionEnabled.add(lblOcrFontName, "8, 8, right, default");
+        comboBoxFontName = new JComboBox(fontList.toArray());
+        panelVisionEnabled.add(comboBoxFontName, "10, 8");
+
+        btnSetupocrregion = new JButton(setupOcrRegionAction);
+        panelVisionEnabled.add(btnSetupocrregion, "12, 8, 3, 1");
+
+        lblStopAfterWrong = new JLabel("Stop after wrong part?");
+        panelVisionEnabled.add(lblStopAfterWrong, "2, 10, right, default");
+
+        checkBoxStopAfterWrongPart = new JCheckBox("");
+        panelVisionEnabled.add(checkBoxStopAfterWrongPart, "4, 10");
+
+        lblFontSizept = new JLabel("OCR Font Size [pt]");
+        lblFontSizept.setToolTipText("The OCR font size in typographic points (1 pt = 1/72 in).");
+        panelVisionEnabled.add(lblFontSizept, "8, 10, right, default");
+
+        textFieldFontSizePt = new JTextField();
+        panelVisionEnabled.add(textFieldFontSizePt, "10, 10");
+        textFieldFontSizePt.setColumns(10);
+
+        btnEditPipeline = new JButton(editPipelineAction);
+        btnEditPipeline.addActionListener(new ActionListener() {
+            public void actionPerformed(ActionEvent e) {
+            }
+        });
+
+        btnSetPartByOcr = new JButton(performOcrAction);
+        panelVisionEnabled.add(btnSetPartByOcr, "12, 10, 3, 1");
+
+        lblDiscoverOnJobStart = new JLabel("Check on Job Start?");
+        lblDiscoverOnJobStart.setToolTipText("<html>On Job Start, check that the correct parts are selected in OCR-enabled feeders at their locations. <br/>\r\nOtherwise the Job is stopped.<br/>\r\nThis will also vision-calibrate the feeders' locations, if calibration is enabled.</html>");
+        panelVisionEnabled.add(lblDiscoverOnJobStart, "2, 12, right, default");
+
+        checkBoxDiscoverOnJobStart = new JCheckBox("");
+        panelVisionEnabled.add(checkBoxDiscoverOnJobStart, "4, 12");
+
+        btnOcrAllFeeders = new JButton(allFeederOcrAction);
+        panelVisionEnabled.add(btnOcrAllFeeders, "12, 12, 3, 1");
+        panelVisionEnabled.add(btnEditPipeline, "2, 16");
+
+        btnResetPipeline = new JButton(resetPipelineAction);
+        panelVisionEnabled.add(btnResetPipeline, "4, 16");
+
+        contentPanel.add(panelFields);
+
+        panelCloning = new JPanel();
+        panelCloning.setBorder(new TitledBorder(null, "Clone Settings", TitledBorder.LEADING, TitledBorder.TOP, null, null));
+        panelFields.add(panelCloning);
+        panelCloning.setLayout(new FormLayout(new ColumnSpec[] {
+                FormSpecs.RELATED_GAP_COLSPEC,
+                FormSpecs.DEFAULT_COLSPEC,
+                FormSpecs.RELATED_GAP_COLSPEC,
+                ColumnSpec.decode("default:grow"),
+                FormSpecs.RELATED_GAP_COLSPEC,
+                FormSpecs.DEFAULT_COLSPEC,
+                FormSpecs.RELATED_GAP_COLSPEC,
+                ColumnSpec.decode("default:grow"),
+                FormSpecs.RELATED_GAP_COLSPEC,
+                FormSpecs.DEFAULT_COLSPEC,
+                FormSpecs.RELATED_GAP_COLSPEC,
+                FormSpecs.DEFAULT_COLSPEC,
+                FormSpecs.RELATED_GAP_COLSPEC,
+                ColumnSpec.decode("default:grow"),},
+                new RowSpec[] {
+                        FormSpecs.RELATED_GAP_ROWSPEC,
+                        FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC,
+                        FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC,
+                        FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC,
+                        FormSpecs.DEFAULT_ROWSPEC,}));
+
+        lblUsedAsTemplate = new JLabel("Use this one as Template?");
+        panelCloning.add(lblUsedAsTemplate, "2, 2, right, default");
+        lblUsedAsTemplate.setToolTipText("<html>Use this feeder as a template for cloning settings to other feeders. <br/>\r\nThe templates are matched by tape & reel specification or package of the parts <br/>\r\nloaded in feeders. <br/>\r\nWhen no template matches formally, the feeder \nwith the greatest similarities <br/>\r\nis taken (feed pitch, tape width, proximity, etc.).</html>");
+
+        checkBoxUsedAsTemplate = new JCheckBox("");
+        checkBoxUsedAsTemplate.setToolTipText("<html>Use this feeder as a template for cloning settings to other feeders. <br/>\r\nThe templates are matched by tape & reel specification or package of the parts <br/>\r\nloaded in feeders. <br/>\r\nWhen no template matches formally, the feeder \nwith the greatest similarities <br/>\r\nis taken (feed pitch, tape width, proximity, etc.).</html>");
+        checkBoxUsedAsTemplate.addPropertyChangeListener(new PropertyChangeListener() {
+            public void propertyChange(PropertyChangeEvent evt) {
+                // by setting anything, we fire a property change
+                if (btnSmartClone != null) {
+                    btnSmartClone.setAction(checkBoxUsedAsTemplate.isSelected() ? feederCloneToAllAction: feederCloneFromTemplate);
+                }
+                // need to "apply" this immediately
+                feeder.setUsedAsTemplate(checkBoxUsedAsTemplate.isSelected());
+            }
+        });
+        panelCloning.add(checkBoxUsedAsTemplate, "4, 2");
+
+        lblCloneLocationSettings = new JLabel("Clone Location Settings?");
+        lblCloneLocationSettings.setToolTipText("Clone the X/Y-invariable Location settings, i.e. Pick Location Z and options. ");
+        panelCloning.add(lblCloneLocationSettings, "8, 2, right, default");
+
+        checkBoxCloneLocationSettings = new JCheckBox("");
+        checkBoxCloneLocationSettings.setSelected(true);
+        checkBoxCloneLocationSettings.setToolTipText("Clone the X/Y-invariable Location settings, i.e. Pick Location Z and options. ");
+        panelCloning.add(checkBoxCloneLocationSettings, "10, 2");
+
+        btnSmartClone = new JButton(feeder.isUsedAsTemplate() ? feederCloneToAllAction : feederCloneFromTemplate);
+        panelCloning.add(btnSmartClone, "14, 2, 1, 7");
+
+        lblTemplate = new JLabel("Template:");
+        panelCloning.add(lblTemplate, "2, 4, right, default");
+
+        textPaneCloneTemplateStatus = new JTextPane();
+        textPaneCloneTemplateStatus.setMaximumSize(new Dimension(400, 2147483647));
+        textPaneCloneTemplateStatus.setText("&nbsp;");
+        textPaneCloneTemplateStatus.setBackground(UIManager.getColor("control"));
+        textPaneCloneTemplateStatus.setContentType("text/html");
+        textPaneCloneTemplateStatus.setEditable(false);
+        textPaneCloneTemplateStatus.putClientProperty(JEditorPane.HONOR_DISPLAY_PROPERTIES, true);
+        panelCloning.add(textPaneCloneTemplateStatus, "4, 4, 1, 5, default, top");
+
+        lblCloneTapeSetting = new JLabel("Clone Tape Setting?");
+        lblCloneTapeSetting.setToolTipText("Clone the Tape Settings. ");
+        panelCloning.add(lblCloneTapeSetting, "8, 4, right, default");
+
+        checkBoxCloneTapeSettings = new JCheckBox("");
+        checkBoxCloneTapeSettings.setSelected(true);
+        checkBoxCloneTapeSettings.setToolTipText("Clone the Tape Settings. ");
+        panelCloning.add(checkBoxCloneTapeSettings, "10, 4");
+
+        lblCloneVisionSettings = new JLabel("Clone Vision Settings?");
+        lblCloneVisionSettings.setToolTipText("Clone the Vision settings, including the pipeline.");
+        panelCloning.add(lblCloneVisionSettings, "8, 6, right, default");
+
+        checkBoxCloneVisionSettings = new JCheckBox("");
+        checkBoxCloneVisionSettings.setToolTipText("Clone the Vision settings, including the pipeline.");
+        checkBoxCloneVisionSettings.setSelected(true);
+        panelCloning.add(checkBoxCloneVisionSettings, "10, 6");
+
+        lblClonePushpullSettings = new JLabel("Clone Push-Pull Settings?");
+        lblClonePushpullSettings.setToolTipText("Clone the Push-Pull Motion Settings.");
+        panelCloning.add(lblClonePushpullSettings, "8, 8, right, default");
+
+        checkBoxClonePushPullSettings = new JCheckBox("");
+        checkBoxClonePushPullSettings.setToolTipText("Clone the Push-Pull Motion Settings.");
+        checkBoxClonePushPullSettings.setSelected(true);
+        panelCloning.add(checkBoxClonePushPullSettings, "10, 8");
+        initDataBindings();
+    }
+
+    @Override
+    public void createBindings() {
+        super.createBindings();
+        LengthConverter lengthConverter = new LengthConverter();
+        IntegerConverter intConverter = new IntegerConverter();
+        LongConverter longConverter = new LongConverter();
+        DoubleConverter doubleConverter =
+                new DoubleConverter(Configuration.get().getLengthDisplayFormat());
+
+        MutableLocationProxy firstPickLocation = new MutableLocationProxy();
+        bind(UpdateStrategy.READ_WRITE, feeder, "location", firstPickLocation, "location");
+        addWrappedBinding(firstPickLocation, "lengthX", textFieldPickLocationX, "text",
+                lengthConverter);
+        addWrappedBinding(firstPickLocation, "lengthY", textFieldPickLocationY, "text",
+                lengthConverter);
+        addWrappedBinding(firstPickLocation, "lengthZ", textFieldPickLocationZ, "text",
+                lengthConverter);
+
+        addWrappedBinding(feeder, "normalizePickLocation", checkBoxNormalizePickLocation, "selected");
+
+        addWrappedBinding(feeder, "rotationInFeeder", textFieldRotationInTape, "text",
+                doubleConverter);
+
+        MutableLocationProxy hole1Location = new MutableLocationProxy();
+        bind(UpdateStrategy.READ_WRITE, feeder, "hole1Location", hole1Location, "location");
+        addWrappedBinding(hole1Location, "lengthX", textFieldHole1LocationX, "text",
+                lengthConverter);
+        addWrappedBinding(hole1Location, "lengthY", textFieldHole1LocationY, "text",
+                lengthConverter);
+
+        MutableLocationProxy hole2Location = new MutableLocationProxy();
+        bind(UpdateStrategy.READ_WRITE, feeder, "hole2Location", hole2Location, "location");
+        addWrappedBinding(hole2Location, "lengthX", textFieldHole2LocationX, "text",
+                lengthConverter);
+        addWrappedBinding(hole2Location, "lengthY", textFieldHole2LocationY, "text",
+                lengthConverter);
+
+        addWrappedBinding(feeder, "snapToAxis", checkBoxSnapToAxis, "selected");
+
+        addWrappedBinding(feeder, "partPitch", textFieldPartPitch, "text", lengthConverter);
+        addWrappedBinding(feeder, "feedPitch", textFieldFeedPitch, "text", lengthConverter);
+        addWrappedBinding(feeder, "feedMultiplier", textFieldFeedMultiplier, "text", longConverter);
+        addWrappedBinding(feeder, "feedCount", textFieldFeedCount, "text", longConverter);
+
+        addWrappedBinding(feeder, "usedAsTemplate", checkBoxUsedAsTemplate, "selected");
+
+        addWrappedBinding(feeder, "calibrationTrigger", comboBoxCalibrationTrigger, "selectedItem");
+
+        addWrappedBinding(feeder, "precisionWanted", textFieldPrecisionWanted, "text", lengthConverter);
+        addWrappedBinding(feeder, "calibrationCount", textFieldCalibrationCount, "text", intConverter);
+        addWrappedBinding(feeder, "precisionAverage", textFieldPrecisionAverage, "text", lengthConverter);
+        addWrappedBinding(feeder, "precisionConfidenceLimit", textFieldPrecisionConfidenceLimit, "text", lengthConverter);
+
+        addWrappedBinding(feeder, "ocrWrongPartAction", comboBoxWrongPartAction, "selectedItem");
+        addWrappedBinding(feeder, "ocrStopAfterWrongPart", checkBoxStopAfterWrongPart, "selected");
+        addWrappedBinding(feeder, "ocrDiscoverOnJobStart", checkBoxDiscoverOnJobStart, "selected");
+        addWrappedBinding(feeder, "ocrFontName", comboBoxFontName, "selectedItem");
+        addWrappedBinding(feeder, "ocrFontSizePt", textFieldFontSizePt, "text", doubleConverter);
+
+        addWrappedBinding(feeder, "cloneTemplateStatus", textPaneCloneTemplateStatus, "text");
+
+        ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldPickLocationX);
+        ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldPickLocationY);
+        ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldPickLocationZ);
+        ComponentDecorators.decorateWithAutoSelect(textFieldRotationInTape);
+        ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldHole1LocationX);
+        ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldHole1LocationY);
+        ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldHole2LocationX);
+        ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldHole2LocationY);
+        ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldPartPitch);
+        ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldFeedPitch);
+        ComponentDecorators.decorateWithAutoSelect(textFieldFontSizePt);
+    }
+
+    private Action editPipelineAction =
+            new AbstractAction("Edit Pipeline") {
+        {
+            putValue(Action.SHORT_DESCRIPTION,
+                    "Edit the Pipeline to be used for all vision operations of this feeder.");
+        }
+
+        @Override
+        public void actionPerformed(ActionEvent e) {
+            if (Configuration.get().getMachine().isEnabled()) {
+                UiUtils.submitUiMachineTask(() -> {
+                    MovableUtils.moveToLocationAtSafeZ(feeder.getCamera(), feeder.getNominalVisionLocation());
+                    SwingUtilities.invokeAndWait(() -> {
+                        UiUtils.messageBoxOnException(() -> {
+                            editPipeline();
+                        });
+                    });
+                });
+            }
+            else {
+                int result = JOptionPane.showConfirmDialog(getTopLevelAncestor(),
+                        "Machine not enabled, unable to move the camera to the right location to edit the pipeline.\n"
+                                +"Do you want to proceed anyway?",
+                                null, JOptionPane.YES_NO_OPTION, JOptionPane.WARNING_MESSAGE);
+                if (result == JOptionPane.YES_OPTION) {
+                    UiUtils.messageBoxOnException(() -> {
+                        editPipeline();
+                    });                    
+                }
+            }
+        }
+    };
+
+    private Action resetPipelineAction =
+            new AbstractAction("Reset Pipeline") {
+        {
+            putValue(Action.SHORT_DESCRIPTION,
+                    "Reset the Pipeline for this feeder to the OpenPNP standard.");
+        }
+
+        @Override
+        public void actionPerformed(ActionEvent e) {
+            UiUtils.messageBoxOnException(() -> {
+                resetPipeline();
+            });
+        }
+    };
+
+    private Action resetStatisticsAction =
+            new AbstractAction("Reset Statistics") {
+        {
+            putValue(Action.SHORT_DESCRIPTION,
+                    "Reset the average obtained precision statistics.");
+        }
+
+        @Override
+        public void actionPerformed(ActionEvent e) {
+            UiUtils.messageBoxOnException(() -> {
+                feeder.resetCalibrationStatistics();
+            });
+        }
+    };
+
+    private Action resetFeedCountAction =
+            new AbstractAction("Reset Feed Count") {
+        {
+            putValue(Action.SHORT_DESCRIPTION,
+                    "Reset the feed count e.g. when a tape has been changed.");
+        }
+
+        @Override
+        public void actionPerformed(ActionEvent e) {
+            int result = JOptionPane.showConfirmDialog(getTopLevelAncestor(),
+                    "This will reset the recorded feed count of this feeder. Are you sure?",
+                    null, JOptionPane.YES_NO_OPTION, JOptionPane.WARNING_MESSAGE);
+            if (result == JOptionPane.YES_OPTION) {
+                UiUtils.messageBoxOnException(() -> {
+                    // we apply this because it is OpenPNP custom to do so 
+                    applyAction.actionPerformed(e);
+                    // set it back to 0
+                    feeder.setFeedCount(0);
+                });
+            }
+        }
+    };
+    private Action discardPartsAction =
+            new AbstractAction("Discard Parts") {
+        {
+            putValue(Action.SHORT_DESCRIPTION,
+                    "Discard parts that have been produced by the last tape transport.");
+        }
+
+        @Override
+        public void actionPerformed(ActionEvent e) {
+            UiUtils.messageBoxOnException(() -> {
+                // we apply this because it is OpenPNP custom to do so 
+                applyAction.actionPerformed(e);
+                // round the feed count up to the next multiple of the parts per feed operation
+                feeder.setFeedCount(((feeder.getFeedCount()-1)/feeder.getPartsPerFeedCycle()+1)*feeder.getPartsPerFeedCycle());
+                feeder.resetCalibration();
+            });
+        }
+    };
+    private Action showVisionFeaturesAction =
+            new AbstractAction("Preview Vision Features") {
+        {
+            putValue(Action.SHORT_DESCRIPTION,
+                    "Preview the features recognized by Computer Vision.");
+        }
+
+        @Override
+        public void actionPerformed(ActionEvent e) {
+            UiUtils.submitUiMachineTask(() -> {
+                feeder.showFeatures();
+            });
+        }
+    };
+    private Action autoSetupAction =
+            new AbstractAction("Auto-Setup with Camera at Pick Location", Icons.captureCamera) {
+        {
+            putValue(Action.SHORT_DESCRIPTION,
+                    "<html>Center the camera on the pick location and press this button to Auto-Setup <br/>"
+                            +"If there are multiple picks per feed cycle, choose the one closest to the tape reel.</html>");
+        }
+
+        @Override
+        public void actionPerformed(ActionEvent e) {
+            UiUtils.messageBoxOnException(() -> {
+                if (checkBoxUsedAsTemplate.isSelected()) {
+                    throw new Exception("This feeder is used as a template and cannot be overwritten.");
+                }
+                int result;
+                if (feeder.getLocation().equals(ReferencePushPullFeeder.nullLocation)) {
+                    // if the feeder.location is completely null, we assume this is a freshly created feeder 
+                    result = JOptionPane.YES_OPTION; 
+                }
+                else {
+                    // ask the user
+                    result = JOptionPane.showConfirmDialog(getTopLevelAncestor(),
+                            "This may overwrite all your current settings. Are you sure?",
+                            null, JOptionPane.YES_NO_OPTION, JOptionPane.WARNING_MESSAGE);
+                }
+                if (result == JOptionPane.YES_OPTION) {
+                    applyAction.actionPerformed(e);
+                    UiUtils.submitUiMachineTask(() -> {
+                        feeder.autoSetup();
+                    });
+                }
+            });
+        }
+    };
+    private Action allFeederOcrAction =
+            new AbstractAction("All Feeder OCR") {
+        {
+            putValue(Action.SHORT_DESCRIPTION,
+                    "<html>Go to all the feeders with OCR and rediscover the parts loaded in them. </html>");
+        }
+
+        @Override
+        public void actionPerformed(ActionEvent e) {
+            applyAction.actionPerformed(e);
+            UiUtils.submitUiMachineTask(() -> {
+                StringBuilder report = new StringBuilder();
+                feeder.performOcrOnAllFeeders(null, false, report);
+                SwingUtilities.invokeLater(() -> {
+                    if (report.length() == 0) {
+                        report.append("No action taken.");
+                    }
+                    JOptionPane.showMessageDialog(getTopLevelAncestor(), "<html>"+report+"</html>", "OCR Report", JOptionPane.INFORMATION_MESSAGE);
+                });
+            });
+        }
+    };
+
+    private Action setupOcrRegionAction =
+            new AbstractAction("Setup OCR Region") {
+        {
+            putValue(Action.SHORT_DESCRIPTION,
+                    "<html>Moves the camera to the vision location and lets you select the OCR region of interest.</html>");
+        }
+
+        @Override
+        public void actionPerformed(ActionEvent e) {
+            applyAction.actionPerformed(e);
+            UiUtils.submitUiMachineTask(() -> {
+                MovableUtils.moveToLocationAtSafeZ(feeder.getCamera(), feeder.getNominalVisionLocation());
+                SwingUtilities.invokeAndWait(() -> {
+                    UiUtils.messageBoxOnException(() -> {
+                        new RegionOfInterestProcess(MainFrame.get(), feeder.getCamera(), "Setup OCR Region") {
+                            @Override 
+                            public void setResult(RegionOfInterest roi) {
+                                feeder.setOcrRegion(roi);
+                            }
+                        };
+                    });
+                });
+            });
+        }
+    };
+
+    private Action performOcrAction =
+            new AbstractAction("Part by OCR") {
+        {
+            putValue(Action.SHORT_DESCRIPTION,
+                    "<html>Perform OCR and assign the recognized part.</html>");
+        }
+
+        @Override
+        public void actionPerformed(ActionEvent e) {
+            applyAction.actionPerformed(e);
+            UiUtils.submitUiMachineTask(() -> {
+                MovableUtils.moveToLocationAtSafeZ(feeder.getCamera(), feeder.getNominalVisionLocation());
+                StringBuilder report = new StringBuilder();
+                feeder.performOcr(OcrWrongPartAction.ChangePart, false, report);
+                if (report.length() == 0) {
+                    report.append("No action taken.");
+                }
+                JOptionPane.showMessageDialog(getTopLevelAncestor(), "<html>"+report+"</html>", "OCR Report", JOptionPane.INFORMATION_MESSAGE);
+            });
+        }
+    };
+
+    private Action feederCloneFromTemplate =
+            new AbstractAction("Clone from Template", Icons.importt) {
+        {
+            putValue(Action.SHORT_DESCRIPTION,
+                    "<html>Clone the settings from the selected template feeder, <br/>transforming any coordinates to the pick location and orientation.</html>");
+        }
+
+        @Override
+        public void actionPerformed(ActionEvent e) {
+            UiUtils.messageBoxOnException(() -> {
+                if (checkBoxUsedAsTemplate.isSelected()) {
+                    throw new Exception("This feeder is used as a template and cannot be overwritten.");
+                }
+                if (!(checkBoxCloneTapeSettings.isSelected()  
+                        || checkBoxClonePushPullSettings.isSelected()
+                        || checkBoxCloneVisionSettings.isSelected())) {
+                    throw new Exception("Please select some feeder settings to clone.");
+                }
+                applyAction.actionPerformed(e);
+                if (feeder.getTemplateFeeder(null) == null) {
+                    throw new Exception("No suitable template feeder found.");
+                }
+                int result = JOptionPane.showConfirmDialog(getTopLevelAncestor(),
+                        "<html><p>This will overwrite the selected settings with those from the template:<br/><br/>"
+                                + feeder.getCloneTemplateStatus()+"<br/><br/>"
+                                + "Are you sure?",
+                                null, JOptionPane.YES_NO_OPTION, JOptionPane.WARNING_MESSAGE);
+                if (result == JOptionPane.YES_OPTION) {
+                    feeder.smartClone(null, 
+                            checkBoxCloneLocationSettings.isSelected(),
+                            checkBoxCloneTapeSettings.isSelected(), 
+                            checkBoxClonePushPullSettings.isSelected(),
+                            checkBoxCloneVisionSettings.isSelected());
+                }
+            });
+        }
+    };
+
+    private Action feederCloneToAllAction =
+            new AbstractAction("Clone to Feeders", Icons.export) {
+        {
+            putValue(Action.SHORT_DESCRIPTION,
+                    "<html>Clone the settings from this feeder to all compatible feeders.</html>");
+        }
+
+        @Override
+        public void actionPerformed(ActionEvent e) {
+            UiUtils.messageBoxOnException(() -> {
+                if (!checkBoxUsedAsTemplate.isSelected()) {
+                    throw new Exception("This feeder is not used as a template.");
+                }
+                if (!(checkBoxCloneTapeSettings.isSelected()  
+                        || checkBoxClonePushPullSettings.isSelected()
+                        || checkBoxCloneVisionSettings.isSelected())) {
+                    throw new Exception("Please select some feeder settings to clone.");
+                }
+                applyAction.actionPerformed(e);
+                if (feeder.getCompatibleFeeders().size() == 0) {
+                    throw new Exception("No suitable feeders found to clone to.");
+                }
+                int result = JOptionPane.showConfirmDialog(getTopLevelAncestor(),
+                        "<html>This will overwrite the selected settings in all the target feeders:<br/><br/>"
+                                + feeder.getCloneTemplateStatus()+"<br/><br/>   "
+                                +"Are you sure?</html>",
+                                null, JOptionPane.YES_NO_OPTION, JOptionPane.WARNING_MESSAGE);
+                if (result == JOptionPane.YES_OPTION) {
+                    for (ReferencePushPullFeeder targetFeeder : feeder.getCompatibleFeeders()) {
+                        targetFeeder.cloneFeederSettings( 
+                                checkBoxCloneLocationSettings.isSelected(),
+                                checkBoxCloneTapeSettings.isSelected(), 
+                                checkBoxClonePushPullSettings.isSelected(),
+                                checkBoxCloneVisionSettings.isSelected(),
+                                feeder);
+                    }
+                }
+            });
+        }
+    };
+
+    private Action plusOneAction =
+            new AbstractAction("", Icons.add) {
+        {
+            putValue(Action.SHORT_DESCRIPTION,
+                    "<html>Add one more feeder like this one, advancing in a row.</html>");
+        }
+
+        @Override
+        public void actionPerformed(ActionEvent e) {
+            UiUtils.messageBoxOnException(() -> {
+                applyAction.actionPerformed(e);
+                ReferencePushPullFeeder newFeeder = feeder.createNewInRow();
+                UiUtils.submitUiMachineTask(() -> {
+                    Camera camera = feeder.getCamera(); 
+                    MovableUtils.moveToLocationAtSafeZ(camera, newFeeder.getPickLocation(0, null));
+                    newFeeder.autoSetup();
+                    SwingUtilities.invokeLater(() -> {
+                        Configuration.get().getBus().post(new FeederSelectedEvent(newFeeder, this));
+                    });
+                });
+            });
+        }
+    };
+
+    private JLabel lblPartPitch;
+    private JTextField textFieldPartPitch;
+    private JTextField textFieldFeedPitch;
+    private JLabel lblFeedPitch;
+    private JPanel panelLocations;
+    private JPanel panelTape;
+    private JPanel panelVision;
+    private JPanel panelVisionEnabled;
+    private LocationButtonsPanel locationButtonsPanelFirstPick;
+    private LocationButtonsPanel locationButtonsPanelHole1;
+    private LocationButtonsPanel locationButtonsPanelHole2;
+    private JLabel lblZ_1;
+    private JLabel lblRotation;
+    private JLabel lblY_1;
+    private JLabel lblX_1;
+    private JLabel lblPickLocation;
+    private JTextField textFieldPickLocationX;
+    private JTextField textFieldPickLocationY;
+    private JTextField textFieldPickLocationZ;
+    private JTextField textFieldRotationInTape;
+    private JLabel lblHole1Location;
+    private JTextField textFieldHole1LocationX;
+    private JTextField textFieldHole1LocationY;
+    private JTextField textFieldHole2LocationX;
+    private JTextField textFieldHole2LocationY;
+    private JButton btnEditPipeline;
+    private JButton btnResetPipeline;
+    private JLabel lblFeedCount;
+    private JTextField textFieldFeedCount;
+    private JButton btnReset;
+    private JButton btnDiscardParts;
+    private JTextField textFieldFeedMultiplier;
+    private JLabel lblMultiplier;
+    private JLabel lblHole2Location;
+    private JButton btnShowVisionFeatures;
+    private JButton btnAutoSetup;
+    private JLabel lblCalibrationTrigger;
+    private JComboBox comboBoxCalibrationTrigger;
+    private JLabel lblCalibrationCount;
+    private JTextField textFieldCalibrationCount;
+    private JLabel lblPrecisionAverage;
+    private JTextField textFieldPrecisionAverage;
+    private JLabel lblPrecisionWanted;
+    private JTextField textFieldPrecisionWanted;
+    private JButton btnResetStatistics;
+    private JLabel lblPrecisionConfidenceLimit;
+    private JTextField textFieldPrecisionConfidenceLimit;
+    private JLabel lblNormalizePickLocation;
+    private JCheckBox checkBoxNormalizePickLocation;
+    private JButton btnSmartClone;
+    private JLabel lblUsedAsTemplate;
+    private JCheckBox checkBoxUsedAsTemplate;
+    private JButton btnSetupocrregion;
+    private JLabel lblOcrFontName;
+    private JComboBox comboBoxFontName;
+    private JLabel lblFontSizept;
+    private JTextField textFieldFontSizePt;
+    private JLabel lblOcrWrongPart;
+    private JComboBox comboBoxWrongPartAction;
+    private JLabel lblDiscoverOnJobStart;
+    private JCheckBox checkBoxDiscoverOnJobStart;
+    private JButton btnOcrAllFeeders;
+    private JLabel lblStopAfterWrong;
+    private JCheckBox checkBoxStopAfterWrongPart;
+    private JLabel lblSnapToAxis;
+    private JCheckBox checkBoxSnapToAxis;
+    private JPanel panelCloning;
+    private JLabel lblCloneTapeSetting;
+    private JCheckBox checkBoxCloneTapeSettings;
+    private JLabel lblCloneVisionSettings;
+    private JCheckBox checkBoxCloneVisionSettings;
+    private JLabel lblClonePushpullSettings;
+    private JCheckBox checkBoxClonePushPullSettings;
+    private JTextPane textPaneCloneTemplateStatus;
+    private JLabel lblTemplate;
+    private JButton button;
+    private JLabel lblCloneLocationSettings;
+    private JCheckBox checkBoxCloneLocationSettings;
+    private JButton btnSetPartByOcr;
+
+    private void editPipeline() throws Exception {
+        Camera camera = feeder.getCamera();
+        CvPipeline pipeline = feeder.getCvPipeline(camera, false, true);
+        CvPipelineEditor editor = new CvPipelineEditor(pipeline);
+        JDialog dialog = new JDialog(MainFrame.get(), feeder.getName() + " Pipeline");
+        dialog.getContentPane().setLayout(new BorderLayout());
+        dialog.getContentPane().add(editor);
+        dialog.setSize(1024, 768);
+        dialog.setVisible(true);
+    }    
+
+    private void resetPipeline() {
+        feeder.resetPipeline();
+    }
+    protected void initDataBindings() {
+    }
+}

--- a/src/main/java/org/openpnp/machine/reference/feeder/wizards/ReferencePushPullMotionConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/wizards/ReferencePushPullMotionConfigurationWizard.java
@@ -1,0 +1,559 @@
+/*
+ * Copyright (C) 2020 <mark@makr.zone>
+ * based on the ReferenceLeverFeeder 
+ * Copyright (C) 2011 Jason von Nieda <jason@vonnieda.org>
+ * 
+ * This file is part of OpenPnP.
+ * 
+ * OpenPnP is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * OpenPnP is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License along with OpenPnP. If not, see
+ * <http://www.gnu.org/licenses/>.
+ * 
+ * For more information about OpenPnP visit http://openpnp.org
+ */
+
+package org.openpnp.machine.reference.feeder.wizards;
+
+import java.awt.Color;
+import java.awt.GraphicsEnvironment;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import javax.swing.BoxLayout;
+import javax.swing.JCheckBox;
+import javax.swing.JComboBox;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JTextField;
+import javax.swing.UIManager;
+import javax.swing.border.TitledBorder;
+
+import org.jdesktop.beansbinding.AutoBinding.UpdateStrategy;
+import org.openpnp.gui.components.ComponentDecorators;
+import org.openpnp.gui.components.LocationButtonsPanel;
+import org.openpnp.gui.support.AbstractConfigurationWizard;
+import org.openpnp.gui.support.ActuatorsComboBoxModel;
+import org.openpnp.gui.support.DoubleConverter;
+import org.openpnp.gui.support.IntegerConverter;
+import org.openpnp.gui.support.LengthConverter;
+import org.openpnp.gui.support.LongConverter;
+import org.openpnp.gui.support.MutableLocationProxy;
+import org.openpnp.machine.reference.feeder.ReferencePushPullFeeder;
+import org.openpnp.model.Configuration;
+import org.openpnp.spi.Head;
+import org.pmw.tinylog.Logger;
+
+import com.jgoodies.forms.layout.ColumnSpec;
+import com.jgoodies.forms.layout.FormLayout;
+import com.jgoodies.forms.layout.FormSpecs;
+import com.jgoodies.forms.layout.RowSpec;
+
+@SuppressWarnings("serial")
+public class ReferencePushPullMotionConfigurationWizard
+extends AbstractConfigurationWizard {
+    private final ReferencePushPullFeeder feeder;
+    private JTextField textFieldFeedStartX;
+    private JTextField textFieldFeedStartY;
+    private JTextField textFieldFeedStartZ;
+    private JTextField textFieldFeedEndX;
+    private JTextField textFieldFeedEndY;
+    private JTextField textFieldFeedEndZ;
+    private JTextField textFieldFeedPush1;
+    private JLabel lblFeedMid1Location;
+    private JTextField textFieldFeedMid1X;
+    private JTextField textFieldFeedMid1Y;
+    private JTextField textFieldFeedMid1Z;
+    private JLabel lblFeedMid2Location;
+    private JTextField textFieldFeedMid2X;
+    private JTextField textFieldFeedMid2Y;
+    private JTextField textFieldFeedMid2Z;
+    private JLabel lblFeedMid3Location;
+    private JTextField textFieldFeedMid3X;
+    private JTextField textFieldFeedMid3Y;
+    private JTextField textFieldFeedMid3Z;
+    private JLabel lblActuatorId;
+    private JComboBox comboBoxFeedActuator;
+    private JLabel lblPeelOffActuatorId;
+    private JComboBox comboBoxPeelOffActuator;
+    private JPanel panelLocations;
+    private JPanel panelPushPull;
+    private LocationButtonsPanel locationButtonsPanelFeedStart;
+    private LocationButtonsPanel locationButtonsPanelFeedMid1;
+    private LocationButtonsPanel locationButtonsPanelFeedMid2;
+    private LocationButtonsPanel locationButtonsPanelFeedMid3;
+    private LocationButtonsPanel locationButtonsPanelFeedEnd;
+    private JLabel lblPush;
+    private JLabel lblMulti;
+    private JLabel lblPull;
+    private JLabel lblFeedSpeed0_1;
+    private JLabel lblFeedSpeed1_2;
+    private JLabel lblFeedSpeed2_3;
+    private JLabel lblFeedSpeed3_4;
+    private JTextField textFieldFeedPush2;
+    private JTextField textFieldFeedPush3;
+    private JTextField textFieldFeedPush4;
+    private JTextField textFieldFeedPull3;
+    private JTextField textFieldFeedPull2;
+    private JTextField textFieldFeedPull1;
+    private JTextField textFieldFeedPull0;
+    private JCheckBox chckbxPush1;
+    private JCheckBox chckbxPush2;
+    private JCheckBox chckbxPush3;
+    private JCheckBox chckbxPushEnd;
+    private JCheckBox chckbxMulti0;
+    private JCheckBox chckbxMulti1;
+    private JCheckBox chckbxMulti2;
+    private JCheckBox chckbxMulti3;
+    private JCheckBox chckbxMultiEnd;
+    private JCheckBox chckbxPull0;
+    private JCheckBox chckbxPull1;
+    private JCheckBox chckbxPull2;
+    private JCheckBox chckbxPull3;
+
+    public ReferencePushPullMotionConfigurationWizard(ReferencePushPullFeeder feeder) {
+        super();
+        this.feeder = feeder;
+
+        JPanel panelFields = new JPanel();
+        panelFields.setLayout(new BoxLayout(panelFields, BoxLayout.Y_AXIS));
+        panelLocations = new JPanel();
+        panelLocations.setBorder(new TitledBorder(null, "Tape Settings", TitledBorder.LEADING,
+                TitledBorder.TOP, null, null));
+
+        panelPushPull = new JPanel();
+        panelFields.add(panelPushPull);
+        panelPushPull.setBorder(new TitledBorder(UIManager.getBorder("TitledBorder.border"), "Push-Pull Settings", TitledBorder.LEADING, TitledBorder.TOP, null, new Color(0, 0, 0)));
+        panelPushPull.setLayout(new FormLayout(new ColumnSpec[] {
+                FormSpecs.RELATED_GAP_COLSPEC,
+                ColumnSpec.decode("default:grow"),
+                FormSpecs.RELATED_GAP_COLSPEC,
+                ColumnSpec.decode("default:grow"),
+                FormSpecs.RELATED_GAP_COLSPEC,
+                ColumnSpec.decode("default:grow"),
+                FormSpecs.RELATED_GAP_COLSPEC,
+                ColumnSpec.decode("default:grow"),
+                FormSpecs.RELATED_GAP_COLSPEC,
+                ColumnSpec.decode("default:grow"),
+                FormSpecs.RELATED_GAP_COLSPEC,
+                FormSpecs.DEFAULT_COLSPEC,
+                FormSpecs.RELATED_GAP_COLSPEC,
+                FormSpecs.DEFAULT_COLSPEC,
+                FormSpecs.RELATED_GAP_COLSPEC,
+                ColumnSpec.decode("default:grow"),
+                FormSpecs.RELATED_GAP_COLSPEC,
+                ColumnSpec.decode("max(100dlu;default):grow"),
+                FormSpecs.RELATED_GAP_COLSPEC,
+                ColumnSpec.decode("left:max(100dlu;default):grow"),},
+                new RowSpec[] {
+                        FormSpecs.RELATED_GAP_ROWSPEC,
+                        FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC,
+                        FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC,
+                        FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC,
+                        FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC,
+                        FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC,
+                        FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC,
+                        FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC,
+                        FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC,
+                        FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC,
+                        FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC,
+                        FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC,
+                        FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC,
+                        FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC,
+                        RowSpec.decode("default:grow"),}));
+
+        lblActuatorId = new JLabel("Actuator");
+        panelPushPull.add(lblActuatorId, "2, 4, right, default");
+
+        Head head = null;
+        try {
+            head = Configuration.get().getMachine().getDefaultHead();
+        }
+        catch (Exception e) {
+            Logger.error(e, "Cannot determine default head of machine.");
+        }
+
+        comboBoxFeedActuator = new JComboBox();
+        panelPushPull.add(comboBoxFeedActuator, "4, 4");
+        comboBoxFeedActuator.setModel(new ActuatorsComboBoxModel(head));
+
+        lblPeelOffActuatorId = new JLabel("Peel Off Actuator");
+        panelPushPull.add(lblPeelOffActuatorId, "6, 4, right, default");
+
+        comboBoxPeelOffActuator = new JComboBox();
+        panelPushPull.add(comboBoxPeelOffActuator, "8, 4");
+        comboBoxPeelOffActuator.setModel(new ActuatorsComboBoxModel(head));
+
+        JLabel lblX = new JLabel("X");
+        panelPushPull.add(lblX, "4, 8");
+
+        JLabel lblY = new JLabel("Y");
+        panelPushPull.add(lblY, "6, 8");
+
+        JLabel lblZ = new JLabel("Z");
+        panelPushPull.add(lblZ, "8, 8");
+
+        lblPush = new JLabel("↓");
+        lblPush.setToolTipText("Locations that are included when pushing.");
+        panelPushPull.add(lblPush, "10, 8, center, default");
+
+        lblMulti = new JLabel("↑↓");
+        lblMulti.setToolTipText("<html>Locations that are included, when actuating multiple times.<br/>\r\nThe combination with the push ↓ and pull ↑ switch is taken.</html>");
+        panelPushPull.add(lblMulti, "12, 8, 3, 1, center, default");
+
+        lblPull = new JLabel("↑");
+        lblPull.setToolTipText("Locations that are included when pulling.");
+        panelPushPull.add(lblPull, "16, 8, center, default");
+
+        JLabel lblFeedStartLocation = new JLabel("Start Location");
+        panelPushPull.add(lblFeedStartLocation, "2, 10, right, default");
+
+        textFieldFeedStartX = new JTextField();
+        panelPushPull.add(textFieldFeedStartX, "4, 10");
+        textFieldFeedStartX.setColumns(8);
+
+        textFieldFeedStartY = new JTextField();
+        panelPushPull.add(textFieldFeedStartY, "6, 10");
+        textFieldFeedStartY.setColumns(8);
+
+        textFieldFeedStartZ = new JTextField();
+        panelPushPull.add(textFieldFeedStartZ, "8, 10");
+        textFieldFeedStartZ.setColumns(8);
+
+        chckbxMulti0 = new JCheckBox("");
+        chckbxMulti0.setToolTipText("Include the Start Location in multi-actuating motion (if the pull switch is also set).");
+        chckbxMulti0.setSelected(true);
+        panelPushPull.add(chckbxMulti0, "12, 10, 3, 1, center, default");
+
+        chckbxPull0 = new JCheckBox("");
+        chckbxPull0.setToolTipText("Go to the Start Location when pulling.");
+        chckbxPull0.setSelected(true);
+        panelPushPull.add(chckbxPull0, "16, 10, center, default");
+
+        locationButtonsPanelFeedStart = new LocationButtonsPanel(textFieldFeedStartX,
+                textFieldFeedStartY, textFieldFeedStartZ, null);
+        locationButtonsPanelFeedStart.setShowPositionToolNoSafeZ(true);
+        panelPushPull.add(locationButtonsPanelFeedStart, "18, 10, 3, 1, fill, default");
+
+        lblFeedSpeed0_1 = new JLabel("Speed ↕");
+        panelPushPull.add(lblFeedSpeed0_1, "8, 12, right, default");
+
+        textFieldFeedPush1 = new JTextField();
+        panelPushPull.add(textFieldFeedPush1, "10, 12, 3, 1");
+        textFieldFeedPush1.setColumns(5);
+
+        textFieldFeedPull0 = new JTextField();
+        panelPushPull.add(textFieldFeedPull0, "14, 12, 3, 1");
+        textFieldFeedPull0.setColumns(10);
+
+        lblFeedMid1Location = new JLabel("Mid 1 Location");
+        panelPushPull.add(lblFeedMid1Location, "2, 14, right, default");
+
+        textFieldFeedMid1X = new JTextField();
+        panelPushPull.add(textFieldFeedMid1X, "4, 14");
+        textFieldFeedMid1X.setColumns(10);
+
+        textFieldFeedMid1Y = new JTextField();
+        panelPushPull.add(textFieldFeedMid1Y, "6, 14");
+        textFieldFeedMid1Y.setColumns(10);
+
+        textFieldFeedMid1Z = new JTextField();
+        panelPushPull.add(textFieldFeedMid1Z, "8, 14");
+        textFieldFeedMid1Z.setColumns(10);
+
+        chckbxPush1 = new JCheckBox("");
+        chckbxPush1.setToolTipText("Go to the Mid 1 Location when pushing.");
+        chckbxPush1.setSelected(true);
+        panelPushPull.add(chckbxPush1, "10, 14, center, default");
+
+        chckbxMulti1 = new JCheckBox("");
+        chckbxMulti1.setToolTipText("Include the Mid 1 Location in multi-actuation motion (if the push/pull switch is also set).");
+        chckbxMulti1.setSelected(true);
+        panelPushPull.add(chckbxMulti1, "12, 14, 3, 1, center, default");
+
+        chckbxPull1 = new JCheckBox("");
+        chckbxPull1.setToolTipText("Go to the Mid 1 Location when pulling.");
+        chckbxPull1.setSelected(true);
+        panelPushPull.add(chckbxPull1, "16, 14, center, default");
+
+        locationButtonsPanelFeedMid1 = new LocationButtonsPanel(textFieldFeedMid1X, textFieldFeedMid1Y, textFieldFeedMid1Z, (JTextField) null);
+        locationButtonsPanelFeedMid1.setShowPositionToolNoSafeZ(true);
+        panelPushPull.add(locationButtonsPanelFeedMid1, "18, 14, 3, 1, fill, default");
+
+        lblFeedSpeed1_2 = new JLabel("Speed ↕");
+        panelPushPull.add(lblFeedSpeed1_2, "8, 16, right, default");
+
+        textFieldFeedPush2 = new JTextField();
+        panelPushPull.add(textFieldFeedPush2, "10, 16, 3, 1");
+        textFieldFeedPush2.setColumns(10);
+
+        textFieldFeedPull1 = new JTextField();
+        textFieldFeedPull1.setColumns(10);
+        panelPushPull.add(textFieldFeedPull1, "14, 16, 3, 1");
+
+        lblFeedMid2Location = new JLabel("Mid 2 Location");
+        panelPushPull.add(lblFeedMid2Location, "2, 18, right, default");
+
+        textFieldFeedMid2X = new JTextField();
+        panelPushPull.add(textFieldFeedMid2X, "4, 18");
+        textFieldFeedMid2X.setColumns(10);
+
+        textFieldFeedMid2Y = new JTextField();
+        panelPushPull.add(textFieldFeedMid2Y, "6, 18");
+        textFieldFeedMid2Y.setColumns(10);
+
+        textFieldFeedMid2Z = new JTextField();
+        panelPushPull.add(textFieldFeedMid2Z, "8, 18");
+        textFieldFeedMid2Z.setColumns(10);
+
+        chckbxPush2 = new JCheckBox("");
+        chckbxPush2.setToolTipText("Go to the Mid 2 Location when pushing.");
+        chckbxPush2.setSelected(true);
+        panelPushPull.add(chckbxPush2, "10, 18, center, default");
+
+        chckbxMulti2 = new JCheckBox("");
+        chckbxMulti2.setToolTipText("Include the Mid 2 Location in multi-actuation motion (if the push/pull switch is also set).");
+        chckbxMulti2.setSelected(true);
+        panelPushPull.add(chckbxMulti2, "12, 18, 3, 1, center, default");
+
+        chckbxPull2 = new JCheckBox("");
+        chckbxPull2.setToolTipText("Go to the Mid 2 Location when pulling.");
+        chckbxPull2.setSelected(true);
+        panelPushPull.add(chckbxPull2, "16, 18, center, default");
+
+        locationButtonsPanelFeedMid2 = new LocationButtonsPanel(textFieldFeedMid2X, textFieldFeedMid2Y, textFieldFeedMid2Z, (JTextField) null);
+        locationButtonsPanelFeedMid2.setShowPositionToolNoSafeZ(true);
+        panelPushPull.add(locationButtonsPanelFeedMid2, "18, 18, 3, 1, fill, default");
+
+        lblFeedSpeed2_3 = new JLabel("Speed ↕");
+        panelPushPull.add(lblFeedSpeed2_3, "8, 20, right, default");
+
+        textFieldFeedPush3 = new JTextField();
+        panelPushPull.add(textFieldFeedPush3, "10, 20, 3, 1");
+        textFieldFeedPush3.setColumns(10);
+
+        textFieldFeedPull2 = new JTextField();
+        textFieldFeedPull2.setColumns(10);
+        panelPushPull.add(textFieldFeedPull2, "14, 20, 3, 1");
+
+        lblFeedMid3Location = new JLabel("Mid 3 Location");
+        panelPushPull.add(lblFeedMid3Location, "2, 22, right, default");
+
+        textFieldFeedMid3X = new JTextField();
+        panelPushPull.add(textFieldFeedMid3X, "4, 22");
+        textFieldFeedMid3X.setColumns(10);
+
+        textFieldFeedMid3Y = new JTextField();
+        panelPushPull.add(textFieldFeedMid3Y, "6, 22");
+        textFieldFeedMid3Y.setColumns(10);
+
+        textFieldFeedMid3Z = new JTextField();
+        panelPushPull.add(textFieldFeedMid3Z, "8, 22, fill, default");
+        textFieldFeedMid3Z.setColumns(10);
+
+        chckbxPush3 = new JCheckBox("");
+        chckbxPush3.setToolTipText("Go to the Mid 3 Location when pushing.");
+        chckbxPush3.setSelected(true);
+        panelPushPull.add(chckbxPush3, "10, 22, center, default");
+
+        chckbxMulti3 = new JCheckBox("");
+        chckbxMulti3.setToolTipText("Include the Mid 3 Location in multi-actuation motion (if the push/pull switch is also set).");
+        chckbxMulti3.setSelected(true);
+        panelPushPull.add(chckbxMulti3, "12, 22, 3, 1, center, default");
+
+        chckbxPull3 = new JCheckBox("");
+        chckbxPull3.setToolTipText("Go to the Mid 3 Location when pulling.");
+        chckbxPull3.setSelected(true);
+        panelPushPull.add(chckbxPull3, "16, 22, center, default");
+
+        locationButtonsPanelFeedMid3 = new LocationButtonsPanel(textFieldFeedMid3X, textFieldFeedMid3Y, textFieldFeedMid3Z, (JTextField) null);
+        locationButtonsPanelFeedMid3.setShowPositionToolNoSafeZ(true);
+        panelPushPull.add(locationButtonsPanelFeedMid3, "18, 22, 3, 1, fill, default");
+
+        lblFeedSpeed3_4 = new JLabel("Speed ↕");
+        panelPushPull.add(lblFeedSpeed3_4, "8, 24, right, default");
+
+        textFieldFeedPush4 = new JTextField();
+        panelPushPull.add(textFieldFeedPush4, "10, 24, 3, 1");
+        textFieldFeedPush4.setColumns(10);
+
+        textFieldFeedPull3 = new JTextField();
+        textFieldFeedPull3.setColumns(10);
+        panelPushPull.add(textFieldFeedPull3, "14, 24, 3, 1");
+
+        JLabel lblFeedEndLocation = new JLabel("End Location");
+        panelPushPull.add(lblFeedEndLocation, "2, 26, right, default");
+
+        textFieldFeedEndX = new JTextField();
+        panelPushPull.add(textFieldFeedEndX, "4, 26");
+        textFieldFeedEndX.setColumns(8);
+
+        textFieldFeedEndY = new JTextField();
+        panelPushPull.add(textFieldFeedEndY, "6, 26");
+        textFieldFeedEndY.setColumns(8);
+
+        textFieldFeedEndZ = new JTextField();
+        panelPushPull.add(textFieldFeedEndZ, "8, 26");
+        textFieldFeedEndZ.setColumns(8);
+
+        chckbxPushEnd = new JCheckBox("");
+        chckbxPushEnd.setToolTipText("Go to the End Location when pushing.");
+        chckbxPushEnd.setSelected(true);
+        panelPushPull.add(chckbxPushEnd, "10, 26, center, default");
+
+        chckbxMultiEnd = new JCheckBox("");
+        chckbxMultiEnd.setToolTipText("Include the End Location in multi-actuation motion (if the push switch is also set).");
+        chckbxMultiEnd.setSelected(true);
+        panelPushPull.add(chckbxMultiEnd, "12, 26, 3, 1, center, default");
+
+        locationButtonsPanelFeedEnd = new LocationButtonsPanel(textFieldFeedEndX, textFieldFeedEndY,
+                textFieldFeedEndZ, null);
+        locationButtonsPanelFeedEnd.setShowPositionToolNoSafeZ(true);
+        panelPushPull.add(locationButtonsPanelFeedEnd, "18, 26, 3, 1, fill, default");
+
+        // Compose a font list of the system, the one currently selected, even if the system does not know it (yet), and the empty selection 
+        List<String> systemFontList = Arrays.asList(GraphicsEnvironment.getLocalGraphicsEnvironment()
+                .getAvailableFontFamilyNames()); 
+        List<String> fontList = new ArrayList<>();
+        if (!systemFontList.contains(feeder.getOcrFontName())) {
+            fontList.add(feeder.getOcrFontName());
+        }
+        fontList.add("");
+        fontList.addAll(systemFontList);
+
+        contentPanel.add(panelFields);
+        initDataBindings();
+    }
+
+    @Override
+    public void createBindings() {
+        LengthConverter lengthConverter = new LengthConverter();
+        IntegerConverter intConverter = new IntegerConverter();
+        LongConverter longConverter = new LongConverter();
+        DoubleConverter doubleConverter =
+                new DoubleConverter(Configuration.get().getLengthDisplayFormat());
+
+        addWrappedBinding(feeder, "actuatorName", comboBoxFeedActuator, "selectedItem");
+        addWrappedBinding(feeder, "peelOffActuatorName", comboBoxPeelOffActuator, "selectedItem");
+
+        addWrappedBinding(feeder, "feedSpeedPush1", textFieldFeedPush1, "text", doubleConverter);
+        addWrappedBinding(feeder, "feedSpeedPush2", textFieldFeedPush2, "text", doubleConverter);
+        addWrappedBinding(feeder, "feedSpeedPush3", textFieldFeedPush3, "text", doubleConverter);
+        addWrappedBinding(feeder, "feedSpeedPushEnd", textFieldFeedPush4, "text", doubleConverter);
+        addWrappedBinding(feeder, "feedSpeedPull3", textFieldFeedPull3, "text", doubleConverter);
+        addWrappedBinding(feeder, "feedSpeedPull2", textFieldFeedPull2, "text", doubleConverter);
+        addWrappedBinding(feeder, "feedSpeedPull1", textFieldFeedPull1, "text", doubleConverter);
+        addWrappedBinding(feeder, "feedSpeedPull0", textFieldFeedPull0, "text", doubleConverter);
+
+        addWrappedBinding(feeder, "includedPush1", chckbxPush1, "selected");
+        addWrappedBinding(feeder, "includedPush2", chckbxPush2, "selected");
+        addWrappedBinding(feeder, "includedPush3", chckbxPush3, "selected");
+        addWrappedBinding(feeder, "includedPushEnd", chckbxPushEnd, "selected");
+
+        addWrappedBinding(feeder, "includedMulti0", chckbxMulti0, "selected");
+        addWrappedBinding(feeder, "includedMulti1", chckbxMulti1, "selected");
+        addWrappedBinding(feeder, "includedMulti2", chckbxMulti2, "selected");
+        addWrappedBinding(feeder, "includedMulti3", chckbxMulti3, "selected");
+        addWrappedBinding(feeder, "includedMultiEnd", chckbxMultiEnd, "selected");
+
+        addWrappedBinding(feeder, "includedPull0", chckbxPull0, "selected");
+        addWrappedBinding(feeder, "includedPull1", chckbxPull1, "selected");
+        addWrappedBinding(feeder, "includedPull2", chckbxPull2, "selected");
+        addWrappedBinding(feeder, "includedPull3", chckbxPull3, "selected");
+
+        MutableLocationProxy feedStartLocation = new MutableLocationProxy();
+        bind(UpdateStrategy.READ_WRITE, feeder, "feedStartLocation", feedStartLocation, "location");
+        addWrappedBinding(feedStartLocation, "lengthX", textFieldFeedStartX, "text",
+                lengthConverter);
+        addWrappedBinding(feedStartLocation, "lengthY", textFieldFeedStartY, "text",
+                lengthConverter);
+        addWrappedBinding(feedStartLocation, "lengthZ", textFieldFeedStartZ, "text",
+                lengthConverter);
+
+        MutableLocationProxy feedMid1Location = new MutableLocationProxy();
+        bind(UpdateStrategy.READ_WRITE, feeder, "feedMid1Location", feedMid1Location, "location");
+        addWrappedBinding(feedMid1Location, "lengthX", textFieldFeedMid1X, "text",
+                lengthConverter);
+        addWrappedBinding(feedMid1Location, "lengthY", textFieldFeedMid1Y, "text",
+                lengthConverter);
+        addWrappedBinding(feedMid1Location, "lengthZ", textFieldFeedMid1Z, "text",
+                lengthConverter);
+
+        MutableLocationProxy feedMid2Location = new MutableLocationProxy();
+        bind(UpdateStrategy.READ_WRITE, feeder, "feedMid2Location", feedMid2Location, "location");
+        addWrappedBinding(feedMid2Location, "lengthX", textFieldFeedMid2X, "text",
+                lengthConverter);
+        addWrappedBinding(feedMid2Location, "lengthY", textFieldFeedMid2Y, "text",
+                lengthConverter);
+        addWrappedBinding(feedMid2Location, "lengthZ", textFieldFeedMid2Z, "text",
+                lengthConverter);
+
+        MutableLocationProxy feedMid3Location = new MutableLocationProxy();
+        bind(UpdateStrategy.READ_WRITE, feeder, "feedMid3Location", feedMid3Location, "location");
+        addWrappedBinding(feedMid3Location, "lengthX", textFieldFeedMid3X, "text",
+                lengthConverter);
+        addWrappedBinding(feedMid3Location, "lengthY", textFieldFeedMid3Y, "text",
+                lengthConverter);
+        addWrappedBinding(feedMid3Location, "lengthZ", textFieldFeedMid3Z, "text",
+                lengthConverter);
+
+        MutableLocationProxy feedEndLocation = new MutableLocationProxy();
+        bind(UpdateStrategy.READ_WRITE, feeder, "feedEndLocation", feedEndLocation, "location");
+        addWrappedBinding(feedEndLocation, "lengthX", textFieldFeedEndX, "text", lengthConverter);
+        addWrappedBinding(feedEndLocation, "lengthY", textFieldFeedEndY, "text", lengthConverter);
+        addWrappedBinding(feedEndLocation, "lengthZ", textFieldFeedEndZ, "text", lengthConverter);
+
+        ComponentDecorators.decorateWithAutoSelect(textFieldFeedPush1);
+        ComponentDecorators.decorateWithAutoSelect(textFieldFeedPush2);
+        ComponentDecorators.decorateWithAutoSelect(textFieldFeedPush3);
+        ComponentDecorators.decorateWithAutoSelect(textFieldFeedPush4);
+        ComponentDecorators.decorateWithAutoSelect(textFieldFeedPull3);
+        ComponentDecorators.decorateWithAutoSelect(textFieldFeedPull2);
+        ComponentDecorators.decorateWithAutoSelect(textFieldFeedPull1);
+        ComponentDecorators.decorateWithAutoSelect(textFieldFeedPull0);
+        ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldFeedStartX);
+        ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldFeedStartY);
+        ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldFeedStartZ);
+        ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldFeedMid1X);
+        ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldFeedMid1Y);
+        ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldFeedMid1Z);
+        ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldFeedMid2X);
+        ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldFeedMid2Y);
+        ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldFeedMid2Z);
+        ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldFeedMid3X);
+        ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldFeedMid3Y);
+        ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldFeedMid3Z);
+        ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldFeedEndX);
+        ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldFeedEndY);
+        ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldFeedEndZ);
+
+        bind(UpdateStrategy.READ, feeder, "actuatorName", locationButtonsPanelFeedStart, "actuatorName");
+        bind(UpdateStrategy.READ, feeder, "actuatorName", locationButtonsPanelFeedMid1, "actuatorName");
+        bind(UpdateStrategy.READ, feeder, "actuatorName", locationButtonsPanelFeedMid2, "actuatorName");
+        bind(UpdateStrategy.READ, feeder, "actuatorName", locationButtonsPanelFeedMid3, "actuatorName");
+        bind(UpdateStrategy.READ, feeder, "actuatorName", locationButtonsPanelFeedEnd, "actuatorName");
+    }
+
+    protected void initDataBindings() {
+    }
+}

--- a/src/main/java/org/openpnp/model/Package.java
+++ b/src/main/java/org/openpnp/model/Package.java
@@ -42,6 +42,9 @@ public class Package extends AbstractModelObject implements Identifiable {
     private String description;
 
     @Attribute(required = false)
+    private String tapeSpecification;
+
+    @Attribute(required = false)
     private double pickVacuumLevel;
 
     @Attribute(required = false)
@@ -89,6 +92,16 @@ public class Package extends AbstractModelObject implements Identifiable {
         Object oldValue = this.description;
         this.description = description;
         firePropertyChange("description", oldValue, description);
+    }
+
+    public String getTapeSpecification() {
+        return tapeSpecification;
+    }
+
+    public void setTapeSpecification(String tapeSpecification) {
+        Object oldValue = this.tapeSpecification;
+        this.tapeSpecification = tapeSpecification;
+        firePropertyChange("tapeSpecification", oldValue, tapeSpecification);
     }
 
     public void setPlaceBlowOffLevel(double level) {

--- a/src/main/java/org/openpnp/model/RegionOfInterest.java
+++ b/src/main/java/org/openpnp/model/RegionOfInterest.java
@@ -1,0 +1,47 @@
+package org.openpnp.model;
+
+import org.simpleframework.xml.Attribute;
+import org.simpleframework.xml.Element;
+
+public class RegionOfInterest {
+    @Element
+    protected Location upperLeftCorner;
+    @Element
+    protected Location upperRightCorner;
+    @Element
+    protected Location lowerLeftCorner;
+    @Attribute
+    protected boolean rectify;
+
+    public RegionOfInterest()
+    {}
+    
+    public RegionOfInterest(Location upperLeftCorner, Location upperRightCorner,
+            Location lowerLeftCorner, boolean rectify) {
+        super();
+        this.upperLeftCorner = upperLeftCorner;
+        this.upperRightCorner = upperRightCorner;
+        this.lowerLeftCorner = lowerLeftCorner;
+        this.rectify = rectify;
+    }
+    public Location getUpperLeftCorner() {
+        return upperLeftCorner;
+    }
+    public Location getUpperRightCorner() {
+        return upperRightCorner;
+    }
+    public Location getLowerLeftCorner() {
+        return lowerLeftCorner;
+    }
+    public boolean isRectify() {
+        return rectify;
+    }
+    
+    public RegionOfInterest rotateXy(double angle) {
+        return new RegionOfInterest(
+                upperLeftCorner.rotateXy(angle),
+                upperRightCorner.rotateXy(angle),
+                lowerLeftCorner.rotateXy(angle),
+                rectify);
+    }
+}

--- a/src/main/java/org/openpnp/spi/Feeder.java
+++ b/src/main/java/org/openpnp/spi/Feeder.java
@@ -65,17 +65,26 @@ public interface Feeder extends Identifiable, Named, WizardConfigurable, Propert
     public Location getPickLocation() throws Exception;
 
     /**
+     * Some feeders need preparation for a Job that is best done up front and in bulk, such as vision 
+     * calibration, actuating covers, checking OCR labels etc. Some prep requires the head moving to the 
+     * feeder. For efficiency the JobProcessor uses a Travelling Salesman algorithm to visit
+     * all these feeders. The locations for these visits are gathered using getJobPreparationLocation().
+     *  
+     * @return The location for the feeder Job preparation visit or null if none.
+     */
+    public Location getJobPreparationLocation();
+    
+    /**
      * Prepares a Feeder for usage in a Job. This is done for all the feeders that are enabled and 
      * contain Parts that are used in pending placements. Preparation is done when the Job is started, 
-     * so it can perform one-time initialization that should not be postponed until the Nozzle.feed() 
+     * so it can perform bulk initialization that should not be postponed until the Nozzle.feed() 
      * 
-     * @param feedersToPrepare Lists all the feeders to be prepared, so bulk preparation is possible. 
-     * Bulk preparation, should only be triggered once for each concern, regardless of subsequent calls 
-     * to this method. Therefore feeders must record whether preparation was already done.
-     *   
+     * @param visit true for visits along the getJobPreparationLocation() travel path, false for 
+     * general preparation (second pass for visited feeders).
+     *  
      * @throws Exception
      */
-    public void prepareForJob(List<Feeder> feedersToPrepare) throws Exception;
+    public void prepareForJob(boolean visit) throws Exception;
     
     /**
      * Commands the Feeder to do anything it needs to do to prepare the part to be picked by the

--- a/src/main/java/org/openpnp/spi/base/AbstractFeeder.java
+++ b/src/main/java/org/openpnp/spi/base/AbstractFeeder.java
@@ -67,7 +67,9 @@ public abstract class AbstractFeeder extends AbstractModelObject implements Feed
 
     @Override
     public void setPart(Part part) {
+        Object oldValue = this.part;
         this.part = part;
+        firePropertyChange("part", oldValue, part);
         this.partId = part.getId();
     }
 

--- a/src/main/java/org/openpnp/util/OpenCvUtils.java
+++ b/src/main/java/org/openpnp/util/OpenCvUtils.java
@@ -48,6 +48,16 @@ public class OpenCvUtils {
             // the caller releases the original Mat there is no memory leak.
             tmp.copyTo(m);
             tmp.release();
+        } 
+        else if (m.type() == CvType.CV_32FC3) {
+            // TemplateMatch creates a CV_32FC3 
+            type = BufferedImage.TYPE_3BYTE_BGR;
+            Mat tmp = new Mat();
+            m.convertTo(tmp, CvType.CV_8UC3, 255);
+            // Copy the results into the original Mat and release our temp copy so that when
+            // the caller releases the original Mat there is no memory leak.
+            tmp.copyTo(m);
+            tmp.release();
         }
         if (type == null) {
             throw new Error(String.format("Unsupported Mat: type %d, channels %d, depth %d",

--- a/src/main/java/org/openpnp/vision/SimpleHistogram.java
+++ b/src/main/java/org/openpnp/vision/SimpleHistogram.java
@@ -1,0 +1,75 @@
+package org.openpnp.vision;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/** 
+ * Very simple histogram with zero knowledge about the range. 
+ * Good only for low numbers of measurements.
+ * The bins are filled with an 2-bin wide square kernel centered on the measurement, recording 
+ * the overlap of the kernel with the bins. If the distribution of measurements clusters near the 
+ * edge between two bins (dithering between the two), the recorded weight is still comparable to a 
+ * similar distribution centered in the middle of a bin. Therefore the minimum/maximum is 
+ * still reliably captured in these cases, even in the presence of background noise. 
+ */
+public class SimpleHistogram {
+    private Map<Integer, Double> histogram = new HashMap<>();
+    private Integer minimum = null;
+    private double minimumVal = Double.NaN;
+    private Integer maximum = null;
+    private double maximumVal = Double.NaN;
+    private double resolution;
+    public SimpleHistogram(double resolution) {
+        this.resolution = resolution;
+    }
+    public void add(double key, double val) {
+        // the three histogram bins around the key position
+        int binY1 = (int)Math.round(key/resolution);   
+        int binY0 = binY1-1; 
+        int binY2 = binY1+1;
+        // calculate the weight according to overlap with the kernel spreading 2 bins 
+        double w1 = 1.0;
+        double w0 = ((binY0+1.5)*resolution - key)/resolution;
+        double w2 = (-(binY2-1.5)*resolution + key)/resolution;
+        add(binY1, w1*val);
+        add(binY0, w0*val);
+        add(binY2, w2*val);
+    }
+    public void add(int key, double val) {
+
+        double newVal = histogram.get(key) == null ? val : histogram.get(key)+val;
+        histogram.put(key, newVal);
+        if (maximum == null || maximumVal < newVal) {
+            maximumVal = newVal;
+            maximum = key;
+        }
+        if (minimum == null || minimumVal > newVal) {
+            minimumVal = newVal;
+            minimum = key;
+        }
+    }
+    public Map<Integer, Double> getHistogram() {
+        return histogram;
+    }
+    public Integer getMinimum() {
+        return minimum;
+    }
+    public double getMinimumKey() {
+        return minimum == null ? Double.NaN : minimum*resolution;
+    }
+    public double getMinimumVal() {
+        return minimumVal;
+    }
+    public Integer getMaximum() {
+        return maximum;
+    }
+    public double getMaximumKey() {
+        return maximum == null ? Double.NaN : maximum*resolution;
+    }
+    public double getMaximumVal() {
+        return maximumVal;
+    }
+    public double getResolution() {
+        return resolution;
+    }
+}

--- a/src/main/java/org/openpnp/vision/pipeline/stages/AffineUnwarp.java
+++ b/src/main/java/org/openpnp/vision/pipeline/stages/AffineUnwarp.java
@@ -1,0 +1,238 @@
+package org.openpnp.vision.pipeline.stages;
+
+import java.awt.geom.AffineTransform;
+import java.awt.geom.Point2D;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.opencv.core.KeyPoint;
+import org.opencv.core.RotatedRect;
+import org.openpnp.vision.pipeline.CvPipeline;
+import org.openpnp.vision.pipeline.CvStage;
+import org.openpnp.vision.pipeline.CvStage.Result.TemplateMatch;
+import org.openpnp.vision.pipeline.Property;
+import org.openpnp.vision.pipeline.Stage;
+import org.simpleframework.xml.Attribute;
+
+@Stage(description="Result model coordinates obtained from images gone through AfficeWarp are not usable as camera "
+        + "coordinates. This stage applies the proper reverse Affine Transformation to reconstruct camera coordinates. "
+        + "The stage currently supports Lists or single instances of Circles, RotatedRects and KeyPoints. "
+        + "For transformations with stretch and shear, some of the model properties are approximated. ")
+public class AffineUnwarp extends CvStage {
+
+    @Attribute(required = false)
+    @Property(description = "Stage name of the AffineWarp.")
+    private String warpStageName = null;
+
+    @Attribute(required = false)
+    @Property(description = "Stage name of the results to unwarp. If empty, takes the working model.")
+    private String resultsStageName = null;
+
+    public String getWarpStageName() {
+        return warpStageName;
+    }
+
+    public void setWarpStageName(String warpStageName) {
+        this.warpStageName = warpStageName;
+    }
+
+    public String getResultsStageName() {
+        return resultsStageName;
+    }
+
+    public void setResultsStageName(String resultsStageName) {
+        this.resultsStageName = resultsStageName;
+    }
+
+    @Override
+    public Result process(CvPipeline pipeline) throws Exception {
+        if (warpStageName == null || warpStageName.isEmpty()) {
+            return null;
+        }
+        Result warpResult = pipeline.getResult(warpStageName);
+        if (warpResult == null || warpResult.getModel() == null) {
+            return null;
+        }
+        if (! (warpResult.getModel() instanceof AffineTransform)) {
+            throw new Exception("Stage "+warpStageName+" result model is not an AffineTransform.");
+        }
+        AffineTransform transform = (AffineTransform)warpResult.getModel();
+        AffineTransform transformInverse = transform.createInverse();
+
+        Object model = null;
+        if (resultsStageName == null || resultsStageName.isEmpty()) {
+            model = pipeline.getWorkingModel();
+        }
+        else {
+            Result result = pipeline.getResult(resultsStageName);
+            if (result == null) {
+                throw new Exception("Stage "+resultsStageName+" not found.");
+            }
+            model = result.getModel();
+        }
+
+        if (model instanceof List) {
+            List newList = null;
+            for (Object item : (List)model) {
+                if ((item) instanceof Result.Circle) {
+                    Result.Circle circle = ((Result.Circle) item);
+                    circle = transformCircle(transformInverse, circle);
+                    if (newList == null) {
+                        newList = new ArrayList<Result.Circle>();
+                    }
+                    newList.add(circle);
+                }
+                else if ((item) instanceof RotatedRect) {
+                    RotatedRect rect = ((RotatedRect) item);
+                    rect = transformRotatedRect(transformInverse, rect);
+                    if (newList == null) {
+                        newList = new ArrayList<RotatedRect>();
+                    }
+                    newList.add(rect);
+                }
+                else if ((item) instanceof TemplateMatch) {
+                    TemplateMatch match = ((TemplateMatch) item);
+                    match = transformTemplateMatch(transformInverse, match);
+                    if (newList == null) {
+                        newList = new ArrayList<TemplateMatch>();
+                    }
+                    newList.add(match);
+                }
+                else if ((item) instanceof KeyPoint) {
+                    KeyPoint keyPoint = ((KeyPoint) item);
+                    keyPoint = transformKeyPoint(transformInverse, keyPoint);
+                    if (newList == null) {
+                        newList = new ArrayList<KeyPoint>();
+                    }
+                    newList.add(keyPoint);
+                }
+                else {
+                    throw new Exception("Unsupported list item.");
+                }
+            }
+            // return new list or pass through empty model
+            if (newList != null) {
+                return new Result(null, newList);
+            }
+            return null;
+        }
+        else if ((model) instanceof Result.Circle) {
+            Result.Circle circle = ((Result.Circle) model);
+            circle = transformCircle(transformInverse, circle);
+            return new Result(null, circle);
+        }
+        else if ((model) instanceof RotatedRect) {
+            RotatedRect rect = ((RotatedRect) model);
+            rect = transformRotatedRect(transformInverse, rect);
+            return new Result(null, rect);
+        }
+        else if ((model) instanceof TemplateMatch) {
+            TemplateMatch match = ((TemplateMatch) model);
+            match = transformTemplateMatch(transformInverse, match);
+            return new Result(null, match);
+        }
+        else if ((model) instanceof KeyPoint) {
+            KeyPoint keyPoint = ((KeyPoint) model);
+            keyPoint = transformKeyPoint(transformInverse, keyPoint);
+            return new Result(null, keyPoint);
+        }
+        else {
+            throw new Exception("Unsupported model type.");
+        }
+    }
+
+    protected KeyPoint transformKeyPoint(AffineTransform transformInverse, KeyPoint keyPoint) {
+        Point2D.Double p0 = new Point2D.Double(keyPoint.pt.x, keyPoint.pt.y);
+        Point2D.Double p1 = new Point2D.Double(keyPoint.pt.x+keyPoint.size*Math.acos(keyPoint.angle), 
+                keyPoint.pt.y-keyPoint.size*Math.acos(keyPoint.angle));
+        Point2D.Double p0T = new Point2D.Double();
+        Point2D.Double p1T = new Point2D.Double();
+        transformInverse.transform(p0, p0T);
+        transformInverse.transform(p1, p1T);
+        // clone
+        keyPoint = new KeyPoint((float)p0T.x, (float)p0T.y, (float)p1T.distance(p0T), (float)Math.atan2(p1.y-p0.y, p1.x-p0.x));
+        return keyPoint;
+    }
+
+    protected RotatedRect transformRotatedRect(AffineTransform transformInverse, RotatedRect rect) {
+        org.opencv.core.Point points[] = new org.opencv.core.Point[4];
+        rect.points(points);
+        int i = 0;
+        Point2D.Double points2D[] = new Point2D.Double[4];
+        Point2D.Double pointsT[] = new Point2D.Double[4];
+        for (org.opencv.core.Point p : points) {
+            points2D[i] = new Point2D.Double(p.x, p.y);
+            pointsT[i] = new Point2D.Double();
+            i++;
+        }
+        transformInverse.transform(points2D[0], pointsT[0]);
+        transformInverse.transform(points2D[1], pointsT[1]);
+        transformInverse.transform(points2D[2], pointsT[2]);
+        transformInverse.transform(points2D[3], pointsT[3]);
+        // take the longer side for the angle
+        if (pointsT[0].distance(pointsT[1]) > pointsT[1].distance(pointsT[2])) { 
+            // vertical is longer
+            double angle = Math.toDegrees(Math.atan2(pointsT[1].y - pointsT[0].y, pointsT[1].x - pointsT[0].x)) + 90;
+            rect = new RotatedRect(
+                    new org.opencv.core.Point(
+                            (pointsT[0].x + pointsT[2].x)/2.0, 
+                            (pointsT[0].y + pointsT[2].y)/2.0),
+                    new org.opencv.core.Size(
+                            pointsT[2].distance(pointsT[1]), // TODO: dot product to compensate shear 
+                            pointsT[1].distance(pointsT[0])),
+                    angle);
+        }
+        else {
+            // horizonal is longer
+            double angle = Math.toDegrees(Math.atan2(pointsT[2].y - pointsT[1].y, pointsT[2].x - pointsT[1].x));
+            rect = new RotatedRect(
+                    new org.opencv.core.Point(
+                            (pointsT[0].x + pointsT[2].x)/2.0, 
+                            (pointsT[0].y + pointsT[2].y)/2.0),
+                    new org.opencv.core.Size(
+                            pointsT[2].distance(pointsT[1]), 
+                            pointsT[1].distance(pointsT[0])),// TODO: dot product to compensate shear
+                    angle);
+        }
+        return rect;
+    }
+
+    protected Result.Circle transformCircle(AffineTransform transformInverse,
+            Result.Circle circle) {
+        Point2D.Double p0 = new Point2D.Double(circle.x, circle.y);
+        Point2D.Double p1 = new Point2D.Double(circle.x+circle.diameter, circle.y);
+        Point2D.Double p2 = new Point2D.Double(circle.x, circle.y+circle.diameter);
+        Point2D.Double p0T = new Point2D.Double();
+        Point2D.Double p1T = new Point2D.Double();
+        Point2D.Double p2T = new Point2D.Double();
+        transformInverse.transform(p0, p0T);
+        transformInverse.transform(p1, p1T);
+        transformInverse.transform(p2, p2T);
+        // if the transform includes shear or stretch, we approximate the diameter by taking the mean
+        circle = new Result.Circle(p0T.x, p0T.y, (p1T.distance(p0T) + p2T.distance(p0T))/2.0);
+        return circle;
+    }
+
+    protected TemplateMatch transformTemplateMatch(AffineTransform transformInverse,
+            TemplateMatch match) {
+        Point2D.Double p0 = new Point2D.Double(match.x, match.y);
+        Point2D.Double p1 = new Point2D.Double(match.x+match.width, match.y+match.height);
+        Point2D.Double p0T = new Point2D.Double();
+        Point2D.Double p1T = new Point2D.Double();
+        transformInverse.transform(p0, p0T);
+        transformInverse.transform(p1, p1T);
+        // if the transform includes shear or stretch or no 90° step rotation, this will only be an approximation
+        if (p0T.x < p1T.x) {
+            double swap = p0T.x;
+            p0T.x = p1T.x;
+            p1T.x = swap;
+        }
+        if (p0T.y < p1T.y) {
+            double swap = p0T.y;
+            p0T.y = p1T.y;
+            p1T.y = swap;
+        }
+        match = new TemplateMatch(p0T.x, p0T.y, p1T.x - p0T.x, p1T.y - p0T.y, match.score);
+        return match;
+    }
+}

--- a/src/main/java/org/openpnp/vision/pipeline/stages/AffineWarp.java
+++ b/src/main/java/org/openpnp/vision/pipeline/stages/AffineWarp.java
@@ -1,0 +1,298 @@
+/*
+ * Copyright (C) 2020 <mark@makr.zone>
+ * Copyright (C) 2011 Jason von Nieda <jason@vonnieda.org>
+ * 
+ * This file is part of OpenPnP.
+ * 
+ * OpenPnP is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * OpenPnP is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License along with OpenPnP. If not, see
+ * <http://www.gnu.org/licenses/>.
+ * 
+ * For more information about OpenPnP visit http://openpnp.org
+ */
+
+package org.openpnp.vision.pipeline.stages;
+
+import java.awt.geom.AffineTransform;
+import java.awt.geom.NoninvertibleTransformException;
+
+import org.opencv.core.Mat;
+import org.opencv.core.MatOfPoint2f;
+import org.opencv.core.Size;
+import org.opencv.imgproc.Imgproc;
+import org.openpnp.model.LengthUnit;
+import org.openpnp.model.Location;
+import org.openpnp.model.RegionOfInterest;
+import org.openpnp.spi.Camera;
+import org.openpnp.vision.pipeline.CvPipeline;
+import org.openpnp.vision.pipeline.CvStage;
+import org.openpnp.vision.pipeline.Property;
+import org.openpnp.vision.pipeline.Stage;
+import org.pmw.tinylog.Logger;
+import org.simpleframework.xml.Attribute;
+
+@Stage(description="Extracts a rectangular (parallelogrammatic) region of interest from the image that can have any position, size, "
+        + "rotation, scale, <em>shear</em> or even be mirrored. A so-called Affine Transformation Warp.<br/>"
+        + "The coordinates are given in real length units rather than pixels and are relative to the camera center, Y pointing up. "
+        + "This allows the pipeline to be independent of camera model and resolution, lens, focus distance etc. <br/>"
+        + "To setup, pin the previous stage and read off length unit coordinates from the mouse position.")
+public class AffineWarp extends CvStage {
+    @Attribute(required = false)
+    @Property(description = "Length unit used in this stage.")
+    private LengthUnit lengthUnit = LengthUnit.Millimeters;
+
+    @Attribute
+    @Property(description = "What will become the left upper corner of the extracted area. X offset from camera location.")
+    private double x0 = 0;
+
+    @Attribute
+    @Property(description = "What will become the left upper corner of the extracted area. Y offset from camera location.")
+    private double y0 = 0;
+
+    @Attribute
+    @Property(description = "What will become the right upper corner of the extracted area. X offset from camera location.")
+    private double x1 = 0;
+
+    @Attribute
+    @Property(description = "What will become the right upper corner of the extracted area. Y offset from camera location.")
+    private double y1 = 0;
+
+    @Attribute
+    @Property(description = "What will become the left lower corner of the extracted area. X offset from camera location.")
+    private double x2 = 0;
+
+    @Attribute
+    @Property(description = "What will become the left lower corner of the extracted area. Y offset from camera location.")
+    private double y2 = 0;
+
+    @Attribute(required=false)
+    @Property(description = "Scale of the transformation. NOTE: subsequent stages must be aware that the camera pixel to units scale has changed.")
+    private double scale = 1.0;
+
+    @Attribute(required=false)
+    @Property(description = "Rectify the transformation to be rectangular. The point [x2, y2] is not interpreted "
+            + "as a corner but as a height indicator.")
+    private boolean rectify = true;
+
+    @Attribute(required=false)
+    @Property(description = "The caller of the pipeline can override the region of interest under this name.")
+    private String regionOfInterestProperty = "regionOfInterest";
+
+    /* broken out in https://github.com/openpnp/openpnp/pull/980
+     * uncomment the @Override as soon as PR #980 is merged
+    @Override*/
+    public LengthUnit getLengthUnit() {
+        return lengthUnit;
+    }
+
+    public void setLengthUnit(LengthUnit lengthUnit) {
+        this.lengthUnit = lengthUnit;
+    }
+
+    public double getX0() {
+        return x0;
+    }
+
+    public void setX0(double x0) {
+        this.x0 = x0;
+    }
+
+    public double getY0() {
+        return y0;
+    }
+
+    public void setY0(double y0) {
+        this.y0 = y0;
+    }
+
+    public double getX1() {
+        return x1;
+    }
+
+    public void setX1(double x1) {
+        this.x1 = x1;
+    }
+
+    public double getY1() {
+        return y1;
+    }
+
+    public void setY1(double y1) {
+        this.y1 = y1;
+    }
+
+    public double getX2() {
+        return x2;
+    }
+
+    public void setX2(double x2) {
+        this.x2 = x2;
+    }
+
+    public double getY2() {
+        return y2;
+    }
+
+    public void setY2(double y2) {
+        this.y2 = y2;
+    }
+
+    public double getScale() {
+        return scale;
+    }
+
+    public void setScale(double scale) {
+        this.scale = scale;
+    }
+
+    public boolean isRectify() {
+        return rectify;
+    }
+
+    public void setRectify(boolean rectify) {
+        this.rectify = rectify;
+    }
+
+    public String getRegionOfInterestProperty() {
+        return regionOfInterestProperty;
+    }
+
+    public void setRegionOfInterestProperty(String regionOfInterestProperty) {
+        this.regionOfInterestProperty = regionOfInterestProperty;
+    }
+
+    @Override
+    public Result process(CvPipeline pipeline) throws Exception {
+        Camera camera = (Camera) pipeline.getProperty("camera");
+        if (camera == null) {
+            throw new Exception("Property \"camera\" is required.");
+        }
+        Location unitsPerPixel = camera.getUnitsPerPixel()
+                .convertToUnits(lengthUnit);
+
+        double x0 = this.x0;
+        double y0 = this.y0;
+        double x1 = this.x1;
+        double y1 = this.y1;
+        double x2 = this.x2;
+        double y2 = this.y2;
+        boolean rectify = this.rectify;
+
+        if (getRegionOfInterestProperty() != null && ! getRegionOfInterestProperty().isEmpty()) {
+            RegionOfInterest roi = (RegionOfInterest) pipeline.getProperty(getRegionOfInterestProperty());
+            if (roi != null) {
+                // the region of interest is overridden by the pipeline caller
+                x0 = roi.getUpperLeftCorner().getX(); 
+                y0 = roi.getUpperLeftCorner().getY();
+                x1 = roi.getUpperRightCorner().getX(); 
+                y1 = roi.getUpperRightCorner().getY();
+                x2 = roi.getLowerLeftCorner().getX(); 
+                y2 = roi.getLowerLeftCorner().getY();
+                rectify = roi.isRectify();
+            }
+        }
+
+        // get the working image
+        Mat mat = pipeline.getWorkingImage();
+
+        double w = Math.sqrt(Math.pow(x1-x0, 2.0) + Math.pow(y1-y0, 2.0));
+        double h = Math.sqrt(Math.pow(x2-x0, 2.0) + Math.pow(y2-y0, 2.0));
+        if (w == 0.0 || h == 0.0) {
+            return null;
+        }
+
+        double x2eff = x2;
+        double y2eff = y2;
+        if (rectify) {
+            // unit vector
+            double ux = (x1-x0)/w;
+            double uy = (y1-y0)/w; // yes, w is the length to norm with
+            // normal vector
+            double nx = -uy;
+            double ny = ux;
+            // height vector
+            double hx = (x2-x0);
+            double hy = (y2-y0);
+            // dot product with the normal vector gives the new height
+            h = hx*nx + hy*ny;
+            x2eff = x0 + h*nx;
+            y2eff = y0 + h*ny;
+        }
+
+        // conversion to pixels
+        double x0Px = x0/unitsPerPixel.getX()+mat.cols() / 2;
+        double y0Px = -y0/unitsPerPixel.getY()+mat.rows() / 2;
+        double x1Px = x1/unitsPerPixel.getX()+mat.cols() / 2;
+        double y1Px = -y1/unitsPerPixel.getY()+mat.rows() / 2;
+        double x2Px = x2eff/unitsPerPixel.getX()+mat.cols() / 2;
+        double y2Px = -y2eff/unitsPerPixel.getY()+mat.rows() / 2;
+
+
+        double wPx = scale*w/unitsPerPixel.getX();
+        double hPx = scale*Math.abs(h)/unitsPerPixel.getY();
+
+        double diagonal = Math.sqrt(Math.pow(mat.cols(), 2.0)+Math.pow(mat.rows(), 2.0));
+        if (wPx > diagonal+2 || hPx > diagonal+2) {
+            // while setting up the affine transform coordinates one by one, huge images can result -> prevent that 
+            Logger.error("["+getClass().getName()+"] affineWarp must not generate an image that is larger than the original");
+            return new Result(mat, "ERROR: affineWarp must not generate an image that is larger than the original");
+        }
+
+        org.opencv.core.Point p0 = new org.opencv.core.Point(x0Px, y0Px); // upper left 
+        org.opencv.core.Point p1 = new org.opencv.core.Point(x1Px, y1Px); // upper right 
+        org.opencv.core.Point p2 = new org.opencv.core.Point(x2Px, y2Px); // lower left 
+
+        org.opencv.core.Point p0T = new org.opencv.core.Point(0, 0);
+        org.opencv.core.Point p1T = new org.opencv.core.Point(wPx, 0);
+        org.opencv.core.Point p2T = new org.opencv.core.Point(0, hPx);
+
+        MatOfPoint2f ma1 = new MatOfPoint2f(p0, p1, p2);
+        MatOfPoint2f ma2 = new MatOfPoint2f(p0T, p1T, p2T);
+
+        // Create the transformation matrix
+        Mat transformMatrix = Imgproc.getAffineTransform(ma1, ma2);
+
+        // Recreate the same in Java
+        AffineTransform affineTransform = getAffineTransform(p0, p1, p2, p0T, p1T, p2T);
+
+        // Create the size
+        Size size = new Size(wPx, hPx);
+
+        // Perform the warpAffine
+        Mat transformed = new Mat();
+        Imgproc.warpAffine(mat, transformed, transformMatrix, size);
+
+
+        return new Result(transformed, affineTransform);
+    }
+
+    protected AffineTransform getAffineTransform(
+            org.opencv.core.Point p0,
+            org.opencv.core.Point p1,
+            org.opencv.core.Point p2,
+            org.opencv.core.Point p0T,
+            org.opencv.core.Point p1T,
+            org.opencv.core.Point p2T) {   
+        AffineTransform unit = new AffineTransform(p1.x - p0.x, p1.y - p0.y, p2.x - p0.x, p2.y - p0.y, p0.x, p0.y);
+        AffineTransform unitT = new AffineTransform(p1T.x -p0T.x, p1T.y - p0T.y, p2T.x - p0T.x, p2T.y - p0T.y, p0T.x, p0T.y);
+        AffineTransform unitInv = null;
+        try {
+            unitInv = unit.createInverse();
+        }
+        catch (NoninvertibleTransformException e) {
+            Logger.error("["+getClass().getName()+"] getAffineTransform() cannot invert transformation");
+            return new AffineTransform();
+        }
+        AffineTransform at = new AffineTransform();
+        at.concatenate(unitT);
+        at.concatenate(unitInv);
+        return at;
+    }
+}

--- a/src/main/java/org/openpnp/vision/pipeline/stages/MatchTemplate.java
+++ b/src/main/java/org/openpnp/vision/pipeline/stages/MatchTemplate.java
@@ -39,7 +39,7 @@ public class MatchTemplate extends CvStage {
      */
     @Attribute
     @Property(description = "If maximum value is below this value, then no matches will be reported. Default is 0.7.")
-    private double threshold = 0.7f;
+    private double threshold = 0.7;
 
     /**
      * Normalized recognition threshold in the interval [0,1]. Used to determine best match of
@@ -49,7 +49,7 @@ public class MatchTemplate extends CvStage {
      */
     @Attribute
     @Property(description = "Normalized minimum recognition threshold for the CCOEFF_NORMED method, in the interval [0,1]. Default is 0.85.")
-    private double corr = 0.85f;
+    private double corr = 0.85;
 
     @Attribute(required = false)
     @Property(description = "Normalize results to maximum value.")

--- a/src/main/java/org/openpnp/vision/pipeline/stages/SimpleOcr.java
+++ b/src/main/java/org/openpnp/vision/pipeline/stages/SimpleOcr.java
@@ -1,0 +1,640 @@
+/*
+ * Copyright (C) 2020 <mark@makr.zone>
+ * Copyright (C) 2011 Jason von Nieda <jason@vonnieda.org>
+ * 
+ * This file is part of OpenPnP.
+ * 
+ * OpenPnP is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * OpenPnP is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License along with OpenPnP. If not, see
+ * <http://www.gnu.org/licenses/>.
+ * 
+ * For more information about OpenPnP visit http://openpnp.org
+ */
+
+package org.openpnp.vision.pipeline.stages;
+
+import java.awt.Color;
+import java.awt.Font;
+import java.awt.FontMetrics;
+import java.awt.Graphics2D;
+import java.awt.Point;
+import java.awt.RenderingHints;
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+
+import javax.imageio.ImageIO;
+
+import org.opencv.core.Core;
+import org.opencv.core.Core.MinMaxLocResult;
+import org.opencv.core.CvType;
+import org.opencv.core.Mat;
+import org.opencv.core.Size;
+import org.opencv.imgcodecs.Imgcodecs;
+import org.opencv.imgproc.Imgproc;
+import org.openpnp.model.Configuration;
+import org.openpnp.model.Length;
+import org.openpnp.model.LengthUnit;
+import org.openpnp.model.Location;
+import org.openpnp.spi.Camera;
+import org.openpnp.util.OpenCvUtils;
+import org.openpnp.vision.pipeline.CvPipeline;
+import org.openpnp.vision.pipeline.CvStage;
+import org.openpnp.vision.pipeline.CvStage.Result.TemplateMatch;
+import org.openpnp.vision.pipeline.Property;
+import org.openpnp.vision.pipeline.Stage;
+import org.pmw.tinylog.Logger;
+import org.simpleframework.xml.Attribute;
+
+@Stage(description="A very simple OCR stage that returns a (multi-line) text string. <br/>"
+        + "Use an AffineWarp stage to extract the region of interest first (for cropping, rotation and acceptable speed).<br/>"
+        + "It is also recommended to convert the image to grayscale first. Do not apply a threshold stage.")
+public class SimpleOcr extends CvStage {
+    @Attribute
+    @Property(description = "Alphabet of all the characters that can be recognized. The smaller the alphabet, the faster and the "
+            + "more reliable the OCR works. The alphabet can be overriden with the \"alphabet\" property.")
+    private String alphabet = "0123456789.-+_RCLDQYXJIVAFH%GMKkmuµnp";
+
+    @Attribute
+    @Property(description = "Name of the font to be recognized. Monospace fonts work much better and allow lower resolution. "
+            + "Use a font where all the used characters are easily distinguishable. Fonts with clear separation between characters "
+            + "are preferred.")
+    private String fontName = "Liberation Mono";
+
+    @Attribute
+    @Property(description = "Size of the font in typographic points (1 pt = 1/72 in).")
+    private double fontSizePt = 7.0;
+
+    @Attribute(required = false)
+    @Property(description = "If the font size is larger in pixels than this value, the OCR stage will resizes the image to a smaller resolution first "
+            + "(to achieve acceptable OCR speed). Alternatively, you can use an AffineWarp stage with scale < 1.0, but then you need to scale your pointSize too.")
+    private int fontMaxPixelSize = 20;
+
+    @Attribute(required = false)
+    @Property(description = "<strong style=\"color:red;\">CAUTION, Quick&Dirty Hack:</strong> This will "
+            + "auto-detect the font size upwards and downwards of your currently set pointSize. "
+            + "This is a one-shot option, used while editing the pipeline. Once the detection is done, the switch "
+            + "is cleared.<br/>"
+            + "The process may take a while and appear to hang, be patient. Afterwards you need to switch stages to refresh the GUI.")
+    private boolean autoDetectSize = false;
+
+    @Attribute(required = false)
+    @Property(description = "Template matching minimum match threshold (CCOEFF_NORMED method). Default is 0.75.")
+    private double threshold = 0.75;
+
+    public enum DrawStyle {
+        None,
+        OverScaledImage, 
+        OverOriginalImage
+    };
+
+    @Attribute(required = false)
+    @Property(description = "Draw the OCR match onto the image. ")
+    private DrawStyle drawStyle = DrawStyle.OverOriginalImage;
+
+    @Attribute(required = false)
+    @Property(description = "Write debug images and messages. Will slow down operation.")
+    private boolean debug;
+
+    public String getAlphabet() {
+        return alphabet;
+    }
+
+    public void setAlphabet(String alphabet) {
+        this.alphabet = alphabet;
+    }
+
+    public String getFontName() {
+        return fontName;
+    }
+
+    public void setFontName(String fontName) {
+        this.fontName = fontName;
+    }
+
+    public double getFontSizePt() {
+        return fontSizePt;
+    }
+
+    public void setFontSizePt(double fontSizePt) {
+        this.fontSizePt = fontSizePt;
+    }
+
+    public double getThreshold() {
+        return threshold;
+    }
+
+    public void setThreshold(double threshold) {
+        this.threshold = threshold;
+    }
+
+    public int getFontMaxPixelSize() {
+        return fontMaxPixelSize;
+    }
+
+    public void setFontMaxPixelSize(int fontMaxPixelSize) {
+        this.fontMaxPixelSize = fontMaxPixelSize;
+    }
+
+    public boolean isAutoDetectSize() {
+        return autoDetectSize;
+    }
+
+    public void setAutoDetectSize(boolean autoDetectSize) {
+        this.autoDetectSize = autoDetectSize;
+    }
+
+    public DrawStyle getDrawStyle() {
+        return drawStyle;
+    }
+
+    public void setDrawStyle(DrawStyle drawStyle) {
+        this.drawStyle = drawStyle;
+    }
+
+    public boolean isDebug() {
+        return debug;
+    }
+
+    public void setDebug(boolean debug) {
+        this.debug = debug;
+    }
+
+    protected static class CharacterMatch extends TemplateMatch {
+        public CharacterMatch(char ch, double x, double y, double width, double height, double score) {
+            super(x, y, width, height, score);
+            this.ch = ch;
+        }
+
+        private char ch;
+        private int bonus = 0;
+        private int malus = 0;
+        private boolean excluded = false; 
+        private int charNum = 0; 
+
+        protected double getOverallScore() {
+            return (score + 0.05*bonus - 0.05* malus); // this is scaled to the width, so narrow characters count as less good matches
+        }
+
+        protected boolean overlaps(CharacterMatch sibling) {
+            final double tolerance = height/10.0+1;
+            return (sibling.x+tolerance < this.x + this.width)
+                    && (sibling.x+sibling.width-tolerance > this.x)
+                    && (sibling.y+tolerance < this.y + this.height)
+                    && (sibling.y+sibling.height-tolerance > this.y);
+        }
+        protected boolean expandsRight(CharacterMatch sibling) {
+            final double tolerance = height/10.0+1;
+            return (Math.abs(sibling.x - this.x) < tolerance
+                    && Math.abs(sibling.y - this.y) < tolerance)
+                    && (sibling.width < this.width);
+        }
+        protected boolean expandsLeft(CharacterMatch sibling) {
+            final double tolerance = height/10.0+1;
+            return (Math.abs(sibling.x + sibling.width - this.x - this.width) < tolerance
+                    && Math.abs(sibling.y - this.y) < tolerance)
+                    && (sibling.width < this.width);
+        }
+        protected boolean precedesInLine(CharacterMatch sibling) {
+            final double tolerance = height/10.0+1;
+            return (Math.abs(sibling.x - (this.x + this.width)) < tolerance
+                    && Math.abs(sibling.y - this.y) < tolerance);
+        }
+        protected void setExcluded() {
+            excluded = true;
+        }
+        protected boolean isExcluded() {
+            return excluded;
+        }
+        protected void setCharNum(int charNum) {
+            this.charNum = charNum;
+            excluded = true;
+        }
+        protected int getCharNum() {
+            return charNum;
+        }
+        public char getCh() {
+            return ch;
+        }
+
+        @Override
+        public String toString() {
+            return "CharacterMatch [x=" + x + ", y=" + y + ", width=" + width + ", height="
+                    + height + ", ch=\"" + ch + "\", score=" + score + ", charNum="+charNum+"]";
+        }
+    }
+
+    @Override
+    public Result process(CvPipeline pipeline) throws Exception {
+        Camera camera = (Camera) pipeline.getProperty("camera");
+        if (camera == null) {
+            throw new Exception("Property \"camera\" is required.");
+        }
+
+        String alphabet = (String)pipeline.getProperty("alphabet");
+        if (alphabet == null) {
+            alphabet = getAlphabet();
+        }
+        if (alphabet == null || alphabet.isEmpty()) {
+            return null;
+        }
+        String fontName = (String)pipeline.getProperty("fontName");
+        if (fontName == null) {
+            fontName = getFontName();
+        }
+        if (fontName == null || fontName.isEmpty()) {
+            return null;
+        }
+        Double fontSizePt = (Double)pipeline.getProperty("fontSizePt");
+        if (fontSizePt == null) {
+            fontSizePt = getFontSizePt();
+        }
+        if (fontSizePt == null || fontSizePt == 0.0) {
+            return null;
+        }
+
+        // Note, the following is an ugly HACK, to get this functionality within the constraints of pipeline processing
+        if (autoDetectSize) {
+            autoDetectSize = false;
+            // very crude and brute force 
+            OcrModel bestRes = null;
+            double bestSize = Double.NaN;
+            for (double testSize = getFontSizePt()*0.5;
+                    testSize < getFontSizePt()*2.0;
+                    testSize *= 1.05) {  // 5% steps
+                Logger.debug("["+getClass().getName()+"] auto-detecting at font size = "+testSize+"pt");
+                OcrModel res = (OcrModel)performOcr(pipeline, camera, fontName, testSize, alphabet).model;
+                if (res.overallScore > 0.0) {
+                    if (bestRes == null ||  bestRes.overallScore < res.overallScore) {
+                        bestRes = res;
+                        bestSize = testSize;
+                        Logger.debug("["+getClass().getName()+"] new best font size = "+testSize+"pt, overallScore = "+bestRes.overallScore+", text = "+bestRes.text);
+                    }
+                }
+            }
+            if (bestRes != null) {
+                setFontSizePt(Math.round(bestSize*100.0)/100.0); 
+                fontSizePt = bestSize;
+            }
+        }
+
+        return performOcr(pipeline, camera, fontName, fontSizePt, alphabet);
+    }
+
+    public static class OcrModel {
+        private String text;
+        private int numChars;
+        private double overallScore;
+
+        public OcrModel(String text, int numChars, double overallScore) {
+            super();
+            this.text = text;
+            this.numChars = numChars;
+            this.overallScore = overallScore;
+        }
+        public String getText() {
+            return text;
+        }
+        public int getNumChars() {
+            return numChars;
+        } 
+        public double getOverallScore() {
+            return overallScore;
+        } 
+        public double getAvgScore() {
+            return overallScore/Math.max(1,  numChars);
+        } 
+
+        @Override
+        public String toString() {
+            return "OcrResult [text=" + text + ", numChars=" + numChars + ", score=" + overallScore + "]";
+        }
+    }
+
+    protected Result performOcr(CvPipeline pipeline, Camera camera, String fontName, double fontSizePt, String alphabet) throws Error, IOException {
+
+        // Determine the scaling factor to go from given LengthUnit/pt units to
+        // Camera units and pixels.
+        Location unitsPerPixel = camera.getUnitsPerPixel().convertToUnits(LengthUnit.Millimeters);
+        Length l = new Length(1.0/72.0, LengthUnit.Inches);
+        l = l.convertToUnits(unitsPerPixel.getUnits());
+        double scalePt = l.getValue()/unitsPerPixel.getY();
+
+        // get the working image
+        Mat textImage = pipeline.getWorkingImage();
+
+        // Automatic rescale, but don't do it if we're already too close i.e. at least a 0.5 x rescale must be achieved,
+        // otherwise the image quality suffers too much.
+        double rescale = 1.0;
+        if (fontMaxPixelSize >= 7 && fontMaxPixelSize < 0.5*rescale*scalePt*fontSizePt) {
+            rescale = fontMaxPixelSize  / (rescale*scalePt*fontSizePt);
+            if (debug) {
+                Logger.debug("["+getClass().getName()+"] rescale of input = "+rescale);
+            }
+        }
+        if (rescale != 1.0) {
+            Mat dst = new Mat();
+            Size size = new Size(textImage.cols()*rescale, textImage.rows()*rescale);
+            Imgproc.resize(textImage, dst, size);
+            // we must NOT do a textImage.release(); It is the property of the previous stage.
+            textImage = dst;
+            scalePt *= rescale;
+            unitsPerPixel = unitsPerPixel.multiply(1.0/rescale, 1.0/rescale, 0, 0);
+        }
+
+        // get the corresponding buffered image type
+        Integer type = null;
+        if (textImage.type() == CvType.CV_8UC1) {
+            type = BufferedImage.TYPE_BYTE_GRAY;
+        }
+        else if (textImage.type() == CvType.CV_8UC3) {
+            type = BufferedImage.TYPE_3BYTE_BGR;
+        }
+        else if (textImage.type() == CvType.CV_32F) {
+            type = BufferedImage.TYPE_BYTE_GRAY;
+            Mat tmp = new Mat();
+            textImage.convertTo(tmp, CvType.CV_8UC1, 255);
+            textImage = tmp;
+        }
+        if (type == null) {
+            throw new Error(String.format("Unsupported Mat: type %d, channels %d, depth %d",
+                    textImage.type(), textImage.channels(), textImage.depth()));
+        }
+
+        // create the font
+        Font font = new Font(fontName, Font.PLAIN, (int)Math.round(scalePt*fontSizePt));
+        // Create a pseudo graphics context to get font metrics 
+        Graphics2D gfm = new BufferedImage(1, 1, type).createGraphics();
+        FontMetrics fm = gfm.getFontMetrics(font);
+        final int maxAscent = fm.getAscent();// fm.getMaxAscent();
+        final int fontHeight = maxAscent+fm.getDescent();//fm.getHeight();
+        final int margin = 0; // tests have shown that no margin is best
+        final int height = fontHeight+2*margin;
+        if (fontHeight < 5 || fontHeight >= textImage.rows()) {
+            // dud
+            return new Result(textImage, new OcrModel("", 0, 0.0));
+        }
+
+        // try find each character of the alphabet in the text image 
+        List<CharacterMatch> matches = new ArrayList<>();
+        for (char ch : alphabet.toCharArray()) {
+            if (ch == ' ' ) {
+                // we can't search for nothing :-) 
+                // spaces will be recognized by discontinuity
+                continue;
+            }
+            String character = new String(new char[] { ch });
+            String characterTag = (Character.isLetterOrDigit(ch) ? character : String.valueOf((int)ch))+"-";
+            // create a template image of the current character
+            int width = fm.stringWidth(character)+2*margin;
+            BufferedImage templateImage =
+                    new BufferedImage(width, height, type);
+            Graphics2D g2d = (Graphics2D) templateImage.getGraphics();
+            g2d.setColor(Color.white);
+            g2d.fillRect(0, 0, width, height);
+            g2d.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+            g2d.setColor(Color.black);
+            g2d.setFont(font);
+            g2d.drawString(character, margin, margin+maxAscent);
+            g2d.dispose();
+            Mat template = OpenCvUtils.toMat(templateImage);
+            if (debug) {
+                File file = Configuration.get().createResourceFile(getClass(), "character-"+characterTag, ".png");
+                Imgcodecs.imwrite(file.getAbsolutePath(), template);
+            }
+
+            // do the actual template match
+            Mat matchMap = new Mat();
+            Imgproc.matchTemplate(textImage, template, matchMap, Imgproc.TM_CCOEFF_NORMED);
+
+            // determine the range
+            MinMaxLocResult mmr = Core.minMaxLoc(matchMap);
+            double maxVal = mmr.maxVal;
+            double rangeMin = threshold;
+            double rangeMax = maxVal;
+
+            // create the matches
+            for (Point point : OpenCvUtils.matMaxima(matchMap, rangeMin, rangeMax)) {
+                int x = point.x;
+                int y = point.y;
+                CharacterMatch match = new CharacterMatch(ch, 
+                        x, y, template.cols(), template.rows(),
+                        matchMap.get(y, x)[0]);
+                matches.add(match);
+            }
+
+            if (debug) {
+                File file = Configuration.get().createResourceFile(getClass(), "match-map-"+characterTag, ".png");
+                // this is a 3x32bit image, cannot save this as .png, need to convert to known image format first
+                BufferedImage img = OpenCvUtils.toBufferedImage(matchMap);
+                ImageIO.write(img, "png", file);
+            }
+
+            // cleanup
+            matchMap.release();
+            template.release();
+        }
+
+        // ready to harvest
+        StringBuilder text = new StringBuilder();
+        double overallScore = 0.0;
+        int numChars = 0;
+
+        if (matches.size() > 0) {
+            // go through all the matches and bonus/malus each other by overlaps (bad) 
+            // and continuity on a line (good). Some special treatment is needed for first/last character in a word
+            // because there is no continuity to judge the quality. Instead we must determine which character expands 
+            // farthest to the edge. Otherwise in some proportional fonts, because an "r" is a partial match of an "n" (which 
+            // is a partial match of an "m" etc.) can have a high template match score and the same continuity as the larger 
+            // character and win. With the first/last character test, this seems to be eliminated.
+            // However, there is still the chance that "rn" is seen as "m", and therefore monospaced fonts are still recommended. 
+            for (CharacterMatch match : matches) {
+                // in a proportional font, the widest character should win at the end of a word/line
+                boolean firstInWord = true;
+                boolean lastInWord = true;
+                for (CharacterMatch sibling : matches) {
+                    if (sibling != match) {
+                        if (match.overlaps(sibling)) {
+                            // overlapping 
+                            sibling.malus++;
+                            if (sibling.expandsLeft(match)) {
+                                // we're not the widest to the left
+                                firstInWord = false;
+                            }
+                            if (sibling.expandsRight(match)) {
+                                // we're not the widest to the right
+                                lastInWord = false;
+                            }
+                        }
+                        else if (match.precedesInLine(sibling)) {
+                            // continuity in line to sibling
+                            match.bonus++;
+                            // we're not at the end of a word
+                            lastInWord = false;
+                        }
+                        else if (sibling.precedesInLine(match)) {
+                            // continuity in line to us
+                            match.bonus++;
+                            // we're not at the beginning of a word
+                            firstInWord = false;
+                        }
+                    }
+                }
+                if (firstInWord) {
+                    // we're the first on the word/line and should win over any narrower character
+                    match.bonus++;
+                }
+                if (lastInWord) {
+                    // we're the last on the word/line and should win over any narrower character
+                    match.bonus++;
+                }
+            }
+
+            // exclude overlaps by overall score, weighing in any bonus/malus 
+            for (CharacterMatch match : matches) {
+                for (CharacterMatch sibling : matches) {
+                    if (match != sibling && match.overlaps(sibling)) {
+                        if (match.getOverallScore() > sibling.getOverallScore()) {
+                            // beat you!
+                            sibling.setExcluded();
+                        }
+                    }
+                }
+            }
+
+            // sort by x 
+            Collections.sort(matches, new Comparator<CharacterMatch>() {
+                @Override
+                public int compare(CharacterMatch o1, CharacterMatch o2) {
+                    return ((Double) o1.x).compareTo(o2.x);
+                }
+            });
+
+            // finally compose the lines of the text
+            double prevLineY = -1;
+            do {
+                // find the next line Y by finding the top-most character
+                int charsLeft = 0;
+                double nextLineY = Double.MAX_VALUE;
+                for (CharacterMatch match : matches) {
+                    if (!match.isExcluded()) {
+                        if (match.y < prevLineY) {
+                            // character off the line grid
+                            match.setExcluded();
+                        }
+                        else {
+                            charsLeft++;
+                            if (match.y < nextLineY) {
+                                nextLineY = match.y;
+                            }
+                        }
+                    }
+                }
+                if (charsLeft == 0) {
+                    break; // done --> 
+                }
+                if (text.length() > 0) {
+                    // this isn't the first line, append new line
+                    text.append('\n');
+                }
+                // anything roughly on the same Y will be composed into the line
+                final double lineTolerance = height / 4;
+                CharacterMatch prevChar = null;
+                for (CharacterMatch match : matches) {
+                    if (!match.isExcluded()) {
+                        if (Math.abs(match.y - nextLineY) < lineTolerance) {
+                            // the character matches the line Y
+                            if (prevChar != null && ! prevChar.precedesInLine(match)) {
+                                // discontinuity detected, first add a space 
+                                // Note, we collapse all whitespace into one space
+                                text.append(' ');
+                            }
+                            // finally harvest the character
+                            text.append(match.getCh());
+                            numChars++;
+                            // we're done with that one
+                            match.setCharNum(numChars);
+                            overallScore += match.getOverallScore();
+                            // remember for space detection
+                            prevChar = match;
+
+                            prevLineY = Math.max(prevLineY, match.y+match.height-lineTolerance);
+                        }
+                    }
+                }
+            }
+            while (true);
+        }
+
+        if (debug) {
+            // just for debugging: sort taken characters first, then others by x  
+            Collections.sort(matches, new Comparator<CharacterMatch>() {
+                @Override
+                public int compare(CharacterMatch o1, CharacterMatch o2) {
+                    if (o1.charNum > 0 && o2.charNum == 0) {
+                        return -1;
+                    }
+                    if (o1.charNum == 0 && o2.charNum > 0) {
+                        return 1;
+                    }
+                    int takenCmp = ((Integer) o1.charNum).compareTo(o2.charNum);
+                    if (takenCmp != 0) {
+                        return takenCmp;
+                    }
+
+                    return ((Double) o1.x).compareTo(o2.x);
+                }
+            });
+            Logger.debug("["+getClass().getName()+"] matches = "+matches);
+        }
+
+        if (drawStyle != DrawStyle.None) {
+            double matchScale = 1.0;
+            if (drawStyle == DrawStyle.OverOriginalImage && rescale != 1.0) {
+                textImage.release();
+                textImage = pipeline.getWorkingImage();
+                scalePt /= rescale;
+                unitsPerPixel = unitsPerPixel.multiply(rescale, rescale, 0, 0);
+                matchScale = 1.0/rescale;
+            }
+            // get the image and convert to RGB
+            BufferedImage image = OpenCvUtils.toBufferedImage(textImage);
+            BufferedImage colorImage = new BufferedImage(textImage.cols(), textImage.rows(), BufferedImage.TYPE_INT_RGB);
+            Graphics2D g2d = (Graphics2D) colorImage.createGraphics();
+            g2d.drawImage(image, 0, 0, null);
+            // scale the font and get metrics
+            Font drawFont = new Font(fontName, Font.PLAIN, (int)Math.round(scalePt*fontSizePt));
+            FontMetrics dfm = g2d.getFontMetrics(drawFont);
+            final int dmaxAscent = dfm.getAscent();// fm.getMaxAscent();
+            g2d.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+            g2d.setFont(drawFont);
+            // overlay the characters
+            for (CharacterMatch match : matches) {
+                if (match.getCharNum() > 0) {
+                    // use green-red color mapping to visualize the score
+                    float score = (float)Math.min(1.0, Math.max(0.0, (match.score-threshold)/(1.0f-(float)threshold)));
+                    float neg_score = 1.0f-score;
+                    g2d.setColor(new Color(neg_score, score,  0.0f,  0.4f));
+                    g2d.drawString(String.valueOf(match.getCh()), 
+                            (int)Math.round(match.getX()*matchScale), (int)Math.round(match.getY()*matchScale+dmaxAscent));
+                }
+            }
+            g2d.dispose();
+            textImage = OpenCvUtils.toMat(colorImage);
+        }
+
+        // deliver the goods 
+        return new Result(textImage, new OcrModel(text.toString(), numChars, overallScore));
+    }
+}

--- a/src/main/java/org/openpnp/vision/pipeline/ui/CvPipelineEditor.java
+++ b/src/main/java/org/openpnp/vision/pipeline/ui/CvPipelineEditor.java
@@ -16,6 +16,8 @@ import org.openpnp.vision.pipeline.stages.BlurGaussian;
 import org.openpnp.vision.pipeline.stages.BlurMedian;
 import org.openpnp.vision.pipeline.stages.ClosestModel;
 import org.openpnp.vision.pipeline.stages.Add;
+import org.openpnp.vision.pipeline.stages.AffineUnwarp;
+import org.openpnp.vision.pipeline.stages.AffineWarp;
 import org.openpnp.vision.pipeline.stages.ComposeResult;
 import org.openpnp.vision.pipeline.stages.ConvertColor;
 import org.openpnp.vision.pipeline.stages.ConvertModelToKeyPoints;
@@ -66,6 +68,7 @@ import org.openpnp.vision.pipeline.stages.Rotate;
 import org.openpnp.vision.pipeline.stages.ScriptRun;
 import org.openpnp.vision.pipeline.stages.SetColor;
 import org.openpnp.vision.pipeline.stages.SimpleBlobDetector;
+import org.openpnp.vision.pipeline.stages.SimpleOcr;
 import org.openpnp.vision.pipeline.stages.SizeCheck;
 import org.openpnp.vision.pipeline.stages.Threshold;
 import org.openpnp.vision.pipeline.stages.ThresholdAdaptive;
@@ -146,6 +149,9 @@ public class CvPipelineEditor extends JPanel {
         registerStageClass(ThresholdAdaptive.class);
         registerStageClass(WritePartTemplateImage.class);
         registerStageClass(ActuatorWrite.class);
+        registerStageClass(AffineWarp.class);
+        registerStageClass(AffineUnwarp.class);
+        registerStageClass(SimpleOcr.class);
         
     }
 

--- a/src/main/resources/org/openpnp/machine/reference/feeder/BlindsFeeder-DefaultPipeline.xml
+++ b/src/main/resources/org/openpnp/machine/reference/feeder/BlindsFeeder-DefaultPipeline.xml
@@ -3,9 +3,9 @@
       <cv-stage class="org.openpnp.vision.pipeline.stages.ImageRead" name="00" enabled="false" file="test.png"/>
       <cv-stage class="org.openpnp.vision.pipeline.stages.ImageCapture" name="0" enabled="true" settle-first="true"/>
       <cv-stage class="org.openpnp.vision.pipeline.stages.BlurGaussian" name="1" enabled="true" kernel-size="3"/>
-      <cv-stage class="org.openpnp.vision.pipeline.stages.ConvertColor" name="2" enabled="true" conversion="Bgr2Hsv"/>
+      <cv-stage class="org.openpnp.vision.pipeline.stages.ConvertColor" name="2" enabled="true" conversion="Bgr2HsvFull"/>
       <cv-stage class="org.openpnp.vision.pipeline.stages.Normalize" name="3" enabled="false"/>
-      <cv-stage class="org.openpnp.vision.pipeline.stages.MaskHsv" name="4" enabled="true" hue-min="45" hue-max="85" saturation-min="50" saturation-max="255" value-min="40" value-max="255" binary-mask="true"/>
+      <cv-stage class="org.openpnp.vision.pipeline.stages.MaskHsv" name="4" enabled="true" hue-min="65" hue-max="115" saturation-min="50" saturation-max="255" value-min="40" value-max="255" binary-mask="true"/>
       <cv-stage class="org.openpnp.vision.pipeline.stages.BlurMedian" name="5" enabled="true" kernel-size="13"/>
       <cv-stage class="org.openpnp.vision.pipeline.stages.FindContours" name="7" enabled="true" retrieval-mode="List" approximation-method="Simple"/>
       <cv-stage class="org.openpnp.vision.pipeline.stages.FilterContours" name="8" enabled="true" contours-stage-name="7" min-area="1000.0" max-area="100000.0"/>

--- a/src/main/resources/org/openpnp/machine/reference/feeder/ReferencePushPullFeeder-DefaultPipeline.xml
+++ b/src/main/resources/org/openpnp/machine/reference/feeder/ReferencePushPullFeeder-DefaultPipeline.xml
@@ -1,0 +1,22 @@
+<cv-pipeline>
+   <stages>
+      <cv-stage class="org.openpnp.vision.pipeline.stages.ImageRead" name="00" enabled="false" file="test.png"/>
+      <cv-stage class="org.openpnp.vision.pipeline.stages.ImageCapture" name="0" enabled="true" settle-first="true" count="1"/>
+      <cv-stage class="org.openpnp.vision.pipeline.stages.BlurGaussian" name="1" enabled="true" kernel-size="5"/>
+      <cv-stage class="org.openpnp.vision.pipeline.stages.AffineWarp" name="11" enabled="true" length-unit="Millimeters" x-0="0.0" y-0="0.0" x-1="0.0" y-1="0.0" x-2="0.0" y-2="0.0" scale="1.0" rectify="true" region-of-interest-property="regionOfInterest"/>
+      <cv-stage class="org.openpnp.vision.pipeline.stages.ConvertColor" name="12" enabled="true" conversion="Bgr2Gray"/>
+      <cv-stage class="org.openpnp.vision.pipeline.stages.HistogramEqualizeAdaptive" name="13" enabled="false" channels-to-equalize="First" clip-limit="2.0" number-of-tile-rows="1" number-of-tile-cols="1"/>
+      <cv-stage class="org.openpnp.vision.pipeline.stages.SimpleOcr" name="OCR" enabled="true" alphabet="0123456789.-+_RCLDQYXJIVAFH%GMKkmuµnp" font-name="Liberation Mono" font-size-pt="7.0" font-max-pixel-size="20" auto-detect-size="false" threshold="0.75" draw-style="OverOriginalImage" debug="false"/>
+      <cv-stage class="org.openpnp.vision.pipeline.stages.ImageRecall" name="20" enabled="true" image-stage-name="1"/>
+      <cv-stage class="org.openpnp.vision.pipeline.stages.MaskCircle" name="21" enabled="true" diameter="600"/>
+      <cv-stage class="org.openpnp.vision.pipeline.stages.ConvertColor" name="22" enabled="true" conversion="Bgr2HsvFull"/>
+      <cv-stage class="org.openpnp.vision.pipeline.stages.Normalize" name="23" enabled="false"/>
+      <cv-stage class="org.openpnp.vision.pipeline.stages.MaskHsv" name="24" enabled="true" auto="false" fraction-to-mask="0.0" hue-min="240" hue-max="130" saturation-min="110" saturation-max="255" value-min="10" value-max="255" invert="false" binary-mask="true"/>
+      <cv-stage class="org.openpnp.vision.pipeline.stages.BlurMedian" name="25" enabled="true" kernel-size="13"/>
+      <cv-stage class="org.openpnp.vision.pipeline.stages.FindContours" name="27" enabled="true" retrieval-mode="List" approximation-method="Simple"/>
+      <cv-stage class="org.openpnp.vision.pipeline.stages.FilterContours" name="28" enabled="true" contours-stage-name="27" min-area="1000.0" max-area="100000.0"/>
+      <cv-stage class="org.openpnp.vision.pipeline.stages.FitEllipseContours" name="results" enabled="true" contours-stage-name="28"/>
+      <cv-stage class="org.openpnp.vision.pipeline.stages.ImageRecall" name="30" enabled="true" image-stage-name="0"/>
+      <cv-stage class="org.openpnp.vision.pipeline.stages.DrawEllipses" name="31" enabled="false" ellipses-stage-name="results" thickness="2"/>
+   </stages>
+</cv-pipeline>


### PR DESCRIPTION
_This is the reinstated #977 (after mistaken merge & revert) for continued discussion and improvement._

# Description
Generic implementation for a feeder that can feed parts by performing push and pull (and other) motions using a head-mounted Actuator.  

- Uses a semantic vision concept based on sprocket holes and knowledge of the EIA 481 standards. 
- Simple OCR vision stage that can read the part from a label on the feeder. 
- OCR based automatic feeder slot swapping, part changing or even new feeder creation. 
- Automatic and learning "only when needed" calibration for feeders that are mounted with large tolerances (+/-2mm). 
- Any part pitch, any feed pitch, any tape width.
- Multi-feed: 2mm pitch/0402 support. For speed, you can also use a multiplier for any pitch. 
- Easy to clone & sync settings between feeders, by package or by (new) Tape&Reel Specification.
- One click setup from the second feeder.
- Handles geometric transformations for all the relevant settings (allows cloning settings from a "west" to a "south" feeder, for instance). 

While this feeder was developed for an upcoming Open Hardware all-3D-printed tape reel feeder, it was an important goal to make it universal. If you like the added functionality, you should also be able to cover most use cases for ReferenceLeverFeeder and ReferenceDragFeeder. 

![vlcsnap-2020-04-10-22h34m30s611](https://user-images.githubusercontent.com/9963310/79021454-d9978080-7b7b-11ea-93f9-b6ddc984d0ef.jpg)

This PR encloses these major building blocks that are carefully modelled for independent reuse by other software and/or pipelines: 

1. the ReferencePushPullFeeder class
2. the SimpleOcr vision stage to read text from the camera
3. the RegionOfInterestProcess guided process to stake out a region of interest (e.g. for OCR) in the camera view using the mouse and without having to go into the pipeline. 
4. the AffineWarp vision stage that is used to extract and rotate the OCR region of interest from the image (it can define the ROI in the stage or get it from the pipeline caller by property)
5. the AffineUnwarp vision stage that transform geometrical vision results back to full camera image coordinates 

The AffineUnwarp is not actually used by the feeder, but it makes the AffineWarp ready for use in BottomVision and FiducialLocator pipelines, where it can speed up subsequent stages by reducing image size. As a benefit, you can let the pipeline end with the warped image and get a nice magnification effect. 

# Justification
## Why yet another feeder class? 
This PR started out from trying to extend ReferenceLeverFeeder. But trying to provide both backwards compatibility and new features, quickly turned out impractical. ReferenceLeverFeeder uses a reference image for vision, that cannot be used for the semantics I needed. Such as "understanding" the tape location and feed direction, cloning and transforming geometry from another feeder, changing from white to black tape, from 2mm to 4mm part pitch without invalidating the vision setup. On the other hand, ReferenceLeverFeeder should also not be burdened by complexity that some (existing) users don't want to use.  

## Why not break up the PR?
As can easily be seen, the building blocks (1 through 4, listed in the Description) all rely on each other. In order to test this code, including the stages using pipeline properties set by the feeder, I couldn't break up the PR. Building block 5 just makes AffineWarp complete for other use.

## Risk of introducing this code
Most of the changes happen in new classes. They are merely registered in existing classes. Unless they are actually instantiated by the user, they are without effect. 

## Changes in existing code
Some words on the changes in existing code (most important ones, roughly ordered by how GitHub lists the changed files):

`CameraView`: I refactored the view pixel to length units calculation out, so I can use it in my RegionOfInterestProcess to calculate the ROI from clicks. See `getCameraViewCenterOffsetsFromXy()`. Tip: use "ignore white-space" setting for diff.

`Package`, `PackagesTableModel`: added the tapeSpecification to the Package in order to group packages further, e.g. a "C" and "R" packages should be treated the same when it comes to feeding them from a tape, as well as various package sizes (0603, 0805, etc.) that still have the same part pitch. The user can now set a common tag such as "8x2" or "8x4" to code the tape width/pitch and other relevant specs. The ReferencePushPullFeeder will then be able to clone/sync settings across this group and automatically create new feeders with one click.  

`Feeder`, `ReferencePnpJobProcessor`, `BlindsFeeder`: reworked the job preparation for feeders that I introduced with the BlindsFeeder. Instead of letting each feeder class do its own Travelling Salesman journey for prep, the job processor now does it globally, so all feeders needing visits by the head will be prepped alongside each other, on a single optimized path. In case of the ReferencePushPullFeeder, the feeder's location is calibrated and the OCR tag verified.

This PR is well prepared for @tonyluken 's #943 as I made the following provisions:

- separated the part rotation in tape from the Rotation of the feeder, same signature as tony's base class implementation (once merged/inherited, it can then be removed from ReferencePushPullFeeder).  
- use the same feeder local transformation as #943
- access all Locations using setters/getter, so a first port should be trivial
- can be simplified, once #943 is merged, to directly work with feeder local coordinates, where needed

# Instructions for Use
For now there is a movie demonstrating the main usage: 
https://youtu.be/5QcJ2ziIJ14
For  _one possible_ use case of this class, employing an all-3D-printed reeled tape feeder, see here:
https://makr.zone/new-all-3d-printed-tapereel-feeder/399/

![vlcsnap-2020-04-10-22h35m03s333](https://user-images.githubusercontent.com/9963310/79021944-2760b880-7b7d-11ea-9e45-7013d5deff40.png)

I will create a Wiki entry when this PR has been merged (with whatever tuning yet required). 

# Implementation Details
1. The feeder class, region of interest process,  AffineWarp, SimpleOcr stages have been tested as shown in the movie. If you look closely you see the AffineWarp is also used in BottomVision, to test the AffineUnwarp stage i.e. transforming the coordinates back to full camera image pixel coordinates. It was also used/tested in the Visual Homing fiducial locator. I also tested a simle Job, mixing BlindsFeeder/ReferencePushPullFeder, testing the latest Travelling Salesman feeder prep and also btw. including the latest merge from `develop` with new OpenCV.
2. I did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. I made changes in the `org.openpnp.spi` or `org.openpnp.model` as listed and justified above.
4. Successful `mvn test` before submitting the Pull Request. 

![grafik](https://user-images.githubusercontent.com/9963310/79022084-7870ac80-7b7d-11ea-9d7e-83efb3004551.png)

