### PR TITLE
Fix/BlindsFeeder: OpenSCAD File Extraction on Linux

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/feeder/wizards/BlindsFeederConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/wizards/BlindsFeederConfigurationWizard.java
@@ -67,6 +67,7 @@ import org.openpnp.spi.HeadMountable;
 import org.openpnp.util.UiUtils;
 import org.openpnp.vision.pipeline.CvPipeline;
 import org.openpnp.vision.pipeline.ui.CvPipelineEditor;
+import org.pmw.tinylog.Logger;
 
 import com.jgoodies.forms.layout.ColumnSpec;
 import com.jgoodies.forms.layout.FormLayout;
@@ -659,6 +660,7 @@ public class BlindsFeederConfigurationWizard extends AbstractConfigurationWizard
                 j.setMultiSelectionEnabled(false);
                 if (j.showOpenDialog(getTopLevelAncestor()) == JFileChooser.APPROVE_OPTION) {
                     File directory = j.getSelectedFile();
+                    boolean opended = true;
                     for (String fileName : new String[] { "BlindsFeeder-Library.scad", "BlindsFeeder-3DPrinting.scad" }) {
                         String fileContent = IOUtils.toString(BlindsFeeder.class
                                 .getResource(fileName));
@@ -669,7 +671,16 @@ public class BlindsFeederConfigurationWizard extends AbstractConfigurationWizard
                         try (PrintWriter out = new PrintWriter(file.getAbsolutePath())) {
                             out.print(fileContent);
                         }
-                        java.awt.Desktop.getDesktop().edit(file);
+                        try {
+                            java.awt.Desktop.getDesktop().edit(file);
+                        }
+                        catch (Exception e1) {
+                            Logger.error(e1);
+                            opended = false;
+                        }
+                    }
+                    if (! opended) {
+                        JOptionPane.showMessageDialog(getTopLevelAncestor(), "<html><p>Files extracted to:</p><p>"+directory.getAbsolutePath()+"</p><p>Cannot open with OpenSCAD automatically (Desktop command failed)</p>");
                     }
                 }
             });


### PR DESCRIPTION
# Description
For the 3D-printed BlindsFeeder you can extract the OpenSCAD model files directly from OpenPNP.

![grafik](https://user-images.githubusercontent.com/9963310/79686811-665cd100-8243-11ea-97d9-9d8bd115cf9d.png)

For more information see the Wiki.
https://github.com/openpnp/openpnp/wiki/BlindsFeeder#modelling-the-feeder

On some platforms (Linux, Debian Buster) the `java.awt.Desktop.getDesktop().edit()` is not supported, [users have reported](https://groups.google.com/d/msg/openpnp/Ew7drDA3J60/a-XU02moDAAJ).

This bugfix catches any exceptions and continues to extract the second file. It reports the error to the user.

![grafik](https://user-images.githubusercontent.com/9963310/79686765-1120bf80-8243-11ea-8e7d-39e9d5a43616.png)

# Justification
Bugfix.

See also:
https://groups.google.com/d/msg/openpnp/Ew7drDA3J60/a-XU02moDAAJ

# Instructions for Use
Just use the
![grafik](https://user-images.githubusercontent.com/9963310/79686854-9c9a5080-8243-11ea-8968-0e3223eea337.png)

# Implementation Details
1. I prompted an exception by debugger.
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. Successful `mvn test` before submitting the Pull Request. 
