### PR TITLE
Fix/NozzleTip Part-On/Part-Off Method Initialize

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/ReferenceNozzleTip.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceNozzleTip.java
@@ -303,6 +303,10 @@ public class ReferenceNozzleTip extends AbstractNozzleTip {
     }
 
     public VacuumMeasurementMethod getMethodPartOn() {
+        if (methodPartOn == null) {
+            // First time access after creation and no @Commit handler: initialize.
+            methodPartOn = VacuumMeasurementMethod.None;
+        }
         return methodPartOn;
     }
 
@@ -375,6 +379,10 @@ public class ReferenceNozzleTip extends AbstractNozzleTip {
     }
 
     public VacuumMeasurementMethod getMethodPartOff() {
+        if (methodPartOff == null) {
+            // First time access after creation and no @Commit handler: initialize.
+            methodPartOff = VacuumMeasurementMethod.None;
+        }
         return methodPartOff;
     }
 


### PR DESCRIPTION
# Description
This is a bugfix for my own #991. 

The new `methodPartOn` and `methodPartOff` properties are initialized to `null` so we can recognize an upgrade and properly migrate the method in the @Commit handler. But when a brand new NozzleTip is created, the `@Commit` method is not called (I was somehow convinced otherwise). So I need to initialize a null method, when it is first accessed.

# Justification
Bug.

# Instructions for Use
Create a new NozzleTip.

# Implementation Details
1. Tested by creating a new NozzleTip before/after bugfix.
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. Successful `mvn test` before submitting the Pull Request. 
