### PR TITLE
Feature/dynamic safe z

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/ReferenceNozzle.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceNozzle.java
@@ -360,6 +360,17 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
     public void moveToSafeZ(double speed) throws Exception {
         Logger.debug("{}.moveToSafeZ({})", getName(), speed);
         Length safeZ = this.safeZ.convertToUnits(getLocation().getUnits());
+        // if safeZ is lower than 0, use dynamic safeZ
+        if (safeZ.getValue() < -0.00001 ) {  // ignore Units, just be sure it's really not set to zero
+            // if a part is loaded, decrease (higher) safeZ
+            if (part != null) {
+                safeZ = safeZ.add(part.getHeight());
+            }
+            // make sure safeZ is never above 0
+            if (safeZ.getValue() > 0 ) {
+                safeZ.setValue(0);
+            }
+        }
         Location l = new Location(getLocation().getUnits(), Double.NaN, Double.NaN,
                 safeZ.getValue(), Double.NaN);
         getDriver().moveTo(this, l, getHead().getMaxPartSpeed() * speed);

--- a/src/main/java/org/openpnp/machine/reference/ReferenceNozzle.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceNozzle.java
@@ -59,6 +59,9 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
     @Element(required = false)
     protected Length safeZ = new Length(0, LengthUnit.Millimeters);
 
+    @Attribute(required = false)
+    private boolean enableDynamicSafeZ = false;
+
     /**
      * TODO Deprecated in favor of vacuumActuatorName. Remove Jan 1, 2021.
      */
@@ -112,6 +115,14 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
 
     public void setLimitRotation(boolean limitRotation) {
         this.limitRotation = limitRotation;
+    }
+
+    public boolean isEnableDynamicSafeZ() {
+        return enableDynamicSafeZ;
+    }
+
+    public void setEnableDynamicSafeZ(boolean enableDynamicSafeZ) {
+        this.enableDynamicSafeZ = enableDynamicSafeZ;
     }
 
     public int getPickDwellMilliseconds() {
@@ -360,8 +371,7 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
     public void moveToSafeZ(double speed) throws Exception {
         Logger.debug("{}.moveToSafeZ({})", getName(), speed);
         Length safeZ = this.safeZ.convertToUnits(getLocation().getUnits());
-        // if safeZ is lower than 0, use dynamic safeZ
-        if (safeZ.getValue() < -0.00001 ) {  // ignore Units, just be sure it's really not set to zero
+        if (enableDynamicSafeZ) { 
             // if a part is loaded, decrease (higher) safeZ
             if (part != null) {
                 safeZ = safeZ.add(part.getHeight());

--- a/src/main/java/org/openpnp/machine/reference/wizards/ReferenceNozzleConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/wizards/ReferenceNozzleConfigurationWizard.java
@@ -41,6 +41,7 @@ import com.jgoodies.forms.layout.ColumnSpec;
 import com.jgoodies.forms.layout.FormLayout;
 import com.jgoodies.forms.layout.FormSpecs;
 import com.jgoodies.forms.layout.RowSpec;
+import javax.swing.SwingConstants;
 
 @SuppressWarnings("serial")
 public class ReferenceNozzleConfigurationWizard extends AbstractConfigurationWizard {
@@ -62,6 +63,8 @@ public class ReferenceNozzleConfigurationWizard extends AbstractConfigurationWiz
     private JTextField pickDwellTf;
     private JTextField placeDwellTf;
     private JLabel lblLimitRota;
+    private JLabel lblDynamicSafeZ;
+    private JCheckBox chckbxDynamicsafez;
 
     public ReferenceNozzleConfigurationWizard(ReferenceNozzle nozzle) {
         this.nozzle = nozzle;
@@ -123,17 +126,31 @@ public class ReferenceNozzleConfigurationWizard extends AbstractConfigurationWiz
         panelSafeZ.setBorder(new TitledBorder(null, "Safe Z", TitledBorder.LEADING,
                 TitledBorder.TOP, null, null));
         contentPanel.add(panelSafeZ);
-        panelSafeZ.setLayout(new FormLayout(
-                new ColumnSpec[] {FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,
-                        FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,},
-                new RowSpec[] {FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,}));
-
-        JLabel lblSafeZ = new JLabel("Safe Z");
-        panelSafeZ.add(lblSafeZ, "2, 2, right, default");
-
-        textFieldSafeZ = new JTextField();
-        panelSafeZ.add(textFieldSafeZ, "4, 2, fill, default");
-        textFieldSafeZ.setColumns(10);
+        panelSafeZ.setLayout(new FormLayout(new ColumnSpec[] {
+                ColumnSpec.decode("max(81dlu;default)"),
+                FormSpecs.RELATED_GAP_COLSPEC,
+                ColumnSpec.decode("114px"),
+                FormSpecs.RELATED_GAP_COLSPEC,
+                FormSpecs.DEFAULT_COLSPEC,},
+            new RowSpec[] {
+                RowSpec.decode("24px"),
+                RowSpec.decode("19px"),}));
+        
+                JLabel lblSafeZ = new JLabel("Safe Z");
+                panelSafeZ.add(lblSafeZ, "1, 1, right, center");
+        
+                textFieldSafeZ = new JTextField();
+                panelSafeZ.add(textFieldSafeZ, "3, 1, fill, top");
+                textFieldSafeZ.setColumns(10);
+                
+                lblDynamicSafeZ = new JLabel("Dynamic Safe Z");
+                lblDynamicSafeZ.setToolTipText("");
+                lblDynamicSafeZ.setHorizontalAlignment(SwingConstants.TRAILING);
+                panelSafeZ.add(lblDynamicSafeZ, "1, 2");
+                
+                chckbxDynamicsafez = new JCheckBox("");
+                chckbxDynamicsafez.setToolTipText("dynamicaly adjust the safeZ, so the bottom of a loaded part is at safeZ if possible");
+                panelSafeZ.add(chckbxDynamicsafez, "3, 2");
 
 
         panelChanger = new JPanel();
@@ -201,6 +218,7 @@ public class ReferenceNozzleConfigurationWizard extends AbstractConfigurationWiz
         addWrappedBinding(headOffsets, "lengthZ", locationZ, "text", lengthConverter);
 
         addWrappedBinding(nozzle, "limitRotation", chckbxLimitRotationTo, "selected");
+        addWrappedBinding(nozzle, "enableDynamicSafeZ", chckbxDynamicsafez, "selected");
         addWrappedBinding(nozzle, "safeZ", textFieldSafeZ, "text", lengthConverter);
         addWrappedBinding(nozzle, "pickDwellMilliseconds", pickDwellTf, "text", intConverter);
         addWrappedBinding(nozzle, "placeDwellMilliseconds", placeDwellTf, "text", intConverter);


### PR DESCRIPTION
# Description
Enables a dynamic safeZ computation for a nozzle.

# Justification
Saves time on all machines with a slow Z axis. Allows to lower the safeZ to a value where the nozzle will never collide with any part on the table (including the PCB with parts). If a part is attached the nozzle will be raised, until the bottom of the part is at safeZ (if possible, nozzle can never be raised above 0). So a collision even with large parts on the nozzle will be avoided.

# Instructions for Use
Enable the "Dynamic Safe Z" in the Nozzle setup, fill in correct height information in the parts and set "safe Z" to a value where the nozzle will never collide with anything mounted on the table.

# Implementation Details
1. How did you test the change?

Tested in the simulator with different part heights.

2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)?

yes.

3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing.

no changes

4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted.

passes.