### PR TITLE
Fix/Z-Probe reading conversion error handling

### DIFF
--- a/src/main/java/org/openpnp/util/Cycles.java
+++ b/src/main/java/org/openpnp/util/Cycles.java
@@ -31,7 +31,15 @@ public class Cycles {
         Location lOld = zProbe.getLocation();
         Location lz = zProbe.getLocation();
         MovableUtils.moveToLocationAtSafeZ(zProbe, l);
-        double z = Double.parseDouble(zProbe.read());
+        double z;
+        String reading = zProbe.read();
+        try {
+            z = Double.parseDouble(reading);
+        }
+        catch (Exception e) {
+            throw new Exception("Head "+Configuration.get().getMachine().getDefaultHead().getName()+" Z Probe "+zProbe.getName()
+            +" conversion failed ("+reading+")", e);
+        }
         lz = lz.add(new Location(LengthUnit.Millimeters, 0, 0, z, 0));
         MovableUtils.moveToLocationAtSafeZ(zProbe, lOld);
         l = l.derive(null, 


### PR DESCRIPTION
# Description
User might create and set a Z Probe actuator just to see what happens (I did). Much later your Location Button Panel Capture Camera Coordinates Button will "inexplicably" stop working i.e. a cryptic NullPointerException stack trace is displayed.
![grafik](https://user-images.githubusercontent.com/9963310/79685362-9e124b80-8238-11ea-850e-8fda9c37ce92.png)

Reason: If you leave an Actuator's GCodeDriver ACTUATOR_READ_REGEX empty, it will return a null String on read. 

This Bugfix adds an Exception message pointing to the Z probe and conversion error.

In case of null:
![grafik](https://user-images.githubusercontent.com/9963310/79685375-bda97400-8238-11ea-9b47-f3cb634baf4d.png)

In case the actuator return a non-number:
![grafik](https://user-images.githubusercontent.com/9963310/79685373-b5e9cf80-8238-11ea-9219-eff53e5ad103.png)

# Justification
See also:
https://groups.google.com/d/msg/openpnp/Ew7drDA3J60/kwVUS_FnAwAJ

# Instructions for Use
Steps to reproduce: Using GCodeDriver add a fresh Actuator as the Z Probe. Press one of the capture buttons:
![grafik](https://user-images.githubusercontent.com/9963310/79685346-686d6280-8238-11ea-8b3c-f8ee8745e132.png)

# Implementation Details
1. I tested this with the NullDriver (I'm currently not at the machine). The NullDriver will always return a random number, therefore I used the debugger to insert a null/non-number reading. 
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. Successful `mvn test` before submitting the Pull Request. 
