### PR TITLE
Flush response buffer before sending a command and fix backlash comp

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/driver/GcodeDriver.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/GcodeDriver.java
@@ -300,6 +300,7 @@ public class GcodeDriver extends AbstractReferenceDriver implements Named, Runna
 
         // Check home complete response against user's regex
         String homeCompleteRegex = getCommand(null, CommandType.HOME_COMPLETE_REGEX);
+        String commandErrorRegex = getCommand(null, CommandType.COMMAND_ERROR_REGEX);
         if (homeCompleteRegex != null) {
             if (timeout == -1) {
                 timeout = Long.MAX_VALUE;
@@ -307,8 +308,16 @@ public class GcodeDriver extends AbstractReferenceDriver implements Named, Runna
             if (!containsMatch(responses, homeCompleteRegex)) {
                 long t = System.currentTimeMillis();
                 boolean done = false;
-                while (!done && System.currentTimeMillis() - t < timeout) {
-                    done = containsMatch(sendCommand(null, 250), homeCompleteRegex);
+                boolean err = false;
+                while (!done && !err && System.currentTimeMillis() - t < timeout) {
+                    responses = sendCommandNoFlush(null, 250); //Don't flush because the response we're looking for could have happened before this send
+                    if (commandErrorRegex != null) {
+                        err = containsMatch(responses, commandErrorRegex);
+                    }
+                    done = containsMatch(responses, homeCompleteRegex);
+                }
+                if (err) {
+                    throw new Exception("Controller raised an error during homing: " + responses);
                 }
                 if (!done) {
                     // Should never get here but just in case.
@@ -492,9 +501,9 @@ public class GcodeDriver extends AbstractReferenceDriver implements Named, Runna
             throws Exception {
         // for options make a local copy of all possibly affected variables
         double backlashOffsetX = this.backlashOffsetX;
-        double backlashOffsetY = this.backlashOffsetX;
-        double backlashOffsetZ = this.backlashOffsetX;
-        double backlashOffsetR = this.backlashOffsetX;
+        double backlashOffsetY = this.backlashOffsetY;
+        double backlashOffsetZ = this.backlashOffsetZ;
+        double backlashOffsetR = this.backlashOffsetR;
         double nonSquarenessFactor = this.nonSquarenessFactor;
         // check options
         for (MoveToOption currentOption: options) {
@@ -732,16 +741,25 @@ public class GcodeDriver extends AbstractReferenceDriver implements Named, Runna
                  * response before continuing. We first search the initial responses from the
                  * command for the regex. If it's not found we then collect responses for up to
                  * timeoutMillis while searching the responses for the regex. As soon as it is
-                 * matched we continue. If it's not matched within the timeout we throw an
-                 * Exception.
+                 * matched we continue. If it's not matched within the timeout or the controller
+                 * reports an error, we throw an Exception.
                  */
                 String moveToCompleteRegex = getCommand(hm, CommandType.MOVE_TO_COMPLETE_REGEX);
+                String commandErrorRegex = getCommand(hm, CommandType.COMMAND_ERROR_REGEX);
                 if (moveToCompleteRegex != null) {
                     if (!containsMatch(responses, moveToCompleteRegex)) {
                         long t = System.currentTimeMillis();
                         boolean done = false;
-                        while (!done && System.currentTimeMillis() - t < timeoutMilliseconds) {
-                            done = containsMatch(sendCommand(null, 250), moveToCompleteRegex);
+                        boolean err = false;
+                        while (!done && !err && System.currentTimeMillis() - t < timeoutMilliseconds) {
+                            responses = sendCommandNoFlush(null, 250); //Don't flush because the response we're looking for could have happened before this send
+                            if (commandErrorRegex != null) {
+                                err = containsMatch(responses, commandErrorRegex);
+                            }
+                            done = containsMatch(responses, moveToCompleteRegex);
+                        }
+                        if (err) {
+                            throw new Exception("Controller raised an error during move: " + responses);
                         }
                         if (!done) {
                             throw new Exception("Timed out waiting for move to complete.");
@@ -961,12 +979,18 @@ public class GcodeDriver extends AbstractReferenceDriver implements Named, Runna
             return new ArrayList<>();
         }
         List<String> responses = new ArrayList<>();
+        boolean first = true;
         for (String command : gCode.split("\n")) {
             command = command.trim();
             if (command.length() == 0) {
                 continue;
             }
-            responses.addAll(sendCommand(command, timeout));
+            if (first) {
+                responses.addAll(sendCommand(command, timeout));
+                first = false;
+            } else {
+                responses.addAll(sendCommandNoFlush(command, timeout));
+            }
         }
         return responses;
     }
@@ -981,6 +1005,13 @@ public class GcodeDriver extends AbstractReferenceDriver implements Named, Runna
         // Read any responses that might be queued up so that when we wait
         // for a response to a command we actually wait for the one we expect.
         responseQueue.drainTo(responses);
+        responses.clear();
+        
+        return sendCommandNoFlush(command, timeout);
+    }
+
+    protected List<String> sendCommandNoFlush(String command, long timeout) throws Exception {
+        List<String> responses = new ArrayList<>();
 
         Logger.debug("sendCommand({}, {})...", command, timeout);
 


### PR DESCRIPTION
# Description
This change forces the GcodeDriver sendCommand to flush the response queue before sending a new command to the controller.  In some cases, prior responses could be queued up and be erroneously interpreted as command completions before the command was actually completed by the controller causing bad things to happen (see the discussion at https://groups.google.com/forum/#!topic/openpnp/Hqo05GerezE).  The Homing regex and Move regex waiting loops were updated to call sendCommandNoFlush which doesn't flush the queue so that responses that the loops are waiting for do not get flushed.  Checking was also added to both loops to throw an exception in the event of a controller error.

This change also fixes backlash compensation that was broken by PR 998 which accidentally set all axis backlash values to that of the x-axis. 

# Justification
See the discussion at https://groups.google.com/forum/#!topic/openpnp/Hqo05GerezE

# Instructions for Use
Flushing of the queue is mainly for controllers that use the MOVE_TO_COMPLETE_REGEX to detect end of moves (like TinyG) .  Note that this fix does not completely eliminate the possibility of a spurious controller response being placed in the queue after it is flushed and before the command is sent but it should greatly reduce the possibility of it occurring.  For TinyG at least, it is also recommended to set the status interval to a very long duration, i.e., set $si=4e9 in the CONNECT_COMMAND to further reduce the possibility of spurious responses being placed in the queue.

# Implementation Details
**1. How did you test the change? Be descriptive.** Found a scenario that was fairly regularly causing an erroneous detection of a move completion before was actually completed (vision processing for a strip feeder was starting before the camera arrived over the strip).  After making this fix, the same scenario was run many times without a problem.
**2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)?** Yes.
**3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing.**  No changes were made in either of these packages.
**4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted.**  Maven tests were run and passed.
