### PR TITLE
Feature/fix bug nozzle tip calibration

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/ReferenceNozzleTipCalibration.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceNozzleTipCalibration.java
@@ -187,7 +187,7 @@ public class ReferenceNozzleTipCalibration extends AbstractModelObject {
             //The expected locations were generated with a deliberate 1 mm runout so the affine scale is a direct 
             //measure of the true runout in millimeters.  However, since the affine transform gives both an x and y
             //scaling, their geometric mean is used to compute the radius.
-            this.radius = new Length( Math.sqrt(ai.xScale * ai.yScale),
+            this.radius = new Length( Math.sqrt(Math.abs(ai.xScale * ai.yScale)),
                     LengthUnit.Millimeters).convertToUnits(this.units).getValue();
             
             //The phase shift is just the rotation of the affine transform (negated because of the subtraction in getRunout)

--- a/src/main/java/org/openpnp/machine/reference/ReferenceNozzleTipCalibration.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceNozzleTipCalibration.java
@@ -186,8 +186,10 @@ public class ReferenceNozzleTipCalibration extends AbstractModelObject {
             
             //The expected locations were generated with a deliberate 1 mm runout so the affine scale is a direct 
             //measure of the true runout in millimeters.  However, since the affine transform gives both an x and y
-            //scaling, their geometric mean is used to compute the radius.
-            this.radius = new Length( Math.sqrt(Math.abs(ai.xScale * ai.yScale)),
+            //scaling, their geometric mean is used to compute the radius.  Note that if measurement noise
+            //dominates the actual runout, it is possible for the scale factors to become negative.  In
+            //that case, the radius will be set to zero.
+            this.radius = new Length( Math.sqrt(Math.max(0, ai.xScale) * Math.max(0, ai.yScale)),
                     LengthUnit.Millimeters).convertToUnits(this.units).getValue();
             
             //The phase shift is just the rotation of the affine transform (negated because of the subtraction in getRunout)


### PR DESCRIPTION
# Description
Fixes a bug in nozzle tip calibration that resultes in NaNs propagating into the nozzle location.  This was only detected when running with the NullDriver and simulated up camera so that the measured runout (which should be theoretically zero) was dominated by noise.  This resulted in a square root of an extremely small but negative scale factor.  The fix is to limit the scale factors to be no less than zero before taking the square root.

# Justification
Fixes a bug that is apparent during certain testing.

# Instructions for Use
No special instructions.

# Implementation Details
1. How did you test the change? **Ran the same scenario that was causing the problem and verified that NaNs no longer occur.**
2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)?  **Yes.**
3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing.  **No changes were made to these packages.**
4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted.  **Maven tests were run and passed.**
