### PR TITLE
Feature/New Script Trigger Camera.AfterSettle added.

### DIFF
--- a/src/main/java/org/openpnp/spi/base/AbstractCamera.java
+++ b/src/main/java/org/openpnp/spi/base/AbstractCamera.java
@@ -673,22 +673,35 @@ public abstract class AbstractCamera extends AbstractModelObject implements Came
         catch (Exception e) {
             Logger.warn(e);
         }
-        
-        if (settleMethod == null) {
-            // Method undetermined, probably created a new camera (no @Commit handler)
-            settleMethod = SettleMethod.FixedTime;
+
+        try {
+            if (settleMethod == null) {
+                // Method undetermined, probably created a new camera (no @Commit handler)
+                settleMethod = SettleMethod.FixedTime;
+            }
+            if (settleMethod == SettleMethod.FixedTime) {
+                try {
+                    Thread.sleep(getSettleTimeMs());
+                }
+                catch (Exception e) {
+
+                }
+                return capture();
+            }
+            else {
+                return autoSettleAndCapture();
+            }
         }
-        if (settleMethod == SettleMethod.FixedTime) {
+        finally {
+
             try {
-                Thread.sleep(getSettleTimeMs());
+                Map<String, Object> globals = new HashMap<>();
+                globals.put("camera", this);
+                Configuration.get().getScripting().on("Camera.AfterSettle", globals);
             }
             catch (Exception e) {
-
+                Logger.warn(e);
             }
-            return capture();
-        }
-        else {
-            return autoSettleAndCapture();
         }
     }
 


### PR DESCRIPTION
# Description
Added the Script Trigger `Camera.AfterSettle` as a counterpart to `Camera.BeforeSettle`. So you can properly switch off LED lights after the settle and final capture. 

# Justification
**EDIT: Autosettling +** Scripted LED lighting doesn't work in OpenPnP 2.0, it seems. 

See
https://groups.google.com/d/msg/openpnp/jnvon8elGzI/tovchONrAAAJ

EDIT: If you use the FixedTime methode (positive Settle Time in the previous version) there is a Thread.sleep() that will make sure there is no unlit frame in the buffer, so this does not happen. During the Thread.sleep there is also no call to `capture()`, so no AfterCapture script can turn the LED back off.

However, if you use Autosettle (negative Settle Time in the previous version) there is a loop of `capture()` calls, each of which turns the LED back off by triggering the AfterCapture script. I'm quite convinced I haven't changed any of that. See the original loop:

https://github.com/openpnp/openpnp/commit/bb5c03521eeca683caefdaec0087082f4f96ae8a#diff-0abadd12f5c7acd7b2a4cabbbc9770f4

However, that's not all. Something must also have changed since the time when `BeforeCapture`/`AfterCapture ` were documented in the Wiki. I guess it's the way the `OpenPnpCaptureCamera` now works, capturing the frame that is readily available and not strictly waiting for a new one. 

https://github.com/openpnp/openpnp/blob/c6c100e175a71460ebfe969a7a880dd46f4e8c61/src/main/java/org/openpnp/machine/reference/camera/OpenPnpCaptureCamera.java#L159-L172

That's good behavior from a performance stand-point, but I suspect it broke the promise that the `BeforeCapture` script actually happens _before_ the frame is taken that `capture()` then delivers.  

Using `Camera.BeforeSettle` and `Camera.AfterSettle` will fix this. 

# Instructions for Use
Use the `Camera.BeforeSettle` and `Camera.AfterSettle` analogous as described here:
https://github.com/openpnp/openpnp/wiki/Scripting#scripting-event-list
If somebody reminds me, I will amend the Wiki, as soon as this is merged.

# Implementation Details
1. Tested by observing log, confirming the right trigger sequence with camera settle.
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. Succesful `mvn test` before submitting the Pull Request.
