### PR TITLE
Linking project overview dashboard to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ you can [use this web based one](http://webchat.freenode.net/?channels=openpnp)
 [![Bugs](https://img.shields.io/github/issues-raw/openpnp/openpnp/bug.svg?label=bugs&colorB=D9472F)](https://github.com/openpnp/openpnp/labels/bug)
 [![Feature Requests](https://img.shields.io/github/issues-raw/openpnp/openpnp/feature-request.svg?label=feature-requests&colorB=bfd4f2)](https://github.com/openpnp/openpnp/labels/feature-request)
 [![Enhancements](https://img.shields.io/github/issues-raw/openpnp/openpnp/enhancement.svg?label=enhancements&colorB=0052cc)](https://github.com/openpnp/openpnp/labels/enhancement)
+[![SourceSpy Dashboard](https://sourcespy.com/shield.svg)](https://sourcespy.com/github/openpnpopenpnp/)
 
 
 Before starting work on a pull request, please read: https://github.com/openpnp/openpnp/wiki/Developers-Guide#contributing


### PR DESCRIPTION
# Description
Adding a link to the README header. The linked dashboard describes overall repository structure. Direct link: https://sourcespy.com/github/openpnpopenpnp/

# Justification
The goal is to help new developers explore project and understand architecture/dependencies. 

# Instructions for Use
Only a documentation change. Available from README page

# Implementation Details
No tests written for README change