### PR TITLE
Added ScalingTransform according to feature request 944

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/driver/GcodeDriver.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/GcodeDriver.java
@@ -1512,4 +1512,28 @@ public class GcodeDriver extends AbstractReferenceDriver implements Named, Runna
         }
     }
     
+    public static class ScalingTransform implements AxisTransform {
+
+        @Attribute(required = false)
+        private double scaleFactor = 1;
+
+        @Override
+        public double toTransformed(Axis axis, HeadMountable hm, double rawCoordinate) {
+            if (scaleFactor == 0) {
+                Logger.info("Scale factor 0 is not allowed, defaults to 1.");
+                scaleFactor = 1;
+            }
+            return rawCoordinate / scaleFactor;
+        }
+
+        @Override
+        public double toRaw(Axis axis, HeadMountable hm, double transformedCoordinate) {
+            if (scaleFactor == 0) {
+                Logger.info("Scale factor 0 is not allowed, defaults to 1.");
+                scaleFactor = 1;
+            }
+            return transformedCoordinate * scaleFactor;
+        }
+    }
+    
 }


### PR DESCRIPTION
https://github.com/openpnp/openpnp/issues/944
-----------------------------------------------------------------------

# Description
Added a function that perform a scaling transform to axes in the GcodeDriver. The axis will move less or more depending on scale factor and report to machine.

# Justification
This is used on machines that don't directly support the length and angle units given by OpenPnP.

# Instructions for Use
Add the property "scale-factor" to GCode part of machine.xml.

<transform class="org.openpnp.machine.reference.driver.GcodeDriver$ScalingTransform" scale-factor="0.1"/>

# Implementation Details
Maven test completed successfully. 
Tested on hardware (Siemens MS-90) with X and Y scale-factor beeng -100 and rotation scale-factor beeing -11.
Tested configuring to scaleFactor = 0. There will be a log entry and factor changes to 1.0.
Default factor is 1.0, which means nothing changes.
