### PR TITLE
Feature/Advanced Vacuum Checks

### DIFF
--- a/src/main/java/org/openpnp/gui/FeedersPanel.java
+++ b/src/main/java/org/openpnp/gui/FeedersPanel.java
@@ -557,7 +557,7 @@ public class FeedersPanel extends JPanel implements WizardContainer {
                 feeder.postPick(nozzle);
 
                 // Perform the vacuum check, if enabled.
-                if (nozzle.isPartOnEnabled()) {
+                if (nozzle.isPartOnEnabled(Nozzle.PartOnStep.AfterPick)) {
                     if(!nozzle.isPartOn()) {
                         throw new JobProcessorException(nozzle, "No part detected.");
                     }

--- a/src/main/java/org/openpnp/gui/components/SimpleGraphView.java
+++ b/src/main/java/org/openpnp/gui/components/SimpleGraphView.java
@@ -1,70 +1,190 @@
+/*
+ * Copyright (C) 2020 <mark@makr.zone>
+ * inspired and based on work by
+ * Copyright (C) 2011 Jason von Nieda <jason@vonnieda.org>
+ * 
+ * This file is part of OpenPnP.
+ * 
+ * OpenPnP is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * OpenPnP is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License along with OpenPnP. If not, see
+ * <http://www.gnu.org/licenses/>.
+ * 
+ * For more information about OpenPnP visit http://openpnp.org
+ */
+
 package org.openpnp.gui.components;
 
 import java.awt.Color;
 import java.awt.Dimension;
+import java.awt.Font;
+import java.awt.FontMetrics;
 import java.awt.Graphics;
 import java.awt.Graphics2D;
 import java.awt.RenderingHints;
-import java.util.Map;
+import java.awt.geom.AffineTransform;
+import java.awt.geom.Point2D;
+import java.awt.geom.Rectangle2D;
+import java.math.RoundingMode;
+import java.text.DecimalFormat;
+import java.util.List;
 
 import javax.swing.JComponent;
 
-import org.openpnp.machine.reference.ReferenceNozzleTip;
+import org.openpnp.util.SimpleGraph;
+import org.openpnp.util.SimpleGraph.DataRow;
+import org.openpnp.util.SimpleGraph.DataScale;
 
+@SuppressWarnings("serial")
 public class SimpleGraphView extends JComponent {  
-    
-    private Map<Double, Double> graph;
-    private final Dimension PREF_SIZE = new Dimension(100, 50);
-    private ReferenceNozzleTip nozzleTip;
-    
-    public SimpleGraphView(ReferenceNozzleTip nozzleTip) {
-        this.nozzleTip = nozzleTip; 
-        //this.setBorder(new TitledBorder(UIManager.getBorder("TitledBorder.border"), "Graph", TitledBorder.LEADING, TitledBorder.TOP, null, new Color(0, 0, 0)));
-    }
 
-    public Map<Double, Double> getGraph() {
-        return graph;
+    private SimpleGraph graph;
+    private final Dimension PREF_SIZE = new Dimension(100, 100);
+
+    public SimpleGraphView() {
     }
-    public void setGraph(Map<Double, Double> graph) {
+    public SimpleGraphView(SimpleGraph graph) {
         this.graph = graph;
     }
-    public void paintComponent(Graphics g)
-    {
+
+    public SimpleGraph getGraph() {
+        return graph;
+    }
+    public void setGraph(SimpleGraph graph) {
+        this.graph = graph;
+        repaint();
+    }
+    protected String formatNumber(double y) {
+        // format numbers without necessary digits (incredibly difficult in Java) 
+        DecimalFormat format = new DecimalFormat("0.####"); // Choose the number of decimal places to work with in case they are different than zero and zero value will be removed
+        format.setRoundingMode(RoundingMode.HALF_UP); // choose your Rounding Mode
+        return format.format(y);
+    }
+    public void paintComponent(Graphics g) {
         super.paintComponent(g);
         Graphics2D g2d = (Graphics2D) g;
         g2d.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
-        Color color1 = new Color(225, 0, 0);
+        
+        Font font = getFont();
+        FontMetrics dfm = g2d.getFontMetrics(font);
+        int fontLineHeight = dfm.getAscent()+1; // numbers are all ascent
+        int fontAscent = dfm.getAscent();
+        g2d.setFont(font);
         int w = getWidth();
         int h = getHeight();
-        double tMin = Double.MAX_VALUE;
-        double tMax = Double.MIN_VALUE;
-        double vMin = Double.MAX_VALUE;
-        double vMax = Double.MIN_VALUE;
-        if (graph != null && graph.size() > 0) {
-            for (double t : graph.keySet()) {
-                double v = graph.get(t);
-                tMin = Math.min(t,  tMin);
-                tMax = Math.max(t,  tMax);
-                vMin = Math.min(v,  vMin);
-                vMax = Math.max(v,  vMax);
-            }
-            double tScale = (w-1)/(tMax-tMin);
-            double vScale = (h-1)/(vMax-vMin);
-            double v0 = Double.NaN;
-            double t0 = Double.NaN;
-            g2d.setColor(color1);
-            for (double t : graph.keySet()) {
-                double v = graph.get(t);
-                if (!Double.isNaN(t0)) {
-                    g2d.drawLine((int)((t0-tMin)*tScale), (int)(h-1-(v0-vMin)*vScale), 
-                            (int)((t-tMin)*tScale), (int)(h-1-(v-vMin)*vScale));
+        if (graph != null) {
+            boolean firstScale = true;
+            for (DataScale dataScale : graph.getDataScales()) {
+                Point2D.Double min = graph.getMinimum(dataScale);
+                Point2D.Double max = graph.getMaximum(dataScale);
+                double xOrigin = (w-1)*graph.getRelativePaddingLeft();
+                double xScale = (w-1)*(1.0-graph.getRelativePaddingLeft()-graph.getRelativePaddingRight())/(max.x-min.x);
+
+                double yOrigin = (h-1)*(1.0-dataScale.getRelativePaddingBottom());
+                double yScale = (h-1)*(1.0-dataScale.getRelativePaddingTop()-dataScale.getRelativePaddingBottom())/(max.y-min.y);
+
+                if (dataScale.getColor() != null) {
+                    double yUnitFont = fontLineHeight/yScale;
+                    double yUnit10 = Math.pow(10.0, Math.ceil(Math.log10(yUnitFont)));
+                    double yUnit = yUnit10;
+                    if (yUnitFont < yUnit/5) {
+                        yUnit /= 5;
+                    }
+                    else if (yUnitFont < yUnit/2) {
+                        yUnit /= 2;
+                    }
+                    double yUnit0 = Math.ceil((min.y+yUnitFont*0.5)/yUnit)*yUnit;
+                    double yUnit1 = Math.floor((max.y-yUnitFont*0.5)/yUnit)*yUnit;
+                    double maxWidth = 0;
+                    // measure longest scale label
+                    for (double y = yUnit0; y <= yUnit1+yUnit*0.5; y += yUnit) {
+                        String text = formatNumber(y);
+                        Rectangle2D bounds = dfm.getStringBounds(text, 0, text.length(), g2d);
+                        maxWidth = Math.max(maxWidth, bounds.getWidth());
+                    }
+                    // draw the scale 
+                    for (double y = yUnit0; y <= yUnit1+yUnit*0.5; y += yUnit) {
+                        g2d.setColor(dataScale.getColor());
+                        g2d.drawLine((int)maxWidth+2, (int)(yOrigin-(y-min.y)*yScale), w-1, (int)(yOrigin-(y-min.y)*yScale));
+                        String text = formatNumber(y);
+                        Rectangle2D bounds = dfm.getStringBounds(text, 0, text.length(), g2d);
+                        g2d.drawString(text, (int)(maxWidth-bounds.getWidth()), (int)(yOrigin-(y-min.y)*yScale)+fontAscent/2);
+                    }
+
+                    if (firstScale) {
+                        double xUnitFont = fontLineHeight/xScale;
+                        double xUnit10 = Math.pow(10.0, Math.ceil(Math.log10(xUnitFont)));
+                        double xUnit = xUnit10;
+                        if (xUnitFont < xUnit/5) {
+                            xUnit /= 5;
+                        }
+                        else if (xUnitFont < xUnit/2) {
+                            xUnit /= 2;
+                        }
+                        double xUnit0;
+                        double xUnit1;
+                        double xMin;
+                        if (graph.isOffsetMode()) {
+                            xUnit0 = 0;
+                            xUnit1 = Math.floor((max.x-min.x-xUnitFont*0.5)/xUnit)*xUnit;
+                            xMin = 0; 
+                        }
+                        else {
+                            xUnit0 = Math.ceil((min.x+xUnitFont*0.5)/xUnit)*xUnit;
+                            xUnit1 = Math.floor((max.x-xUnitFont*0.5)/xUnit)*xUnit;
+                            xMin = min.x;
+                        }
+                        maxWidth = 0;
+                        // measure longest scale label
+                        for (double x = xUnit0; x <= xUnit1+xUnit*0.5; x += xUnit) {
+                            String text = formatNumber(x);
+                            Rectangle2D bounds = dfm.getStringBounds(text, 0, text.length(), g2d);
+                            maxWidth = Math.max(maxWidth, bounds.getWidth());
+                        }
+                        // draw the scale 
+                        for (double x = xUnit0; x <= xUnit1+xUnit*0.5; x += xUnit) {
+                            g2d.setColor(dataScale.getColor());
+                            g2d.drawLine((int)(xOrigin+(x-xMin)*xScale), h-1-(int)maxWidth-2, (int)(xOrigin+(x-xMin)*xScale), 0);
+                            String text = formatNumber(x);
+                            Rectangle2D bounds = dfm.getStringBounds(text, 0, text.length(), g2d);
+                            AffineTransform transform = g2d.getTransform();
+                            int tx = (int)(xOrigin+(x-xMin)*xScale)+fontAscent/2;
+                            int ty = (int)(h - 1 - maxWidth  + bounds.getWidth());
+                            g2d.rotate(-Math.PI/2.0, tx, ty);
+                            g2d.drawString(text, tx, ty);
+                            g2d.setTransform(transform); 
+                        }
+                    }
+
+                }
+                for (DataRow dataRow : dataScale.getDataRows()) {
+                    List<Double> xAxis = dataRow.getXAxis();
+                    double y0 = Double.NaN;
+                    double x0 = Double.NaN;
+                    g2d.setColor(dataRow.getColor());
+                    for (double x : xAxis) {
+                        double y = dataRow.getDataPoint(x);
+                        if (!Double.isNaN(x0)) {
+                            g2d.drawLine((int)(xOrigin+(x0-min.x)*xScale), (int)(yOrigin-(y0-min.y)*yScale), 
+                                    (int)(xOrigin+(x-min.x)*xScale), (int)(yOrigin-(y-min.y)*yScale));
+                        }
+                        x0 = x;
+                        y0 = y;
+                    }
                 }
             }
         }
         else {
-            g2d.setColor(color1);
-            g2d.drawLine(0, 0, w-1, h-1);
-            g2d.drawLine(0, h-1, w-1, 0);
+            g2d.setColor(new Color(0, 0, 0, 64));
+            String text = "no data";
+            Rectangle2D bounds = dfm.getStringBounds(text, 0, text.length(), g2d);
+            g2d.drawString(text, (int)(Math.min(h, w)/2-bounds.getWidth()/2), (int)(h/2));
         }
     }
     @Override

--- a/src/main/java/org/openpnp/gui/components/SimpleGraphView.java
+++ b/src/main/java/org/openpnp/gui/components/SimpleGraphView.java
@@ -1,0 +1,77 @@
+package org.openpnp.gui.components;
+
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.RenderingHints;
+import java.util.Map;
+
+import javax.swing.JComponent;
+
+import org.openpnp.machine.reference.ReferenceNozzleTip;
+
+public class SimpleGraphView extends JComponent {  
+    
+    private Map<Double, Double> graph;
+    private final Dimension PREF_SIZE = new Dimension(100, 50);
+    private ReferenceNozzleTip nozzleTip;
+    
+    public SimpleGraphView(ReferenceNozzleTip nozzleTip) {
+        this.nozzleTip = nozzleTip; 
+        //this.setBorder(new TitledBorder(UIManager.getBorder("TitledBorder.border"), "Graph", TitledBorder.LEADING, TitledBorder.TOP, null, new Color(0, 0, 0)));
+    }
+
+    public Map<Double, Double> getGraph() {
+        return graph;
+    }
+    public void setGraph(Map<Double, Double> graph) {
+        this.graph = graph;
+    }
+    public void paintComponent(Graphics g)
+    {
+        super.paintComponent(g);
+        Graphics2D g2d = (Graphics2D) g;
+        g2d.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+        Color color1 = new Color(225, 0, 0);
+        int w = getWidth();
+        int h = getHeight();
+        double tMin = Double.MAX_VALUE;
+        double tMax = Double.MIN_VALUE;
+        double vMin = Double.MAX_VALUE;
+        double vMax = Double.MIN_VALUE;
+        if (graph != null && graph.size() > 0) {
+            for (double t : graph.keySet()) {
+                double v = graph.get(t);
+                tMin = Math.min(t,  tMin);
+                tMax = Math.max(t,  tMax);
+                vMin = Math.min(v,  vMin);
+                vMax = Math.max(v,  vMax);
+            }
+            double tScale = (w-1)/(tMax-tMin);
+            double vScale = (h-1)/(vMax-vMin);
+            double v0 = Double.NaN;
+            double t0 = Double.NaN;
+            g2d.setColor(color1);
+            for (double t : graph.keySet()) {
+                double v = graph.get(t);
+                if (!Double.isNaN(t0)) {
+                    g2d.drawLine((int)((t0-tMin)*tScale), (int)(h-1-(v0-vMin)*vScale), 
+                            (int)((t-tMin)*tScale), (int)(h-1-(v-vMin)*vScale));
+                }
+            }
+        }
+        else {
+            g2d.setColor(color1);
+            g2d.drawLine(0, 0, w-1, h-1);
+            g2d.drawLine(0, h-1, w-1, 0);
+        }
+    }
+    @Override
+    public Dimension getPreferredSize() {
+        Dimension superDim = super.getPreferredSize();
+        int width = (int)Math.max(superDim.getWidth(), PREF_SIZE.getWidth());
+        int height = (int)Math.max(superDim.getHeight(), PREF_SIZE.getHeight()); 
+        return new Dimension(width, height);
+    }
+}

--- a/src/main/java/org/openpnp/gui/components/SimpleGraphView.java
+++ b/src/main/java/org/openpnp/gui/components/SimpleGraphView.java
@@ -45,7 +45,7 @@ import org.openpnp.util.SimpleGraph.DataScale;
 public class SimpleGraphView extends JComponent {  
 
     private SimpleGraph graph;
-    private final Dimension PREF_SIZE = new Dimension(100, 100);
+    private final Dimension preferredSize = new Dimension(100, 80);
 
     public SimpleGraphView() {
     }
@@ -190,8 +190,8 @@ public class SimpleGraphView extends JComponent {
     @Override
     public Dimension getPreferredSize() {
         Dimension superDim = super.getPreferredSize();
-        int width = (int)Math.max(superDim.getWidth(), PREF_SIZE.getWidth());
-        int height = (int)Math.max(superDim.getHeight(), PREF_SIZE.getHeight()); 
+        int width = (int)Math.max(superDim.getWidth(), preferredSize.getWidth());
+        int height = (int)Math.max(superDim.getHeight(), preferredSize.getHeight()); 
         return new Dimension(width, height);
     }
 }

--- a/src/main/java/org/openpnp/machine/reference/ReferenceNozzle.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceNozzle.java
@@ -743,7 +743,7 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
 
     protected Double readReferenceVacuumLevel(VacuumMeasurementMethod method, int referenceDwell) throws Exception {
         Actuator referenceVacuumActuator = null;
-        if (method == VacuumMeasurementMethod.RelativeTrendFromPump) {
+        if (method == VacuumMeasurementMethod.RelativeToPump) {
             referenceVacuumActuator = getHead().getPump();
         }
         else if (method == VacuumMeasurementMethod.RelativeTrend) {
@@ -778,13 +778,13 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
             nt.setVacuumTrendPartOnReading(vacuumTrend);
             // check the reference range 
             if (vacuumReferenceLevel < nt.getVacuumLevelPartOnLow() || vacuumReferenceLevel > nt.getVacuumLevelPartOnHigh()) {
-                Logger.debug("Nozzle tip {} reference vacuum level {} outside Part On range {} .. {}", 
+                Logger.debug("Nozzle tip {} reference vacuum level {} outside PartOn range {} .. {}", 
                         nt.getName(), vacuumReferenceLevel, nt.getVacuumLevelPartOnLow(), nt.getVacuumLevelPartOnHigh());
                 return false;
             }
             // so far so good, check trend
             if (vacuumTrend < nt.getVacuumTrendPartOnLow() || vacuumTrend > nt.getVacuumTrendPartOnHigh()) {
-                Logger.debug("Nozzle tip {} relative vacuum trend {} outside Part On range {} .. {}", 
+                Logger.debug("Nozzle tip {} relative vacuum trend {} outside PartOn range {} .. {}", 
                         nt.getName(), vacuumTrend, nt.getVacuumTrendPartOnLow(), nt.getVacuumTrendPartOnHigh());
                 return false;
             }
@@ -796,7 +796,7 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
             nt.setVacuumTrendPartOnReading(null);
             // check the range
             if (vacuumLevel < nt.getVacuumLevelPartOnLow() || vacuumLevel <= nt.getVacuumLevelPartOnHigh()) {
-                Logger.debug("Nozzle tip {} absolute vacuum level {} outside Part On range {} .. {}", 
+                Logger.debug("Nozzle tip {} absolute vacuum level {} outside PartOn range {} .. {}", 
                         nt.getName(), vacuumLevel, nt.getVacuumLevelPartOnLow(), nt.getVacuumLevelPartOnHigh());
                 return false;
             }
@@ -824,13 +824,13 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
                 nt.setVacuumTrendPartOffReading(vacuumTrend);
                 // check the reference range 
                 if (vacuumReferenceLevel < nt.getVacuumLevelPartOffLow() || vacuumReferenceLevel > nt.getVacuumLevelPartOffHigh()) {
-                    Logger.debug("Nozzle tip {} reference vacuum level {} outside Part Off range {} .. {}", 
+                    Logger.debug("Nozzle tip {} reference vacuum level {} outside PartOff range {} .. {}", 
                             nt.getName(), vacuumReferenceLevel, nt.getVacuumLevelPartOffLow(), nt.getVacuumLevelPartOffHigh());
                     return false;
                 }
                 // so far so good, check trend
                 if (vacuumTrend < nt.getVacuumTrendPartOffLow() || vacuumTrend > nt.getVacuumTrendPartOffHigh()) {
-                    Logger.debug("Nozzle tip {} relative vacuum trend {} outside Part Off range {} .. {}", 
+                    Logger.debug("Nozzle tip {} relative vacuum trend {} outside PartOff range {} .. {}", 
                             nt.getName(), vacuumTrend, nt.getVacuumTrendPartOffLow(), nt.getVacuumTrendPartOffHigh());
                     return false;
                 }
@@ -842,7 +842,7 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
                 nt.setVacuumTrendPartOffReading(null);
                 // check the range
                 if (vacuumLevel < nt.getVacuumLevelPartOffLow() || vacuumLevel <= nt.getVacuumLevelPartOffHigh()) {
-                    Logger.debug("Nozzle tip {} absolute vacuum level {} outside Part Off range {} .. {}", 
+                    Logger.debug("Nozzle tip {} absolute vacuum level {} outside PartOff range {} .. {}", 
                             nt.getName(), vacuumLevel, nt.getVacuumLevelPartOffLow(), nt.getVacuumLevelPartOffHigh());
                     return false;
                 }

--- a/src/main/java/org/openpnp/machine/reference/ReferenceNozzle.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceNozzle.java
@@ -208,7 +208,7 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
             actuateVacuumValve(true);
         }
 
-        // wait for the Dwell Time and/or make sure the vacuum level builds up to the desired value (with timeout)
+        // wait for the Dwell Time and/or make sure the vacuum level builds up to the desired range (with timeout)
         establishPickVacuumLevel(this.getPickDwellMilliseconds() + nozzleTip.getPickDwellMilliseconds());
 
         getMachine().fireMachineHeadActivity(head);
@@ -250,7 +250,7 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
             actuateVacuumValve(false);
         }
 
-        // wait for the Dwell Time or make sure the vacuum level decays to the desired value (with timeout)
+        // wait for the Dwell Time and/or make sure the vacuum level decays to the desired range (with timeout)
         establishPlaceVacuumLevel(this.getPlaceDwellMilliseconds() + nozzleTip.getPlaceDwellMilliseconds());
 
         this.part = null;
@@ -951,7 +951,7 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
 
             // switch vacuum on for the test
             actuateVacuumValve(true);
-            // wait for the Dwell Time and/or and follow the vacuum level 
+            // wait for the Dwell Time and/or follow the vacuum level 
             double vacuumLevel = readPartOffVacuumLevel(nt.getPartOffProbingMilliseconds());
 
             if (nt.getMethodPartOff().isDifferenceMethod()) {

--- a/src/main/java/org/openpnp/machine/reference/ReferenceNozzleTip.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceNozzleTip.java
@@ -24,6 +24,7 @@ import org.openpnp.spi.Head;
 import org.openpnp.spi.Nozzle;
 import org.openpnp.spi.PropertySheetHolder;
 import org.openpnp.spi.base.AbstractNozzleTip;
+import org.openpnp.util.SimpleGraph;
 import org.openpnp.util.UiUtils;
 import org.simpleframework.xml.Attribute;
 import org.simpleframework.xml.Element;
@@ -121,8 +122,8 @@ public class ReferenceNozzleTip extends AbstractNozzleTip {
     private Double vacuumRelativePartOnReading = null;
     private Double vacuumLevelPartOffReading = null;
     private Double vacuumRelativePartOffReading = null;
-    private Map<Double, Double> vacuumPartOnGraph = null;
-    private Map<Double, Double> vacuumPartOffGraph = null;
+    private SimpleGraph vacuumPartOnGraph = null;
+    private SimpleGraph vacuumPartOffGraph = null;
     
     public ReferenceNozzleTip() {
     }
@@ -427,11 +428,11 @@ public class ReferenceNozzleTip extends AbstractNozzleTip {
         }
     }
 
-    public Map<Double, Double> getVacuumPartOnGraph() {
+    public SimpleGraph getVacuumPartOnGraph() {
         return vacuumPartOnGraph;
     }
 
-    public void setVacuumPartOnGraph(Map<Double, Double> vacuumPartOnGraph) {
+    public void setVacuumPartOnGraph(SimpleGraph vacuumPartOnGraph) {
         Object oldValue = vacuumPartOnGraph;
         this.vacuumPartOnGraph = vacuumPartOnGraph;
         if (!(oldValue == null && vacuumPartOnGraph == null)) { // only fire when values are set
@@ -439,11 +440,11 @@ public class ReferenceNozzleTip extends AbstractNozzleTip {
         }
     }
 
-    public Map<Double, Double> getVacuumPartOffGraph() {
+    public SimpleGraph getVacuumPartOffGraph() {
         return vacuumPartOffGraph;
     }
 
-    public void setVacuumPartOffGraph(Map<Double, Double> vacuumPartOffGraph) {
+    public void setVacuumPartOffGraph(SimpleGraph vacuumPartOffGraph) {
         Object oldValue = vacuumPartOffGraph;
         this.vacuumPartOffGraph = vacuumPartOffGraph;
         if (!(oldValue == null && vacuumPartOffGraph == null)) { // only fire when values are set

--- a/src/main/java/org/openpnp/machine/reference/ReferenceNozzleTip.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceNozzleTip.java
@@ -1,6 +1,8 @@
 package org.openpnp.machine.reference;
 
 import java.awt.event.ActionEvent;
+import java.util.HashMap;
+import java.util.Map;
 
 import javax.swing.AbstractAction;
 import javax.swing.Action;
@@ -63,10 +65,10 @@ public class ReferenceNozzleTip extends AbstractNozzleTip {
         None, 
         Absolute,
         RelativeTrend,
-        RelativeTrendFromPump;
+        RelativeToPump;
         
         public boolean isTrendMethod() {
-            return this == RelativeTrend || this == RelativeTrendFromPump;
+            return this == RelativeTrend || this == RelativeToPump;
         }
     }
 
@@ -126,6 +128,8 @@ public class ReferenceNozzleTip extends AbstractNozzleTip {
     private Double vacuumTrendPartOnReading = null;
     private Double vacuumLevelPartOffReading = null;
     private Double vacuumTrendPartOffReading = null;
+    private Map<Double, Double> vacuumPartOnGraph = null;
+    private Map<Double, Double> vacuumPartOffGraph = null;
     
     public ReferenceNozzleTip() {
     }
@@ -444,6 +448,30 @@ public class ReferenceNozzleTip extends AbstractNozzleTip {
         this.vacuumTrendPartOffReading = vacuumTrendPartOffReading;
         if (!(oldValue == null && vacuumTrendPartOffReading == null)) { // only fire when values are set
             firePropertyChange("vacuumTrendPartOffReading", oldValue, vacuumTrendPartOffReading);
+        }
+    }
+
+    public Map<Double, Double> getVacuumPartOnGraph() {
+        return vacuumPartOnGraph;
+    }
+
+    public void setVacuumPartOnGraph(Map<Double, Double> vacuumPartOnGraph) {
+        Object oldValue = vacuumPartOnGraph;
+        this.vacuumPartOnGraph = vacuumPartOnGraph;
+        if (!(oldValue == null && vacuumPartOnGraph == null)) { // only fire when values are set
+            firePropertyChange("vacuumPartOnGraph", oldValue, vacuumPartOnGraph);
+        }
+    }
+
+    public Map<Double, Double> getVacuumPartOffGraph() {
+        return vacuumPartOffGraph;
+    }
+
+    public void setVacuumPartOffGraph(Map<Double, Double> vacuumPartOffGraph) {
+        Object oldValue = vacuumPartOffGraph;
+        this.vacuumPartOffGraph = vacuumPartOffGraph;
+        if (!(oldValue == null && vacuumPartOffGraph == null)) { // only fire when values are set
+            firePropertyChange("vacuumPartOffGraph", oldValue, vacuumPartOffGraph);
         }
     }
 

--- a/src/main/java/org/openpnp/machine/reference/ReferenceNozzleTip.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceNozzleTip.java
@@ -448,7 +448,7 @@ public class ReferenceNozzleTip extends AbstractNozzleTip {
     }
 
     public void setVacuumLevelPartOnReading(Double vacuumLevelPartOnReading) {
-        Object oldValue = vacuumLevelPartOnReading;
+        Object oldValue = this.vacuumLevelPartOnReading;
         this.vacuumLevelPartOnReading = vacuumLevelPartOnReading;
         if (!(oldValue == null && vacuumLevelPartOnReading == null)) { // only fire when values are set
             firePropertyChange("vacuumLevelPartOnReading", oldValue, vacuumLevelPartOnReading);
@@ -460,7 +460,7 @@ public class ReferenceNozzleTip extends AbstractNozzleTip {
     }
 
     public void setVacuumDifferencePartOnReading(Double vacuumDifferencePartOnReading) {
-        Object oldValue = vacuumLevelPartOnReading;
+        Object oldValue = this.vacuumDifferencePartOnReading;
         this.vacuumDifferencePartOnReading = vacuumDifferencePartOnReading;
         if (!(oldValue == null && vacuumDifferencePartOnReading == null)) { // only fire when values are set
             firePropertyChange("vacuumDifferencePartOnReading", oldValue, vacuumDifferencePartOnReading);
@@ -472,7 +472,7 @@ public class ReferenceNozzleTip extends AbstractNozzleTip {
     }
 
     public void setVacuumLevelPartOffReading(Double vacuumLevelPartOffReading) {
-        Object oldValue = vacuumLevelPartOnReading;
+        Object oldValue = this.vacuumLevelPartOffReading;
         this.vacuumLevelPartOffReading = vacuumLevelPartOffReading;
         if (!(oldValue == null && vacuumLevelPartOffReading == null)) { // only fire when values are set
             firePropertyChange("vacuumLevelPartOffReading", oldValue, vacuumLevelPartOffReading);
@@ -484,7 +484,7 @@ public class ReferenceNozzleTip extends AbstractNozzleTip {
     }
 
     public void setVacuumDifferencePartOffReading(Double vacuumDifferencePartOffReading) {
-        Object oldValue = vacuumLevelPartOnReading;
+        Object oldValue = this.vacuumDifferencePartOffReading;
         this.vacuumDifferencePartOffReading = vacuumDifferencePartOffReading;
         if (!(oldValue == null && vacuumDifferencePartOffReading == null)) { // only fire when values are set
             firePropertyChange("vacuumDifferencePartOffReading", oldValue, vacuumDifferencePartOffReading);
@@ -496,10 +496,10 @@ public class ReferenceNozzleTip extends AbstractNozzleTip {
     }
 
     public void setVacuumPartOnGraph(SimpleGraph vacuumPartOnGraph) {
-        Object oldValue = vacuumPartOnGraph;
+        Object oldValue = this.vacuumPartOnGraph;
         this.vacuumPartOnGraph = vacuumPartOnGraph;
         if (!(oldValue == null && vacuumPartOnGraph == null)) { // only fire when values are set
-            firePropertyChange("vacuumPartOnGraph", null/*oldValue*/, vacuumPartOnGraph);
+            firePropertyChange("vacuumPartOnGraph", oldValue, vacuumPartOnGraph);
         }
     }
 
@@ -508,10 +508,10 @@ public class ReferenceNozzleTip extends AbstractNozzleTip {
     }
 
     public void setVacuumPartOffGraph(SimpleGraph vacuumPartOffGraph) {
-        Object oldValue = vacuumPartOffGraph;
+        Object oldValue = this.vacuumPartOffGraph;
         this.vacuumPartOffGraph = vacuumPartOffGraph;
         if (!(oldValue == null && vacuumPartOffGraph == null)) { // only fire when values are set
-            firePropertyChange("vacuumPartOffGraph", null/*oldValue*/, vacuumPartOffGraph);
+            firePropertyChange("vacuumPartOffGraph", oldValue, vacuumPartOffGraph);
         }
     }
 
@@ -558,16 +558,16 @@ public class ReferenceNozzleTip extends AbstractNozzleTip {
         // start a new graph 
         SimpleGraph vacuumGraph = new SimpleGraph();
         vacuumGraph.setOffsetMode(true);
-        vacuumGraph.setRelativePaddingLeft(0.1);
+        vacuumGraph.setRelativePaddingLeft(0.05);
         long t = System.currentTimeMillis();
         // init pressure scale
         SimpleGraph.DataScale vacuumScale =  vacuumGraph.getScale(PRESSURE);
-        vacuumScale.setRelativePaddingBottom(0.25);
+        vacuumScale.setRelativePaddingBottom(0.3);
         vacuumScale.setColor(new Color(0, 0, 0, 64));
         // init valve scale
         SimpleGraph.DataScale valveScale =  vacuumGraph.getScale(BOOLEAN);
-        valveScale.setRelativePaddingTop(0.8);
-        valveScale.setRelativePaddingBottom(0.1);
+        valveScale.setRelativePaddingTop(0.75);
+        valveScale.setRelativePaddingBottom(0.2);
         // record the current pressure
         SimpleGraph.DataRow vacuumData = vacuumGraph.getRow(PRESSURE, VACUUM);
         vacuumData.setColor(new Color(255, 0, 0));

--- a/src/main/java/org/openpnp/machine/reference/ReferenceNozzleTip.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceNozzleTip.java
@@ -26,6 +26,7 @@ import org.openpnp.spi.PropertySheetHolder;
 import org.openpnp.spi.base.AbstractNozzleTip;
 import org.openpnp.util.SimpleGraph;
 import org.openpnp.util.UiUtils;
+import org.pmw.tinylog.Logger;
 import org.simpleframework.xml.Attribute;
 import org.simpleframework.xml.Element;
 import org.simpleframework.xml.core.Commit;
@@ -65,10 +66,10 @@ public class ReferenceNozzleTip extends AbstractNozzleTip {
     public enum VacuumMeasurementMethod {
         None, 
         Absolute,
-        RelativeTrend;
+        Difference;
         
-        public boolean isRelativeMethod() {
-            return this == RelativeTrend;
+        public boolean isDifferenceMethod() {
+            return this == Difference;
         }
     }
 
@@ -85,10 +86,10 @@ public class ReferenceNozzleTip extends AbstractNozzleTip {
     private double vacuumLevelPartOnHigh;
 
     @Element(required = false)
-    private double vacuumRelativePartOnLow;
+    private double vacuumDifferencePartOnLow;
 
     @Element(required = false)
-    private double vacuumRelativePartOnHigh;
+    private double vacuumDifferencePartOnHigh;
 
     @Element(required = false)
     VacuumMeasurementMethod methodPartOff = null;
@@ -106,10 +107,10 @@ public class ReferenceNozzleTip extends AbstractNozzleTip {
     private int partOffProbingMilliseconds;
 
     @Element(required = false)
-    private double vacuumRelativePartOffLow;
+    private double vacuumDifferencePartOffLow;
 
     @Element(required = false)
-    private double vacuumRelativePartOffHigh;
+    private double vacuumDifferencePartOffHigh;
 
     @Element(required = false)
     private Length diameterLow = new Length(0, LengthUnit.Millimeters);
@@ -119,9 +120,9 @@ public class ReferenceNozzleTip extends AbstractNozzleTip {
 
     // last vacuum readings 
     private Double vacuumLevelPartOnReading = null;
-    private Double vacuumRelativePartOnReading = null;
+    private Double vacuumDifferencePartOnReading = null;
     private Double vacuumLevelPartOffReading = null;
-    private Double vacuumRelativePartOffReading = null;
+    private Double vacuumDifferencePartOffReading = null;
     private SimpleGraph vacuumPartOnGraph = null;
     private SimpleGraph vacuumPartOffGraph = null;
     
@@ -143,6 +144,22 @@ public class ReferenceNozzleTip extends AbstractNozzleTip {
             }
         }
         if (methodPartOff == null) {
+            // use the same as the former pick dwell time.
+            partOffProbingMilliseconds = pickDwellMilliseconds;
+            try {
+                // also add the nozzle's pick dwell time
+                Nozzle nozzle = Configuration.get()
+                                             .getMachine()
+                                             .getDefaultHead()
+                                             .getDefaultNozzle();
+                if (nozzle instanceof ReferenceNozzle) {
+                    ReferenceNozzle refNozzle = (ReferenceNozzle) nozzle;
+                    partOffProbingMilliseconds += refNozzle.getPickDwellMilliseconds();
+                } 
+            }
+            catch (Exception e) {
+                Logger.info("Cannot fully upgrade partOffProbingMilliseconds time", e);
+            }
             if (vacuumLevelPartOffLow < vacuumLevelPartOffHigh) {
                 // was enabled
                 methodPartOff = VacuumMeasurementMethod.Absolute;
@@ -308,20 +325,20 @@ public class ReferenceNozzleTip extends AbstractNozzleTip {
         this.vacuumLevelPartOnHigh = vacuumLevelPartOnHigh;
     }
 
-    public double getVacuumRelativePartOnLow() {
-        return vacuumRelativePartOnLow;
+    public double getVacuumDifferencePartOnLow() {
+        return vacuumDifferencePartOnLow;
     }
 
-    public void setVacuumRelativePartOnLow(double vacuumRelativePartOnLow) {
-        this.vacuumRelativePartOnLow = vacuumRelativePartOnLow;
+    public void setVacuumDifferencePartOnLow(double vacuumDifferencePartOnLow) {
+        this.vacuumDifferencePartOnLow = vacuumDifferencePartOnLow;
     }
 
-    public double getVacuumRelativePartOnHigh() {
-        return vacuumRelativePartOnHigh;
+    public double getVacuumDifferencePartOnHigh() {
+        return vacuumDifferencePartOnHigh;
     }
 
-    public void setVacuumRelativePartOnHigh(double vacuumRelativePartOnHigh) {
-        this.vacuumRelativePartOnHigh = vacuumRelativePartOnHigh;
+    public void setVacuumDifferencePartOnHigh(double vacuumDifferencePartOnHigh) {
+        this.vacuumDifferencePartOnHigh = vacuumDifferencePartOnHigh;
     }
 
     public VacuumMeasurementMethod getMethodPartOff() {
@@ -364,20 +381,20 @@ public class ReferenceNozzleTip extends AbstractNozzleTip {
         this.partOffProbingMilliseconds = partOffProbingMilliseconds;
     }
 
-    public double getVacuumRelativePartOffLow() {
-        return vacuumRelativePartOffLow;
+    public double getVacuumDifferencePartOffLow() {
+        return vacuumDifferencePartOffLow;
     }
 
-    public void setVacuumRelativePartOffLow(double vacuumRelativePartOffLow) {
-        this.vacuumRelativePartOffLow = vacuumRelativePartOffLow;
+    public void setVacuumDifferencePartOffLow(double vacuumDifferencePartOffLow) {
+        this.vacuumDifferencePartOffLow = vacuumDifferencePartOffLow;
     }
 
-    public double getVacuumRelativePartOffHigh() {
-        return vacuumRelativePartOffHigh;
+    public double getVacuumDifferencePartOffHigh() {
+        return vacuumDifferencePartOffHigh;
     }
 
-    public void setVacuumRelativePartOffHigh(double vacuumRelativePartOffHigh) {
-        this.vacuumRelativePartOffHigh = vacuumRelativePartOffHigh;
+    public void setVacuumDifferencePartOffHigh(double vacuumDifferencePartOffHigh) {
+        this.vacuumDifferencePartOffHigh = vacuumDifferencePartOffHigh;
     }
 
     public Double getVacuumLevelPartOnReading() {
@@ -392,15 +409,15 @@ public class ReferenceNozzleTip extends AbstractNozzleTip {
         }
     }
 
-    public Double getVacuumRelativePartOnReading() {
-        return vacuumRelativePartOnReading;
+    public Double getVacuumDifferencePartOnReading() {
+        return vacuumDifferencePartOnReading;
     }
 
-    public void setVacuumRelativePartOnReading(Double vacuumRelativePartOnReading) {
+    public void setVacuumDifferencePartOnReading(Double vacuumDifferencePartOnReading) {
         Object oldValue = vacuumLevelPartOnReading;
-        this.vacuumRelativePartOnReading = vacuumRelativePartOnReading;
-        if (!(oldValue == null && vacuumRelativePartOnReading == null)) { // only fire when values are set
-            firePropertyChange("vacuumRelativePartOnReading", oldValue, vacuumRelativePartOnReading);
+        this.vacuumDifferencePartOnReading = vacuumDifferencePartOnReading;
+        if (!(oldValue == null && vacuumDifferencePartOnReading == null)) { // only fire when values are set
+            firePropertyChange("vacuumDifferencePartOnReading", oldValue, vacuumDifferencePartOnReading);
         }
     }
 
@@ -416,15 +433,15 @@ public class ReferenceNozzleTip extends AbstractNozzleTip {
         }
     }
 
-    public Double getVacuumRelativePartOffReading() {
-        return vacuumRelativePartOffReading;
+    public Double getVacuumDifferencePartOffReading() {
+        return vacuumDifferencePartOffReading;
     }
 
-    public void setVacuumRelativePartOffReading(Double vacuumRelativePartOffReading) {
+    public void setVacuumDifferencePartOffReading(Double vacuumDifferencePartOffReading) {
         Object oldValue = vacuumLevelPartOnReading;
-        this.vacuumRelativePartOffReading = vacuumRelativePartOffReading;
-        if (!(oldValue == null && vacuumRelativePartOffReading == null)) { // only fire when values are set
-            firePropertyChange("vacuumRelativePartOffReading", oldValue, vacuumRelativePartOffReading);
+        this.vacuumDifferencePartOffReading = vacuumDifferencePartOffReading;
+        if (!(oldValue == null && vacuumDifferencePartOffReading == null)) { // only fire when values are set
+            firePropertyChange("vacuumDifferencePartOffReading", oldValue, vacuumDifferencePartOffReading);
         }
     }
 

--- a/src/main/java/org/openpnp/machine/reference/ReferenceNozzleTip.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceNozzleTip.java
@@ -64,19 +64,18 @@ public class ReferenceNozzleTip extends AbstractNozzleTip {
     public enum VacuumMeasurementMethod {
         None, 
         Absolute,
-        RelativeTrend,
-        RelativeToPump;
+        RelativeTrend;
         
-        public boolean isTrendMethod() {
-            return this == RelativeTrend || this == RelativeToPump;
+        public boolean isRelativeMethod() {
+            return this == RelativeTrend;
         }
     }
 
     @Element(required = false)
-    VacuumMeasurementMethod methodPartOn = VacuumMeasurementMethod.Absolute;
+    VacuumMeasurementMethod methodPartOn = null;
 
     @Attribute(required = false)
-    private int partOnDwellMilliseconds;
+    private boolean establishPartOnLevel;
 
     @Element(required = false)
     private double vacuumLevelPartOnLow;
@@ -84,23 +83,17 @@ public class ReferenceNozzleTip extends AbstractNozzleTip {
     @Element(required = false)
     private double vacuumLevelPartOnHigh;
 
-    @Attribute(required = false)
-    private int partOnTrendMilliseconds;
+    @Element(required = false)
+    private double vacuumRelativePartOnLow;
 
     @Element(required = false)
-    private double vacuumTrendPartOnLow;
+    private double vacuumRelativePartOnHigh;
 
     @Element(required = false)
-    private double vacuumTrendPartOnHigh;
-
-    @Element(required = false)
-    VacuumMeasurementMethod methodPartOff = VacuumMeasurementMethod.Absolute;
+    VacuumMeasurementMethod methodPartOff = null;
 
     @Attribute(required = false)
-    private int partOffDwellMilliseconds = -1;
-
-    @Attribute(required = false)
-    private boolean valveEnabledForPartOff = true;
+    private boolean establishPartOffLevel;
 
     @Element(required = false)
     private double vacuumLevelPartOffLow;
@@ -109,13 +102,13 @@ public class ReferenceNozzleTip extends AbstractNozzleTip {
     private double vacuumLevelPartOffHigh;
 
     @Attribute(required = false)
-    private int partOffTrendMilliseconds;
+    private int partOffProbingMilliseconds;
 
     @Element(required = false)
-    private double vacuumTrendPartOffLow;
+    private double vacuumRelativePartOffLow;
 
     @Element(required = false)
-    private double vacuumTrendPartOffHigh;
+    private double vacuumRelativePartOffHigh;
 
     @Element(required = false)
     private Length diameterLow = new Length(0, LengthUnit.Millimeters);
@@ -125,9 +118,9 @@ public class ReferenceNozzleTip extends AbstractNozzleTip {
 
     // last vacuum readings 
     private Double vacuumLevelPartOnReading = null;
-    private Double vacuumTrendPartOnReading = null;
+    private Double vacuumRelativePartOnReading = null;
     private Double vacuumLevelPartOffReading = null;
-    private Double vacuumTrendPartOffReading = null;
+    private Double vacuumRelativePartOffReading = null;
     private Map<Double, Double> vacuumPartOnGraph = null;
     private Map<Double, Double> vacuumPartOffGraph = null;
     
@@ -139,10 +132,7 @@ public class ReferenceNozzleTip extends AbstractNozzleTip {
         /**
          * Backwards compatibility.
          */
-        if (partOffDwellMilliseconds == -1) {
-            // the pick time was previously used for this
-            partOffDwellMilliseconds = pickDwellMilliseconds;
-            // also initialize part on/off test enabling
+        if (methodPartOn == null) {
             if (vacuumLevelPartOnLow < vacuumLevelPartOnHigh) {
                 // was enabled
                 methodPartOn = VacuumMeasurementMethod.Absolute;
@@ -150,6 +140,8 @@ public class ReferenceNozzleTip extends AbstractNozzleTip {
             else {
                 methodPartOn = VacuumMeasurementMethod.None;
             }
+        }
+        if (methodPartOff == null) {
             if (vacuumLevelPartOffLow < vacuumLevelPartOffHigh) {
                 // was enabled
                 methodPartOff = VacuumMeasurementMethod.Absolute;
@@ -291,12 +283,12 @@ public class ReferenceNozzleTip extends AbstractNozzleTip {
         this.methodPartOn = methodPartOn;
     }
 
-    public int getPartOnDwellMilliseconds() {
-        return partOnDwellMilliseconds;
+    public boolean isEstablishPartOnLevel() {
+        return establishPartOnLevel;
     }
 
-    public void setPartOnDwellMilliseconds(int partOnDwellMilliseconds) {
-        this.partOnDwellMilliseconds = partOnDwellMilliseconds;
+    public void setEstablishPartOnLevel(boolean establishPartOnLevel) {
+        this.establishPartOnLevel = establishPartOnLevel;
     }
 
     public double getVacuumLevelPartOnLow() {
@@ -315,28 +307,20 @@ public class ReferenceNozzleTip extends AbstractNozzleTip {
         this.vacuumLevelPartOnHigh = vacuumLevelPartOnHigh;
     }
 
-    public int getPartOnTrendMilliseconds() {
-        return partOnTrendMilliseconds;
+    public double getVacuumRelativePartOnLow() {
+        return vacuumRelativePartOnLow;
     }
 
-    public void setPartOnTrendMilliseconds(int partOnTrendMilliseconds) {
-        this.partOnTrendMilliseconds = partOnTrendMilliseconds;
+    public void setVacuumRelativePartOnLow(double vacuumRelativePartOnLow) {
+        this.vacuumRelativePartOnLow = vacuumRelativePartOnLow;
     }
 
-    public double getVacuumTrendPartOnLow() {
-        return vacuumTrendPartOnLow;
+    public double getVacuumRelativePartOnHigh() {
+        return vacuumRelativePartOnHigh;
     }
 
-    public void setVacuumTrendPartOnLow(double vacuumTrendPartOnLow) {
-        this.vacuumTrendPartOnLow = vacuumTrendPartOnLow;
-    }
-
-    public double getVacuumTrendPartOnHigh() {
-        return vacuumTrendPartOnHigh;
-    }
-
-    public void setVacuumTrendPartOnHigh(double vacuumTrendPartOnHigh) {
-        this.vacuumTrendPartOnHigh = vacuumTrendPartOnHigh;
+    public void setVacuumRelativePartOnHigh(double vacuumRelativePartOnHigh) {
+        this.vacuumRelativePartOnHigh = vacuumRelativePartOnHigh;
     }
 
     public VacuumMeasurementMethod getMethodPartOff() {
@@ -347,20 +331,12 @@ public class ReferenceNozzleTip extends AbstractNozzleTip {
         this.methodPartOff = methodPartOff;
     }
 
-    public boolean isValveEnabledForPartOff() {
-        return valveEnabledForPartOff;
+    public boolean isEstablishPartOffLevel() {
+        return establishPartOffLevel;
     }
 
-    public void setValveEnabledForPartOff(boolean valveEnabledForPartOff) {
-        this.valveEnabledForPartOff = valveEnabledForPartOff;
-    }
-
-    public int getPartOffDwellMilliseconds() {
-        return partOffDwellMilliseconds;
-    }
-
-    public void setPartOffDwellMilliseconds(int partOffDwellMilliseconds) {
-        this.partOffDwellMilliseconds = partOffDwellMilliseconds;
+    public void setEstablishPartOffLevel(boolean establishPartOffLevel) {
+        this.establishPartOffLevel = establishPartOffLevel;
     }
 
     public double getVacuumLevelPartOffLow() {
@@ -379,28 +355,28 @@ public class ReferenceNozzleTip extends AbstractNozzleTip {
         this.vacuumLevelPartOffHigh = vacuumLevelPartOffHigh;
     }
 
-    public int getPartOffTrendMilliseconds() {
-        return partOffTrendMilliseconds;
+    public int getPartOffProbingMilliseconds() {
+        return partOffProbingMilliseconds;
     }
 
-    public void setPartOffTrendMilliseconds(int partOffTrendMilliseconds) {
-        this.partOffTrendMilliseconds = partOffTrendMilliseconds;
+    public void setPartOffProbingMilliseconds(int partOffProbingMilliseconds) {
+        this.partOffProbingMilliseconds = partOffProbingMilliseconds;
     }
 
-    public double getVacuumTrendPartOffLow() {
-        return vacuumTrendPartOffLow;
+    public double getVacuumRelativePartOffLow() {
+        return vacuumRelativePartOffLow;
     }
 
-    public void setVacuumTrendPartOffLow(double vacuumTrendPartOffLow) {
-        this.vacuumTrendPartOffLow = vacuumTrendPartOffLow;
+    public void setVacuumRelativePartOffLow(double vacuumRelativePartOffLow) {
+        this.vacuumRelativePartOffLow = vacuumRelativePartOffLow;
     }
 
-    public double getVacuumTrendPartOffHigh() {
-        return vacuumTrendPartOffHigh;
+    public double getVacuumRelativePartOffHigh() {
+        return vacuumRelativePartOffHigh;
     }
 
-    public void setVacuumTrendPartOffHigh(double vacuumTrendPartOffHigh) {
-        this.vacuumTrendPartOffHigh = vacuumTrendPartOffHigh;
+    public void setVacuumRelativePartOffHigh(double vacuumRelativePartOffHigh) {
+        this.vacuumRelativePartOffHigh = vacuumRelativePartOffHigh;
     }
 
     public Double getVacuumLevelPartOnReading() {
@@ -415,15 +391,15 @@ public class ReferenceNozzleTip extends AbstractNozzleTip {
         }
     }
 
-    public Double getVacuumTrendPartOnReading() {
-        return vacuumTrendPartOnReading;
+    public Double getVacuumRelativePartOnReading() {
+        return vacuumRelativePartOnReading;
     }
 
-    public void setVacuumTrendPartOnReading(Double vacuumTrendPartOnReading) {
+    public void setVacuumRelativePartOnReading(Double vacuumRelativePartOnReading) {
         Object oldValue = vacuumLevelPartOnReading;
-        this.vacuumTrendPartOnReading = vacuumTrendPartOnReading;
-        if (!(oldValue == null && vacuumTrendPartOnReading == null)) { // only fire when values are set
-            firePropertyChange("vacuumTrendPartOnReading", oldValue, vacuumTrendPartOnReading);
+        this.vacuumRelativePartOnReading = vacuumRelativePartOnReading;
+        if (!(oldValue == null && vacuumRelativePartOnReading == null)) { // only fire when values are set
+            firePropertyChange("vacuumRelativePartOnReading", oldValue, vacuumRelativePartOnReading);
         }
     }
 
@@ -439,15 +415,15 @@ public class ReferenceNozzleTip extends AbstractNozzleTip {
         }
     }
 
-    public Double getVacuumTrendPartOffReading() {
-        return vacuumTrendPartOffReading;
+    public Double getVacuumRelativePartOffReading() {
+        return vacuumRelativePartOffReading;
     }
 
-    public void setVacuumTrendPartOffReading(Double vacuumTrendPartOffReading) {
+    public void setVacuumRelativePartOffReading(Double vacuumRelativePartOffReading) {
         Object oldValue = vacuumLevelPartOnReading;
-        this.vacuumTrendPartOffReading = vacuumTrendPartOffReading;
-        if (!(oldValue == null && vacuumTrendPartOffReading == null)) { // only fire when values are set
-            firePropertyChange("vacuumTrendPartOffReading", oldValue, vacuumTrendPartOffReading);
+        this.vacuumRelativePartOffReading = vacuumRelativePartOffReading;
+        if (!(oldValue == null && vacuumRelativePartOffReading == null)) { // only fire when values are set
+            firePropertyChange("vacuumRelativePartOffReading", oldValue, vacuumRelativePartOffReading);
         }
     }
 

--- a/src/main/java/org/openpnp/machine/reference/ReferenceNozzleTip.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceNozzleTip.java
@@ -25,6 +25,7 @@ import org.openpnp.spi.base.AbstractNozzleTip;
 import org.openpnp.util.UiUtils;
 import org.simpleframework.xml.Attribute;
 import org.simpleframework.xml.Element;
+import org.simpleframework.xml.core.Commit;
 
 public class ReferenceNozzleTip extends AbstractNozzleTip {
     @Attribute(required = false)
@@ -57,12 +58,47 @@ public class ReferenceNozzleTip extends AbstractNozzleTip {
     
     @Element(required = false)
     private ReferenceNozzleTipCalibration calibration = new ReferenceNozzleTipCalibration();
-    
+
+    public enum VacuumMeasurementMethod {
+        None, 
+        Absolute,
+        RelativeTrend,
+        RelativeTrendFromPump;
+        
+        public boolean isTrendMethod() {
+            return this == RelativeTrend || this == RelativeTrendFromPump;
+        }
+    }
+
+    @Element(required = false)
+    VacuumMeasurementMethod methodPartOn = VacuumMeasurementMethod.Absolute;
+
+    @Attribute(required = false)
+    private int partOnDwellMilliseconds;
+
     @Element(required = false)
     private double vacuumLevelPartOnLow;
 
     @Element(required = false)
     private double vacuumLevelPartOnHigh;
+
+    @Attribute(required = false)
+    private int partOnTrendMilliseconds;
+
+    @Element(required = false)
+    private double vacuumTrendPartOnLow;
+
+    @Element(required = false)
+    private double vacuumTrendPartOnHigh;
+
+    @Element(required = false)
+    VacuumMeasurementMethod methodPartOff = VacuumMeasurementMethod.Absolute;
+
+    @Attribute(required = false)
+    private int partOffDwellMilliseconds = -1;
+
+    @Attribute(required = false)
+    private boolean valveEnabledForPartOff = true;
 
     @Element(required = false)
     private double vacuumLevelPartOffLow;
@@ -70,13 +106,54 @@ public class ReferenceNozzleTip extends AbstractNozzleTip {
     @Element(required = false)
     private double vacuumLevelPartOffHigh;
 
+    @Attribute(required = false)
+    private int partOffTrendMilliseconds;
+
+    @Element(required = false)
+    private double vacuumTrendPartOffLow;
+
+    @Element(required = false)
+    private double vacuumTrendPartOffHigh;
+
     @Element(required = false)
     private Length diameterLow = new Length(0, LengthUnit.Millimeters);
 
     @Attribute(required = false)
     private boolean isPushAndDragAllowed = false;
 
+    // last vacuum readings 
+    private Double vacuumLevelPartOnReading = null;
+    private Double vacuumTrendPartOnReading = null;
+    private Double vacuumLevelPartOffReading = null;
+    private Double vacuumTrendPartOffReading = null;
+    
     public ReferenceNozzleTip() {
+    }
+
+    @Commit
+    public void commit() {
+        /**
+         * Backwards compatibility.
+         */
+        if (partOffDwellMilliseconds == -1) {
+            // the pick time was previously used for this
+            partOffDwellMilliseconds = pickDwellMilliseconds;
+            // also initialize part on/off test enabling
+            if (vacuumLevelPartOnLow < vacuumLevelPartOnHigh) {
+                // was enabled
+                methodPartOn = VacuumMeasurementMethod.Absolute;
+            }
+            else {
+                methodPartOn = VacuumMeasurementMethod.None;
+            }
+            if (vacuumLevelPartOffLow < vacuumLevelPartOffHigh) {
+                // was enabled
+                methodPartOff = VacuumMeasurementMethod.Absolute;
+            }
+            else {
+                methodPartOff = VacuumMeasurementMethod.None;
+            }
+        }
     }
 
     @Override
@@ -202,6 +279,22 @@ public class ReferenceNozzleTip extends AbstractNozzleTip {
         return null;
     }
 
+    public VacuumMeasurementMethod getMethodPartOn() {
+        return methodPartOn;
+    }
+
+    public void setMethodPartOn(VacuumMeasurementMethod methodPartOn) {
+        this.methodPartOn = methodPartOn;
+    }
+
+    public int getPartOnDwellMilliseconds() {
+        return partOnDwellMilliseconds;
+    }
+
+    public void setPartOnDwellMilliseconds(int partOnDwellMilliseconds) {
+        this.partOnDwellMilliseconds = partOnDwellMilliseconds;
+    }
+
     public double getVacuumLevelPartOnLow() {
         return vacuumLevelPartOnLow;
     }
@@ -218,6 +311,54 @@ public class ReferenceNozzleTip extends AbstractNozzleTip {
         this.vacuumLevelPartOnHigh = vacuumLevelPartOnHigh;
     }
 
+    public int getPartOnTrendMilliseconds() {
+        return partOnTrendMilliseconds;
+    }
+
+    public void setPartOnTrendMilliseconds(int partOnTrendMilliseconds) {
+        this.partOnTrendMilliseconds = partOnTrendMilliseconds;
+    }
+
+    public double getVacuumTrendPartOnLow() {
+        return vacuumTrendPartOnLow;
+    }
+
+    public void setVacuumTrendPartOnLow(double vacuumTrendPartOnLow) {
+        this.vacuumTrendPartOnLow = vacuumTrendPartOnLow;
+    }
+
+    public double getVacuumTrendPartOnHigh() {
+        return vacuumTrendPartOnHigh;
+    }
+
+    public void setVacuumTrendPartOnHigh(double vacuumTrendPartOnHigh) {
+        this.vacuumTrendPartOnHigh = vacuumTrendPartOnHigh;
+    }
+
+    public VacuumMeasurementMethod getMethodPartOff() {
+        return methodPartOff;
+    }
+
+    public void setMethodPartOff(VacuumMeasurementMethod methodPartOff) {
+        this.methodPartOff = methodPartOff;
+    }
+
+    public boolean isValveEnabledForPartOff() {
+        return valveEnabledForPartOff;
+    }
+
+    public void setValveEnabledForPartOff(boolean valveEnabledForPartOff) {
+        this.valveEnabledForPartOff = valveEnabledForPartOff;
+    }
+
+    public int getPartOffDwellMilliseconds() {
+        return partOffDwellMilliseconds;
+    }
+
+    public void setPartOffDwellMilliseconds(int partOffDwellMilliseconds) {
+        this.partOffDwellMilliseconds = partOffDwellMilliseconds;
+    }
+
     public double getVacuumLevelPartOffLow() {
         return vacuumLevelPartOffLow;
     }
@@ -232,6 +373,78 @@ public class ReferenceNozzleTip extends AbstractNozzleTip {
 
     public void setVacuumLevelPartOffHigh(double vacuumLevelPartOffHigh) {
         this.vacuumLevelPartOffHigh = vacuumLevelPartOffHigh;
+    }
+
+    public int getPartOffTrendMilliseconds() {
+        return partOffTrendMilliseconds;
+    }
+
+    public void setPartOffTrendMilliseconds(int partOffTrendMilliseconds) {
+        this.partOffTrendMilliseconds = partOffTrendMilliseconds;
+    }
+
+    public double getVacuumTrendPartOffLow() {
+        return vacuumTrendPartOffLow;
+    }
+
+    public void setVacuumTrendPartOffLow(double vacuumTrendPartOffLow) {
+        this.vacuumTrendPartOffLow = vacuumTrendPartOffLow;
+    }
+
+    public double getVacuumTrendPartOffHigh() {
+        return vacuumTrendPartOffHigh;
+    }
+
+    public void setVacuumTrendPartOffHigh(double vacuumTrendPartOffHigh) {
+        this.vacuumTrendPartOffHigh = vacuumTrendPartOffHigh;
+    }
+
+    public Double getVacuumLevelPartOnReading() {
+        return vacuumLevelPartOnReading;
+    }
+
+    public void setVacuumLevelPartOnReading(Double vacuumLevelPartOnReading) {
+        Object oldValue = vacuumLevelPartOnReading;
+        this.vacuumLevelPartOnReading = vacuumLevelPartOnReading;
+        if (!(oldValue == null && vacuumLevelPartOnReading == null)) { // only fire when values are set
+            firePropertyChange("vacuumLevelPartOnReading", oldValue, vacuumLevelPartOnReading);
+        }
+    }
+
+    public Double getVacuumTrendPartOnReading() {
+        return vacuumTrendPartOnReading;
+    }
+
+    public void setVacuumTrendPartOnReading(Double vacuumTrendPartOnReading) {
+        Object oldValue = vacuumLevelPartOnReading;
+        this.vacuumTrendPartOnReading = vacuumTrendPartOnReading;
+        if (!(oldValue == null && vacuumTrendPartOnReading == null)) { // only fire when values are set
+            firePropertyChange("vacuumTrendPartOnReading", oldValue, vacuumTrendPartOnReading);
+        }
+    }
+
+    public Double getVacuumLevelPartOffReading() {
+        return vacuumLevelPartOffReading;
+    }
+
+    public void setVacuumLevelPartOffReading(Double vacuumLevelPartOffReading) {
+        Object oldValue = vacuumLevelPartOnReading;
+        this.vacuumLevelPartOffReading = vacuumLevelPartOffReading;
+        if (!(oldValue == null && vacuumLevelPartOffReading == null)) { // only fire when values are set
+            firePropertyChange("vacuumLevelPartOffReading", oldValue, vacuumLevelPartOffReading);
+        }
+    }
+
+    public Double getVacuumTrendPartOffReading() {
+        return vacuumTrendPartOffReading;
+    }
+
+    public void setVacuumTrendPartOffReading(Double vacuumTrendPartOffReading) {
+        Object oldValue = vacuumLevelPartOnReading;
+        this.vacuumTrendPartOffReading = vacuumTrendPartOffReading;
+        if (!(oldValue == null && vacuumTrendPartOffReading == null)) { // only fire when values are set
+            firePropertyChange("vacuumTrendPartOffReading", oldValue, vacuumTrendPartOffReading);
+        }
     }
 
     @Override

--- a/src/main/java/org/openpnp/machine/reference/ReferencePnpJobProcessor.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferencePnpJobProcessor.java
@@ -642,6 +642,23 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
             throw new JobProcessorException(feeder, lastException);
         }
         
+        private void checkPartOff(Nozzle nozzle, Part part) throws JobProcessorException {
+            if (!nozzle.isPartOffEnabled(Nozzle.PartOffStep.BeforePick)) {
+                return;
+            }
+            try {
+                if (!nozzle.isPartOff()) {
+                    throw new JobProcessorException(nozzle, "Part detected on nozzle before pick.");
+                }
+            }
+            catch (JobProcessorException e) {
+                throw e;
+            }
+            catch (Exception e) {
+                throw new JobProcessorException(nozzle, e);
+            }
+        }
+        
         private void pick(Nozzle nozzle, Feeder feeder, Placement placement, Part part) throws JobProcessorException {
             try {
                 fireTextStatus("Pick %s from %s for %s.", part.getId(), feeder.getName(),
@@ -650,6 +667,8 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
                 // Move to pick location.
                 MovableUtils.moveToLocationAtSafeZ(nozzle, feeder.getPickLocation());
 
+                // Last chance to check if any previously picked part is off
+                checkPartOff(nozzle, part);
 
                 // Pick
                 nozzle.pick(part);
@@ -672,7 +691,7 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
         }
         
         private void checkPartOn(Nozzle nozzle) throws JobProcessorException {
-            if (!nozzle.isPartOnEnabled()) {
+            if (!nozzle.isPartOnEnabled(Nozzle.PartOnStep.AfterPick)) {
                 return;
             }
             try {
@@ -747,7 +766,7 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
         }
         
         private void checkPartOn(Nozzle nozzle) throws JobProcessorException {
-            if (!nozzle.isPartOnEnabled()) {
+            if (!nozzle.isPartOnEnabled(Nozzle.PartOnStep.Align)) {
                 return;
             }
             try {
@@ -823,7 +842,7 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
         }
         
         private void checkPartOn(Nozzle nozzle) throws JobProcessorException {
-            if (!nozzle.isPartOnEnabled()) {
+            if (!nozzle.isPartOnEnabled(Nozzle.PartOnStep.BeforePlace)) {
                 return;
             }
             try {
@@ -840,7 +859,7 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
         }
         
         private void checkPartOff(Nozzle nozzle, Part part) throws JobProcessorException {
-            if (!nozzle.isPartOffEnabled()) {
+            if (!nozzle.isPartOffEnabled(Nozzle.PartOffStep.AfterPlace)) {
                 return;
             }
             try {

--- a/src/main/java/org/openpnp/machine/reference/ReferencePnpJobProcessor.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferencePnpJobProcessor.java
@@ -586,7 +586,13 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
             }
 
             feed(feeder, nozzle);
-            
+
+            // TODO: move over the pick location first to let more time pass? 
+            // What happens if feeders already position the nozzle in feed()? 
+            // (there are several, e.g. drag, lever, push-pull, blinds feeder with push cover)
+            // it did not work in my tests, as the previous check already built up some underpressure
+            checkPartOff(nozzle, part);
+
             pick(nozzle, feeder, placement, part);
 
             /** 
@@ -666,9 +672,6 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
                 
                 // Move to pick location.
                 MovableUtils.moveToLocationAtSafeZ(nozzle, feeder.getPickLocation());
-
-                // Last chance to check if any previously picked part is off
-                checkPartOff(nozzle, part);
 
                 // Pick
                 nozzle.pick(part);

--- a/src/main/java/org/openpnp/machine/reference/wizards/ReferenceNozzleTipPartDetectionWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/wizards/ReferenceNozzleTipPartDetectionWizard.java
@@ -422,9 +422,9 @@ public class ReferenceNozzleTipPartDetectionWizard extends AbstractConfiguration
         vacuumLevelPartOffLow.setVisible(partOff);
         vacuumLevelPartOffHigh.setVisible(partOff);
         vacuumLevelPartOffReading.setVisible(partOff);
+        lblProbingTimePartOff.setVisible(partOff);
+        partOffProbingMilliseconds.setVisible(partOff);
         
-        lblProbingTimePartOff.setVisible(partOffDifference);
-        partOffProbingMilliseconds.setVisible(partOffDifference);
         lblPartOffDifferenceRange.setVisible(partOffDifference);
         vacuumDifferencePartOffLow.setVisible(partOffDifference);
         vacuumDifferencePartOffHigh.setVisible(partOffDifference);

--- a/src/main/java/org/openpnp/machine/reference/wizards/ReferenceNozzleTipPartDetectionWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/wizards/ReferenceNozzleTipPartDetectionWizard.java
@@ -20,6 +20,7 @@
 package org.openpnp.machine.reference.wizards;
 
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 
 import javax.swing.JLabel;
@@ -28,6 +29,7 @@ import javax.swing.JTextField;
 import javax.swing.border.TitledBorder;
 
 import org.openpnp.gui.components.ComponentDecorators;
+import org.openpnp.gui.components.SimpleGraphView;
 import org.openpnp.gui.support.AbstractConfigurationWizard;
 import org.openpnp.gui.support.DoubleConverter;
 import org.openpnp.gui.support.IntegerConverter;
@@ -41,10 +43,16 @@ import com.jgoodies.forms.layout.FormLayout;
 import com.jgoodies.forms.layout.FormSpecs;
 import com.jgoodies.forms.layout.RowSpec;
 import javax.swing.JComboBox;
+import javax.swing.JComponent;
 import javax.swing.JCheckBox;
 import java.awt.BorderLayout;
 import javax.swing.UIManager;
 import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.GradientPaint;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.RenderingHints;
 import java.beans.PropertyChangeListener;
 import java.beans.PropertyChangeEvent;
 
@@ -73,6 +81,10 @@ public class ReferenceNozzleTipPartDetectionWizard extends AbstractConfiguration
                 FormSpecs.RELATED_GAP_COLSPEC,
                 FormSpecs.DEFAULT_COLSPEC,},
             new RowSpec[] {
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
                 FormSpecs.RELATED_GAP_ROWSPEC,
                 FormSpecs.DEFAULT_ROWSPEC,
                 FormSpecs.RELATED_GAP_ROWSPEC,
@@ -154,10 +166,13 @@ public class ReferenceNozzleTipPartDetectionWizard extends AbstractConfiguration
         panelPartOnVacuumSensing.add(vacuumTrendPartOnReading, "10, 12, fill, default");
         vacuumTrendPartOnReading.setColumns(10);
         
-        panelPartOffVacuumSettings = new JPanel();
-        panelPartOffVacuumSettings.setBorder(new TitledBorder(UIManager.getBorder("TitledBorder.border"), "Part Off Vacuum Sensing", TitledBorder.LEADING, TitledBorder.TOP, null, new Color(0, 0, 0)));
-        contentPanel.add(panelPartOffVacuumSettings);
-        panelPartOffVacuumSettings.setLayout(new FormLayout(new ColumnSpec[] {
+        vacuumPartOnGraph = new SimpleGraphView(nozzleTip);
+        panelPartOnVacuumSensing.add(vacuumPartOnGraph, "4, 16, 7, 1");
+        
+        panelPartOffVacuumSensing = new JPanel();
+        panelPartOffVacuumSensing.setBorder(new TitledBorder(UIManager.getBorder("TitledBorder.border"), "Part Off Vacuum Sensing", TitledBorder.LEADING, TitledBorder.TOP, null, new Color(0, 0, 0)));
+        contentPanel.add(panelPartOffVacuumSensing);
+        panelPartOffVacuumSensing.setLayout(new FormLayout(new ColumnSpec[] {
                 FormSpecs.RELATED_GAP_COLSPEC,
                 FormSpecs.DEFAULT_COLSPEC,
                 FormSpecs.RELATED_GAP_COLSPEC,
@@ -182,10 +197,14 @@ public class ReferenceNozzleTipPartDetectionWizard extends AbstractConfiguration
                 FormSpecs.RELATED_GAP_ROWSPEC,
                 FormSpecs.DEFAULT_ROWSPEC,
                 FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
                 FormSpecs.DEFAULT_ROWSPEC,}));
         
         lblPartOffMeasurement = new JLabel("Measurement Method");
-        panelPartOffVacuumSettings.add(lblPartOffMeasurement, "2, 2");
+        panelPartOffVacuumSensing.add(lblPartOffMeasurement, "2, 2");
         
         methodPartOff = new JComboBox(ReferenceNozzleTip.VacuumMeasurementMethod.values());
         methodPartOff.addPropertyChangeListener(new PropertyChangeListener() {
@@ -193,71 +212,74 @@ public class ReferenceNozzleTipPartDetectionWizard extends AbstractConfiguration
                 adaptDialog();
             }
         });
-        panelPartOffVacuumSettings.add(methodPartOff, "4, 2, 3, 1");
+        panelPartOffVacuumSensing.add(methodPartOff, "4, 2, 3, 1");
         
         lblValveEnabled = new JLabel("Enable Valve for Test?");
-        panelPartOffVacuumSettings.add(lblValveEnabled, "2, 4");
+        panelPartOffVacuumSensing.add(lblValveEnabled, "2, 4");
         lblValveEnabled.setToolTipText("");
         
         valveEnabledForPartOff = new JCheckBox("");
-        panelPartOffVacuumSettings.add(valveEnabledForPartOff, "4, 4");
+        panelPartOffVacuumSensing.add(valveEnabledForPartOff, "4, 4");
         
         lblPartOffLowValue = new JLabel("Low Value");
-        panelPartOffVacuumSettings.add(lblPartOffLowValue, "4, 6");
+        panelPartOffVacuumSensing.add(lblPartOffLowValue, "4, 6");
         
         lblPartOffHighValue = new JLabel("High Value");
-        panelPartOffVacuumSettings.add(lblPartOffHighValue, "6, 6");
+        panelPartOffVacuumSensing.add(lblPartOffHighValue, "6, 6");
         
         lblPartOffLastReading = new JLabel("Last Reading");
-        panelPartOffVacuumSettings.add(lblPartOffLastReading, "10, 6");
+        panelPartOffVacuumSensing.add(lblPartOffLastReading, "10, 6");
         
         lblPartOffDwell = new JLabel("Dwell Time (ms)");
         lblPartOffDwell.setToolTipText("<html>\r\n<p>For the absolute measurement method, this is an extra dwell time after placing, <br />\r\nraising the nozzle to Safe Z and optionally opening the valve.</p>\r\n<p>\r\nFor relative trend measurements methods, this is a dwell time after closing the valve<br />\r\nbefore taking the reference reading for the trend. This happens before any place \r\ndwell times. </p>\r\n</html>\r\n");
-        panelPartOffVacuumSettings.add(lblPartOffDwell, "2, 8, right, default");
+        panelPartOffVacuumSensing.add(lblPartOffDwell, "2, 8, right, default");
         
         partOffDwellMilliseconds = new JTextField();
         partOffDwellMilliseconds.setToolTipText("<html>\r\n<p>For the absolute measurement method, this is an extra dwell time after placing, <br />\r\nraising the nozzle to Safe Z and optionally opening the valve.</p>\r\n<p>\r\nFor relative trend measurements methods, this is a dwell time after closing the valve<br />\r\nbefore taking the reference reading for the trend. This happens before any place \r\ndwell times. </p>\r\n</html>\r\n");
-        panelPartOffVacuumSettings.add(partOffDwellMilliseconds, "4, 8");
+        panelPartOffVacuumSensing.add(partOffDwellMilliseconds, "4, 8");
         partOffDwellMilliseconds.setColumns(10);
         
         lblPartOffNozzle = new JLabel("Vacuum Range");
-        panelPartOffVacuumSettings.add(lblPartOffNozzle, "2, 10, right, default");
+        panelPartOffVacuumSensing.add(lblPartOffNozzle, "2, 10, right, default");
         
         vacuumLevelPartOffLow = new JTextField();
-        panelPartOffVacuumSettings.add(vacuumLevelPartOffLow, "4, 10");
+        panelPartOffVacuumSensing.add(vacuumLevelPartOffLow, "4, 10");
         vacuumLevelPartOffLow.setColumns(10);
         
         vacuumLevelPartOffHigh = new JTextField();
-        panelPartOffVacuumSettings.add(vacuumLevelPartOffHigh, "6, 10");
+        panelPartOffVacuumSensing.add(vacuumLevelPartOffHigh, "6, 10");
         vacuumLevelPartOffHigh.setColumns(10);
         
         vacuumLevelPartOffReading = new JTextField();
         vacuumLevelPartOffReading.setEditable(false);
-        panelPartOffVacuumSettings.add(vacuumLevelPartOffReading, "10, 10, fill, default");
+        panelPartOffVacuumSensing.add(vacuumLevelPartOffReading, "10, 10, fill, default");
         vacuumLevelPartOffReading.setColumns(10);
         
         lblTrendTimePartOff = new JLabel("Trend time (ms)");
-        panelPartOffVacuumSettings.add(lblTrendTimePartOff, "2, 12, right, default");
+        panelPartOffVacuumSensing.add(lblTrendTimePartOff, "2, 12, right, default");
         
         partOffTrendMilliseconds = new JTextField();
-        panelPartOffVacuumSettings.add(partOffTrendMilliseconds, "4, 12, default, center");
+        panelPartOffVacuumSensing.add(partOffTrendMilliseconds, "4, 12, default, center");
         partOffTrendMilliseconds.setColumns(10);
         
         lblPartOffTrendRange = new JLabel("Trend Range");
-        panelPartOffVacuumSettings.add(lblPartOffTrendRange, "2, 14, right, default");
+        panelPartOffVacuumSensing.add(lblPartOffTrendRange, "2, 14, right, default");
         
         vacuumTrendPartOffLow = new JTextField();
-        panelPartOffVacuumSettings.add(vacuumTrendPartOffLow, "4, 14, fill, default");
+        panelPartOffVacuumSensing.add(vacuumTrendPartOffLow, "4, 14, fill, default");
         vacuumTrendPartOffLow.setColumns(10);
         
         vacuumTrendPartOffHigh = new JTextField();
-        panelPartOffVacuumSettings.add(vacuumTrendPartOffHigh, "6, 14, fill, default");
+        panelPartOffVacuumSensing.add(vacuumTrendPartOffHigh, "6, 14, fill, default");
         vacuumTrendPartOffHigh.setColumns(10);
         
         vacuumTrendPartOffReading = new JTextField();
         vacuumTrendPartOffReading.setEditable(false);
-        panelPartOffVacuumSettings.add(vacuumTrendPartOffReading, "10, 14, fill, default");
+        panelPartOffVacuumSensing.add(vacuumTrendPartOffReading, "10, 14, fill, default");
         vacuumTrendPartOffReading.setColumns(10);
+        
+        vacuumPartOffGraph = new SimpleGraphView(nozzleTip);
+        panelPartOffVacuumSensing.add(vacuumPartOffGraph, "4, 18, 7, 1");
     }
     
     private JLabel lblPartOnLowValue;
@@ -276,7 +298,7 @@ public class ReferenceNozzleTipPartDetectionWizard extends AbstractConfiguration
     private JTextField partOffDwellMilliseconds;
     private JCheckBox valveEnabledForPartOff;
     private JLabel lblValveEnabled;
-    private JPanel panelPartOffVacuumSettings;
+    private JPanel panelPartOffVacuumSensing;
     private JLabel lblTrendTimePartOff;
     private JTextField partOffTrendMilliseconds;
     private JLabel lblPartOffTrendRange;
@@ -297,6 +319,8 @@ public class ReferenceNozzleTipPartDetectionWizard extends AbstractConfiguration
     private JTextField vacuumTrendPartOnReading;
     private JTextField vacuumLevelPartOffReading;
     private JTextField vacuumTrendPartOffReading;
+    private SimpleGraphView vacuumPartOnGraph;
+    private SimpleGraphView vacuumPartOffGraph;
     
     private void adaptDialog() {
         VacuumMeasurementMethod methodOn = (VacuumMeasurementMethod)methodPartOn.getSelectedItem();
@@ -386,6 +410,9 @@ public class ReferenceNozzleTipPartDetectionWizard extends AbstractConfiguration
         addWrappedBinding(nozzleTip, "vacuumTrendPartOffLow", vacuumTrendPartOffLow, "text", doubleConverter);
         addWrappedBinding(nozzleTip, "vacuumTrendPartOffHigh", vacuumTrendPartOffHigh, "text", doubleConverter);
         addWrappedBinding(nozzleTip, "vacuumTrendPartOffReading", vacuumTrendPartOffReading, "text", doubleConverter);
+        
+        addWrappedBinding(nozzleTip, "vacuumPartOnGraph", vacuumPartOnGraph, "graph");
+        addWrappedBinding(nozzleTip, "vacuumPartOffGraph", vacuumPartOffGraph, "graph");
 
         ComponentDecorators.decorateWithAutoSelect(partOnDwellMilliseconds);
         ComponentDecorators.decorateWithAutoSelect(partOnTrendMilliseconds);

--- a/src/main/java/org/openpnp/machine/reference/wizards/ReferenceNozzleTipPartDetectionWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/wizards/ReferenceNozzleTipPartDetectionWizard.java
@@ -100,6 +100,8 @@ public class ReferenceNozzleTipPartDetectionWizard extends AbstractConfiguration
                 FormSpecs.RELATED_GAP_ROWSPEC,
                 FormSpecs.DEFAULT_ROWSPEC,
                 FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
                 RowSpec.decode("default:grow"),}));
         
         lblPartOnMeasurement = new JLabel("Measurement Method");
@@ -113,8 +115,8 @@ public class ReferenceNozzleTipPartDetectionWizard extends AbstractConfiguration
         });
         panelPartOnVacuumSensing.add(methodPartOn, "4, 2, 3, 1");
         
-        lblEstablishPartOnLevel = new JLabel("Establish Level");
-        lblEstablishPartOnLevel.setToolTipText("While the nozzle is pressed down on the part in the pick operation, the vacuum level is repeatedly measured until it reaches the Vacuum Range. ");
+        lblEstablishPartOnLevel = new JLabel("Establish Level?");
+        lblEstablishPartOnLevel.setToolTipText("<html>While the nozzle is pressed down on the part in the pick operation,<br/>\r\nthe vacuum level is repeatedly measured until it builds up to the Vacuum Range <br/>\r\nor the Pick Dwell Time timeout expires, whichever comes first.\r\n</html>");
         panelPartOnVacuumSensing.add(lblEstablishPartOnLevel, "2, 4, right, default");
         
         establishPartOnLevel = new JCheckBox("");
@@ -125,53 +127,65 @@ public class ReferenceNozzleTipPartDetectionWizard extends AbstractConfiguration
         });
         panelPartOnVacuumSensing.add(establishPartOnLevel, "4, 4");
         
+        lblPerformPartOnChecks = new JLabel("Perform Checks?");
+        panelPartOnVacuumSensing.add(lblPerformPartOnChecks, "2, 6, right, default");
+        
+        partOnCheckAfterPick = new JCheckBox("After Pick");
+        panelPartOnVacuumSensing.add(partOnCheckAfterPick, "4, 6");
+        
+        partOnCheckAlign = new JCheckBox("Alignment");
+        panelPartOnVacuumSensing.add(partOnCheckAlign, "6, 6");
+        
+        partOnCheckBeforePlace = new JCheckBox("Before Place");
+        panelPartOnVacuumSensing.add(partOnCheckBeforePlace, "10, 6");
+        
         lblPartOnLowValue = new JLabel("Low Value");
-        panelPartOnVacuumSensing.add(lblPartOnLowValue, "4, 6");
+        panelPartOnVacuumSensing.add(lblPartOnLowValue, "4, 8");
         
         lblPartOnHighValue = new JLabel("High Value");
-        panelPartOnVacuumSensing.add(lblPartOnHighValue, "6, 6");
+        panelPartOnVacuumSensing.add(lblPartOnHighValue, "6, 8");
         
         lblPartOnLastReading = new JLabel("Last Reading");
-        panelPartOnVacuumSensing.add(lblPartOnLastReading, "10, 6");
+        panelPartOnVacuumSensing.add(lblPartOnLastReading, "10, 8");
         
         lblPartOnNozzle = new JLabel("Vacuum Range");
-        panelPartOnVacuumSensing.add(lblPartOnNozzle, "2, 8, right, default");
+        panelPartOnVacuumSensing.add(lblPartOnNozzle, "2, 10, right, default");
         
         vacuumLevelPartOnLow = new JTextField();
-        panelPartOnVacuumSensing.add(vacuumLevelPartOnLow, "4, 8");
+        panelPartOnVacuumSensing.add(vacuumLevelPartOnLow, "4, 10");
         vacuumLevelPartOnLow.setColumns(10);
         
         vacuumLevelPartOnHigh = new JTextField();
-        panelPartOnVacuumSensing.add(vacuumLevelPartOnHigh, "6, 8");
+        panelPartOnVacuumSensing.add(vacuumLevelPartOnHigh, "6, 10");
         vacuumLevelPartOnHigh.setColumns(10);
         
         vacuumLevelPartOnReading = new JTextField();
         vacuumLevelPartOnReading.setEditable(false);
-        panelPartOnVacuumSensing.add(vacuumLevelPartOnReading, "10, 8, right, top");
+        panelPartOnVacuumSensing.add(vacuumLevelPartOnReading, "10, 10, fill, top");
         vacuumLevelPartOnReading.setColumns(10);
         
         lblPartOnDifferenceRange = new JLabel("Difference Range");
-        panelPartOnVacuumSensing.add(lblPartOnDifferenceRange, "2, 10, right, default");
+        panelPartOnVacuumSensing.add(lblPartOnDifferenceRange, "2, 12, right, default");
         
         vacuumDifferencePartOnLow = new JTextField();
         vacuumDifferencePartOnLow.setColumns(10);
-        panelPartOnVacuumSensing.add(vacuumDifferencePartOnLow, "4, 10, fill, default");
+        panelPartOnVacuumSensing.add(vacuumDifferencePartOnLow, "4, 12, fill, default");
         
         vacuumDifferencePartOnHigh = new JTextField();
-        panelPartOnVacuumSensing.add(vacuumDifferencePartOnHigh, "6, 10, fill, default");
+        panelPartOnVacuumSensing.add(vacuumDifferencePartOnHigh, "6, 12, fill, default");
         vacuumDifferencePartOnHigh.setColumns(10);
         
         vacuumDifferencePartOnReading = new JTextField();
         vacuumDifferencePartOnReading.setEditable(false);
-        panelPartOnVacuumSensing.add(vacuumDifferencePartOnReading, "10, 10, fill, default");
+        panelPartOnVacuumSensing.add(vacuumDifferencePartOnReading, "10, 12, fill, default");
         vacuumDifferencePartOnReading.setColumns(10);
         
         lblLegendPartOn = new JLabel("<html>\r\n<p style=\"text-align:right\">Vacuum <span style=\"color:#FF0000\">&mdash;&mdash;</span></p>\r\n<p/>\r\n<p style=\"text-align:right\">Valve <span style=\"color:#005BD9\">&mdash;&mdash;</span></p>\r\n</html>");
-        panelPartOnVacuumSensing.add(lblLegendPartOn, "2, 14, right, default");
+        panelPartOnVacuumSensing.add(lblLegendPartOn, "2, 16, right, default");
         
         vacuumPartOnGraph = new SimpleGraphView();
         vacuumPartOnGraph.setFont(new Font("SansSerif", Font.PLAIN, 9));
-        panelPartOnVacuumSensing.add(vacuumPartOnGraph, "4, 14, 9, 1, default, fill");
+        panelPartOnVacuumSensing.add(vacuumPartOnGraph, "4, 16, 9, 1, default, fill");
         
         panelPartOffVacuumSensing = new JPanel();
         panelPartOffVacuumSensing.setBorder(new TitledBorder(UIManager.getBorder("TitledBorder.border"), "Part Off Vacuum Sensing", TitledBorder.LEADING, TitledBorder.TOP, null, new Color(0, 0, 0)));
@@ -207,6 +221,8 @@ public class ReferenceNozzleTipPartDetectionWizard extends AbstractConfiguration
                 FormSpecs.RELATED_GAP_ROWSPEC,
                 FormSpecs.DEFAULT_ROWSPEC,
                 FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
                 RowSpec.decode("default:grow"),}));
         
         lblPartOffMeasurement = new JLabel("Measurement Method");
@@ -220,8 +236,8 @@ public class ReferenceNozzleTipPartDetectionWizard extends AbstractConfiguration
         });
         panelPartOffVacuumSensing.add(methodPartOff, "4, 2, 3, 1");
         
-        lblEstablishPartOffLevel = new JLabel("Establish Level");
-        lblEstablishPartOffLevel.setToolTipText("While the nozzle is pressed down on the part in the pick operation, the vacuum level is repeatedly measured until it reaches the Vacuum Range or the timeout is reached.");
+        lblEstablishPartOffLevel = new JLabel("Establish Level?");
+        lblEstablishPartOffLevel.setToolTipText("<html>While the nozzle is pressed down on the part in the place operation,<br/>\r\nthe vacuum level is repeatedly measured until it decays to the Vacuum Range <br/>\r\nor the Place Dwell Time timeout expires, whichever comes first.\r\n</html>");
         panelPartOffVacuumSensing.add(lblEstablishPartOffLevel, "2, 4, right, default");
         
         establishPartOffLevel = new JCheckBox("");
@@ -232,60 +248,69 @@ public class ReferenceNozzleTipPartDetectionWizard extends AbstractConfiguration
         });
         panelPartOffVacuumSensing.add(establishPartOffLevel, "4, 4");
         
+        lblPerformPartOffChecks = new JLabel("Perform Checks?");
+        panelPartOffVacuumSensing.add(lblPerformPartOffChecks, "2, 6, right, default");
+        
+        partOffCheckAfterPlace = new JCheckBox("After Place");
+        panelPartOffVacuumSensing.add(partOffCheckAfterPlace, "4, 6");
+        
+        partOffCheckBeforePick = new JCheckBox("Before Pick");
+        panelPartOffVacuumSensing.add(partOffCheckBeforePick, "6, 6");
+        
         lblPartOffLowValue = new JLabel("Low Value");
-        panelPartOffVacuumSensing.add(lblPartOffLowValue, "4, 6");
+        panelPartOffVacuumSensing.add(lblPartOffLowValue, "4, 8");
         
         lblPartOffHighValue = new JLabel("High Value");
-        panelPartOffVacuumSensing.add(lblPartOffHighValue, "6, 6");
+        panelPartOffVacuumSensing.add(lblPartOffHighValue, "6, 8");
         
         lblPartOffLastReading = new JLabel("Last Reading");
-        panelPartOffVacuumSensing.add(lblPartOffLastReading, "10, 6");
+        panelPartOffVacuumSensing.add(lblPartOffLastReading, "10, 8");
         
         lblPartOffNozzle = new JLabel("Vacuum Range");
-        panelPartOffVacuumSensing.add(lblPartOffNozzle, "2, 8, right, default");
+        panelPartOffVacuumSensing.add(lblPartOffNozzle, "2, 10, right, default");
         
         vacuumLevelPartOffLow = new JTextField();
-        panelPartOffVacuumSensing.add(vacuumLevelPartOffLow, "4, 8");
+        panelPartOffVacuumSensing.add(vacuumLevelPartOffLow, "4, 10");
         vacuumLevelPartOffLow.setColumns(10);
         
         vacuumLevelPartOffHigh = new JTextField();
-        panelPartOffVacuumSensing.add(vacuumLevelPartOffHigh, "6, 8");
+        panelPartOffVacuumSensing.add(vacuumLevelPartOffHigh, "6, 10");
         vacuumLevelPartOffHigh.setColumns(10);
         
         vacuumLevelPartOffReading = new JTextField();
         vacuumLevelPartOffReading.setEditable(false);
-        panelPartOffVacuumSensing.add(vacuumLevelPartOffReading, "10, 8, fill, default");
+        panelPartOffVacuumSensing.add(vacuumLevelPartOffReading, "10, 10, fill, default");
         vacuumLevelPartOffReading.setColumns(10);
         
         lblProbingTimePartOff = new JLabel("Probing time (ms)");
-        panelPartOffVacuumSensing.add(lblProbingTimePartOff, "2, 10, right, default");
+        panelPartOffVacuumSensing.add(lblProbingTimePartOff, "2, 12, right, default");
         
         partOffProbingMilliseconds = new JTextField();
-        panelPartOffVacuumSensing.add(partOffProbingMilliseconds, "4, 10, default, center");
+        panelPartOffVacuumSensing.add(partOffProbingMilliseconds, "4, 12, default, center");
         partOffProbingMilliseconds.setColumns(10);
         
         lblPartOffDifferenceRange = new JLabel("Difference Range");
-        panelPartOffVacuumSensing.add(lblPartOffDifferenceRange, "2, 12, right, default");
+        panelPartOffVacuumSensing.add(lblPartOffDifferenceRange, "2, 14, right, default");
         
         vacuumDifferencePartOffLow = new JTextField();
-        panelPartOffVacuumSensing.add(vacuumDifferencePartOffLow, "4, 12, fill, default");
+        panelPartOffVacuumSensing.add(vacuumDifferencePartOffLow, "4, 14, fill, default");
         vacuumDifferencePartOffLow.setColumns(10);
         
         vacuumDifferencePartOffHigh = new JTextField();
-        panelPartOffVacuumSensing.add(vacuumDifferencePartOffHigh, "6, 12, fill, default");
+        panelPartOffVacuumSensing.add(vacuumDifferencePartOffHigh, "6, 14, fill, default");
         vacuumDifferencePartOffHigh.setColumns(10);
         
         vacuumDifferencePartOffReading = new JTextField();
         vacuumDifferencePartOffReading.setEditable(false);
-        panelPartOffVacuumSensing.add(vacuumDifferencePartOffReading, "10, 12, fill, default");
+        panelPartOffVacuumSensing.add(vacuumDifferencePartOffReading, "10, 14, fill, default");
         vacuumDifferencePartOffReading.setColumns(10);
         
         lblLegendPartOff = new JLabel("<html>\r\n<p style=\"text-align:right\">Vacuum <span style=\"color:#FF0000\">&mdash;&mdash;</span></p>\r\n<p/>\r\n<p style=\"text-align:right\">Valve <span style=\"color:#005BD9\">&mdash;&mdash;</span></p>\r\n</html>");
-        panelPartOffVacuumSensing.add(lblLegendPartOff, "2, 16, right, default");
+        panelPartOffVacuumSensing.add(lblLegendPartOff, "2, 18, right, default");
         
         vacuumPartOffGraph = new SimpleGraphView();
         vacuumPartOffGraph.setFont(new Font("SansSerif", Font.PLAIN, 9));
-        panelPartOffVacuumSensing.add(vacuumPartOffGraph, "4, 16, 9, 1, default, fill");
+        panelPartOffVacuumSensing.add(vacuumPartOffGraph, "4, 18, 9, 1, default, fill");
     }
     
     private JLabel lblPartOnLowValue;
@@ -325,6 +350,13 @@ public class ReferenceNozzleTipPartDetectionWizard extends AbstractConfiguration
     private JCheckBox establishPartOffLevel;
     private JLabel lblLegendPartOn;
     private JLabel lblLegendPartOff;
+    private JLabel lblPerformPartOnChecks;
+    private JCheckBox partOnCheckAfterPick;
+    private JCheckBox partOnCheckAlign;
+    private JCheckBox partOnCheckBeforePlace;
+    private JLabel lblPerformPartOffChecks;
+    private JCheckBox partOffCheckAfterPlace;
+    private JCheckBox partOffCheckBeforePick;
     
     private void adaptDialog() {
         VacuumMeasurementMethod methodOn = (VacuumMeasurementMethod)methodPartOn.getSelectedItem();
@@ -344,6 +376,10 @@ public class ReferenceNozzleTipPartDetectionWizard extends AbstractConfiguration
          
         lblEstablishPartOnLevel.setVisible(partOn);
         establishPartOnLevel.setVisible(partOn);
+        lblPerformPartOnChecks.setVisible(partOn);
+        partOnCheckAfterPick.setVisible(partOn);
+        partOnCheckAlign.setVisible(partOn);
+        partOnCheckBeforePlace.setVisible(partOn);
         lblPartOnLowValue.setVisible(partOn);
         lblPartOnHighValue.setVisible(partOn);
         lblPartOnLastReading.setVisible(partOn);
@@ -376,6 +412,9 @@ public class ReferenceNozzleTipPartDetectionWizard extends AbstractConfiguration
          
         lblEstablishPartOffLevel.setVisible(partOff);
         establishPartOffLevel.setVisible(partOff);
+        lblPerformPartOffChecks.setVisible(partOff);
+        partOffCheckAfterPlace.setVisible(partOff);
+        partOffCheckBeforePick.setVisible(partOff);
         lblPartOffLowValue.setVisible(partOff);
         lblPartOffHighValue.setVisible(partOff);
         lblPartOffLastReading.setVisible(partOff);
@@ -401,6 +440,9 @@ public class ReferenceNozzleTipPartDetectionWizard extends AbstractConfiguration
 
         addWrappedBinding(nozzleTip, "methodPartOn", methodPartOn, "selectedItem");
         addWrappedBinding(nozzleTip, "establishPartOnLevel", establishPartOnLevel, "selected");
+        addWrappedBinding(nozzleTip, "partOnCheckAfterPick", partOnCheckAfterPick, "selected");
+        addWrappedBinding(nozzleTip, "partOnCheckAlign", partOnCheckAlign, "selected");
+        addWrappedBinding(nozzleTip, "partOnCheckBeforePlace", partOnCheckBeforePlace, "selected");
         addWrappedBinding(nozzleTip, "vacuumLevelPartOnLow", vacuumLevelPartOnLow, "text", doubleConverter);
         addWrappedBinding(nozzleTip, "vacuumLevelPartOnHigh", vacuumLevelPartOnHigh, "text", doubleConverter);
         addWrappedBinding(nozzleTip, "vacuumLevelPartOnReading", vacuumLevelPartOnReading, "text", doubleConverter);
@@ -410,6 +452,8 @@ public class ReferenceNozzleTipPartDetectionWizard extends AbstractConfiguration
 
         addWrappedBinding(nozzleTip, "methodPartOff", methodPartOff, "selectedItem");
         addWrappedBinding(nozzleTip, "establishPartOffLevel", establishPartOffLevel, "selected");
+        addWrappedBinding(nozzleTip, "partOffCheckAfterPlace", partOffCheckAfterPlace, "selected");
+        addWrappedBinding(nozzleTip, "partOffCheckBeforePick", partOffCheckBeforePick, "selected");
         addWrappedBinding(nozzleTip, "vacuumLevelPartOffLow", vacuumLevelPartOffLow, "text", doubleConverter);
         addWrappedBinding(nozzleTip, "vacuumLevelPartOffHigh", vacuumLevelPartOffHigh, "text", doubleConverter);
         addWrappedBinding(nozzleTip, "vacuumLevelPartOffReading", vacuumLevelPartOffReading, "text", doubleConverter);

--- a/src/main/java/org/openpnp/machine/reference/wizards/ReferenceNozzleTipPartDetectionWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/wizards/ReferenceNozzleTipPartDetectionWizard.java
@@ -94,8 +94,6 @@ public class ReferenceNozzleTipPartDetectionWizard extends AbstractConfiguration
                 FormSpecs.RELATED_GAP_ROWSPEC,
                 FormSpecs.DEFAULT_ROWSPEC,
                 FormSpecs.RELATED_GAP_ROWSPEC,
-                FormSpecs.DEFAULT_ROWSPEC,
-                FormSpecs.RELATED_GAP_ROWSPEC,
                 FormSpecs.DEFAULT_ROWSPEC,}));
         
         lblPartOnMeasurement = new JLabel("Measurement Method");
@@ -109,23 +107,21 @@ public class ReferenceNozzleTipPartDetectionWizard extends AbstractConfiguration
         });
         panelPartOnVacuumSensing.add(methodPartOn, "4, 2, 3, 1");
         
+        lblEstablishPartOnLevel = new JLabel("Establish Level");
+        lblEstablishPartOnLevel.setToolTipText("While the nozzle is pressed down on the part in the pick operation, the vacuum level is repeatedly measured until it reaches the Vacuum Range. ");
+        panelPartOnVacuumSensing.add(lblEstablishPartOnLevel, "2, 4, right, default");
+        
+        establishPartOnLevel = new JCheckBox("");
+        panelPartOnVacuumSensing.add(establishPartOnLevel, "4, 4");
+        
         lblPartOnLowValue = new JLabel("Low Value");
-        panelPartOnVacuumSensing.add(lblPartOnLowValue, "4, 4");
+        panelPartOnVacuumSensing.add(lblPartOnLowValue, "4, 6");
         
         lblPartOnHighValue = new JLabel("High Value");
-        panelPartOnVacuumSensing.add(lblPartOnHighValue, "6, 4");
+        panelPartOnVacuumSensing.add(lblPartOnHighValue, "6, 6");
         
         lblPartOnLastReading = new JLabel("Last Reading");
-        panelPartOnVacuumSensing.add(lblPartOnLastReading, "10, 4");
-        
-        lblPartOnDwell = new JLabel("Dwell Time (ms)");
-        lblPartOnDwell.setToolTipText("<html>\r\n<p>For the absolute measurement method, this is an extra dwell time after picking <br />\r\nand raising the nozzle to Safe Z.</p>\r\n<p>\r\nFor relative trend measurements methods, this is a dwell time after opening the valve<br />\r\nbefore taking the reference reading for the trend. This happens before any pick\r\ndwell times. </p>\r\n</html>\r\n");
-        panelPartOnVacuumSensing.add(lblPartOnDwell, "2, 6, right, default");
-        
-        partOnDwellMilliseconds = new JTextField();
-        partOnDwellMilliseconds.setToolTipText("<html>\r\n<p>For the absolute measurement method, this is an extra dwell time after picking <br />\r\nand raising the nozzle to Safe Z.</p>\r\n<p>\r\nFor relative trend measurements methods, this is a dwell time after opening the valve<br />\r\nbefore taking the reference reading for the trend. This happens before any pick\r\ndwell times. </p>\r\n</html>\r\n");
-        panelPartOnVacuumSensing.add(partOnDwellMilliseconds, "4, 6, fill, default");
-        partOnDwellMilliseconds.setColumns(10);
+        panelPartOnVacuumSensing.add(lblPartOnLastReading, "10, 6");
         
         lblPartOnNozzle = new JLabel("Vacuum Range");
         panelPartOnVacuumSensing.add(lblPartOnNozzle, "2, 8, right, default");
@@ -143,33 +139,27 @@ public class ReferenceNozzleTipPartDetectionWizard extends AbstractConfiguration
         panelPartOnVacuumSensing.add(vacuumLevelPartOnReading, "10, 8, right, top");
         vacuumLevelPartOnReading.setColumns(10);
         
-        lblTrendTimePartOn = new JLabel("Trend time (ms)");
-        panelPartOnVacuumSensing.add(lblTrendTimePartOn, "2, 10, right, default");
+        lblPartOnRelativeRange = new JLabel("Relative Range");
+        panelPartOnVacuumSensing.add(lblPartOnRelativeRange, "2, 10, right, default");
         
-        partOnTrendMilliseconds = new JTextField();
-        panelPartOnVacuumSensing.add(partOnTrendMilliseconds, "4, 10, fill, default");
-        partOnTrendMilliseconds.setColumns(10);
+        vacuumRelativePartOnLow = new JTextField();
+        vacuumRelativePartOnLow.setColumns(10);
+        panelPartOnVacuumSensing.add(vacuumRelativePartOnLow, "4, 10, fill, default");
         
-        lblPartOnTrendRange = new JLabel("Trend Range");
-        panelPartOnVacuumSensing.add(lblPartOnTrendRange, "2, 12, right, default");
+        vacuumRelativePartOnHigh = new JTextField();
+        panelPartOnVacuumSensing.add(vacuumRelativePartOnHigh, "6, 10, fill, default");
+        vacuumRelativePartOnHigh.setColumns(10);
         
-        vacuumTrendPartOnLow = new JTextField();
-        vacuumTrendPartOnLow.setColumns(10);
-        panelPartOnVacuumSensing.add(vacuumTrendPartOnLow, "4, 12, fill, default");
-        
-        vacuumTrendPartOnHigh = new JTextField();
-        panelPartOnVacuumSensing.add(vacuumTrendPartOnHigh, "6, 12, fill, default");
-        vacuumTrendPartOnHigh.setColumns(10);
-        
-        vacuumTrendPartOnReading = new JTextField();
-        vacuumTrendPartOnReading.setEditable(false);
-        panelPartOnVacuumSensing.add(vacuumTrendPartOnReading, "10, 12, fill, default");
-        vacuumTrendPartOnReading.setColumns(10);
+        vacuumRelativePartOnReading = new JTextField();
+        vacuumRelativePartOnReading.setEditable(false);
+        panelPartOnVacuumSensing.add(vacuumRelativePartOnReading, "10, 10, fill, default");
+        vacuumRelativePartOnReading.setColumns(10);
         
         vacuumPartOnGraph = new SimpleGraphView(nozzleTip);
-        panelPartOnVacuumSensing.add(vacuumPartOnGraph, "4, 16, 7, 1");
+        panelPartOnVacuumSensing.add(vacuumPartOnGraph, "4, 14, 7, 1");
         
         panelPartOffVacuumSensing = new JPanel();
+        panelPartOffVacuumSensing.setToolTipText("During the Place operation, the level is repeatedly measured until it reaches the Vacuum Range.");
         panelPartOffVacuumSensing.setBorder(new TitledBorder(UIManager.getBorder("TitledBorder.border"), "Part Off Vacuum Sensing", TitledBorder.LEADING, TitledBorder.TOP, null, new Color(0, 0, 0)));
         contentPanel.add(panelPartOffVacuumSensing);
         panelPartOffVacuumSensing.setLayout(new FormLayout(new ColumnSpec[] {
@@ -199,8 +189,6 @@ public class ReferenceNozzleTipPartDetectionWizard extends AbstractConfiguration
                 FormSpecs.RELATED_GAP_ROWSPEC,
                 FormSpecs.DEFAULT_ROWSPEC,
                 FormSpecs.RELATED_GAP_ROWSPEC,
-                FormSpecs.DEFAULT_ROWSPEC,
-                FormSpecs.RELATED_GAP_ROWSPEC,
                 FormSpecs.DEFAULT_ROWSPEC,}));
         
         lblPartOffMeasurement = new JLabel("Measurement Method");
@@ -214,12 +202,12 @@ public class ReferenceNozzleTipPartDetectionWizard extends AbstractConfiguration
         });
         panelPartOffVacuumSensing.add(methodPartOff, "4, 2, 3, 1");
         
-        lblValveEnabled = new JLabel("Enable Valve for Test?");
-        panelPartOffVacuumSensing.add(lblValveEnabled, "2, 4");
-        lblValveEnabled.setToolTipText("");
+        lblEstablishPartOffLevel = new JLabel("Establish Level");
+        lblEstablishPartOffLevel.setToolTipText("While the nozzle is pressed down on the part in the pick operation, the vacuum level is repeatedly measured until it reaches the Vacuum Range or the timeout is reached.");
+        panelPartOffVacuumSensing.add(lblEstablishPartOffLevel, "2, 4, right, default");
         
-        valveEnabledForPartOff = new JCheckBox("");
-        panelPartOffVacuumSensing.add(valveEnabledForPartOff, "4, 4");
+        establishPartOffLevel = new JCheckBox("");
+        panelPartOffVacuumSensing.add(establishPartOffLevel, "4, 4");
         
         lblPartOffLowValue = new JLabel("Low Value");
         panelPartOffVacuumSensing.add(lblPartOffLowValue, "4, 6");
@@ -230,56 +218,47 @@ public class ReferenceNozzleTipPartDetectionWizard extends AbstractConfiguration
         lblPartOffLastReading = new JLabel("Last Reading");
         panelPartOffVacuumSensing.add(lblPartOffLastReading, "10, 6");
         
-        lblPartOffDwell = new JLabel("Dwell Time (ms)");
-        lblPartOffDwell.setToolTipText("<html>\r\n<p>For the absolute measurement method, this is an extra dwell time after placing, <br />\r\nraising the nozzle to Safe Z and optionally opening the valve.</p>\r\n<p>\r\nFor relative trend measurements methods, this is a dwell time after closing the valve<br />\r\nbefore taking the reference reading for the trend. This happens before any place \r\ndwell times. </p>\r\n</html>\r\n");
-        panelPartOffVacuumSensing.add(lblPartOffDwell, "2, 8, right, default");
-        
-        partOffDwellMilliseconds = new JTextField();
-        partOffDwellMilliseconds.setToolTipText("<html>\r\n<p>For the absolute measurement method, this is an extra dwell time after placing, <br />\r\nraising the nozzle to Safe Z and optionally opening the valve.</p>\r\n<p>\r\nFor relative trend measurements methods, this is a dwell time after closing the valve<br />\r\nbefore taking the reference reading for the trend. This happens before any place \r\ndwell times. </p>\r\n</html>\r\n");
-        panelPartOffVacuumSensing.add(partOffDwellMilliseconds, "4, 8");
-        partOffDwellMilliseconds.setColumns(10);
-        
         lblPartOffNozzle = new JLabel("Vacuum Range");
-        panelPartOffVacuumSensing.add(lblPartOffNozzle, "2, 10, right, default");
+        panelPartOffVacuumSensing.add(lblPartOffNozzle, "2, 8, right, default");
         
         vacuumLevelPartOffLow = new JTextField();
-        panelPartOffVacuumSensing.add(vacuumLevelPartOffLow, "4, 10");
+        panelPartOffVacuumSensing.add(vacuumLevelPartOffLow, "4, 8");
         vacuumLevelPartOffLow.setColumns(10);
         
         vacuumLevelPartOffHigh = new JTextField();
-        panelPartOffVacuumSensing.add(vacuumLevelPartOffHigh, "6, 10");
+        panelPartOffVacuumSensing.add(vacuumLevelPartOffHigh, "6, 8");
         vacuumLevelPartOffHigh.setColumns(10);
         
         vacuumLevelPartOffReading = new JTextField();
         vacuumLevelPartOffReading.setEditable(false);
-        panelPartOffVacuumSensing.add(vacuumLevelPartOffReading, "10, 10, fill, default");
+        panelPartOffVacuumSensing.add(vacuumLevelPartOffReading, "10, 8, fill, default");
         vacuumLevelPartOffReading.setColumns(10);
         
-        lblTrendTimePartOff = new JLabel("Trend time (ms)");
-        panelPartOffVacuumSensing.add(lblTrendTimePartOff, "2, 12, right, default");
+        lblProbingTimePartOff = new JLabel("Probing time (ms)");
+        panelPartOffVacuumSensing.add(lblProbingTimePartOff, "2, 10, right, default");
         
-        partOffTrendMilliseconds = new JTextField();
-        panelPartOffVacuumSensing.add(partOffTrendMilliseconds, "4, 12, default, center");
-        partOffTrendMilliseconds.setColumns(10);
+        partOffProbingMilliseconds = new JTextField();
+        panelPartOffVacuumSensing.add(partOffProbingMilliseconds, "4, 10, default, center");
+        partOffProbingMilliseconds.setColumns(10);
         
-        lblPartOffTrendRange = new JLabel("Trend Range");
-        panelPartOffVacuumSensing.add(lblPartOffTrendRange, "2, 14, right, default");
+        lblPartOffRelativeRange = new JLabel("Relative Range");
+        panelPartOffVacuumSensing.add(lblPartOffRelativeRange, "2, 12, right, default");
         
-        vacuumTrendPartOffLow = new JTextField();
-        panelPartOffVacuumSensing.add(vacuumTrendPartOffLow, "4, 14, fill, default");
-        vacuumTrendPartOffLow.setColumns(10);
+        vacuumRelativePartOffLow = new JTextField();
+        panelPartOffVacuumSensing.add(vacuumRelativePartOffLow, "4, 12, fill, default");
+        vacuumRelativePartOffLow.setColumns(10);
         
-        vacuumTrendPartOffHigh = new JTextField();
-        panelPartOffVacuumSensing.add(vacuumTrendPartOffHigh, "6, 14, fill, default");
-        vacuumTrendPartOffHigh.setColumns(10);
+        vacuumRelativePartOffHigh = new JTextField();
+        panelPartOffVacuumSensing.add(vacuumRelativePartOffHigh, "6, 12, fill, default");
+        vacuumRelativePartOffHigh.setColumns(10);
         
-        vacuumTrendPartOffReading = new JTextField();
-        vacuumTrendPartOffReading.setEditable(false);
-        panelPartOffVacuumSensing.add(vacuumTrendPartOffReading, "10, 14, fill, default");
-        vacuumTrendPartOffReading.setColumns(10);
+        vacuumRelativePartOffReading = new JTextField();
+        vacuumRelativePartOffReading.setEditable(false);
+        panelPartOffVacuumSensing.add(vacuumRelativePartOffReading, "10, 12, fill, default");
+        vacuumRelativePartOffReading.setColumns(10);
         
         vacuumPartOffGraph = new SimpleGraphView(nozzleTip);
-        panelPartOffVacuumSensing.add(vacuumPartOffGraph, "4, 18, 7, 1");
+        panelPartOffVacuumSensing.add(vacuumPartOffGraph, "4, 16, 7, 1");
     }
     
     private JLabel lblPartOnLowValue;
@@ -294,95 +273,88 @@ public class ReferenceNozzleTipPartDetectionWizard extends AbstractConfiguration
     private JComboBox methodPartOn;
     private JLabel lblPartOffMeasurement;
     private JComboBox methodPartOff;
-    private JLabel lblPartOffDwell;
-    private JTextField partOffDwellMilliseconds;
-    private JCheckBox valveEnabledForPartOff;
-    private JLabel lblValveEnabled;
     private JPanel panelPartOffVacuumSensing;
-    private JLabel lblTrendTimePartOff;
-    private JTextField partOffTrendMilliseconds;
-    private JLabel lblPartOffTrendRange;
-    private JTextField vacuumTrendPartOffLow;
-    private JTextField vacuumTrendPartOffHigh;
-    private JLabel lblPartOnDwell;
-    private JTextField partOnDwellMilliseconds;
-    private JLabel lblTrendTimePartOn;
-    private JTextField partOnTrendMilliseconds;
-    private JLabel lblPartOnTrendRange;
-    private JTextField vacuumTrendPartOnLow;
-    private JTextField vacuumTrendPartOnHigh;
+    private JLabel lblProbingTimePartOff;
+    private JTextField partOffProbingMilliseconds;
+    private JLabel lblPartOffRelativeRange;
+    private JTextField vacuumRelativePartOffLow;
+    private JTextField vacuumRelativePartOffHigh;
+    private JLabel lblPartOnRelativeRange;
+    private JTextField vacuumRelativePartOnLow;
+    private JTextField vacuumRelativePartOnHigh;
     private JLabel lblPartOffLowValue;
     private JLabel lblPartOffHighValue;
     private JLabel lblPartOnLastReading;
     private JLabel lblPartOffLastReading;
     private JTextField vacuumLevelPartOnReading;
-    private JTextField vacuumTrendPartOnReading;
+    private JTextField vacuumRelativePartOnReading;
     private JTextField vacuumLevelPartOffReading;
-    private JTextField vacuumTrendPartOffReading;
+    private JTextField vacuumRelativePartOffReading;
     private SimpleGraphView vacuumPartOnGraph;
     private SimpleGraphView vacuumPartOffGraph;
+    private JCheckBox establishPartOnLevel;
+    private JLabel lblEstablishPartOnLevel;
+    private JLabel lblEstablishPartOffLevel;
+    private JCheckBox establishPartOffLevel;
     
     private void adaptDialog() {
         VacuumMeasurementMethod methodOn = (VacuumMeasurementMethod)methodPartOn.getSelectedItem();
         boolean partOn = true;
-        boolean partOnTrend = true;
+        boolean partOnRelative = true;
         if (methodOn == VacuumMeasurementMethod.None) {
             // hide all 
             partOn = false;
-            partOnTrend = false;
+            partOnRelative = false;
         }
-        else if (!methodOn.isTrendMethod()) {
-            partOnTrend = false;
+        else if (!methodOn.isRelativeMethod()) {
+            partOnRelative = false;
         }
          
+        lblEstablishPartOnLevel.setVisible(partOn);
+        establishPartOnLevel.setVisible(partOn);
         lblPartOnLowValue.setVisible(partOn);
         lblPartOnHighValue.setVisible(partOn);
         lblPartOnLastReading.setVisible(partOn);
-        lblPartOnDwell.setVisible(partOn);
-        partOnDwellMilliseconds.setVisible(partOn);
         lblPartOnNozzle.setVisible(partOn);
         vacuumLevelPartOnLow.setVisible(partOn);
         vacuumLevelPartOnHigh.setVisible(partOn);
         vacuumLevelPartOnReading.setVisible(partOn);
         
-        lblTrendTimePartOn.setVisible(partOnTrend);
-        partOnTrendMilliseconds.setVisible(partOnTrend);
-        lblPartOnTrendRange.setVisible(partOnTrend);
-        vacuumTrendPartOnLow.setVisible(partOnTrend);
-        vacuumTrendPartOnHigh.setVisible(partOnTrend);
-        vacuumTrendPartOnReading.setVisible(partOnTrend);
+        lblPartOnRelativeRange.setVisible(partOnRelative);
+        vacuumRelativePartOnLow.setVisible(partOnRelative);
+        vacuumRelativePartOnHigh.setVisible(partOnRelative);
+        vacuumRelativePartOnReading.setVisible(partOnRelative);
+        vacuumPartOnGraph.setVisible(partOn);
         
         VacuumMeasurementMethod methodOff = (VacuumMeasurementMethod)methodPartOff.getSelectedItem();
         boolean partOff = true;
-        boolean partOffTrend = true;
+        boolean partOffRelative = true;
         if (methodOff == VacuumMeasurementMethod.None) {
             // hide all 
             partOff = false;
-            partOffTrend = false;
+            partOffRelative = false;
         }
-        else if (!methodOff.isTrendMethod()) {
-            partOffTrend = false;
+        else if (!methodOff.isRelativeMethod()) {
+            partOffRelative = false;
         }
          
-        lblValveEnabled.setVisible(partOff && ! partOffTrend);
-        valveEnabledForPartOff.setVisible(partOff && ! partOffTrend);
+        lblEstablishPartOffLevel.setVisible(partOn);
+        establishPartOffLevel.setVisible(partOn);
         lblPartOffLowValue.setVisible(partOff);
         lblPartOffHighValue.setVisible(partOff);
         lblPartOffLastReading.setVisible(partOff);
-        lblPartOffDwell.setVisible(partOff);
-        partOffDwellMilliseconds.setVisible(partOff);
         lblPartOffNozzle.setVisible(partOff);
         vacuumLevelPartOffLow.setVisible(partOff);
         vacuumLevelPartOffHigh.setVisible(partOff);
         vacuumLevelPartOffReading.setVisible(partOff);
         
-        lblTrendTimePartOff.setVisible(partOffTrend);
-        partOffTrendMilliseconds.setVisible(partOffTrend);
-        lblPartOffTrendRange.setVisible(partOffTrend);
-        vacuumTrendPartOffLow.setVisible(partOffTrend);
-        vacuumTrendPartOffHigh.setVisible(partOffTrend);
-        vacuumTrendPartOffReading.setVisible(partOffTrend);
-        
+        lblProbingTimePartOff.setVisible(partOffRelative);
+        partOffProbingMilliseconds.setVisible(partOffRelative);
+        lblPartOffRelativeRange.setVisible(partOffRelative);
+        vacuumRelativePartOffLow.setVisible(partOffRelative);
+        vacuumRelativePartOffHigh.setVisible(partOffRelative);
+        vacuumRelativePartOffReading.setVisible(partOffRelative);
+        vacuumPartOffGraph.setVisible(partOff);
     }
 
     @Override
@@ -391,41 +363,36 @@ public class ReferenceNozzleTipPartDetectionWizard extends AbstractConfiguration
         IntegerConverter integerConverter = new IntegerConverter();
 
         addWrappedBinding(nozzleTip, "methodPartOn", methodPartOn, "selectedItem");
-        addWrappedBinding(nozzleTip, "partOnDwellMilliseconds", partOnDwellMilliseconds, "text", integerConverter);
+        addWrappedBinding(nozzleTip, "establishPartOnLevel", establishPartOnLevel, "selected");
         addWrappedBinding(nozzleTip, "vacuumLevelPartOnLow", vacuumLevelPartOnLow, "text", doubleConverter);
         addWrappedBinding(nozzleTip, "vacuumLevelPartOnHigh", vacuumLevelPartOnHigh, "text", doubleConverter);
         addWrappedBinding(nozzleTip, "vacuumLevelPartOnReading", vacuumLevelPartOnReading, "text", doubleConverter);
-        addWrappedBinding(nozzleTip, "partOnTrendMilliseconds", partOnTrendMilliseconds, "text", integerConverter);
-        addWrappedBinding(nozzleTip, "vacuumTrendPartOnLow", vacuumTrendPartOnLow, "text", doubleConverter);
-        addWrappedBinding(nozzleTip, "vacuumTrendPartOnHigh", vacuumTrendPartOnHigh, "text", doubleConverter);
-        addWrappedBinding(nozzleTip, "vacuumTrendPartOnReading", vacuumTrendPartOnReading, "text", doubleConverter);
+        addWrappedBinding(nozzleTip, "vacuumRelativePartOnLow", vacuumRelativePartOnLow, "text", doubleConverter);
+        addWrappedBinding(nozzleTip, "vacuumRelativePartOnHigh", vacuumRelativePartOnHigh, "text", doubleConverter);
+        addWrappedBinding(nozzleTip, "vacuumRelativePartOnReading", vacuumRelativePartOnReading, "text", doubleConverter);
 
         addWrappedBinding(nozzleTip, "methodPartOff", methodPartOff, "selectedItem");
-        addWrappedBinding(nozzleTip, "valveEnabledForPartOff", valveEnabledForPartOff, "selected");
-        addWrappedBinding(nozzleTip, "partOffDwellMilliseconds", partOffDwellMilliseconds, "text", integerConverter);
+        addWrappedBinding(nozzleTip, "establishPartOffLevel", establishPartOffLevel, "selected");
         addWrappedBinding(nozzleTip, "vacuumLevelPartOffLow", vacuumLevelPartOffLow, "text", doubleConverter);
         addWrappedBinding(nozzleTip, "vacuumLevelPartOffHigh", vacuumLevelPartOffHigh, "text", doubleConverter);
         addWrappedBinding(nozzleTip, "vacuumLevelPartOffReading", vacuumLevelPartOffReading, "text", doubleConverter);
-        addWrappedBinding(nozzleTip, "partOffTrendMilliseconds", partOffTrendMilliseconds, "text", integerConverter);
-        addWrappedBinding(nozzleTip, "vacuumTrendPartOffLow", vacuumTrendPartOffLow, "text", doubleConverter);
-        addWrappedBinding(nozzleTip, "vacuumTrendPartOffHigh", vacuumTrendPartOffHigh, "text", doubleConverter);
-        addWrappedBinding(nozzleTip, "vacuumTrendPartOffReading", vacuumTrendPartOffReading, "text", doubleConverter);
+        addWrappedBinding(nozzleTip, "partOffProbingMilliseconds", partOffProbingMilliseconds, "text", integerConverter);
+        addWrappedBinding(nozzleTip, "vacuumRelativePartOffLow", vacuumRelativePartOffLow, "text", doubleConverter);
+        addWrappedBinding(nozzleTip, "vacuumRelativePartOffHigh", vacuumRelativePartOffHigh, "text", doubleConverter);
+        addWrappedBinding(nozzleTip, "vacuumRelativePartOffReading", vacuumRelativePartOffReading, "text", doubleConverter);
         
         addWrappedBinding(nozzleTip, "vacuumPartOnGraph", vacuumPartOnGraph, "graph");
         addWrappedBinding(nozzleTip, "vacuumPartOffGraph", vacuumPartOffGraph, "graph");
 
-        ComponentDecorators.decorateWithAutoSelect(partOnDwellMilliseconds);
-        ComponentDecorators.decorateWithAutoSelect(partOnTrendMilliseconds);
-        ComponentDecorators.decorateWithAutoSelect(partOffDwellMilliseconds);
-        ComponentDecorators.decorateWithAutoSelect(partOffTrendMilliseconds);
+        ComponentDecorators.decorateWithAutoSelect(partOffProbingMilliseconds);
         
         ComponentDecorators.decorateWithAutoSelect(vacuumLevelPartOnLow);
         ComponentDecorators.decorateWithAutoSelect(vacuumLevelPartOnHigh);
-        ComponentDecorators.decorateWithAutoSelect(vacuumTrendPartOnLow);
-        ComponentDecorators.decorateWithAutoSelect(vacuumTrendPartOnHigh);
+        ComponentDecorators.decorateWithAutoSelect(vacuumRelativePartOnLow);
+        ComponentDecorators.decorateWithAutoSelect(vacuumRelativePartOnHigh);
         ComponentDecorators.decorateWithAutoSelect(vacuumLevelPartOffLow);
         ComponentDecorators.decorateWithAutoSelect(vacuumLevelPartOffHigh);
-        ComponentDecorators.decorateWithAutoSelect(vacuumTrendPartOffLow);
-        ComponentDecorators.decorateWithAutoSelect(vacuumTrendPartOffHigh);
+        ComponentDecorators.decorateWithAutoSelect(vacuumRelativePartOffLow);
+        ComponentDecorators.decorateWithAutoSelect(vacuumRelativePartOffHigh);
     }
 }

--- a/src/main/java/org/openpnp/machine/reference/wizards/ReferenceNozzleTipPartDetectionWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/wizards/ReferenceNozzleTipPartDetectionWizard.java
@@ -150,21 +150,21 @@ public class ReferenceNozzleTipPartDetectionWizard extends AbstractConfiguration
         panelPartOnVacuumSensing.add(vacuumLevelPartOnReading, "10, 8, right, top");
         vacuumLevelPartOnReading.setColumns(10);
         
-        lblPartOnRelativeRange = new JLabel("Relative Range");
-        panelPartOnVacuumSensing.add(lblPartOnRelativeRange, "2, 10, right, default");
+        lblPartOnDifferenceRange = new JLabel("Difference Range");
+        panelPartOnVacuumSensing.add(lblPartOnDifferenceRange, "2, 10, right, default");
         
-        vacuumRelativePartOnLow = new JTextField();
-        vacuumRelativePartOnLow.setColumns(10);
-        panelPartOnVacuumSensing.add(vacuumRelativePartOnLow, "4, 10, fill, default");
+        vacuumDifferencePartOnLow = new JTextField();
+        vacuumDifferencePartOnLow.setColumns(10);
+        panelPartOnVacuumSensing.add(vacuumDifferencePartOnLow, "4, 10, fill, default");
         
-        vacuumRelativePartOnHigh = new JTextField();
-        panelPartOnVacuumSensing.add(vacuumRelativePartOnHigh, "6, 10, fill, default");
-        vacuumRelativePartOnHigh.setColumns(10);
+        vacuumDifferencePartOnHigh = new JTextField();
+        panelPartOnVacuumSensing.add(vacuumDifferencePartOnHigh, "6, 10, fill, default");
+        vacuumDifferencePartOnHigh.setColumns(10);
         
-        vacuumRelativePartOnReading = new JTextField();
-        vacuumRelativePartOnReading.setEditable(false);
-        panelPartOnVacuumSensing.add(vacuumRelativePartOnReading, "10, 10, fill, default");
-        vacuumRelativePartOnReading.setColumns(10);
+        vacuumDifferencePartOnReading = new JTextField();
+        vacuumDifferencePartOnReading.setEditable(false);
+        panelPartOnVacuumSensing.add(vacuumDifferencePartOnReading, "10, 10, fill, default");
+        vacuumDifferencePartOnReading.setColumns(10);
         
         lblLegendPartOn = new JLabel("<html>\r\n<p style=\"text-align:right\">Vacuum <span style=\"color:#FF0000\">&mdash;&mdash;</span></p>\r\n<p/>\r\n<p style=\"text-align:right\">Valve <span style=\"color:#005BD9\">&mdash;&mdash;</span></p>\r\n</html>");
         panelPartOnVacuumSensing.add(lblLegendPartOn, "2, 14, right, default");
@@ -264,21 +264,21 @@ public class ReferenceNozzleTipPartDetectionWizard extends AbstractConfiguration
         panelPartOffVacuumSensing.add(partOffProbingMilliseconds, "4, 10, default, center");
         partOffProbingMilliseconds.setColumns(10);
         
-        lblPartOffRelativeRange = new JLabel("Relative Range");
-        panelPartOffVacuumSensing.add(lblPartOffRelativeRange, "2, 12, right, default");
+        lblPartOffDifferenceRange = new JLabel("Difference Range");
+        panelPartOffVacuumSensing.add(lblPartOffDifferenceRange, "2, 12, right, default");
         
-        vacuumRelativePartOffLow = new JTextField();
-        panelPartOffVacuumSensing.add(vacuumRelativePartOffLow, "4, 12, fill, default");
-        vacuumRelativePartOffLow.setColumns(10);
+        vacuumDifferencePartOffLow = new JTextField();
+        panelPartOffVacuumSensing.add(vacuumDifferencePartOffLow, "4, 12, fill, default");
+        vacuumDifferencePartOffLow.setColumns(10);
         
-        vacuumRelativePartOffHigh = new JTextField();
-        panelPartOffVacuumSensing.add(vacuumRelativePartOffHigh, "6, 12, fill, default");
-        vacuumRelativePartOffHigh.setColumns(10);
+        vacuumDifferencePartOffHigh = new JTextField();
+        panelPartOffVacuumSensing.add(vacuumDifferencePartOffHigh, "6, 12, fill, default");
+        vacuumDifferencePartOffHigh.setColumns(10);
         
-        vacuumRelativePartOffReading = new JTextField();
-        vacuumRelativePartOffReading.setEditable(false);
-        panelPartOffVacuumSensing.add(vacuumRelativePartOffReading, "10, 12, fill, default");
-        vacuumRelativePartOffReading.setColumns(10);
+        vacuumDifferencePartOffReading = new JTextField();
+        vacuumDifferencePartOffReading.setEditable(false);
+        panelPartOffVacuumSensing.add(vacuumDifferencePartOffReading, "10, 12, fill, default");
+        vacuumDifferencePartOffReading.setColumns(10);
         
         lblLegendPartOff = new JLabel("<html>\r\n<p style=\"text-align:right\">Vacuum <span style=\"color:#FF0000\">&mdash;&mdash;</span></p>\r\n<p/>\r\n<p style=\"text-align:right\">Valve <span style=\"color:#005BD9\">&mdash;&mdash;</span></p>\r\n</html>");
         panelPartOffVacuumSensing.add(lblLegendPartOff, "2, 16, right, default");
@@ -303,20 +303,20 @@ public class ReferenceNozzleTipPartDetectionWizard extends AbstractConfiguration
     private JPanel panelPartOffVacuumSensing;
     private JLabel lblProbingTimePartOff;
     private JTextField partOffProbingMilliseconds;
-    private JLabel lblPartOffRelativeRange;
-    private JTextField vacuumRelativePartOffLow;
-    private JTextField vacuumRelativePartOffHigh;
-    private JLabel lblPartOnRelativeRange;
-    private JTextField vacuumRelativePartOnLow;
-    private JTextField vacuumRelativePartOnHigh;
+    private JLabel lblPartOffDifferenceRange;
+    private JTextField vacuumDifferencePartOffLow;
+    private JTextField vacuumDifferencePartOffHigh;
+    private JLabel lblPartOnDifferenceRange;
+    private JTextField vacuumDifferencePartOnLow;
+    private JTextField vacuumDifferencePartOnHigh;
     private JLabel lblPartOffLowValue;
     private JLabel lblPartOffHighValue;
     private JLabel lblPartOnLastReading;
     private JLabel lblPartOffLastReading;
     private JTextField vacuumLevelPartOnReading;
-    private JTextField vacuumRelativePartOnReading;
+    private JTextField vacuumDifferencePartOnReading;
     private JTextField vacuumLevelPartOffReading;
-    private JTextField vacuumRelativePartOffReading;
+    private JTextField vacuumDifferencePartOffReading;
     private SimpleGraphView vacuumPartOnGraph;
     private SimpleGraphView vacuumPartOffGraph;
     private JCheckBox establishPartOnLevel;
@@ -330,16 +330,16 @@ public class ReferenceNozzleTipPartDetectionWizard extends AbstractConfiguration
         VacuumMeasurementMethod methodOn = (VacuumMeasurementMethod)methodPartOn.getSelectedItem();
         boolean establishOn = establishPartOnLevel.isSelected();
         boolean partOn = true;
-        boolean partOnRelative = true;
-        boolean graphOn = establishOn || methodOn.isRelativeMethod();
+        boolean partOnDifference = true;
+        boolean graphOn = establishOn || methodOn.isDifferenceMethod();
         if (methodOn == VacuumMeasurementMethod.None) {
             // hide all 
             partOn = false;
-            partOnRelative = false;
+            partOnDifference = false;
             graphOn = false;
         }
-        else if (!methodOn.isRelativeMethod()) {
-            partOnRelative = false;
+        else if (!methodOn.isDifferenceMethod()) {
+            partOnDifference = false;
         }
          
         lblEstablishPartOnLevel.setVisible(partOn);
@@ -352,26 +352,26 @@ public class ReferenceNozzleTipPartDetectionWizard extends AbstractConfiguration
         vacuumLevelPartOnHigh.setVisible(partOn);
         vacuumLevelPartOnReading.setVisible(partOn);
         
-        lblPartOnRelativeRange.setVisible(partOnRelative);
-        vacuumRelativePartOnLow.setVisible(partOnRelative);
-        vacuumRelativePartOnHigh.setVisible(partOnRelative);
-        vacuumRelativePartOnReading.setVisible(partOnRelative);
+        lblPartOnDifferenceRange.setVisible(partOnDifference);
+        vacuumDifferencePartOnLow.setVisible(partOnDifference);
+        vacuumDifferencePartOnHigh.setVisible(partOnDifference);
+        vacuumDifferencePartOnReading.setVisible(partOnDifference);
         lblLegendPartOn.setVisible(graphOn);
         vacuumPartOnGraph.setVisible(graphOn);
         
         VacuumMeasurementMethod methodOff = (VacuumMeasurementMethod)methodPartOff.getSelectedItem();
         boolean establishOff = establishPartOffLevel.isSelected();
         boolean partOff = true;
-        boolean partOffRelative = true;
-        boolean graphOff = establishOff || methodOff.isRelativeMethod();
+        boolean partOffDifference = true;
+        boolean graphOff = establishOff || methodOff.isDifferenceMethod();
         if (methodOff == VacuumMeasurementMethod.None) {
             // hide all 
             partOff = false;
-            partOffRelative = false;
+            partOffDifference = false;
             graphOff = false;
         }
-        else if (!methodOff.isRelativeMethod()) {
-            partOffRelative = false;
+        else if (!methodOff.isDifferenceMethod()) {
+            partOffDifference = false;
         }
          
         lblEstablishPartOffLevel.setVisible(partOff);
@@ -384,12 +384,12 @@ public class ReferenceNozzleTipPartDetectionWizard extends AbstractConfiguration
         vacuumLevelPartOffHigh.setVisible(partOff);
         vacuumLevelPartOffReading.setVisible(partOff);
         
-        lblProbingTimePartOff.setVisible(partOffRelative);
-        partOffProbingMilliseconds.setVisible(partOffRelative);
-        lblPartOffRelativeRange.setVisible(partOffRelative);
-        vacuumRelativePartOffLow.setVisible(partOffRelative);
-        vacuumRelativePartOffHigh.setVisible(partOffRelative);
-        vacuumRelativePartOffReading.setVisible(partOffRelative);
+        lblProbingTimePartOff.setVisible(partOffDifference);
+        partOffProbingMilliseconds.setVisible(partOffDifference);
+        lblPartOffDifferenceRange.setVisible(partOffDifference);
+        vacuumDifferencePartOffLow.setVisible(partOffDifference);
+        vacuumDifferencePartOffHigh.setVisible(partOffDifference);
+        vacuumDifferencePartOffReading.setVisible(partOffDifference);
         lblLegendPartOff.setVisible(graphOff);
         vacuumPartOffGraph.setVisible(graphOff);
     }
@@ -404,9 +404,9 @@ public class ReferenceNozzleTipPartDetectionWizard extends AbstractConfiguration
         addWrappedBinding(nozzleTip, "vacuumLevelPartOnLow", vacuumLevelPartOnLow, "text", doubleConverter);
         addWrappedBinding(nozzleTip, "vacuumLevelPartOnHigh", vacuumLevelPartOnHigh, "text", doubleConverter);
         addWrappedBinding(nozzleTip, "vacuumLevelPartOnReading", vacuumLevelPartOnReading, "text", doubleConverter);
-        addWrappedBinding(nozzleTip, "vacuumRelativePartOnLow", vacuumRelativePartOnLow, "text", doubleConverter);
-        addWrappedBinding(nozzleTip, "vacuumRelativePartOnHigh", vacuumRelativePartOnHigh, "text", doubleConverter);
-        addWrappedBinding(nozzleTip, "vacuumRelativePartOnReading", vacuumRelativePartOnReading, "text", doubleConverter);
+        addWrappedBinding(nozzleTip, "vacuumDifferencePartOnLow", vacuumDifferencePartOnLow, "text", doubleConverter);
+        addWrappedBinding(nozzleTip, "vacuumDifferencePartOnHigh", vacuumDifferencePartOnHigh, "text", doubleConverter);
+        addWrappedBinding(nozzleTip, "vacuumDifferencePartOnReading", vacuumDifferencePartOnReading, "text", doubleConverter);
 
         addWrappedBinding(nozzleTip, "methodPartOff", methodPartOff, "selectedItem");
         addWrappedBinding(nozzleTip, "establishPartOffLevel", establishPartOffLevel, "selected");
@@ -414,9 +414,9 @@ public class ReferenceNozzleTipPartDetectionWizard extends AbstractConfiguration
         addWrappedBinding(nozzleTip, "vacuumLevelPartOffHigh", vacuumLevelPartOffHigh, "text", doubleConverter);
         addWrappedBinding(nozzleTip, "vacuumLevelPartOffReading", vacuumLevelPartOffReading, "text", doubleConverter);
         addWrappedBinding(nozzleTip, "partOffProbingMilliseconds", partOffProbingMilliseconds, "text", integerConverter);
-        addWrappedBinding(nozzleTip, "vacuumRelativePartOffLow", vacuumRelativePartOffLow, "text", doubleConverter);
-        addWrappedBinding(nozzleTip, "vacuumRelativePartOffHigh", vacuumRelativePartOffHigh, "text", doubleConverter);
-        addWrappedBinding(nozzleTip, "vacuumRelativePartOffReading", vacuumRelativePartOffReading, "text", doubleConverter);
+        addWrappedBinding(nozzleTip, "vacuumDifferencePartOffLow", vacuumDifferencePartOffLow, "text", doubleConverter);
+        addWrappedBinding(nozzleTip, "vacuumDifferencePartOffHigh", vacuumDifferencePartOffHigh, "text", doubleConverter);
+        addWrappedBinding(nozzleTip, "vacuumDifferencePartOffReading", vacuumDifferencePartOffReading, "text", doubleConverter);
         
         addWrappedBinding(nozzleTip, "vacuumPartOnGraph", vacuumPartOnGraph, "graph");
         
@@ -460,11 +460,11 @@ public class ReferenceNozzleTipPartDetectionWizard extends AbstractConfiguration
         
         ComponentDecorators.decorateWithAutoSelect(vacuumLevelPartOnLow);
         ComponentDecorators.decorateWithAutoSelect(vacuumLevelPartOnHigh);
-        ComponentDecorators.decorateWithAutoSelect(vacuumRelativePartOnLow);
-        ComponentDecorators.decorateWithAutoSelect(vacuumRelativePartOnHigh);
+        ComponentDecorators.decorateWithAutoSelect(vacuumDifferencePartOnLow);
+        ComponentDecorators.decorateWithAutoSelect(vacuumDifferencePartOnHigh);
         ComponentDecorators.decorateWithAutoSelect(vacuumLevelPartOffLow);
         ComponentDecorators.decorateWithAutoSelect(vacuumLevelPartOffHigh);
-        ComponentDecorators.decorateWithAutoSelect(vacuumRelativePartOffLow);
-        ComponentDecorators.decorateWithAutoSelect(vacuumRelativePartOffHigh);
+        ComponentDecorators.decorateWithAutoSelect(vacuumDifferencePartOffLow);
+        ComponentDecorators.decorateWithAutoSelect(vacuumDifferencePartOffHigh);
     }
 }

--- a/src/main/java/org/openpnp/machine/reference/wizards/ReferenceNozzleTipPartDetectionWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/wizards/ReferenceNozzleTipPartDetectionWizard.java
@@ -37,6 +37,7 @@ import org.openpnp.machine.reference.ReferenceNozzleTip;
 import org.openpnp.machine.reference.ReferenceNozzleTip.VacuumMeasurementMethod;
 import org.openpnp.machine.reference.feeder.BlindsFeeder;
 import org.openpnp.model.Configuration;
+import org.openpnp.util.SimpleGraph;
 
 import com.jgoodies.forms.layout.ColumnSpec;
 import com.jgoodies.forms.layout.FormLayout;
@@ -55,6 +56,7 @@ import java.awt.Graphics2D;
 import java.awt.RenderingHints;
 import java.beans.PropertyChangeListener;
 import java.beans.PropertyChangeEvent;
+import java.awt.Font;
 
 public class ReferenceNozzleTipPartDetectionWizard extends AbstractConfigurationWizard {
     private final ReferenceNozzleTip nozzleTip;
@@ -79,6 +81,10 @@ public class ReferenceNozzleTipPartDetectionWizard extends AbstractConfiguration
                 FormSpecs.RELATED_GAP_COLSPEC,
                 FormSpecs.DEFAULT_COLSPEC,
                 FormSpecs.RELATED_GAP_COLSPEC,
+                FormSpecs.DEFAULT_COLSPEC,
+                FormSpecs.RELATED_GAP_COLSPEC,
+                ColumnSpec.decode("default:grow"),
+                FormSpecs.RELATED_GAP_COLSPEC,
                 FormSpecs.DEFAULT_COLSPEC,},
             new RowSpec[] {
                 FormSpecs.RELATED_GAP_ROWSPEC,
@@ -94,7 +100,7 @@ public class ReferenceNozzleTipPartDetectionWizard extends AbstractConfiguration
                 FormSpecs.RELATED_GAP_ROWSPEC,
                 FormSpecs.DEFAULT_ROWSPEC,
                 FormSpecs.RELATED_GAP_ROWSPEC,
-                FormSpecs.DEFAULT_ROWSPEC,}));
+                RowSpec.decode("default:grow"),}));
         
         lblPartOnMeasurement = new JLabel("Measurement Method");
         panelPartOnVacuumSensing.add(lblPartOnMeasurement, "2, 2, right, default");
@@ -112,6 +118,11 @@ public class ReferenceNozzleTipPartDetectionWizard extends AbstractConfiguration
         panelPartOnVacuumSensing.add(lblEstablishPartOnLevel, "2, 4, right, default");
         
         establishPartOnLevel = new JCheckBox("");
+        establishPartOnLevel.addPropertyChangeListener(new PropertyChangeListener() {
+            public void propertyChange(PropertyChangeEvent evt) {
+                adaptDialog();
+            }
+        });
         panelPartOnVacuumSensing.add(establishPartOnLevel, "4, 4");
         
         lblPartOnLowValue = new JLabel("Low Value");
@@ -155,11 +166,14 @@ public class ReferenceNozzleTipPartDetectionWizard extends AbstractConfiguration
         panelPartOnVacuumSensing.add(vacuumRelativePartOnReading, "10, 10, fill, default");
         vacuumRelativePartOnReading.setColumns(10);
         
-        vacuumPartOnGraph = new SimpleGraphView(nozzleTip);
-        panelPartOnVacuumSensing.add(vacuumPartOnGraph, "4, 14, 7, 1");
+        lblLegendPartOn = new JLabel("<html>\r\n<p style=\"text-align:right\">Vacuum <span style=\"color:#FF0000\">&mdash;&mdash;</span></p>\r\n<p/>\r\n<p style=\"text-align:right\">Valve <span style=\"color:#005BD9\">&mdash;&mdash;</span></p>\r\n</html>");
+        panelPartOnVacuumSensing.add(lblLegendPartOn, "2, 14, right, default");
+        
+        vacuumPartOnGraph = new SimpleGraphView();
+        vacuumPartOnGraph.setFont(new Font("SansSerif", Font.PLAIN, 9));
+        panelPartOnVacuumSensing.add(vacuumPartOnGraph, "4, 14, 9, 1, default, fill");
         
         panelPartOffVacuumSensing = new JPanel();
-        panelPartOffVacuumSensing.setToolTipText("During the Place operation, the level is repeatedly measured until it reaches the Vacuum Range.");
         panelPartOffVacuumSensing.setBorder(new TitledBorder(UIManager.getBorder("TitledBorder.border"), "Part Off Vacuum Sensing", TitledBorder.LEADING, TitledBorder.TOP, null, new Color(0, 0, 0)));
         contentPanel.add(panelPartOffVacuumSensing);
         panelPartOffVacuumSensing.setLayout(new FormLayout(new ColumnSpec[] {
@@ -171,6 +185,10 @@ public class ReferenceNozzleTipPartDetectionWizard extends AbstractConfiguration
                 ColumnSpec.decode("max(50dlu;default)"),
                 FormSpecs.RELATED_GAP_COLSPEC,
                 FormSpecs.DEFAULT_COLSPEC,
+                FormSpecs.RELATED_GAP_COLSPEC,
+                FormSpecs.DEFAULT_COLSPEC,
+                FormSpecs.RELATED_GAP_COLSPEC,
+                ColumnSpec.decode("default:grow"),
                 FormSpecs.RELATED_GAP_COLSPEC,
                 FormSpecs.DEFAULT_COLSPEC,},
             new RowSpec[] {
@@ -189,7 +207,7 @@ public class ReferenceNozzleTipPartDetectionWizard extends AbstractConfiguration
                 FormSpecs.RELATED_GAP_ROWSPEC,
                 FormSpecs.DEFAULT_ROWSPEC,
                 FormSpecs.RELATED_GAP_ROWSPEC,
-                FormSpecs.DEFAULT_ROWSPEC,}));
+                RowSpec.decode("default:grow"),}));
         
         lblPartOffMeasurement = new JLabel("Measurement Method");
         panelPartOffVacuumSensing.add(lblPartOffMeasurement, "2, 2");
@@ -207,6 +225,11 @@ public class ReferenceNozzleTipPartDetectionWizard extends AbstractConfiguration
         panelPartOffVacuumSensing.add(lblEstablishPartOffLevel, "2, 4, right, default");
         
         establishPartOffLevel = new JCheckBox("");
+        establishPartOffLevel.addPropertyChangeListener(new PropertyChangeListener() {
+            public void propertyChange(PropertyChangeEvent evt) {
+                adaptDialog();
+            }
+        });
         panelPartOffVacuumSensing.add(establishPartOffLevel, "4, 4");
         
         lblPartOffLowValue = new JLabel("Low Value");
@@ -257,8 +280,12 @@ public class ReferenceNozzleTipPartDetectionWizard extends AbstractConfiguration
         panelPartOffVacuumSensing.add(vacuumRelativePartOffReading, "10, 12, fill, default");
         vacuumRelativePartOffReading.setColumns(10);
         
-        vacuumPartOffGraph = new SimpleGraphView(nozzleTip);
-        panelPartOffVacuumSensing.add(vacuumPartOffGraph, "4, 16, 7, 1");
+        lblLegendPartOff = new JLabel("<html>\r\n<p style=\"text-align:right\">Vacuum <span style=\"color:#FF0000\">&mdash;&mdash;</span></p>\r\n<p/>\r\n<p style=\"text-align:right\">Valve <span style=\"color:#005BD9\">&mdash;&mdash;</span></p>\r\n</html>");
+        panelPartOffVacuumSensing.add(lblLegendPartOff, "2, 16, right, default");
+        
+        vacuumPartOffGraph = new SimpleGraphView();
+        vacuumPartOffGraph.setFont(new Font("SansSerif", Font.PLAIN, 9));
+        panelPartOffVacuumSensing.add(vacuumPartOffGraph, "4, 16, 9, 1, default, fill");
     }
     
     private JLabel lblPartOnLowValue;
@@ -296,15 +323,20 @@ public class ReferenceNozzleTipPartDetectionWizard extends AbstractConfiguration
     private JLabel lblEstablishPartOnLevel;
     private JLabel lblEstablishPartOffLevel;
     private JCheckBox establishPartOffLevel;
+    private JLabel lblLegendPartOn;
+    private JLabel lblLegendPartOff;
     
     private void adaptDialog() {
         VacuumMeasurementMethod methodOn = (VacuumMeasurementMethod)methodPartOn.getSelectedItem();
+        boolean establishOn = establishPartOnLevel.isSelected();
         boolean partOn = true;
         boolean partOnRelative = true;
+        boolean graphOn = establishOn || methodOn.isRelativeMethod();
         if (methodOn == VacuumMeasurementMethod.None) {
             // hide all 
             partOn = false;
             partOnRelative = false;
+            graphOn = false;
         }
         else if (!methodOn.isRelativeMethod()) {
             partOnRelative = false;
@@ -324,22 +356,26 @@ public class ReferenceNozzleTipPartDetectionWizard extends AbstractConfiguration
         vacuumRelativePartOnLow.setVisible(partOnRelative);
         vacuumRelativePartOnHigh.setVisible(partOnRelative);
         vacuumRelativePartOnReading.setVisible(partOnRelative);
-        vacuumPartOnGraph.setVisible(partOn);
+        lblLegendPartOn.setVisible(graphOn);
+        vacuumPartOnGraph.setVisible(graphOn);
         
         VacuumMeasurementMethod methodOff = (VacuumMeasurementMethod)methodPartOff.getSelectedItem();
+        boolean establishOff = establishPartOffLevel.isSelected();
         boolean partOff = true;
         boolean partOffRelative = true;
+        boolean graphOff = establishOff || methodOff.isRelativeMethod();
         if (methodOff == VacuumMeasurementMethod.None) {
             // hide all 
             partOff = false;
             partOffRelative = false;
+            graphOff = false;
         }
         else if (!methodOff.isRelativeMethod()) {
             partOffRelative = false;
         }
          
-        lblEstablishPartOffLevel.setVisible(partOn);
-        establishPartOffLevel.setVisible(partOn);
+        lblEstablishPartOffLevel.setVisible(partOff);
+        establishPartOffLevel.setVisible(partOff);
         lblPartOffLowValue.setVisible(partOff);
         lblPartOffHighValue.setVisible(partOff);
         lblPartOffLastReading.setVisible(partOff);
@@ -354,7 +390,8 @@ public class ReferenceNozzleTipPartDetectionWizard extends AbstractConfiguration
         vacuumRelativePartOffLow.setVisible(partOffRelative);
         vacuumRelativePartOffHigh.setVisible(partOffRelative);
         vacuumRelativePartOffReading.setVisible(partOffRelative);
-        vacuumPartOffGraph.setVisible(partOff);
+        lblLegendPartOff.setVisible(graphOff);
+        vacuumPartOffGraph.setVisible(graphOff);
     }
 
     @Override
@@ -382,7 +419,42 @@ public class ReferenceNozzleTipPartDetectionWizard extends AbstractConfiguration
         addWrappedBinding(nozzleTip, "vacuumRelativePartOffReading", vacuumRelativePartOffReading, "text", doubleConverter);
         
         addWrappedBinding(nozzleTip, "vacuumPartOnGraph", vacuumPartOnGraph, "graph");
-        addWrappedBinding(nozzleTip, "vacuumPartOffGraph", vacuumPartOffGraph, "graph");
+        
+        final boolean testMode = false;
+        if (!testMode) {
+            addWrappedBinding(nozzleTip, "vacuumPartOffGraph", vacuumPartOffGraph, "graph");
+        }
+        else {
+            SimpleGraph vacuumGraph = new SimpleGraph();
+            vacuumGraph.setOffsetMode(true);
+            vacuumGraph.setRelativePaddingLeft(0.1);
+            long t = System.currentTimeMillis();
+            double scale = Math.exp(Math.random()*7.0-3.0);
+            double offset = (Math.random()-0.3)*scale*2.0;
+            long duration = (long)(Math.random()*1000.0);
+            // init pressure scale
+            SimpleGraph.DataScale vacuumScale =  vacuumGraph.getScale("P");
+            vacuumScale.setRelativePaddingBottom(0.25);
+            vacuumScale.setColor(new Color(0, 0, 0, 64));
+            // init valve scale
+            SimpleGraph.DataScale valveScale =  vacuumGraph.getScale("B");
+            valveScale.setRelativePaddingTop(0.8);
+            valveScale.setRelativePaddingBottom(0.1);
+            // record the current pressure
+            SimpleGraph.DataRow vacuumData = vacuumGraph.getRow("P", "V");
+            vacuumData.setColor(new Color(255, 0, 0));
+            // record the valve switching off
+            SimpleGraph.DataRow valveData = vacuumGraph.getRow("B", "S");
+            valveData.setColor(new Color(00, 0x5B, 0xD9));
+            valveData.recordDataPoint(t-1, 0);
+            valveData.recordDataPoint(t, 1);
+            for (long td = t; td < t+duration; td++) {
+                vacuumData.recordDataPoint(td, Math.sin(td*3.0/duration)*scale+offset+Math.random()*scale*0.05);
+            }
+            valveData.recordDataPoint(t+duration-1, 1);
+            valveData.recordDataPoint(t+duration, 0);
+            vacuumPartOffGraph.setGraph(vacuumGraph);
+        }
 
         ComponentDecorators.decorateWithAutoSelect(partOffProbingMilliseconds);
         

--- a/src/main/java/org/openpnp/spi/Nozzle.java
+++ b/src/main/java/org/openpnp/spi/Nozzle.java
@@ -74,20 +74,36 @@ public interface Nozzle
      * if a user initiated, manual, pick is performed with no Part to reference. 
      */
     public Part getPart();
-    
+
+    public enum PartOnStep {
+        AfterPick,
+        Align,
+        BeforePlace
+    }
+
     /**
      * Returns true if the isPartOn() method is available. Some machines do not have
      * vacuum sensors or other part detection sensors, so this feature is optional.
+     * 
+     * @param step determines which JobProcessor Step wants to perform the check 
      * @return
      */
-    public boolean isPartOnEnabled();
+    public boolean isPartOnEnabled(PartOnStep step);
     
+
+    public enum PartOffStep {
+        AfterPlace,
+        BeforePick
+    }
+
     /**
      * Returns true if the isPartOff() method is available. Some machines do not have
      * vacuum sensors or other part detection sensors, so this feature is optional.
+     * 
+     * @param step determines which JobProcessor Step wants to perform the check 
      * @return
      */
-    public boolean isPartOffEnabled();
+    public boolean isPartOffEnabled(PartOffStep step);
 
     /**
      * Returns true if a part appears to be on the nozzle. This is typically implemented by

--- a/src/main/java/org/openpnp/util/SimpleGraph.java
+++ b/src/main/java/org/openpnp/util/SimpleGraph.java
@@ -1,0 +1,282 @@
+/*
+ * Copyright (C) 2020 <mark@makr.zone>
+ * inspired and based on work by
+ * Copyright (C) 2011 Jason von Nieda <jason@vonnieda.org>
+ * 
+ * This file is part of OpenPnP.
+ * 
+ * OpenPnP is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * OpenPnP is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License along with OpenPnP. If not, see
+ * <http://www.gnu.org/licenses/>.
+ * 
+ * For more information about OpenPnP visit http://openpnp.org
+ */
+
+package org.openpnp.util;
+
+import java.awt.Color;
+import java.awt.geom.Point2D;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+
+public class SimpleGraph {
+
+    private boolean offsetMode = false;
+    private double relativePaddingLeft;
+    private double relativePaddingRight;
+    private List<DataScale> dataScales = new ArrayList<>();  
+
+    public static class DataScale {
+        private String label;
+        private Color color = null;
+        private List<DataRow> dataRows = new ArrayList<>();
+        private double relativePaddingTop;
+        private double relativePaddingBottom;
+
+
+        public void addDataRow(DataRow dataRow) {
+            dataRows.add(dataRow);
+        }
+        public List<DataRow> getDataRows() {
+            return dataRows;
+        }
+
+        public DataScale(String label) {
+            super();
+            this.label = label;
+        }
+
+        public Point2D.Double getMinimum() {
+            Point2D.Double minimum = null;
+            for (DataRow dataRow : dataRows) {
+                Point2D.Double rowMin = dataRow.getMinimum();
+                if (minimum == null) {
+                    minimum = rowMin;
+                }
+                else {
+                    minimum.x = Math.min(rowMin.x, minimum.x);
+                    minimum.y = Math.min(rowMin.y, minimum.y);
+                }
+            }
+            return minimum; 
+        }
+        public String getLabel() {
+            return label;
+        }
+
+        public Color getColor() {
+            return color;
+        }
+        public void setColor(Color color) {
+            this.color = color;
+        }
+        public double getRelativePaddingTop() {
+            return relativePaddingTop;
+        }
+        public void setRelativePaddingTop(double relativePaddingTop) {
+            this.relativePaddingTop = relativePaddingTop;
+        }
+        public double getRelativePaddingBottom() {
+            return relativePaddingBottom;
+        }
+        public void setRelativePaddingBottom(double relativePaddingBottom) {
+            this.relativePaddingBottom = relativePaddingBottom;
+        }
+
+        public Point2D.Double getMaximum() {
+            Point2D.Double maximum = null;
+            for (DataRow dataRow : dataRows) {
+                Point2D.Double rowMax = dataRow.getMaximum();
+                if (maximum == null) {
+                    maximum = rowMax;
+                }
+                else {
+                    maximum.x = Math.max(rowMax.x, maximum.x);
+                    maximum.y = Math.max(rowMax.y, maximum.y);
+                }
+            }
+            return maximum; 
+        }
+    } 
+
+    public void addDataScale(DataScale dataScale) {
+        dataScales.add(dataScale);
+    }
+    public DataScale getScale(String label) {
+        for (DataScale dataScale : dataScales) {
+            if (dataScale.getLabel().equals(label)) {
+                return dataScale;
+            }
+        }
+        DataScale dataScale = new DataScale(label);
+        addDataScale(dataScale);
+        return dataScale;
+    }
+    public List<DataScale> getDataScales() {
+        return dataScales;
+    }
+    public DataRow getRow(String scaleLabel, String label) {
+        DataScale dataScale = getScale(scaleLabel);
+        for (DataRow dataRow : dataScale.dataRows) {
+            if (dataRow.getLabel().equals(label)) {
+                return dataRow;
+            }
+        }
+        DataRow dataRow = new DataRow(label, new Color(0, 0, 0));
+        dataScale.addDataRow(dataRow);
+        return dataRow;
+    }
+
+    public boolean isOffsetMode() {
+        return offsetMode;
+    }
+    public void setOffsetMode(boolean offsetMode) {
+        this.offsetMode = offsetMode;
+    }
+
+    public double getRelativePaddingLeft() {
+        return relativePaddingLeft;
+    }
+    public void setRelativePaddingLeft(double relativePaddingLeft) {
+        this.relativePaddingLeft = relativePaddingLeft;
+    }
+    public double getRelativePaddingRight() {
+        return relativePaddingRight;
+    }
+    public void setRelativePaddingRight(double relativePaddingRight) {
+        this.relativePaddingRight = relativePaddingRight;
+    }
+
+    public static class DataRow {
+        private String label;
+        private Color color;
+        private HashMap<Double, Double> data = new HashMap<>();
+
+        // housekeeping
+        boolean dirty = false;
+        private List<Double> sortedKeys;
+        private Point2D.Double minimum = null;
+        private Point2D.Double maximum = null;
+
+        public DataRow(String label, Color color) {
+            super();
+            this.label = label;
+            this.color = color;
+        }
+
+        public void recordDataPoint(double x, double y) {
+            data.put(x, y);
+            dirty = true;
+        }
+        public void recordDataPoint(long x, double y) {
+            data.put((double)x, y);
+            dirty = true;
+        }
+        public Double getDataPoint(double x) {
+            return data.get(x);
+        }
+        public int size() {
+            return data.size();
+        }
+
+        protected void recalc() {
+            if (dirty) {
+                sortedKeys = new ArrayList<Double>(data.size());
+                sortedKeys.addAll(data.keySet());
+                Collections.sort(sortedKeys);
+                minimum = null;
+                maximum = null;
+                for (double x : sortedKeys) {
+                    double y = data.get(x);
+                    if (minimum == null) {
+                        minimum = new Point2D.Double(x, y);
+                    }
+                    else {
+                        minimum.x = Math.min(x, minimum.x);
+                        minimum.y = Math.min(y, minimum.y);
+                    }
+                    if (maximum == null) {
+                        maximum = new Point2D.Double(x, y);
+                    }
+                    else {
+                        maximum.x = Math.max(x, maximum.x);
+                        maximum.y = Math.max(y, maximum.y);
+                    }
+                }
+                dirty = false;
+            }
+        }
+
+        public List<Double> getXAxis() {
+            recalc();
+            return sortedKeys;
+        }
+        public Point2D.Double getMinimum() {
+            recalc();
+            if (minimum == null) {
+                return new Point2D.Double();
+            }
+            else {
+                return (Point2D.Double)minimum.clone();
+            }
+        }
+        public Point2D.Double getMaximum() {
+            recalc();
+            if (maximum == null) {
+                return new Point2D.Double();
+            }
+            else {
+                return (Point2D.Double)maximum.clone();
+            }
+        }
+        public String getLabel() {
+            return label;
+        }
+        public Color getColor() {
+            return color;
+        }
+        public void setColor(Color color) {
+            this.color = color;
+        }
+        public HashMap<Double, Double> getData() {
+            return data;
+        }
+        public void setData(HashMap<Double, Double> data) {
+            this.data = data;
+        }
+
+    }
+
+
+    public Point2D.Double getMinimum(DataScale dataScaleForY) {
+        Point2D.Double minimum = dataScaleForY.getMinimum();
+        // expand x axis over all the scales 
+        for (DataScale dataScale : dataScales) {
+            if (dataScale != dataScaleForY) {
+                Point2D.Double scaleMin = dataScale.getMinimum();
+                minimum.x = Math.min(scaleMin.x, minimum.x);
+            }
+        }
+        return minimum; 
+    }
+    public Point2D.Double getMaximum(DataScale dataScaleForY) {
+        Point2D.Double maximum = dataScaleForY.getMaximum();
+        // expand x axis over all the scales 
+        for (DataScale dataScale : dataScales) {
+            if (dataScale != dataScaleForY) {
+                Point2D.Double scaleMin = dataScale.getMaximum();
+                maximum.x = Math.max(scaleMin.x, maximum.x);
+            }
+        }
+        return maximum; 
+    }
+}


### PR DESCRIPTION
# Description

This PR adds advanced methods of part-on/part-off vacuum testing to OpenPNP, while keeping the previous simple functionality available. 

## Feature List

1. Easier setup with Measurement Method combo box. Detection can be switched off without having to overwrite your values.
2. The method combo box controls the visible fields in the Wizard, so it can be easy or it can be advanced, as users like it. 
3. New "Difference" method allows you to specify the permissible _change_ in the vacuum level, in addition to the absolute level.
4. Therefore, much finer nuances in changes of the vacuum level can be discriminated, which is essential for the very small nozzle tips with high air flow resistance and/or strong pumps and/or vacuum reservoir systems and/or multi-nozzle systems with crosstalk.
6. The vacuum level can be monitored/polled while picking or placing a part, so OpenPNP can go on, as soon as the desired buildup/decay level is reached. The former dwell time becomes a timeout. 
7. Much faster picks and places result in the majority of cases, while gaining robustness for the few exceptions. The timeout/dwell time can now be increased without _general_ speed penalty. The wait will only be incurred in the rare worst case.
8. Graphical diagnostics allow a much more informed approach. How fast do the vacuum levels build up or decay? How fast is your sensor? How fast is OpenPNP in querying the controller? No more guesswork! No more browsing in the endless log. 
9. I wanted to hook up the oscilloscope, but then thought, why not use OpenPNP instead?

![grafik](https://user-images.githubusercontent.com/9963310/79808951-90abad00-836f-11ea-8be6-8fb860adf4ab.png)

# Justification

Following [some discussions in the group](https://groups.google.com/d/msg/openpnp/gL7uEjKmLzU/oOaAlRBdAgAJ) and negative 0402 tests on my machine, and some long thinking about why the detection actually works (and why not), it appears that the current absolute pressure level part-on/part-off vacuum testing method will not work with fast operation and/or small nozzle tips and/or strong pumps and/or vacuum reservoirs and/or multiple nozzles with crosstalk. The baseline of the pressure is simply too varied, the difference between the part obstruction or not obstructing a fine nozzle tip is too small. 

I did my best to try and ensure that the old settings will be ported over and if people don't like the new way, it should work as before. 

A lot of thought and work has gone into reducing the changes in existing core and reference classes to a minimum and to keeping the outer layers (JobProcessor, spi and model interfaces) almost untouched. Most remaining changes are additive, either truly new classes, methods and fields or high-level ifs in methods to separate new from old ways. Adding a new Nozzle subclass was evaluated but found impractical, frankly not least by being convinced of the general usefulness of the new implementation for many users. 

However, this surely needs some thorough review, and I am prepared to make changes as needed. 

The before pick part-off test needs to be rethought, IMHO. Comments in the code.  

The way I implemented the check options (org.openpnp.spi.Nozzle.PartOnStep and org.openpnp.spi.Nozzle.PartOffStep) is just a proposal. I'm awaiting guidance. 

# Instructions for Use

The user interface complexity scales with the Measurement Method, dynamically:
From "None"...
![grafik](https://user-images.githubusercontent.com/9963310/79808758-17ac5580-836f-11ea-840b-59f65845fa0f.png)
to "Absolute" 
![grafik](https://user-images.githubusercontent.com/9963310/79808833-46c2c700-836f-11ea-8592-2454c27de99b.png)
to "Difference"
![grafik](https://user-images.githubusercontent.com/9963310/79809341-6a3a4180-8370-11ea-9a8d-fccabc5ba93c.png)

As you see in the last image, the settings are two folded for Part On (after pick) and Part Off (after place) sensing. 

The "Establish Level?" checkboxes enable life monitoring of the pressure while the nozzle tip is pressed down on the part, either while picking or placing. As soon as the level reaches the target Vacuum Range, OpenPNP can go on and lift the nozzle. This is also needed if you want the graph. 

With the "Perform Checks?" checkboxes, you can choose when to check for Part On/Part Off. [The need for these was also concluded in the group](https://groups.google.com/d/msg/openpnp/gL7uEjKmLzU/M87TLphqAgAJ). 

The "Vacuum Range" settings are the absolute vacuum readings you want to achieve. In Absolute mode the are the only criteria for the checks.

The "Last Reading" will be set after a pick or place has taken place. This will be the value that either satisfied or violated the last absolute check. 

In Difference mode you also get a Difference Range to specify the allowed _change_ in pressure, as compared to the baseline measurement. 

In Part On checks, the baseline is the pressure that was reached before lifting the nozzle. A fluctuating pump pressure, due to hysteresis regulation or crosstalk with a second nozzle, or a recent dip in the pump pressure due to part loss, will be compensated. 

In Part Off checks, the baseline is the pressure that is measured right before opening the valve for the check. 

Again a "Last Reading" is provided to see the result of the last check.  

The "Probing time" is a new separate dwell time for the Part Off check. The pick dwell time can now be different for obvious good reasons. On my machine the probe time must be quite small to get (somewhat) conclusive results. 

In the following image you see the both "Part Off" checks enabled, the first might be usable, because the rise in pressure in the first 40ms is clearly a reaction to the valve opening. But the second check won't work, as the checks are too close together and the pressure rise is still very much influenced by the first check. 

![grafik](https://user-images.githubusercontent.com/9963310/79810071-71fae580-8372-11ea-8342-fcd2d295c034.png)

As you can see, the graphical diagnostic (some repetitions of it) can also tell you real quick when something _won't_ work and you can make an informed decision to give it up. ;-) 

# Implementation Details
1. This was Job-Tested on my machine. **But this obviously needs to be tested by more people and machines.** 
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. Changes in the `org.openpnp.spi` or `org.openpnp.model` packages (Nozzle) were needed to enable/disable the different JobProcessor checks. 
4. Successful `mvn test` before submitting the Pull Request. 
