### PR TITLE
Snap the camera jogging angle when holding down the ALT button

### DIFF
--- a/src/main/java/org/openpnp/gui/components/CameraView.java
+++ b/src/main/java/org/openpnp/gui/components/CameraView.java
@@ -646,6 +646,11 @@ public class CameraView extends JComponent implements CameraListener {
     private void drawCircle(Graphics2D g2d, int centerX, int centerY, int radius) {
         g2d.drawArc(centerX - radius, centerY - radius, radius * 2, radius * 2, 0, 360);
     }
+
+    private double snapRotationAngleToTypicalAngles(double angle) {
+        // Round to typical pcb placing angles
+        return ((int) Math.round(angle / 45)) * 45.0;
+    }
     
     private void paintDragJogRotationHandle(Graphics2D g2d, boolean active) {
         if (camera.getHead() == null) {
@@ -677,6 +682,12 @@ public class CameraView extends JComponent implements CameraListener {
             // Now draw the circular handle at it's target position in the active color
             double rotTargetHandleAngle = Math.toDegrees(Math.atan2(targetY - (height / 2), targetX - (width / 2)));
             rotTargetHandleAngle = Utils2D.normalizeAngle(rotTargetHandleAngle);
+
+            // If the alt button is pressed snap to certain angles
+            if(dragJoggingTarget.isAltDown()) {
+                rotTargetHandleAngle = snapRotationAngleToTypicalAngles(rotTargetHandleAngle);
+            }
+
             double rotTargetHandleX = rotHandleRadius * Math.cos(Math.toRadians(rotTargetHandleAngle)) + (width / 2.);
             double rotTargetHandleY = rotHandleRadius * Math.sin(Math.toRadians(rotTargetHandleAngle)) + (height / 2.);
             g2d.setColor(dragJogHandleActiveColor);
@@ -1332,6 +1343,12 @@ public class CameraView extends JComponent implements CameraListener {
 
         double rotTargetHandleAngle = Math.toDegrees(Math.atan2(e.getY() - (height / 2), e.getX() - (width / 2)));
         rotTargetHandleAngle = Utils2D.normalizeAngle(rotTargetHandleAngle);
+
+        // If the alt button is pressed snap to certain angles
+        if(e.isAltDown()) {
+            rotTargetHandleAngle = snapRotationAngleToTypicalAngles(rotTargetHandleAngle);
+        }
+
         double targetAngle = Utils2D.normalizeAngle(-(rotTargetHandleAngle + 90));
         UiUtils.submitUiMachineTask(() -> {
             if (camera.getHead() == null) {


### PR DESCRIPTION
This lacks information about the board rotation, but as uses generally try to XY align their boards it might still be an improvement. Could also be changed to snapping to 15° angles

# Description
Snaps the visible camera jogging button when holding down the ALT button.

# Justification
I saw the youtube video about the visual jogging and saw Jason struggling with getting the angle right

# Instructions for Use
Use visual jogging and hold down the ALT button. The rotation will snap into multiples of 45°

@vonnieda Feel free to reject. I know that the camera lacks knowledge of the real orientation of the board, but as most machines mount the PCB in some axis aligned fashion this still seems as an improvement to me
