### PR TITLE
Bugfix/Wrong event handler for ComboBox/Checkbox changes.

### DIFF
--- a/src/main/java/org/openpnp/gui/wizards/CameraVisionConfigurationWizard.java
+++ b/src/main/java/org/openpnp/gui/wizards/CameraVisionConfigurationWizard.java
@@ -22,6 +22,8 @@ package org.openpnp.gui.wizards;
 import java.awt.Font;
 import java.awt.HeadlessException;
 import java.awt.event.ActionEvent;
+import java.awt.event.ItemEvent;
+import java.awt.event.ItemListener;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 
@@ -107,8 +109,8 @@ public class CameraVisionConfigurationWizard extends AbstractConfigurationWizard
         panelVision.add(lblSettleMethod, "2, 2, 1, 3, right, default");
 
         settleMethod = new JComboBox(AbstractCamera.SettleMethod.values());
-        settleMethod.addPropertyChangeListener(new PropertyChangeListener() {
-            public void propertyChange(PropertyChangeEvent evt) {
+        settleMethod.addItemListener(new ItemListener() {
+            public void itemStateChanged(ItemEvent e) {
                 adaptDialog();
             }
         });
@@ -224,8 +226,8 @@ public class CameraVisionConfigurationWizard extends AbstractConfigurationWizard
         panelVision.add(lblSettleDiagnostics, "8, 12, right, default");
 
         settleDiagnostics = new JCheckBox("");
-        settleDiagnostics.addPropertyChangeListener(new PropertyChangeListener() {
-            public void propertyChange(PropertyChangeEvent evt) {
+        settleDiagnostics.addItemListener(new ItemListener() {
+            public void itemStateChanged(ItemEvent e) {
                 adaptDialog();
             }
         });
@@ -318,6 +320,7 @@ public class CameraVisionConfigurationWizard extends AbstractConfigurationWizard
             btnTestRotate.setVisible(false);
             btnTestZ.setVisible(false);
         }
+        adaptDialog();
     }
 
     private HeadMountable getJogTool() {

--- a/src/main/java/org/openpnp/machine/reference/wizards/ReferenceNozzleTipPartDetectionWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/wizards/ReferenceNozzleTipPartDetectionWizard.java
@@ -19,13 +19,19 @@
 
 package org.openpnp.machine.reference.wizards;
 
+import java.awt.Color;
+import java.awt.Font;
+import java.awt.event.ItemEvent;
+import java.awt.event.ItemListener;
 import java.util.HashSet;
-import java.util.Map;
 import java.util.Set;
 
+import javax.swing.JCheckBox;
+import javax.swing.JComboBox;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JTextField;
+import javax.swing.UIManager;
 import javax.swing.border.TitledBorder;
 
 import org.openpnp.gui.components.ComponentDecorators;
@@ -35,28 +41,12 @@ import org.openpnp.gui.support.DoubleConverter;
 import org.openpnp.gui.support.IntegerConverter;
 import org.openpnp.machine.reference.ReferenceNozzleTip;
 import org.openpnp.machine.reference.ReferenceNozzleTip.VacuumMeasurementMethod;
-import org.openpnp.machine.reference.feeder.BlindsFeeder;
 import org.openpnp.model.Configuration;
-import org.openpnp.util.SimpleGraph;
 
 import com.jgoodies.forms.layout.ColumnSpec;
 import com.jgoodies.forms.layout.FormLayout;
 import com.jgoodies.forms.layout.FormSpecs;
 import com.jgoodies.forms.layout.RowSpec;
-import javax.swing.JComboBox;
-import javax.swing.JComponent;
-import javax.swing.JCheckBox;
-import java.awt.BorderLayout;
-import javax.swing.UIManager;
-import java.awt.Color;
-import java.awt.Dimension;
-import java.awt.GradientPaint;
-import java.awt.Graphics;
-import java.awt.Graphics2D;
-import java.awt.RenderingHints;
-import java.beans.PropertyChangeListener;
-import java.beans.PropertyChangeEvent;
-import java.awt.Font;
 
 public class ReferenceNozzleTipPartDetectionWizard extends AbstractConfigurationWizard {
     private final ReferenceNozzleTip nozzleTip;
@@ -108,8 +98,8 @@ public class ReferenceNozzleTipPartDetectionWizard extends AbstractConfiguration
         panelPartOnVacuumSensing.add(lblPartOnMeasurement, "2, 2, right, default");
         
         methodPartOn = new JComboBox(ReferenceNozzleTip.VacuumMeasurementMethod.values());
-        methodPartOn.addPropertyChangeListener(new PropertyChangeListener() {
-            public void propertyChange(PropertyChangeEvent evt) {
+        methodPartOn.addItemListener(new ItemListener() {
+            public void itemStateChanged(ItemEvent e) {
                 adaptDialog();
             }
         });
@@ -120,8 +110,8 @@ public class ReferenceNozzleTipPartDetectionWizard extends AbstractConfiguration
         panelPartOnVacuumSensing.add(lblEstablishPartOnLevel, "2, 4, right, default");
         
         establishPartOnLevel = new JCheckBox("");
-        establishPartOnLevel.addPropertyChangeListener(new PropertyChangeListener() {
-            public void propertyChange(PropertyChangeEvent evt) {
+        establishPartOnLevel.addItemListener(new ItemListener() {
+            public void itemStateChanged(ItemEvent e) {
                 adaptDialog();
             }
         });
@@ -229,8 +219,8 @@ public class ReferenceNozzleTipPartDetectionWizard extends AbstractConfiguration
         panelPartOffVacuumSensing.add(lblPartOffMeasurement, "2, 2");
         
         methodPartOff = new JComboBox(ReferenceNozzleTip.VacuumMeasurementMethod.values());
-        methodPartOff.addPropertyChangeListener(new PropertyChangeListener() {
-            public void propertyChange(PropertyChangeEvent evt) {
+        methodPartOff.addItemListener(new ItemListener() {
+            public void itemStateChanged(ItemEvent e) {
                 adaptDialog();
             }
         });
@@ -241,8 +231,8 @@ public class ReferenceNozzleTipPartDetectionWizard extends AbstractConfiguration
         panelPartOffVacuumSensing.add(lblEstablishPartOffLevel, "2, 4, right, default");
         
         establishPartOffLevel = new JCheckBox("");
-        establishPartOffLevel.addPropertyChangeListener(new PropertyChangeListener() {
-            public void propertyChange(PropertyChangeEvent evt) {
+        establishPartOffLevel.addItemListener(new ItemListener() {
+            public void itemStateChanged(ItemEvent e) {
                 adaptDialog();
             }
         });
@@ -483,5 +473,7 @@ public class ReferenceNozzleTipPartDetectionWizard extends AbstractConfiguration
         ComponentDecorators.decorateWithAutoSelect(vacuumLevelPartOffHigh);
         ComponentDecorators.decorateWithAutoSelect(vacuumDifferencePartOffLow);
         ComponentDecorators.decorateWithAutoSelect(vacuumDifferencePartOffHigh);
+
+        adaptDialog();
     }
 }


### PR DESCRIPTION
# Description
Bugfix of my own #995 and #991. 

Used the wrong event handler to get combo box `selectedItem` and checkbox `selected` changes in Wizards. It seems the change of these "properties" are not deemed "property changes" in Java Swing but "item state changes" (the documentation is so abstract, it is useless). 

The wrong events still worked on Windows, due to side effects. Those helpful side effects seem not present on other plattforms/looks & feels. 

Also cleaned up superfluous imports from before.

# Justification
Bugfix.

See also:
https://groups.google.com/d/msg/openpnp/hP4PdTdvjgo/kz3vSg1FAgAJ

# Instructions for Use
In the Camera Vision Wizard change the Method combo box and/or the Diagnostics checkbox. The visible Wizard dialog elements should adapt to the choice.

In the Nozzle Tip Part Detection Wizard change one of the Measurement Method combo boxes or one of the Establish Level checkboxes. The visible Wizard dialog elements should adapt to the choice.

# Implementation Details
1. Did test the changes, though only on Windows (again). Hope that Keith will test this again, once available.
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. Successful `mvn test` before submitting the Pull Request. 
