### PR TITLE
Feature/improve nozzle tip calibration

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/ReferenceNozzleTipCalibration.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceNozzleTipCalibration.java
@@ -144,9 +144,9 @@ public class ReferenceNozzleTipCalibration extends AbstractModelObject {
         @Attribute(required = false)
         protected LengthUnit units = LengthUnit.Millimeters;
         @Attribute(required = false)
-        protected double peakError;
+        protected Double peakError;
         @Attribute(required = false)
-        protected double rmsError;
+        protected Double rmsError;
 
         public ModelBasedRunoutCompensation() {
         }
@@ -210,7 +210,7 @@ public class ReferenceNozzleTipCalibration extends AbstractModelObject {
         private void estimateModelError(List<Location> nozzleTipMeasuredLocations) {
             Location peakErrorLocation = new Location(this.units);
             double sumError2 = 0;
-            peakError = 0;
+            peakError = 0.0;
             for (Location l : nozzleTipMeasuredLocations) {
                 //can't use getOffset here because it may be overridden
                 Location m = getRunout(l.getRotation()).add(new Location(this.units, this.centerX, this.centerY, 0, 0));
@@ -402,7 +402,7 @@ public class ReferenceNozzleTipCalibration extends AbstractModelObject {
          * @return The peak error (in this.units) of the measured nozzle tip
          * locations relative to the locations computed by the model
          */
-        public double getPeakError() {
+        public Double getPeakError() {
             return peakError;
         }
         
@@ -410,7 +410,7 @@ public class ReferenceNozzleTipCalibration extends AbstractModelObject {
          * @return The rms error (in this.units) of the measured nozzle tip
          * locations relative to the locations computed by the model
          */
-       public double getRmsError() {
+       public Double getRmsError() {
             return rmsError;
         }
     }
@@ -498,7 +498,8 @@ public class ReferenceNozzleTipCalibration extends AbstractModelObject {
     }
 
     @Attribute(required = false)
-    private ReferenceNozzleTipCalibration.RunoutCompensationAlgorithm runoutCompensationAlgorithm = RunoutCompensationAlgorithm.ModelCameraOffset;
+    private ReferenceNozzleTipCalibration.RunoutCompensationAlgorithm runoutCompensationAlgorithm =
+        RunoutCompensationAlgorithm.ModelCameraOffsetAffine;
     
     @Attribute(required = false)
     private double version = 1.0;
@@ -522,6 +523,18 @@ public class ReferenceNozzleTipCalibration extends AbstractModelObject {
             version = 2.0;
             // Force ModelCameraOffset calibration system.
             runoutCompensationAlgorithm = RunoutCompensationAlgorithm.ModelCameraOffset;
+        }
+        
+        //Update from KASA to Affine transform technique
+        if (version < 2.1) {
+            version = 2.1; //bump version number so this update is only done once
+            if (runoutCompensationAlgorithm == RunoutCompensationAlgorithm.Model) {
+                runoutCompensationAlgorithm = RunoutCompensationAlgorithm.ModelAffine;
+            } else if (runoutCompensationAlgorithm == RunoutCompensationAlgorithm.ModelNoOffset) {
+                runoutCompensationAlgorithm = RunoutCompensationAlgorithm.ModelNoOffsetAffine;
+            } else if (runoutCompensationAlgorithm == RunoutCompensationAlgorithm.ModelCameraOffset) {
+                runoutCompensationAlgorithm = RunoutCompensationAlgorithm.ModelCameraOffsetAffine;
+            }
         }
     }
 

--- a/src/main/java/org/openpnp/machine/reference/ReferenceNozzleTipCalibration.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceNozzleTipCalibration.java
@@ -430,7 +430,7 @@ public class ReferenceNozzleTipCalibration extends AbstractModelObject {
     private double angleStop = 180;
     // The excenter radius as a ratio of the camera minimum dimension.  
     @Attribute(required = false)
-    private double excenterRatio = 0.45;
+    private double excenterRatio = 0.25;
 
     @Attribute(required = false)
     private boolean enabled;

--- a/src/main/java/org/openpnp/machine/reference/ReferenceNozzleTipCalibration.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceNozzleTipCalibration.java
@@ -490,7 +490,7 @@ public class ReferenceNozzleTipCalibration extends AbstractModelObject {
     private Map<String, RunoutCompensation> runoutCompensationLookup = new HashMap<>();
 
     public enum RunoutCompensationAlgorithm {
-        Model, ModelNoOffset, ModelCameraOffset, ModelCameraOffsetAffine, Table
+        Model, ModelAffine, ModelNoOffset, ModelNoOffsetAffine, ModelCameraOffset, ModelCameraOffsetAffine, Table
     }
 
     public enum RecalibrationTrigger {
@@ -659,8 +659,12 @@ public class ReferenceNozzleTipCalibration extends AbstractModelObject {
             if (!calibrateCamera) {
                 if (this.runoutCompensationAlgorithm == RunoutCompensationAlgorithm.Model) {
                     this.setRunoutCompensation(nozzle, new ModelBasedRunoutCompensation(nozzleTipMeasuredLocations));
+                } else if (this.runoutCompensationAlgorithm == RunoutCompensationAlgorithm.ModelAffine) {
+                    this.setRunoutCompensation(nozzle, new ModelBasedRunoutCompensation(nozzleTipMeasuredLocations, nozzleTipExpectedLocations));
                 } else if (this.runoutCompensationAlgorithm == RunoutCompensationAlgorithm.ModelNoOffset) {
                     this.setRunoutCompensation(nozzle, new ModelBasedRunoutNoOffsetCompensation(nozzleTipMeasuredLocations));
+                } else if (this.runoutCompensationAlgorithm == RunoutCompensationAlgorithm.ModelNoOffsetAffine) {
+                    this.setRunoutCompensation(nozzle, new ModelBasedRunoutNoOffsetCompensation(nozzleTipMeasuredLocations, nozzleTipExpectedLocations));
                 } else if (this.runoutCompensationAlgorithm == RunoutCompensationAlgorithm.ModelCameraOffset) {
                     this.setRunoutCompensation(nozzle, new ModelBasedRunoutCameraOffsetCompensation(nozzleTipMeasuredLocations));
                 } else if (this.runoutCompensationAlgorithm == RunoutCompensationAlgorithm.ModelCameraOffsetAffine) {
@@ -670,7 +674,11 @@ public class ReferenceNozzleTipCalibration extends AbstractModelObject {
                 }
             }
             else {
-                if (this.runoutCompensationAlgorithm == RunoutCompensationAlgorithm.ModelCameraOffsetAffine) {
+                if ((this.runoutCompensationAlgorithm == RunoutCompensationAlgorithm.ModelAffine) ||
+                    (this.runoutCompensationAlgorithm == RunoutCompensationAlgorithm.ModelNoOffsetAffine) ||
+                    (this.runoutCompensationAlgorithm == RunoutCompensationAlgorithm.ModelCameraOffsetAffine)) {
+                    //This camera alignment stuff should be moved out of nozzle tip calibration
+                    //and placed with the rest of the camera setup stuff
                     AffineTransform at = Utils2D.deriveAffineTransform(nozzleTipMeasuredLocations, nozzleTipExpectedLocations);
                     Utils2D.AffineInfo ai = Utils2D.affineInfo(at);
                     Logger.debug("[nozzleTipCalibration]bottom camera affine transform: " + ai);

--- a/src/main/java/org/openpnp/machine/reference/wizards/ReferenceNozzleTipCalibrationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/wizards/ReferenceNozzleTipCalibrationWizard.java
@@ -92,7 +92,7 @@ public class ReferenceNozzleTipCalibrationWizard extends AbstractConfigurationWi
 
 
         panelCalibration = new JPanel();
-        panelCalibration.setBorder(new TitledBorder(null, "Calibration (EXPERIMENTAL!)",
+        panelCalibration.setBorder(new TitledBorder(null, "Calibration",
                 TitledBorder.LEADING, TitledBorder.TOP, null, null));
         contentPanel.add(panelCalibration);
         panelCalibration.setLayout(new FormLayout(new ColumnSpec[] {


### PR DESCRIPTION
# Description
Fixed a bug in nozzle tip calibration that could, in some cases, cause the runout error to double rather than being canceled.  Also added a new technique for nozzle tip calibration based on affine transforms which should be more robust to measurement outliers.

A couple of small changes were also made to the calibration process:

1. When the pipeline returns more than one result for a single measurement, instead of just picking the first result, which may be erroneous (and logging a message that the user would only see if he knows to examine the logs), it now rejects all the results for that measurement and counts it as a misdetection (which will cause an error to be thrown if too many misdetects occur).
2.  Instead of waiting until all measurements are taken before checking for too many misdetects, it now checks after each measurement and throws the error as soon as the misdetect threshold is crossed.

# Justification
Improves placement accuracy

# Instructions for Use
No special instructions for the bug fix.  To use the new nozzle tip calibration technique, edit machine.xml and replace all occurrances of:
       runout-compensation-algorithm="ModelCameraOffset"
with:
       runout-compensation-algorithm="ModelCameraOffsetAffine"

# Implementation Details
**1. How did you test the change?** Tested the bug fix by duplicating the conditions under which it would occur (phase shifts near 180 degrees) and verified that it now handles the condition correctly.  The new technique was tested in simulation as well as run it on a real machine  to verify comparable or better results than with the original technique.
**2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)?**  Yes.
**3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing.**  No changes were made to these packages
**4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted.**  Maven tests were run and passed.
