### PR TITLE
Fix/BlindsFeeder: Prefer the nozzle given in feed() to actuate the cover.

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/feeder/BlindsFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/BlindsFeeder.java
@@ -337,12 +337,12 @@ public class BlindsFeeder extends ReferenceFeeder {
                 if (!isCoverOpen()) {
                     // Note, with CoverActuation.OpenOnJobStart, this should only happen with a manual or exceptional feed.
                     // Also restore the previously loaded NozzleTip afterwards. 
-                    actuateCover(true, true, true);
+                    actuateCover(nozzle, true, true, true);
                 }
             }
         }
         else if (coverType == CoverType.PushCover) {
-            actuateCover(true);
+            actuateCover(nozzle, true);
         }
         // increase the feed count 
         setFeedCount(getFeedCount() + 1);
@@ -1230,28 +1230,23 @@ public class BlindsFeeder extends ReferenceFeeder {
             return nozzleTipLoadedBefore;
         }
     }
-    public static NozzleAndTipForPushing getNozzleAndTipForPushing(Part favoredCompatiblePart, boolean loadNozzleTipIfNeeded) throws Exception {
-        // first search for any NozzleTip already loaded that may be used for pushing 
-        Machine machine = Configuration.get().getMachine();
-        for (Head head : machine.getHeads()) {
-            // first search for a favored nozzle tip
-            if (favoredCompatiblePart != null 
-                    && favoredCompatiblePart.getPackage() != null) {
-                for (Nozzle nozzle :  head.getNozzles()) {
-                    if (nozzle.getPart() == null) { 
-                        // Nozzle is free
-                        NozzleTip nozzleTip = nozzle.getNozzleTip();
-                        if (nozzleTip.isPushAndDragAllowed()) {
-                            if (favoredCompatiblePart.getPackage()
-                                    .getCompatibleNozzleTips().contains(nozzleTip)) {
-                                // Return the nozzle and nozzle tip.
-                                return new NozzleAndTipForPushing(nozzle, nozzleTip);
-                            }
-                        }
-                    }
+    public static NozzleAndTipForPushing getNozzleAndTipForPushing(Nozzle preferredNozzle, boolean loadNozzleTipIfNeeded) throws Exception {
+        // Search for any nozzle and nozzle tip that may be used for cover pushing. 
+        // First, try the preferredNozzle.
+        if (preferredNozzle != null ) {
+            if (preferredNozzle.getPart() == null) { 
+                // Nozzle is free
+                NozzleTip nozzleTip = preferredNozzle.getNozzleTip();
+                if (nozzleTip.isPushAndDragAllowed()) {
+                    // Return the nozzle and nozzle tip.
+                    return new NozzleAndTipForPushing(preferredNozzle, nozzleTip);
                 }
             }
-            // then just take any
+        }
+
+        // Second, try any free nozzle with loaded nozzle tip. 
+        Machine machine = Configuration.get().getMachine();
+        for (Head head : machine.getHeads()) {
             for (Nozzle nozzle :  head.getNozzles()) {
                 if (nozzle.getPart() == null) { 
                     // Nozzle is free
@@ -1264,8 +1259,9 @@ public class BlindsFeeder extends ReferenceFeeder {
             }
         }
 
-        // We arrived here, so none was found.
+        // Third, try load a nozzle tip for pushing.
         if (loadNozzleTipIfNeeded) {
+            // We're allowed to load the nozzle tip, go find a free nozzle.
             for (Head head : machine.getHeads()) {
                 for (Nozzle nozzle :  head.getNozzles()) {
                     if (nozzle.getPart() == null) { 
@@ -1310,12 +1306,16 @@ public class BlindsFeeder extends ReferenceFeeder {
         }
     }
 
-    public void actuateCover(boolean openState) throws Exception {
+    public void actuateCover(Nozzle preferredNozzle, boolean openState) throws Exception {
         // If needed, load a NozzleTip that allows pushing but do not restore the previously loaded NozzleTip. 
-        actuateCover(openState, true, false);
+        actuateCover(preferredNozzle, openState, true, false);
     }
 
-    public void actuateCover(boolean openState, boolean loadNozzleTipIfNeeded, boolean restoreNozzleTip) throws Exception {
+    public void actuateCover(boolean openState) throws Exception {
+        actuateCover(null, openState);
+    }
+
+    public void actuateCover(Nozzle preferredNozzle, boolean openState, boolean loadNozzleTipIfNeeded, boolean restoreNozzleTip) throws Exception {
         if (coverType == CoverType.NoCover) {
             throw new Exception("Feeder " + getName() + ": has no cover to actuate.");
         }
@@ -1325,7 +1325,7 @@ public class BlindsFeeder extends ReferenceFeeder {
             }
 
             // Get the nozzle for pushing
-            NozzleAndTipForPushing nozzleAndTipForPushing = BlindsFeeder.getNozzleAndTipForPushing(getPart(), loadNozzleTipIfNeeded);
+            NozzleAndTipForPushing nozzleAndTipForPushing = BlindsFeeder.getNozzleAndTipForPushing(preferredNozzle, loadNozzleTipIfNeeded);
             Nozzle nozzle = nozzleAndTipForPushing.getNozzle();
             NozzleTip nozzleTip = nozzleAndTipForPushing.getNozzleTip();
             if (nozzleTip == null) {

--- a/src/main/java/org/openpnp/machine/reference/feeder/wizards/BlindsFeederConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/wizards/BlindsFeederConfigurationWizard.java
@@ -25,13 +25,11 @@ package org.openpnp.machine.reference.feeder.wizards;
 import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
 import java.io.File;
 import java.io.PrintWriter;
 
 import javax.swing.AbstractAction;
 import javax.swing.Action;
-import javax.swing.Icon;
 import javax.swing.JButton;
 import javax.swing.JCheckBox;
 import javax.swing.JComboBox;
@@ -839,7 +837,7 @@ public class BlindsFeederConfigurationWizard extends AbstractConfigurationWizard
         public void actionPerformed(ActionEvent e) {
             applyAction.actionPerformed(e);
             UiUtils.submitUiMachineTask(() -> {
-                feeder.actuateCover(true);
+                feeder.actuateCover(MainFrame.get().getMachineControls().getSelectedNozzle(), true);
             });
         }
     };
@@ -853,7 +851,7 @@ public class BlindsFeederConfigurationWizard extends AbstractConfigurationWizard
         public void actionPerformed(ActionEvent e) {
             applyAction.actionPerformed(e);
             UiUtils.submitUiMachineTask(() -> {
-                feeder.actuateCover(false);
+                feeder.actuateCover(MainFrame.get().getMachineControls().getSelectedNozzle(), false);
             });
         }
     };


### PR DESCRIPTION
# Description
I was mistaken, when I said in #979 that the nozzle to be used for the `pick()` is not provided in a `feed()`. This PR now correctly propagates the `feed()` nozzle into the cover actuation and prefers its use. 

In the same spirit the Open/Close buttons in the Wizard will try to use the nozzle selected in the machine controls. 

Note, the preferred nozzle is still subject to its loaded nozzle tip allowing dragging & pushing. Otherwise, a different nozzle with nozzle tip allowing dragging & pushing will be used or (optionally) a nozzle tip change will be performed. 

# Justification
The change only concerns the BlindsFeeder, therefore risk to other (i.e. more broadly used) code is absent. Even though I couldn't test it fully, because I have no multi-nozzle machine, it would be nice to have this merged in `develop` for broader testing by BlindsFeeder early adopters. 

See also #979 and
https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!msg/openpnp/Ew7drDA3J60/2sjUt7T5AAAJ

# Instructions for Use
Start a job with two parts in two BlindsFeeders in a multiple nozzle machine. 

# Implementation Details
1.  On my single nozzle machine, I can't test the favoring code. I hope Jed Smith will be able to do that, provided he has access to a new `develop` release. I will try to organize this with him.
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. Successful run `mvn test` before submitting the Pull Request.
