### PR TITLE
Feature/add two component alignment

### DIFF
--- a/src/main/java/org/openpnp/gui/processes/MultiPlacementBoardLocationProcess.java
+++ b/src/main/java/org/openpnp/gui/processes/MultiPlacementBoardLocationProcess.java
@@ -259,15 +259,15 @@ public class MultiPlacementBoardLocationProcess {
             
             String errString = "";
             if (Math.abs(ai.xScale-1) > props.scalingTolerance) {
-                errString += "the x scaling = " + String.format("%.5f", ai.xScale) + " is outside expected range of [" +
+                errString += "x scaling = " + String.format("%.5f", ai.xScale) + " which is outside the expected range of [" +
                         String.format("%.5f", 1-props.scalingTolerance) + ", " + String.format("%.5f", 1+props.scalingTolerance) + "], ";
             }
             if (Math.abs(ai.yScale-1) > props.scalingTolerance) {
-                errString += "the y scaling = " + String.format("%.5f", ai.yScale) + " is outside expected range of [" +
+                errString += "y scaling = " + String.format("%.5f", ai.yScale) + " which is outside the expected range of [" +
                         String.format("%.5f", 1-props.scalingTolerance) + ", " + String.format("%.5f", 1+props.scalingTolerance) + "], ";
             }
             if (Math.abs(ai.xShear) > props.shearingTolerance) {
-                errString += "the x shearing = " + String.format("%.5f", ai.xShear) + " is outside expected range of [" +
+                errString += "x shearing = " + String.format("%.5f", ai.xShear) + " which is outside the expected range of [" +
                         String.format("%.5f", -props.shearingTolerance) + ", " + String.format("%.5f", props.shearingTolerance) + "], ";
             }
             if (boardOffset > props.boardLocationTolerance.convertToUnits(LengthUnit.Millimeters).getValue()) {

--- a/src/main/java/org/openpnp/machine/reference/vision/ReferenceFiducialLocator.java
+++ b/src/main/java/org/openpnp/machine/reference/vision/ReferenceFiducialLocator.java
@@ -18,7 +18,6 @@ import org.opencv.core.KeyPoint;
 import org.openpnp.gui.MainFrame;
 import org.openpnp.gui.components.CameraView;
 import org.openpnp.gui.support.LengthConverter;
-import org.openpnp.gui.support.MessageBoxes;
 import org.openpnp.gui.support.PropertySheetWizardAdapter;
 import org.openpnp.gui.support.Wizard;
 import org.openpnp.machine.reference.vision.wizards.ReferenceFiducialLocatorConfigurationWizard;
@@ -181,15 +180,15 @@ public class ReferenceFiducialLocator implements FiducialLocator {
         //Check for out-of-nominal conditions
         String errString = "";
         if (Math.abs(ai.xScale-1) > tolerances.scalingTolerance) {
-            errString += "the x scaling = " + String.format("%.5f", ai.xScale) + " is outside of the expected range of [" +
+            errString += "x scaling = " + String.format("%.5f", ai.xScale) + " which is outside the expected range of [" +
                     String.format("%.5f", 1-tolerances.scalingTolerance) + ", " + String.format("%.5f", 1+tolerances.scalingTolerance) + "], ";
         }
         if (Math.abs(ai.yScale-1) > tolerances.scalingTolerance) {
-            errString += "the y scaling = " + String.format("%.5f", ai.yScale) + " is outside of the expected range of [" +
+            errString += "the y scaling = " + String.format("%.5f", ai.yScale) + " which is outside the expected range of [" +
                     String.format("%.5f", 1-tolerances.scalingTolerance) + ", " + String.format("%.5f", 1+tolerances.scalingTolerance) + "], ";
         }
         if (Math.abs(ai.xShear) > tolerances.shearingTolerance) {
-            errString += "the x shearing = " + String.format("%.5f", ai.xShear) + " is outside of the expected range of [" +
+            errString += "the x shearing = " + String.format("%.5f", ai.xShear) + " which is outside the expected range of [" +
                     String.format("%.5f", -tolerances.shearingTolerance) + ", " + String.format("%.5f", tolerances.shearingTolerance) + "], ";
         }
         if (boardOffset > tolerances.boardLocationTolerance.convertToUnits(LengthUnit.Millimeters).getValue()) {


### PR DESCRIPTION

# Description
Added back the capability to do a manual 2 placement board alignment without having to set the initial board location and rotation first.  Moved the tolerances for both the board multi-placement and fuducial alignment into the machine.xml file so users can adjust them if need be.  Also clarified error and exception messages so that the user can better understand why the alignment failed.

# Justification
Returns lost functionality and makes the process easier to understand if an error occurs.

# Instructions for Use
For folks that are happy with the existing functionality there is no real change other than improved error messaging if something goes wrong.  

For those wishing to go back to the manual two placement method, the machine.xml file needs to be edited.  Search for the MultiPlacementBoardLocationProperties section (this section will only exist after attempting a multi-placement alignment with this new update and subsequent save of the machine.xml file) and change the value of auto-move-for-all-placements from true to false.  Also, the value of board-location-tolerance needs to be changed from 5.0 to a large value, say 5000.0 to prevent erroneous failures of the process.

# Implementation Details
1. How did you test the change? **Ran several test scenarios on my machine to verify the current functionality still works and the new(old) capability can also be used.  Created deliberate error conditions and observed the error messages.**
2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)?  **Yes.**
3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing.  **No changes were made to these packages.**
4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted.  **Maven test were run and passed.**
