### PR TITLE
Added(optional) option-flags to the moveTo command.

### DIFF
--- a/src/main/java/org/openpnp/machine/marek/MarekNozzle.java
+++ b/src/main/java/org/openpnp/machine/marek/MarekNozzle.java
@@ -9,6 +9,7 @@ import org.openpnp.model.Length;
 import org.openpnp.model.LengthUnit;
 import org.openpnp.model.Location;
 import org.openpnp.spi.Actuator;
+import org.openpnp.spi.Movable.MoveToOption;
 import org.pmw.tinylog.Logger;
 
 public class MarekNozzle extends ReferenceNozzle {
@@ -21,7 +22,7 @@ public class MarekNozzle extends ReferenceNozzle {
     }
     
     @Override
-    public void moveTo(Location location, double speed) throws Exception {
+    public void moveTo(Location location, double speed, MoveToOption... options) throws Exception {
         // Shortcut Double.NaN. Sending Double.NaN in a Location is an old API that should no
         // longer be used. It will be removed eventually:
         // https://github.com/openpnp/openpnp/issues/255
@@ -107,7 +108,7 @@ public class MarekNozzle extends ReferenceNozzle {
 
         location = location.convertToUnits(loc.getUnits()); // convert units back; // Cri's change
 
-        ((ReferenceHead) getHead()).moveTo(this, location, getHead().getMaxPartSpeed() * speed);
+        ((ReferenceHead) getHead()).moveTo(this, location, getHead().getMaxPartSpeed() * speed, options);
         getMachine().fireMachineHeadActivity(head);
     }
 

--- a/src/main/java/org/openpnp/machine/neoden4/NeoDen4Driver.java
+++ b/src/main/java/org/openpnp/machine/neoden4/NeoDen4Driver.java
@@ -11,6 +11,7 @@ import org.openpnp.machine.reference.ReferenceHead;
 import org.openpnp.machine.reference.ReferenceHeadMountable;
 import org.openpnp.machine.reference.ReferenceMachine;
 import org.openpnp.machine.reference.ReferenceNozzle;
+import org.openpnp.machine.reference.ReferenceDriver.MoveToOptions;
 import org.openpnp.machine.reference.driver.AbstractReferenceDriver;
 import org.openpnp.model.Configuration;
 import org.openpnp.model.LengthUnit;
@@ -488,7 +489,7 @@ public class NeoDen4Driver extends AbstractReferenceDriver implements Named {
     }
 
     @Override
-    public void moveTo(ReferenceHeadMountable hm, Location location, double speed)
+    public void moveTo(ReferenceHeadMountable hm, Location location, double speed, MoveToOptions...options)
             throws Exception {
         location = location.convertToUnits(units);
         location = location.subtract(hm.getHeadOffsets());

--- a/src/main/java/org/openpnp/machine/neoden4/NeoDen4Driver.java
+++ b/src/main/java/org/openpnp/machine/neoden4/NeoDen4Driver.java
@@ -11,12 +11,12 @@ import org.openpnp.machine.reference.ReferenceHead;
 import org.openpnp.machine.reference.ReferenceHeadMountable;
 import org.openpnp.machine.reference.ReferenceMachine;
 import org.openpnp.machine.reference.ReferenceNozzle;
-import org.openpnp.machine.reference.ReferenceDriver.MoveToOptions;
 import org.openpnp.machine.reference.driver.AbstractReferenceDriver;
 import org.openpnp.model.Configuration;
 import org.openpnp.model.LengthUnit;
 import org.openpnp.model.Location;
 import org.openpnp.model.Named;
+import org.openpnp.spi.Movable.MoveToOption;
 import org.openpnp.spi.Nozzle;
 import org.pmw.tinylog.Logger;
 import org.simpleframework.xml.Attribute;
@@ -489,7 +489,7 @@ public class NeoDen4Driver extends AbstractReferenceDriver implements Named {
     }
 
     @Override
-    public void moveTo(ReferenceHeadMountable hm, Location location, double speed, MoveToOptions...options)
+    public void moveTo(ReferenceHeadMountable hm, Location location, double speed, MoveToOption...options)
             throws Exception {
         location = location.convertToUnits(units);
         location = location.subtract(hm.getHeadOffsets());

--- a/src/main/java/org/openpnp/machine/reference/ReferenceActuator.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceActuator.java
@@ -115,7 +115,7 @@ public class ReferenceActuator extends AbstractActuator implements ReferenceHead
     }
 
     @Override
-    public void moveTo(Location location, double speed) throws Exception {
+    public void moveTo(Location location, double speed, MoveToOption... options) throws Exception {
         Logger.debug("{}.moveTo({}, {})", getName(), location, speed);
         ((ReferenceHead) getHead()).moveTo(this, location, getHead().getMaxPartSpeed() * speed);
         getMachine().fireMachineHeadActivity(head);

--- a/src/main/java/org/openpnp/machine/reference/ReferenceCamera.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceCamera.java
@@ -53,6 +53,7 @@ import org.openpnp.model.Configuration;
 import org.openpnp.model.Length;
 import org.openpnp.model.LengthUnit;
 import org.openpnp.model.Location;
+import org.openpnp.spi.Movable.MoveToOption;
 import org.openpnp.spi.base.AbstractCamera;
 import org.openpnp.util.OpenCvUtils;
 import org.openpnp.vision.LensCalibration;
@@ -232,9 +233,9 @@ public abstract class ReferenceCamera extends AbstractCamera implements Referenc
     }
 
     @Override
-    public void moveTo(Location location, double speed) throws Exception {
+    public void moveTo(Location location, double speed, MoveToOption... options) throws Exception {
         Logger.debug("moveTo({}, {})", location, speed);
-        ((ReferenceHead) getHead()).moveTo(this, location, getHead().getMaxPartSpeed() * speed);
+        ((ReferenceHead) getHead()).moveTo(this, location, getHead().getMaxPartSpeed() * speed, options);
         getMachine().fireMachineHeadActivity(head);
     }
 

--- a/src/main/java/org/openpnp/machine/reference/ReferenceDriver.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceDriver.java
@@ -22,6 +22,7 @@ package org.openpnp.machine.reference;
 import java.io.Closeable;
 
 import org.openpnp.model.Location;
+import org.openpnp.spi.Movable.MoveToOption;
 import org.openpnp.spi.PropertySheetHolder;
 import org.openpnp.spi.WizardConfigurable;
 
@@ -44,16 +45,7 @@ public interface ReferenceDriver extends WizardConfigurable, PropertySheetHolder
      * 
      * @throws Exception
      */
-    public void home(ReferenceHead head) throws Exception;
-    
-    
-    /**
-     * Contains all possible options for the moveTo command.
-     * RAW: disable all internal corrections, just tell the driver to move to that position
-     * NO_BACKSLASH: disable backslash compensation
-     */
-    public enum MoveToOptions { RAW, NO_BACKSLASH, NO_NONSQUARNESS }
-    
+    public void home(ReferenceHead head) throws Exception;    
 
     /**
      * Moves the specified HeadMountable to the given location at a speed defined by (maximum feed
@@ -68,7 +60,7 @@ public interface ReferenceDriver extends WizardConfigurable, PropertySheetHolder
      * @param options zero to n options from the MoveToOptions enum.
      * @throws Exception
      */
-    public void moveTo(ReferenceHeadMountable hm, Location location, double speed, MoveToOptions... options) throws Exception;
+    public void moveTo(ReferenceHeadMountable hm, Location location, double speed, MoveToOption... options) throws Exception;
 
     /**
      * Returns a clone of the HeadMountable's current location. It's important that the returned

--- a/src/main/java/org/openpnp/machine/reference/ReferenceDriver.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceDriver.java
@@ -45,6 +45,15 @@ public interface ReferenceDriver extends WizardConfigurable, PropertySheetHolder
      * @throws Exception
      */
     public void home(ReferenceHead head) throws Exception;
+    
+    
+    /**
+     * Contains all possible options for the moveTo command.
+     * RAW: disable all internal corrections, just tell the driver to move to that position
+     * NO_BACKSLASH: disable backslash compensation
+     */
+    public enum MoveToOptions { RAW, NO_BACKSLASH, NO_NONSQUARNESS }
+    
 
     /**
      * Moves the specified HeadMountable to the given location at a speed defined by (maximum feed
@@ -54,11 +63,12 @@ public interface ReferenceDriver extends WizardConfigurable, PropertySheetHolder
      * HeadMountable object types include Nozzle, Camera and Actuator.
      * 
      * @param hm
-     * @param location
-     * @param speed
+     * @param location destination
+     * @param speed relative speed (0-1) of the move
+     * @param options zero to n options from the MoveToOptions enum.
      * @throws Exception
      */
-    public void moveTo(ReferenceHeadMountable hm, Location location, double speed) throws Exception;
+    public void moveTo(ReferenceHeadMountable hm, Location location, double speed, MoveToOptions... options) throws Exception;
 
     /**
      * Returns a clone of the HeadMountable's current location. It's important that the returned

--- a/src/main/java/org/openpnp/machine/reference/ReferenceHead.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceHead.java
@@ -33,6 +33,7 @@ import org.openpnp.model.Configuration;
 import org.openpnp.model.Location;
 import org.openpnp.spi.HeadMountable;
 import org.openpnp.spi.PropertySheetHolder;
+import org.openpnp.spi.Movable.MoveToOption;
 import org.openpnp.spi.base.AbstractHead;
 import org.pmw.tinylog.Logger;
 
@@ -101,7 +102,7 @@ public class ReferenceHead extends AbstractHead {
         return true;
     }
 
-    public void moveTo(ReferenceHeadMountable hm, Location location, double speed) throws Exception {
+    public void moveTo(ReferenceHeadMountable hm, Location location, double speed, MoveToOption... options) throws Exception {
         if (! isInsideSoftLimits(hm, location)) {
             throw new Exception(String.format("Can't move %s to %s, outside of soft limits on head %s.",
                     hm.getName(), location, getName()));

--- a/src/main/java/org/openpnp/machine/reference/ReferenceNozzle.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceNozzle.java
@@ -30,6 +30,7 @@ import org.openpnp.spi.Camera;
 import org.openpnp.spi.Nozzle;
 import org.openpnp.spi.NozzleTip;
 import org.openpnp.spi.PropertySheetHolder;
+import org.openpnp.spi.Movable.MoveToOption;
 import org.openpnp.spi.base.AbstractNozzle;
 import org.openpnp.util.MovableUtils;
 import org.openpnp.util.SimpleGraph;
@@ -334,7 +335,7 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
     }
 
     @Override
-    public void moveTo(Location location, double speed) throws Exception {
+    public void moveTo(Location location, double speed, MoveToOption... options) throws Exception {
         // Shortcut Double.NaN. Sending Double.NaN in a Location is an old API that should no
         // longer be used. It will be removed eventually:
         // https://github.com/openpnp/openpnp/issues/255
@@ -372,7 +373,7 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
         } else {
             Logger.debug("{}.moveTo({}, {})", getName(), location, speed);
         }
-        ((ReferenceHead) getHead()).moveTo(this, location, getHead().getMaxPartSpeed() * speed);
+        ((ReferenceHead) getHead()).moveTo(this, location, getHead().getMaxPartSpeed() * speed, options);
         getMachine().fireMachineHeadActivity(head);
     }
 
@@ -668,8 +669,8 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
     }
 
     @Override
-    public void moveTo(Location location) throws Exception {
-        moveTo(location, getHead().getMachine().getSpeed());
+    public void moveTo(Location location, MoveToOption... options) throws Exception {
+        moveTo(location, getHead().getMachine().getSpeed(), options);
     }
 
     @Override

--- a/src/main/java/org/openpnp/machine/reference/ReferenceNozzle.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceNozzle.java
@@ -366,6 +366,12 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
         }
 
         ReferenceNozzleTip calibrationNozzleTip = getCalibrationNozzleTip();
+        // check if totally raw move, in that case disable nozzle calibration
+        for (MoveToOption option: options) {
+            if (option == MoveToOption.RAW) {
+                calibrationNozzleTip = null;
+            }
+        }
         if (calibrationNozzleTip != null && calibrationNozzleTip.getCalibration().isCalibrated(this)) {
             Location correctionOffset = calibrationNozzleTip.getCalibration().getCalibratedOffset(this, location.getRotation());
             location = location.subtract(correctionOffset);

--- a/src/main/java/org/openpnp/machine/reference/ReferenceNozzle.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceNozzle.java
@@ -368,7 +368,7 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
         ReferenceNozzleTip calibrationNozzleTip = getCalibrationNozzleTip();
         // check if totally raw move, in that case disable nozzle calibration
         for (MoveToOption option: options) {
-            if (option == MoveToOption.RAW) {
+            if (option == MoveToOption.RawMove) {
                 calibrationNozzleTip = null;
             }
         }

--- a/src/main/java/org/openpnp/machine/reference/driver/GcodeDriver.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/GcodeDriver.java
@@ -27,6 +27,7 @@ import org.openpnp.machine.reference.ReferenceDriver;
 import org.openpnp.machine.reference.ReferenceHead;
 import org.openpnp.machine.reference.ReferenceHeadMountable;
 import org.openpnp.machine.reference.ReferenceMachine;
+import org.openpnp.machine.reference.ReferenceDriver.MoveToOptions;
 import org.openpnp.machine.reference.driver.wizards.GcodeDriverConsole;
 import org.openpnp.machine.reference.driver.wizards.GcodeDriverGcodes;
 import org.openpnp.machine.reference.driver.wizards.GcodeDriverSettings;
@@ -487,8 +488,36 @@ public class GcodeDriver extends AbstractReferenceDriver implements Named, Runna
     }
 
     @Override
-    public void moveTo(ReferenceHeadMountable hm, Location location, double speed)
+    public void moveTo(ReferenceHeadMountable hm, Location location, double speed, MoveToOptions...options)
             throws Exception {
+        // for options make a local copy of all possibly affected variables
+        double backlashOffsetX = this.backlashOffsetX;
+        double backlashOffsetY = this.backlashOffsetX;
+        double backlashOffsetZ = this.backlashOffsetX;
+        double backlashOffsetR = this.backlashOffsetX;
+        double nonSquarenessFactor = this.nonSquarenessFactor;
+        // check options
+        for (MoveToOptions currentOption: options) {
+            switch (currentOption) {
+                case NO_BACKSLASH:          // for this move backslash is zero
+                    backlashOffsetX = 0;
+                    backlashOffsetY = 0;
+                    backlashOffsetZ = 0;
+                    backlashOffsetR = 0;
+                    break;
+                case NO_NONSQUARNESS:       // for this move nonSquarnessFactor is zero
+                    nonSquarenessFactor = 0;
+                    break;
+                case RAW:                   // for this move all corrections are zero
+                    backlashOffsetX = 0;
+                    backlashOffsetY = 0;
+                    backlashOffsetZ = 0;
+                    backlashOffsetR = 0;
+                    nonSquarenessFactor = 0;
+                    break;
+            }
+        }
+        
         // keep copy for calling subdrivers as to not add offset on offset
         Location locationOriginal = location;
 

--- a/src/main/java/org/openpnp/machine/reference/driver/GcodeDriver.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/GcodeDriver.java
@@ -27,7 +27,6 @@ import org.openpnp.machine.reference.ReferenceDriver;
 import org.openpnp.machine.reference.ReferenceHead;
 import org.openpnp.machine.reference.ReferenceHeadMountable;
 import org.openpnp.machine.reference.ReferenceMachine;
-import org.openpnp.machine.reference.ReferenceDriver.MoveToOptions;
 import org.openpnp.machine.reference.driver.wizards.GcodeDriverConsole;
 import org.openpnp.machine.reference.driver.wizards.GcodeDriverGcodes;
 import org.openpnp.machine.reference.driver.wizards.GcodeDriverSettings;
@@ -38,6 +37,7 @@ import org.openpnp.model.Named;
 import org.openpnp.model.Part;
 import org.openpnp.spi.Head;
 import org.openpnp.spi.HeadMountable;
+import org.openpnp.spi.Movable.MoveToOption;
 import org.openpnp.spi.Nozzle;
 import org.openpnp.spi.PropertySheetHolder;
 import org.openpnp.spi.base.SimplePropertySheetHolder;
@@ -488,7 +488,7 @@ public class GcodeDriver extends AbstractReferenceDriver implements Named, Runna
     }
 
     @Override
-    public void moveTo(ReferenceHeadMountable hm, Location location, double speed, MoveToOptions...options)
+    public void moveTo(ReferenceHeadMountable hm, Location location, double speed, MoveToOption...options)
             throws Exception {
         // for options make a local copy of all possibly affected variables
         double backlashOffsetX = this.backlashOffsetX;
@@ -497,16 +497,13 @@ public class GcodeDriver extends AbstractReferenceDriver implements Named, Runna
         double backlashOffsetR = this.backlashOffsetX;
         double nonSquarenessFactor = this.nonSquarenessFactor;
         // check options
-        for (MoveToOptions currentOption: options) {
+        for (MoveToOption currentOption: options) {
             switch (currentOption) {
-                case NO_BACKSLASH:          // for this move backslash is zero
+                case NO_ADDITIONAL_MOVES:     // for this move backslash is zero
                     backlashOffsetX = 0;
                     backlashOffsetY = 0;
                     backlashOffsetZ = 0;
                     backlashOffsetR = 0;
-                    break;
-                case NO_NONSQUARNESS:       // for this move nonSquarnessFactor is zero
-                    nonSquarenessFactor = 0;
                     break;
                 case RAW:                   // for this move all corrections are zero
                     backlashOffsetX = 0;

--- a/src/main/java/org/openpnp/machine/reference/driver/GcodeDriver.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/GcodeDriver.java
@@ -499,13 +499,13 @@ public class GcodeDriver extends AbstractReferenceDriver implements Named, Runna
         // check options
         for (MoveToOption currentOption: options) {
             switch (currentOption) {
-                case NO_ADDITIONAL_MOVES:     // for this move backslash is zero
+                case SpeedOverPrecision:     // for this move backslash is zero
                     backlashOffsetX = 0;
                     backlashOffsetY = 0;
                     backlashOffsetZ = 0;
                     backlashOffsetR = 0;
                     break;
-                case RAW:                   // for this move all corrections are zero
+                case RawMove:                   // for this move all corrections are zero
                     backlashOffsetX = 0;
                     backlashOffsetY = 0;
                     backlashOffsetZ = 0;

--- a/src/main/java/org/openpnp/machine/reference/driver/NullDriver.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/NullDriver.java
@@ -36,6 +36,7 @@ import org.openpnp.model.Configuration;
 import org.openpnp.model.LengthUnit;
 import org.openpnp.model.Location;
 import org.openpnp.spi.Head;
+import org.openpnp.spi.Movable.MoveToOption;
 import org.openpnp.spi.PropertySheetHolder;
 import org.pmw.tinylog.Logger;
 import org.simpleframework.xml.Attribute;
@@ -98,7 +99,7 @@ public class NullDriver implements ReferenceDriver {
      * considerations when writing your own driver.
      */
     @Override
-    public void moveTo(ReferenceHeadMountable hm, Location location, double speed, MoveToOptions... options)
+    public void moveTo(ReferenceHeadMountable hm, Location location, double speed, MoveToOption... options)
             throws Exception {
         Logger.debug("moveTo({}, {}, {})", hm, location, speed);
         checkEnabled();

--- a/src/main/java/org/openpnp/machine/reference/driver/NullDriver.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/NullDriver.java
@@ -32,7 +32,6 @@ import org.openpnp.machine.reference.ReferenceDriver;
 import org.openpnp.machine.reference.ReferenceHead;
 import org.openpnp.machine.reference.ReferenceHeadMountable;
 import org.openpnp.machine.reference.ReferenceMachine;
-import org.openpnp.machine.reference.ReferenceNozzle;
 import org.openpnp.model.Configuration;
 import org.openpnp.model.LengthUnit;
 import org.openpnp.model.Location;
@@ -99,7 +98,7 @@ public class NullDriver implements ReferenceDriver {
      * considerations when writing your own driver.
      */
     @Override
-    public void moveTo(ReferenceHeadMountable hm, Location location, double speed)
+    public void moveTo(ReferenceHeadMountable hm, Location location, double speed, MoveToOptions... options)
             throws Exception {
         Logger.debug("moveTo({}, {}, {})", hm, location, speed);
         checkEnabled();

--- a/src/main/java/org/openpnp/spi/Movable.java
+++ b/src/main/java/org/openpnp/spi/Movable.java
@@ -8,9 +8,8 @@ public interface Movable extends Locatable {
      * RAW: disable all internal corrections, just tell the driver to move to that position
      * NO_ADDITIONAL_MOVES: disable backslash compensation or anything else, that causes aditional moves
      */
-    public enum MoveToOption { RAW, NO_ADDITIONAL_MOVES }
+    public enum MoveToOption { RawMove, SpeedOverPrecision }
 
-    
     
     /**
      * Move the object to the Location at the feedRate.

--- a/src/main/java/org/openpnp/spi/Movable.java
+++ b/src/main/java/org/openpnp/spi/Movable.java
@@ -2,7 +2,16 @@ package org.openpnp.spi;
 
 import org.openpnp.model.Location;
 
-public interface Movable extends Locatable {
+public interface Movable extends Locatable {    
+    /**
+     * Contains all possible options for the moveTo command.
+     * RAW: disable all internal corrections, just tell the driver to move to that position
+     * NO_ADDITIONAL_MOVES: disable backslash compensation or anything else, that causes aditional moves
+     */
+    public enum MoveToOption { RAW, NO_ADDITIONAL_MOVES }
+
+    
+    
     /**
      * Move the object to the Location at the feedRate.
      * 
@@ -13,9 +22,9 @@ public interface Movable extends Locatable {
      *        minimum feed rate while still moving.
      * @throws Exception
      */
-    public void moveTo(Location location, double speed) throws Exception;
+    public void moveTo(Location location, double speed, MoveToOption... options) throws Exception;
 
-    public void moveTo(Location location) throws Exception;
+    public void moveTo(Location location, MoveToOption... options) throws Exception;
 
     public void moveToSafeZ(double speed) throws Exception;
 

--- a/src/main/java/org/openpnp/spi/base/AbstractActuator.java
+++ b/src/main/java/org/openpnp/spi/base/AbstractActuator.java
@@ -61,8 +61,8 @@ public abstract class AbstractActuator extends AbstractModelObject implements Ac
     }
 
     @Override
-    public void moveTo(Location location) throws Exception {
-        moveTo(location, getHead().getMachine().getSpeed());
+    public void moveTo(Location location, MoveToOption... options) throws Exception {
+        moveTo(location, getHead().getMachine().getSpeed(), options);
     }
 
     @Override

--- a/src/main/java/org/openpnp/spi/base/AbstractCamera.java
+++ b/src/main/java/org/openpnp/spi/base/AbstractCamera.java
@@ -37,6 +37,7 @@ import org.openpnp.spi.Camera;
 import org.openpnp.spi.Head;
 import org.openpnp.spi.HeadMountable;
 import org.openpnp.spi.VisionProvider;
+import org.openpnp.spi.Movable.MoveToOption;
 import org.openpnp.util.OpenCvUtils;
 import org.openpnp.util.SimpleGraph;
 import org.pmw.tinylog.Logger;
@@ -881,8 +882,8 @@ public abstract class AbstractCamera extends AbstractModelObject implements Came
     }
     
     @Override
-    public void moveTo(Location location) throws Exception {
-        moveTo(location, getHead().getMachine().getSpeed());
+    public void moveTo(Location location, MoveToOption... options) throws Exception {
+        moveTo(location, getHead().getMachine().getSpeed(), options);
     }
 
     @Override

--- a/src/test/java/BasicJobTest.java
+++ b/src/test/java/BasicJobTest.java
@@ -9,6 +9,7 @@ import org.openpnp.machine.reference.ReferenceHeadMountable;
 import org.openpnp.machine.reference.ReferenceMachine;
 import org.openpnp.machine.reference.ReferenceNozzle;
 import org.openpnp.machine.reference.ReferencePnpJobProcessor;
+import org.openpnp.machine.reference.ReferenceDriver.MoveToOptions;
 import org.openpnp.machine.reference.driver.test.TestDriver;
 import org.openpnp.machine.reference.driver.test.TestDriver.TestDriverDelegate;
 import org.openpnp.model.Board;
@@ -155,7 +156,7 @@ public class BasicJobTest {
         }
 
         @Override
-        public void moveTo(ReferenceHeadMountable hm, Location location, double speed)
+        public void moveTo(ReferenceHeadMountable hm, Location location, double speed, MoveToOptions...options)
                 throws Exception {
             System.out.println(hm + " " + location);
             if (expectedOps.isEmpty()) {

--- a/src/test/java/BasicJobTest.java
+++ b/src/test/java/BasicJobTest.java
@@ -9,7 +9,6 @@ import org.openpnp.machine.reference.ReferenceHeadMountable;
 import org.openpnp.machine.reference.ReferenceMachine;
 import org.openpnp.machine.reference.ReferenceNozzle;
 import org.openpnp.machine.reference.ReferencePnpJobProcessor;
-import org.openpnp.machine.reference.ReferenceDriver.MoveToOptions;
 import org.openpnp.machine.reference.driver.test.TestDriver;
 import org.openpnp.machine.reference.driver.test.TestDriver.TestDriverDelegate;
 import org.openpnp.model.Board;
@@ -24,6 +23,7 @@ import org.openpnp.spi.Camera;
 import org.openpnp.spi.Head;
 import org.openpnp.spi.HeadMountable;
 import org.openpnp.spi.Machine;
+import org.openpnp.spi.Movable.MoveToOption;
 import org.openpnp.spi.Nozzle;
 
 import com.google.common.io.Files;
@@ -156,7 +156,7 @@ public class BasicJobTest {
         }
 
         @Override
-        public void moveTo(ReferenceHeadMountable hm, Location location, double speed, MoveToOptions...options)
+        public void moveTo(ReferenceHeadMountable hm, Location location, double speed, MoveToOption...options)
                 throws Exception {
             System.out.println(hm + " " + location);
             if (expectedOps.isEmpty()) {

--- a/src/test/java/VisionUtilsTest.java
+++ b/src/test/java/VisionUtilsTest.java
@@ -15,6 +15,7 @@ import org.openpnp.spi.Head;
 import org.openpnp.spi.HeadMountable;
 import org.openpnp.spi.PropertySheetHolder;
 import org.openpnp.spi.VisionProvider;
+import org.openpnp.spi.Movable.MoveToOption;
 import org.openpnp.util.VisionUtils;
 
 
@@ -51,7 +52,7 @@ public class VisionUtilsTest {
         }
 
         @Override
-        public void moveTo(Location location, double speed) throws Exception {
+        public void moveTo(Location location, double speed, MoveToOption... options) throws Exception {
 
         }
 
@@ -210,8 +211,8 @@ public class VisionUtilsTest {
         }
 
         @Override
-        public void moveTo(Location location) throws Exception {
-            moveTo(location, getHead().getMachine().getSpeed());
+        public void moveTo(Location location, MoveToOption... options) throws Exception {
+            moveTo(location, getHead().getMachine().getSpeed(), options);
         }
 
         @Override

--- a/src/test/java/org/openpnp/machine/reference/driver/test/TestDriver.java
+++ b/src/test/java/org/openpnp/machine/reference/driver/test/TestDriver.java
@@ -35,7 +35,7 @@ public class TestDriver implements ReferenceDriver {
     }
 
     @Override
-    public void moveTo(ReferenceHeadMountable hm, Location location, double speed)
+    public void moveTo(ReferenceHeadMountable hm, Location location, double speed, MoveToOptions...options)
             throws Exception {
         // Subtract the offsets from the incoming Location. This converts the
         // offset coordinates to driver / absolute coordinates.
@@ -91,7 +91,7 @@ public class TestDriver implements ReferenceDriver {
         }
 
         @Override
-        public void moveTo(ReferenceHeadMountable hm, Location location, double speed)
+        public void moveTo(ReferenceHeadMountable hm, Location location, double speed, MoveToOptions...options)
                 throws Exception {
 
         }

--- a/src/test/java/org/openpnp/machine/reference/driver/test/TestDriver.java
+++ b/src/test/java/org/openpnp/machine/reference/driver/test/TestDriver.java
@@ -10,9 +10,9 @@ import org.openpnp.machine.reference.ReferenceActuator;
 import org.openpnp.machine.reference.ReferenceDriver;
 import org.openpnp.machine.reference.ReferenceHead;
 import org.openpnp.machine.reference.ReferenceHeadMountable;
-import org.openpnp.machine.reference.ReferenceNozzle;
 import org.openpnp.model.LengthUnit;
 import org.openpnp.model.Location;
+import org.openpnp.spi.Movable.MoveToOption;
 import org.openpnp.spi.PropertySheetHolder;
 import org.simpleframework.xml.Attribute;
 
@@ -35,7 +35,7 @@ public class TestDriver implements ReferenceDriver {
     }
 
     @Override
-    public void moveTo(ReferenceHeadMountable hm, Location location, double speed, MoveToOptions...options)
+    public void moveTo(ReferenceHeadMountable hm, Location location, double speed, MoveToOption...options)
             throws Exception {
         // Subtract the offsets from the incoming Location. This converts the
         // offset coordinates to driver / absolute coordinates.
@@ -91,7 +91,7 @@ public class TestDriver implements ReferenceDriver {
         }
 
         @Override
-        public void moveTo(ReferenceHeadMountable hm, Location location, double speed, MoveToOptions...options)
+        public void moveTo(ReferenceHeadMountable hm, Location location, double speed, MoveToOption...options)
                 throws Exception {
 
         }


### PR DESCRIPTION
# Description
The moveTo() command in the Movable-interface (and all classes implementing it) now accepts optional flags, that are described in the enum "MoveToOption".

In the GcodeDriver these options are evaluated.

# Justification
This allows other functions selectively to disable certain features, that usually improves the movement quality, but might not suitable in this situation.
Examples:
 - backslash compensation can create mechanical stress during nozzle change (pressing into the nozzle tip holder)
 - small movements without the need for precision are way slower with backslash compensation. (e.g. "stirring in a heap feeder)

# Instructions for Use
only used by developers.

# Implementation Details
1. How did you test the change? Be descriptive. Untested code will not be accepted.

Tested it in the simulator. Larger tests following with the HeapFeeder implementation.

2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)?

yes

3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing.

yes

4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted.

passes.

Recommend to wait a bit until the heap feeder exist as a first "User" so there have been more testing.