### PR TITLE
Fix/release all mat

### DIFF
--- a/src/main/java/org/openpnp/vision/pipeline/stages/MaskHsv.java
+++ b/src/main/java/org/openpnp/vision/pipeline/stages/MaskHsv.java
@@ -170,8 +170,10 @@ public class MaskHsv extends CvStage {
     public Result process(CvPipeline pipeline) throws Exception {
         Mat mat = pipeline.getWorkingImage();
         Mat mask = mat.clone();
+        Mat masked = mat.clone();
         Scalar color = FluentCv.colorToScalar(Color.black);
         mask.setTo(color);
+        masked.setTo(color);
         
         if (auto) {
             // Note that in the code below, because hue, saturation, and value are each considered separately
@@ -435,7 +437,13 @@ public class MaskHsv extends CvStage {
 
         double fractionActuallyMasked = 1.0 - Core.countNonZero(mask) / (double) ( mat.rows() * mat.cols() ) ;
         Logger.trace( "Fraction actually masked = " + fractionActuallyMasked );
-        
-        return new Result(mask);
+        if (binaryMask) {
+            masked.release();
+            return new Result(mask);
+        } else {
+            mat.copyTo(masked, mask);
+            mat.release();
+            return new Result(masked);
+        }
     }
 }

--- a/src/main/java/org/openpnp/vision/pipeline/stages/MaskHsv.java
+++ b/src/main/java/org/openpnp/vision/pipeline/stages/MaskHsv.java
@@ -442,7 +442,7 @@ public class MaskHsv extends CvStage {
             return new Result(mask);
         } else {
             mat.copyTo(masked, mask);
-            mat.release();
+            mask.release();
             return new Result(masked);
         }
     }

--- a/src/main/java/org/openpnp/vision/pipeline/stages/MaskHsv.java
+++ b/src/main/java/org/openpnp/vision/pipeline/stages/MaskHsv.java
@@ -170,10 +170,8 @@ public class MaskHsv extends CvStage {
     public Result process(CvPipeline pipeline) throws Exception {
         Mat mat = pipeline.getWorkingImage();
         Mat mask = mat.clone();
-        Mat masked = mat.clone();
         Scalar color = FluentCv.colorToScalar(Color.black);
         mask.setTo(color);
-        masked.setTo(color);
         
         if (auto) {
             // Note that in the code below, because hue, saturation, and value are each considered separately
@@ -391,6 +389,12 @@ public class MaskHsv extends CvStage {
                 endIdx = -1;
                 startIdx = -1;
             }
+            workingMat.release();
+            mv.release();
+            hist.release();
+            ranges.release();
+            channels.release();
+            histSize.release();
             setValueMax( endIdx );
             Logger.trace( "valueMax = " + valueMax );
             setValueMin( startIdx );
@@ -420,6 +424,7 @@ public class MaskHsv extends CvStage {
             Core.inRange(mat, min, max, mask2);
           
             Core.bitwise_or(mask, mask2, mask);
+            mask2.release();
         }
 
         //The mask is normally inverted because it is used to copy the unmasked portions of the
@@ -431,12 +436,6 @@ public class MaskHsv extends CvStage {
         double fractionActuallyMasked = 1.0 - Core.countNonZero(mask) / (double) ( mat.rows() * mat.cols() ) ;
         Logger.trace( "Fraction actually masked = " + fractionActuallyMasked );
         
-        if (binaryMask) {
-            return new Result(mask);
-        } 
-        else {
-            mat.copyTo(masked, mask);
-            return new Result(masked);
-        }
+        return new Result(mask);
     }
 }

--- a/src/main/java/org/openpnp/vision/pipeline/stages/Normalize.java
+++ b/src/main/java/org/openpnp/vision/pipeline/stages/Normalize.java
@@ -26,6 +26,7 @@ public class Normalize extends CvStage {
 	    }
           }
 	  src.put(0, 0, pixel);
+	  dst.release();
 	}
 
     @Override


### PR DESCRIPTION
# Description
Made sure for all temporary Mat* Objects in the Stages MaskHsv and Normalize  the release() function ist called to avoid memory leaks.

# Justification
The Mat-Objects are suspected to create memory leaks. So try to avoid that.

# Instructions for Use
Should change nothing for the user.

# Implementation Details
1. How did you test the change? - Run it on my machine. Hard to tell if really an improvement, but no downsides noticed.
2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)? - Yes
3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing. - No
4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted. - Succeed