### PR TITLE
WIP: Reusable CVPipelines

### DIFF
--- a/src/main/java/org/openpnp/gui/support/NamedListCellRenderer.java
+++ b/src/main/java/org/openpnp/gui/support/NamedListCellRenderer.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2011 Jason von Nieda <jason@vonnieda.org>
+ * 
+ * This file is part of OpenPnP.
+ * 
+ * OpenPnP is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * OpenPnP is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License along with OpenPnP. If not, see
+ * <http://www.gnu.org/licenses/>.
+ * 
+ * For more information about OpenPnP visit http://openpnp.org
+ */
+
+package org.openpnp.gui.support;
+
+import org.openpnp.model.Named;
+
+import javax.swing.*;
+import java.awt.*;
+
+@SuppressWarnings("serial")
+public class NamedListCellRenderer<T extends Named> extends DefaultListCellRenderer {
+
+    @Override
+    public Component getListCellRendererComponent(JList list, Object value, int index, boolean isSelected, boolean cellHasFocus) {
+        Component component = super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
+        if(value != null) {
+            ((JLabel) component).setText(((T) value).getName());
+        }
+        return component;
+    }
+
+}

--- a/src/main/java/org/openpnp/gui/support/NamedObjectToStringConverter.java
+++ b/src/main/java/org/openpnp/gui/support/NamedObjectToStringConverter.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2011 Jason von Nieda <jason@vonnieda.org>
+ * 
+ * This file is part of OpenPnP.
+ * 
+ * OpenPnP is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * OpenPnP is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License along with OpenPnP. If not, see
+ * <http://www.gnu.org/licenses/>.
+ * 
+ * For more information about OpenPnP visit http://openpnp.org
+ */
+
+package org.openpnp.gui.support;
+
+import org.jdesktop.swingx.autocomplete.ObjectToStringConverter;
+import org.openpnp.model.Named;
+
+public class NamedObjectToStringConverter<T extends Named>
+        extends ObjectToStringConverter {
+    public String getPreferredStringForItem(Object o) {
+        if (o == null) {
+            return null;
+        }
+        T t = (T) o;
+        return t.getName() == null ? "" : t.getName();
+    }
+}

--- a/src/main/java/org/openpnp/gui/support/PipelinesComboBoxModel.java
+++ b/src/main/java/org/openpnp/gui/support/PipelinesComboBoxModel.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2011 Jason von Nieda <jason@vonnieda.org>
+ * 
+ * This file is part of OpenPnP.
+ * 
+ * OpenPnP is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * OpenPnP is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License along with OpenPnP. If not, see
+ * <http://www.gnu.org/licenses/>.
+ * 
+ * For more information about OpenPnP visit http://openpnp.org
+ */
+
+package org.openpnp.gui.support;
+
+import org.openpnp.model.Configuration;
+import org.openpnp.spi.Pipeline;
+
+import javax.swing.*;
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
+import java.util.ArrayList;
+
+@SuppressWarnings("serial")
+public class PipelinesComboBoxModel extends DefaultComboBoxModel<Pipeline> implements PropertyChangeListener {
+
+    private IdentifiableComparator<Pipeline> comparator = new IdentifiableComparator<>();
+
+    public PipelinesComboBoxModel() {
+        addAllElements();
+        Configuration.get().addPropertyChangeListener("pipelines", this);
+    }
+
+    private void addAllElements() {
+        ArrayList<Pipeline> pipelines = new ArrayList<>(Configuration.get().getMachine().getPipelines());
+        pipelines.sort(comparator);
+        for (Pipeline pipeline : pipelines) {
+            addElement(pipeline);
+        }
+    }
+
+    @Override
+    public void propertyChange(PropertyChangeEvent evt) {
+        removeAllElements();
+        addAllElements();
+    }
+}

--- a/src/main/java/org/openpnp/machine/reference/ReferenceMachine.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceMachine.java
@@ -54,26 +54,16 @@ import org.openpnp.machine.reference.feeder.ReferenceTrayFeeder;
 import org.openpnp.machine.reference.feeder.ReferenceTubeFeeder;
 import org.openpnp.machine.reference.feeder.SchultzFeeder;
 import org.openpnp.machine.reference.feeder.SlotSchultzFeeder;
-import org.openpnp.machine.reference.psh.ActuatorsPropertySheetHolder;
-import org.openpnp.machine.reference.psh.CamerasPropertySheetHolder;
-import org.openpnp.machine.reference.psh.NozzleTipsPropertySheetHolder;
-import org.openpnp.machine.reference.psh.SignalersPropertySheetHolder;
+import org.openpnp.machine.reference.pipeline.ReferenceBottomPipeline;
+import org.openpnp.machine.reference.pipeline.ReferenceStripFeederPipeline;
+import org.openpnp.machine.reference.psh.*;
 import org.openpnp.machine.reference.signaler.ActuatorSignaler;
 import org.openpnp.machine.reference.signaler.SoundSignaler;
 import org.openpnp.machine.reference.vision.ReferenceBottomVision;
 import org.openpnp.machine.reference.vision.ReferenceFiducialLocator;
 import org.openpnp.machine.reference.wizards.ReferenceMachineConfigurationWizard;
 import org.openpnp.model.Configuration;
-import org.openpnp.spi.Actuator;
-import org.openpnp.spi.Camera;
-import org.openpnp.spi.Feeder;
-import org.openpnp.spi.FiducialLocator;
-import org.openpnp.spi.Head;
-import org.openpnp.spi.Nozzle;
-import org.openpnp.spi.PartAlignment;
-import org.openpnp.spi.PnpJobProcessor;
-import org.openpnp.spi.PropertySheetHolder;
-import org.openpnp.spi.Signaler;
+import org.openpnp.spi.*;
 import org.openpnp.spi.base.AbstractMachine;
 import org.openpnp.spi.base.SimplePropertySheetHolder;
 import org.pmw.tinylog.Logger;
@@ -194,6 +184,7 @@ public class ReferenceMachine extends AbstractMachine {
             vision.add(alignment);
         }
         vision.add(getFiducialLocator());
+        vision.add(new PipelinesPropertySheetHolder(this, "Pipelines", getPipelines(), null));
         children.add(new SimplePropertySheetHolder("Vision", vision));
         return children.toArray(new PropertySheetHolder[] {});
     }
@@ -270,6 +261,14 @@ public class ReferenceMachine extends AbstractMachine {
         List<Class<? extends Signaler>> l = new ArrayList<>();
         l.add(SoundSignaler.class);
         l.add(ActuatorSignaler.class);
+        return l;
+    }
+
+    @Override
+    public List<Class<? extends Pipeline>> getCompatiblePipelineClasses() {
+        List<Class<? extends Pipeline>> l = new ArrayList<>();
+        l.add(ReferenceBottomPipeline.class);
+        l.add(ReferenceStripFeederPipeline.class);
         return l;
     }
 

--- a/src/main/java/org/openpnp/machine/reference/pipeline/ReferenceBottomPipeline.java
+++ b/src/main/java/org/openpnp/machine/reference/pipeline/ReferenceBottomPipeline.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2011 Jason von Nieda <jason@vonnieda.org>
+ *
+ * This file is part of OpenPnP.
+ *
+ * OpenPnP is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * OpenPnP is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with OpenPnP. If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * For more information about OpenPnP visit http://openpnp.org
+ */
+
+package org.openpnp.machine.reference.pipeline;
+
+import org.apache.commons.io.IOUtils;
+import org.openpnp.machine.reference.vision.ReferenceBottomVision;
+import org.openpnp.model.Board;
+import org.openpnp.spi.base.AbstractPipeline;
+import org.openpnp.vision.pipeline.CvPipeline;
+
+public class ReferenceBottomPipeline extends AbstractPipeline {
+
+    public CvPipeline createDefaultCvPipeline() {
+        try {
+            String xml = IOUtils.toString(ReferenceBottomVision.class.getResource(
+                    "ReferenceBottomVision-DefaultPipeline.xml"));
+            return new CvPipeline(xml);
+        }
+        catch (Exception e) {
+            throw new Error(e);
+        }
+    }
+
+    @Override
+    public Board.Side getBoardSide() {
+        return Board.Side.Bottom;
+    }
+}

--- a/src/main/java/org/openpnp/machine/reference/pipeline/ReferenceStripFeederPipeline.java
+++ b/src/main/java/org/openpnp/machine/reference/pipeline/ReferenceStripFeederPipeline.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2011 Jason von Nieda <jason@vonnieda.org>
+ *
+ * This file is part of OpenPnP.
+ *
+ * OpenPnP is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * OpenPnP is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with OpenPnP. If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * For more information about OpenPnP visit http://openpnp.org
+ */
+
+package org.openpnp.machine.reference.pipeline;
+
+import org.apache.commons.io.IOUtils;
+import org.openpnp.machine.reference.feeder.ReferenceStripFeeder;
+import org.openpnp.model.Board;
+import org.openpnp.spi.base.AbstractPipeline;
+import org.openpnp.vision.pipeline.CvPipeline;
+
+public class ReferenceStripFeederPipeline extends AbstractPipeline {
+
+    public CvPipeline createDefaultCvPipeline() {
+        try {
+            String xml = IOUtils.toString(ReferenceStripFeeder.class
+                    .getResource("ReferenceStripFeeder-DefaultPipeline.xml"));
+            return new CvPipeline(xml);
+        }
+        catch (Exception e) {
+            throw new Error(e);
+        }
+    }
+
+    @Override
+    public Board.Side getBoardSide() {
+        return Board.Side.Top;
+    }
+}

--- a/src/main/java/org/openpnp/machine/reference/pipeline/wizards/PipelineConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/pipeline/wizards/PipelineConfigurationWizard.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2011 Jason von Nieda <jason@vonnieda.org>
+ * 
+ * This file is part of OpenPnP.
+ * 
+ * OpenPnP is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * OpenPnP is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License along with OpenPnP. If not, see
+ * <http://www.gnu.org/licenses/>.
+ * 
+ * For more information about OpenPnP visit http://openpnp.org
+ */
+
+package org.openpnp.machine.reference.pipeline.wizards;
+
+import com.jgoodies.forms.layout.ColumnSpec;
+import com.jgoodies.forms.layout.FormLayout;
+import com.jgoodies.forms.layout.FormSpecs;
+import com.jgoodies.forms.layout.RowSpec;
+import org.openpnp.gui.MainFrame;
+import org.openpnp.gui.support.AbstractConfigurationWizard;
+import org.openpnp.spi.Pipeline;
+import org.openpnp.util.UiUtils;
+import org.openpnp.vision.pipeline.CvPipeline;
+import org.openpnp.vision.pipeline.ui.CvPipelineEditor;
+import org.openpnp.vision.pipeline.ui.CvPipelineEditorDialog;
+
+import javax.swing.*;
+import javax.swing.border.TitledBorder;
+
+@SuppressWarnings("serial")
+public class PipelineConfigurationWizard extends AbstractConfigurationWizard {
+
+    private Pipeline pipeline;
+
+    public PipelineConfigurationWizard(Pipeline pipeline) {
+        this.pipeline = pipeline;
+        createUi();
+    }
+
+    private void createUi() {
+
+        JPanel pipelinePanel = new JPanel();
+        pipelinePanel.setBorder(new TitledBorder(null, "Pipeline", TitledBorder.LEADING, TitledBorder.TOP,
+                null, null));
+
+        contentPanel.add(pipelinePanel);
+
+        pipelinePanel.setLayout(
+            new FormLayout(
+                new ColumnSpec[] {
+                    FormSpecs.RELATED_GAP_COLSPEC,
+                    ColumnSpec.decode("right:default"),
+                    FormSpecs.RELATED_GAP_COLSPEC,
+                    ColumnSpec.decode("default:grow"),},
+                new RowSpec[] {
+                    FormSpecs.RELATED_GAP_ROWSPEC,
+                    FormSpecs.DEFAULT_ROWSPEC
+                }
+            )
+        );
+
+        JLabel lblPipeline = new JLabel("Pipeline");
+        pipelinePanel.add(lblPipeline, "2, 2");
+
+        JButton editPipelineButton = new JButton("Edit");
+        editPipelineButton.addActionListener(e -> UiUtils.messageBoxOnException(this::editPipeline));
+
+        pipelinePanel.add(editPipelineButton, "4, 2");
+    }
+
+    private void editPipeline() throws Exception {
+        CvPipeline pipeline = this.pipeline.getCvPipeline();
+        pipeline.setProperty("camera", this.pipeline.getCamera());
+        pipeline.setProperty("nozzle", MainFrame.get().getMachineControls().getSelectedNozzle());
+        CvPipelineEditor editor = new CvPipelineEditor(pipeline);
+        JDialog dialog = new CvPipelineEditorDialog(MainFrame.get(), this.pipeline.getName(), editor);
+        dialog.setVisible(true);
+    }
+
+    @Override
+    public void createBindings() {
+        //addWrappedBinding(signaler, "enableErrorSound", chckbxError, "selected");
+    }
+}

--- a/src/main/java/org/openpnp/machine/reference/pipeline/wizards/PipelineUsageWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/pipeline/wizards/PipelineUsageWizard.java
@@ -1,0 +1,22 @@
+package org.openpnp.machine.reference.pipeline.wizards;
+
+import org.openpnp.gui.support.AbstractConfigurationWizard;
+import org.openpnp.spi.Pipeline;
+
+/**
+ * The idea of this class is to give an overview which items do use the pipeline
+ */
+public class PipelineUsageWizard extends AbstractConfigurationWizard {
+
+    private Pipeline pipeline;
+
+    public PipelineUsageWizard(Pipeline pipeline) {
+        super();
+        this.pipeline = pipeline;
+    }
+
+    @Override
+    public void createBindings() {
+
+    }
+}

--- a/src/main/java/org/openpnp/machine/reference/psh/PipelinesPropertySheetHolder.java
+++ b/src/main/java/org/openpnp/machine/reference/psh/PipelinesPropertySheetHolder.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2011 Jason von Nieda <jason@vonnieda.org>
+ *
+ * This file is part of OpenPnP.
+ *
+ * OpenPnP is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * OpenPnP is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with OpenPnP. If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * For more information about OpenPnP visit http://openpnp.org
+ */
+
+package org.openpnp.machine.reference.psh;
+
+import org.openpnp.gui.MainFrame;
+import org.openpnp.gui.components.ClassSelectionDialog;
+import org.openpnp.gui.support.Icons;
+import org.openpnp.gui.support.MessageBoxes;
+import org.openpnp.model.Configuration;
+import org.openpnp.spi.Machine;
+import org.openpnp.spi.Pipeline;
+import org.openpnp.spi.PropertySheetHolder;
+import org.openpnp.spi.base.SimplePropertySheetHolder;
+
+import javax.swing.*;
+import java.awt.event.ActionEvent;
+import java.util.List;
+
+public class PipelinesPropertySheetHolder extends SimplePropertySheetHolder {
+    final Machine machine;
+
+    public PipelinesPropertySheetHolder(Machine machine, String title, List<? extends PropertySheetHolder> children,
+                                        Icon icon) {
+        super(title, children, icon);
+        this.machine = machine;
+    }
+
+    @Override
+    public Action[] getPropertySheetHolderActions() {
+        return new Action[] { newAction };
+    }
+
+    public Action newAction = new AbstractAction() {
+        {
+            putValue(SMALL_ICON, Icons.add);
+            putValue(NAME, "New Pipeline...");
+            putValue(SHORT_DESCRIPTION, "Create a new pipeline.");
+        }
+
+        @Override
+        public void actionPerformed(ActionEvent arg0) {
+            Configuration configuration = Configuration.get();
+            ClassSelectionDialog<Pipeline> dialog = new ClassSelectionDialog<>(MainFrame.get(),
+                    "Select Pipeline...", "Please select a Pipeline implemention from the list below.",
+                    configuration.getMachine().getCompatiblePipelineClasses());
+            dialog.setVisible(true);
+            Class<? extends Pipeline> cls = dialog.getSelectedClass();
+            if (cls == null) {
+                return;
+            }
+            try {
+                Pipeline pipeline = cls.newInstance();
+
+                machine.addPipeline(pipeline);
+            }
+            catch (Exception e) {
+                MessageBoxes.errorBox(MainFrame.get(), "Error", e);
+            }
+        }
+    };
+}

--- a/src/main/java/org/openpnp/spi/Machine.java
+++ b/src/main/java/org/openpnp/spi/Machine.java
@@ -75,6 +75,14 @@ public interface Machine extends WizardConfigurable, PropertySheetHolder, Closea
     public Camera getCamera(String id);
 
     /**
+     * Gets a global list of defined pipelines which can be reused in other places
+     * @return
+     */
+    public List<Pipeline> getPipelines();
+
+    public Pipeline getPipeline(String id);
+
+    /**
      * Get a list of Actuators that are attached to this Machine and not to a Head.
      * 
      * @return
@@ -147,6 +155,8 @@ public interface Machine extends WizardConfigurable, PropertySheetHolder, Closea
 
     public List<Class<? extends Signaler>> getCompatibleSignalerClasses();
 
+    public List<Class<? extends Pipeline>> getCompatiblePipelineClasses();
+
     public void addFeeder(Feeder feeder) throws Exception;
 
     public void removeFeeder(Feeder feeder);
@@ -162,6 +172,10 @@ public interface Machine extends WizardConfigurable, PropertySheetHolder, Closea
     public void addActuator(Actuator actuator) throws Exception;
 
     public void removeActuator(Actuator actuator);
+
+    public void addPipeline(Pipeline pipeline) throws Exception;
+
+    public void removePipeline(Pipeline pipeline);
 
     public PnpJobProcessor getPnpJobProcessor();
     

--- a/src/main/java/org/openpnp/spi/Pipeline.java
+++ b/src/main/java/org/openpnp/spi/Pipeline.java
@@ -1,0 +1,31 @@
+package org.openpnp.spi;
+
+import org.openpnp.model.Identifiable;
+import org.openpnp.model.Named;
+import org.openpnp.vision.pipeline.CvPipeline;
+
+public interface Pipeline extends Identifiable, Named, PropertySheetHolder {
+
+    /**
+     * Get the attached CvPipeline
+     * @return
+     */
+    public CvPipeline getCvPipeline();
+
+    /**
+     * Get the default pipeline for this class
+     * @return
+     */
+    public CvPipeline createDefaultCvPipeline();
+
+    /**
+     * Reset the pipeline to its default
+     */
+    public void resetCvPipeline();
+
+    /**
+     * Return the associated camera with the pipeline
+     * @return
+     */
+    public Camera getCamera() throws Exception;
+}

--- a/src/main/java/org/openpnp/spi/base/AbstractMachine.java
+++ b/src/main/java/org/openpnp/spi/base/AbstractMachine.java
@@ -17,15 +17,7 @@ import javax.swing.Icon;
 import org.openpnp.model.AbstractModelObject;
 import org.openpnp.model.LengthUnit;
 import org.openpnp.model.Location;
-import org.openpnp.spi.Actuator;
-import org.openpnp.spi.Camera;
-import org.openpnp.spi.Feeder;
-import org.openpnp.spi.Head;
-import org.openpnp.spi.Machine;
-import org.openpnp.spi.MachineListener;
-import org.openpnp.spi.NozzleTip;
-import org.openpnp.spi.Signaler;
-import org.openpnp.spi.PartAlignment;
+import org.openpnp.spi.*;
 import org.openpnp.util.IdentifiableList;
 import org.simpleframework.xml.Attribute;
 import org.simpleframework.xml.Element;
@@ -64,6 +56,9 @@ public abstract class AbstractMachine extends AbstractModelObject implements Mac
 
     @ElementList(required = false)
     protected IdentifiableList<Actuator> actuators = new IdentifiableList<>();
+
+    @ElementList(required = false)
+    protected IdentifiableList<Pipeline> pipelines = new IdentifiableList<>();
 
     @ElementList(required = false)
     protected IdentifiableList<PartAlignment> partAlignments = new IdentifiableList<>();
@@ -142,6 +137,16 @@ public abstract class AbstractMachine extends AbstractModelObject implements Mac
     @Override
     public Camera getCamera(String id) {
         return cameras.get(id);
+    }
+
+    @Override
+    public List<Pipeline> getPipelines() {
+        return Collections.unmodifiableList(pipelines);
+    }
+
+    @Override
+    public Pipeline getPipeline(String id) {
+        return pipelines.get(id);
     }
 
     @Override
@@ -225,6 +230,20 @@ public abstract class AbstractMachine extends AbstractModelObject implements Mac
         int index = cameras.indexOf(camera);
         if (cameras.remove(camera)) {
             fireIndexedPropertyChange("cameras", index, camera, null);
+        }
+    }
+
+    @Override
+    public void addPipeline(Pipeline pipeline) throws Exception {
+        pipelines.add(pipeline);
+        fireIndexedPropertyChange("pipelines", pipelines.size() - 1, null, pipeline);
+    }
+
+    @Override
+    public void removePipeline(Pipeline pipeline) {
+        int index = pipelines.indexOf(pipeline);
+        if (pipelines.remove(pipeline)) {
+            fireIndexedPropertyChange("pipelines", index, pipeline, null);
         }
     }
     

--- a/src/main/java/org/openpnp/spi/base/AbstractPipeline.java
+++ b/src/main/java/org/openpnp/spi/base/AbstractPipeline.java
@@ -1,0 +1,133 @@
+package org.openpnp.spi.base;
+
+import org.openpnp.gui.MainFrame;
+import org.openpnp.gui.support.Icons;
+import org.openpnp.gui.support.PropertySheetWizardAdapter;
+import org.openpnp.gui.support.Wizard;
+import org.openpnp.machine.reference.pipeline.wizards.PipelineConfigurationWizard;
+import org.openpnp.machine.reference.pipeline.wizards.PipelineUsageWizard;
+import org.openpnp.model.AbstractModelObject;
+import org.openpnp.model.Board;
+import org.openpnp.model.Configuration;
+import org.openpnp.spi.Camera;
+import org.openpnp.spi.Pipeline;
+import org.openpnp.spi.PropertySheetHolder;
+import org.openpnp.spi.WizardConfigurable;
+import org.openpnp.util.VisionUtils;
+import org.openpnp.vision.pipeline.CvPipeline;
+import org.simpleframework.xml.Attribute;
+import org.simpleframework.xml.Element;
+
+import javax.swing.*;
+import java.awt.event.ActionEvent;
+
+public abstract class AbstractPipeline extends AbstractModelObject implements Pipeline, WizardConfigurable {
+
+    @Attribute
+    protected String id;
+
+    @Attribute(required = false)
+    protected String name;
+
+    @Element(required = false)
+    protected CvPipeline pipeline = createDefaultCvPipeline();
+
+    public AbstractPipeline() {
+        this.id = Configuration.createId("CVP");
+        this.name = getClass().getSimpleName();
+    }
+
+    @Override
+    public String getId() {
+        return id;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public void setName(String name) {
+        this.name = name;
+        firePropertyChange("name", null, name);
+    }
+
+    public CvPipeline getCvPipeline() {
+        return pipeline;
+    }
+
+    @Override
+    public void resetCvPipeline() {
+        this.pipeline = createDefaultCvPipeline();
+    }
+
+    public abstract Board.Side getBoardSide();
+
+    @Override
+    public Camera getCamera() throws Exception {
+
+        Board.Side side = getBoardSide();
+
+        if(side == Board.Side.Top) {
+            return VisionUtils.getTopVisionCamera();
+        }
+
+        if(side == Board.Side.Bottom) {
+            return VisionUtils.getBottomVisionCamera();
+        }
+
+        throw new Exception("No suitable camera found on the machine.");
+    }
+
+    @Override
+    public String getPropertySheetHolderTitle() {
+        return getClass().getSimpleName() + " " + getName();
+    }
+
+    @Override
+    public PropertySheetHolder[] getChildPropertySheetHolders() {
+        return null;
+    }
+
+    @Override
+    public PropertySheet[] getPropertySheets() {
+        return new PropertySheet[] {
+            new PropertySheetWizardAdapter(getConfigurationWizard()),
+            new PropertySheetWizardAdapter(new PipelineUsageWizard(this), "Usage")
+        };
+    }
+
+    @Override
+    public Icon getPropertySheetHolderIcon() {
+        return null;
+    }
+
+    @Override
+    public Action[] getPropertySheetHolderActions() {
+        return new Action[] { deleteAction };
+    }
+
+    @Override
+    public Wizard getConfigurationWizard() {
+        return new PipelineConfigurationWizard(this);
+    }
+
+    public Action deleteAction = new AbstractAction("Delete Pipeline") {
+        {
+            putValue(SMALL_ICON, Icons.delete);
+            putValue(NAME, "Delete Pipeline");
+            putValue(SHORT_DESCRIPTION, "Delete the currently selected pipeline.");
+        }
+
+        @Override
+        public void actionPerformed(ActionEvent arg0) {
+            int ret = JOptionPane.showConfirmDialog(MainFrame.get(),
+                    "Are you sure you want to delete " + getName() + "?",
+                    "Delete " + getName() + "?", JOptionPane.YES_NO_OPTION);
+            if (ret == JOptionPane.YES_OPTION) {
+                Configuration.get().getMachine().removePipeline(AbstractPipeline.this);
+            }
+        }
+    };
+}

--- a/src/main/java/org/openpnp/util/VisionUtils.java
+++ b/src/main/java/org/openpnp/util/VisionUtils.java
@@ -13,10 +13,7 @@ import org.openpnp.model.Length;
 import org.openpnp.model.Location;
 import org.openpnp.model.Part;
 import org.openpnp.model.Point;
-import org.openpnp.spi.Camera;
-import org.openpnp.spi.HeadMountable;
-import org.openpnp.spi.Nozzle;
-import org.openpnp.spi.PartAlignment;
+import org.openpnp.spi.*;
 import org.openpnp.spi.PartAlignment.PartAlignmentOffset;
 import org.pmw.tinylog.Logger;
 
@@ -129,6 +126,18 @@ public class VisionUtils {
             }
         }
         throw new Exception("No up-looking camera found on the machine to use for bottom vision.");
+    }
+
+    public static Camera getTopVisionCamera() throws Exception {
+        for (Head head : Configuration.get().getMachine().getHeads()) {
+            for (Camera camera : head.getCameras()) {
+                if (camera.getLooking() == Camera.Looking.Down) {
+                    return camera;
+                }
+            }
+        }
+
+        throw new Exception("No down-looking camera found on the machine to use for top vision.");
     }
     
     public static double toPixels(Length length, Camera camera) {

--- a/src/main/resources/config/machine.xml
+++ b/src/main/resources/config/machine.xml
@@ -27,56 +27,56 @@
          </head>
       </heads>
       <feeders>
-         <feeder class="org.openpnp.machine.reference.feeder.ReferenceStripFeeder" id="F5" name="Upper Strips - 1" enabled="true" part-id="R0805-1K" tape-type="WhitePaper" vision-enabled="true" feed-count="0">
+         <feeder class="org.openpnp.machine.reference.feeder.ReferenceStripFeeder" id="F5" name="Upper Strips - 1" enabled="true" part-id="R0805-1K" pipeline-id="CVP1590234206047" tape-type="WhitePaper" vision-enabled="true" feed-count="0">
             <location units="Millimeters" x="0.0" y="0.0" z="0.0" rotation="0.0"/>
             <reference-hole-location units="Millimeters" x="138.715" y="88.244" z="0.0" rotation="0.0"/>
             <last-hole-location units="Millimeters" x="139.057" y="84.226" z="0.0" rotation="0.0"/>
             <part-pitch value="4.0" units="Millimeters"/>
             <tape-width value="8.0" units="Millimeters"/>
          </feeder>
-         <feeder class="org.openpnp.machine.reference.feeder.ReferenceStripFeeder" id="F6" name="Upper Strips - 2" enabled="true" part-id="R0805-1K" tape-type="WhitePaper" vision-enabled="true" feed-count="0">
+         <feeder class="org.openpnp.machine.reference.feeder.ReferenceStripFeeder" id="F6" name="Upper Strips - 2" enabled="true" part-id="R0805-1K" pipeline-id="CVP1590234206047" tape-type="WhitePaper" vision-enabled="true" feed-count="0">
             <location units="Millimeters" x="0.0" y="0.0" z="0.0" rotation="0.0"/>
             <reference-hole-location units="Millimeters" x="155.055" y="87.275" z="0.0" rotation="0.0"/>
             <last-hole-location units="Millimeters" x="154.713" y="83.314" z="0.0" rotation="0.0"/>
             <part-pitch value="4.0" units="Millimeters"/>
             <tape-width value="8.0" units="Millimeters"/>
          </feeder>
-         <feeder class="org.openpnp.machine.reference.feeder.ReferenceStripFeeder" id="F7" name="Upper Strips - 3" enabled="true" part-id="R0805-1K" tape-type="WhitePaper" vision-enabled="true" feed-count="0">
+         <feeder class="org.openpnp.machine.reference.feeder.ReferenceStripFeeder" id="F7" name="Upper Strips - 3" enabled="true" part-id="R0805-1K" pipeline-id="CVP1590234206047" tape-type="WhitePaper" vision-enabled="true" feed-count="0">
             <location units="Millimeters" x="0.0" y="0.0" z="0.0" rotation="0.0"/>
             <reference-hole-location units="Millimeters" x="172.679" y="56.242" z="0.0" rotation="0.0"/>
             <last-hole-location units="Millimeters" x="172.251" y="60.289" z="0.0" rotation="0.0"/>
             <part-pitch value="4.0" units="Millimeters"/>
             <tape-width value="8.0" units="Millimeters"/>
          </feeder>
-         <feeder class="org.openpnp.machine.reference.feeder.ReferenceStripFeeder" id="F8" name="Upper Strips - 4" enabled="true" part-id="R0805-1K" tape-type="WhitePaper" vision-enabled="true" feed-count="0">
+         <feeder class="org.openpnp.machine.reference.feeder.ReferenceStripFeeder" id="F8" name="Upper Strips - 4" enabled="true" part-id="R0805-1K" pipeline-id="CVP1590234206047" tape-type="WhitePaper" vision-enabled="true" feed-count="0">
             <location units="Millimeters" x="0.0" y="0.0" z="0.0" rotation="0.0"/>
             <reference-hole-location units="Millimeters" x="184.199" y="55.074" z="0.0" rotation="0.0"/>
             <last-hole-location units="Millimeters" x="184.456" y="59.035" z="0.0" rotation="0.0"/>
             <part-pitch value="4.0" units="Millimeters"/>
             <tape-width value="8.0" units="Millimeters"/>
          </feeder>
-         <feeder class="org.openpnp.machine.reference.feeder.ReferenceStripFeeder" id="F1" name="Lower Strips - 1" enabled="true" part-id="R0805-1K" tape-type="WhitePaper" vision-enabled="true" feed-count="0">
+         <feeder class="org.openpnp.machine.reference.feeder.ReferenceStripFeeder" id="F1" name="Lower Strips - 1" enabled="true" part-id="R0805-1K" pipeline-id="CVP1590234206047" tape-type="WhitePaper" vision-enabled="true" feed-count="0">
             <location units="Millimeters" x="0.0" y="0.0" z="0.0" rotation="0.0"/>
             <reference-hole-location units="Millimeters" x="147.347" y="40.285" z="0.0" rotation="0.0"/>
             <last-hole-location units="Millimeters" x="147.433" y="36.238" z="0.0" rotation="0.0"/>
             <part-pitch value="4.0" units="Millimeters"/>
             <tape-width value="8.0" units="Millimeters"/>
          </feeder>
-         <feeder class="org.openpnp.machine.reference.feeder.ReferenceStripFeeder" id="F2" name="Lower Strips - 2" enabled="true" part-id="R0603-1K" tape-type="WhitePaper" vision-enabled="true" feed-count="0">
+         <feeder class="org.openpnp.machine.reference.feeder.ReferenceStripFeeder" id="F2" name="Lower Strips - 2" enabled="true" part-id="R0603-1K" pipeline-id="CVP1590234206047" tape-type="WhitePaper" vision-enabled="true" feed-count="0">
             <location units="Millimeters" x="0.0" y="0.0" z="0.0" rotation="0.0"/>
             <reference-hole-location units="Millimeters" x="157.385" y="40.199" z="0.0" rotation="0.0"/>
             <last-hole-location units="Millimeters" x="157.328" y="36.267" z="0.0" rotation="0.0"/>
             <part-pitch value="4.0" units="Millimeters"/>
             <tape-width value="8.0" units="Millimeters"/>
          </feeder>
-         <feeder class="org.openpnp.machine.reference.feeder.ReferenceStripFeeder" id="F3" name="Lower Strips - 3" enabled="true" part-id="R0402-1K" tape-type="WhitePaper" vision-enabled="true" feed-count="0">
+         <feeder class="org.openpnp.machine.reference.feeder.ReferenceStripFeeder" id="F3" name="Lower Strips - 3" enabled="true" part-id="R0402-1K" pipeline-id="CVP1590234206047" tape-type="WhitePaper" vision-enabled="true" feed-count="0">
             <location units="Millimeters" x="0.0" y="0.0" z="0.0" rotation="0.0"/>
             <reference-hole-location units="Millimeters" x="167.366" y="40.256" z="0.0" rotation="0.0"/>
             <last-hole-location units="Millimeters" x="167.366" y="36.295" z="0.0" rotation="0.0"/>
             <part-pitch value="2.0" units="Millimeters"/>
             <tape-width value="8.0" units="Millimeters"/>
          </feeder>
-         <feeder class="org.openpnp.machine.reference.feeder.ReferenceStripFeeder" id="F4" name="Lower Strips - 4" enabled="true" part-id="R0201-1K" tape-type="WhitePaper" vision-enabled="true" feed-count="0">
+         <feeder class="org.openpnp.machine.reference.feeder.ReferenceStripFeeder" id="F4" name="Lower Strips - 4" enabled="true" part-id="R0201-1K" pipeline-id="CVP1590234206047" tape-type="WhitePaper" vision-enabled="true" feed-count="0">
             <location units="Millimeters" x="0.0" y="0.0" z="0.0" rotation="0.0"/>
             <reference-hole-location units="Millimeters" x="177.404" y="40.256" z="0.0" rotation="0.0"/>
             <last-hole-location units="Millimeters" x="177.376" y="36.267" z="0.0" rotation="0.0"/>
@@ -96,6 +96,25 @@
             </calibration>
          </camera>
       </cameras>
+      <pipelines>
+         <pipeline class="org.openpnp.machine.reference.pipeline.ReferenceStripFeederPipeline" id="CVP1590234206047" name="ReferenceStripFeederPipeline">
+            <pipeline>
+               <stages>
+                  <cv-stage class="org.openpnp.vision.pipeline.stages.ImageCapture" name="original" enabled="true" settle-first="true" count="1"/>
+                  <cv-stage class="org.openpnp.vision.pipeline.stages.BlurMedian" name="cleanup-original" enabled="true" kernel-size="5"/>
+                  <cv-stage class="org.openpnp.vision.pipeline.stages.ConvertColor" name="gray" enabled="true" conversion="Bgr2Gray"/>
+                  <cv-stage class="org.openpnp.vision.pipeline.stages.DetectEdgesCanny" name="find-edges" enabled="true" threshold-1="5.0" threshold-2="15.0"/>
+                  <cv-stage class="org.openpnp.vision.pipeline.stages.BlurGaussian" name="predetect-1" enabled="true" kernel-size="5"/>
+                  <cv-stage class="org.openpnp.vision.pipeline.stages.BlurMedian" name="predetect-2" enabled="false" kernel-size="7"/>
+                  <cv-stage class="org.openpnp.vision.pipeline.stages.DetectFixedCirclesHough" name="results" enabled="true" dp="1.0" param-1="25.0" param-2="20.0"/>
+                  <cv-stage class="org.openpnp.vision.pipeline.stages.ImageRecall" name="recalled" enabled="true" image-stage-name="original"/>
+                  <cv-stage class="org.openpnp.vision.pipeline.stages.DrawCircles" name="display" enabled="true" circles-stage-name="results" thickness="1">
+                     <color r="255" g="0" b="0" a="255"/>
+                  </cv-stage>
+               </stages>
+            </pipeline>
+         </pipeline>
+      </pipelines>
       <nozzle-tips>
          <nozzle-tip class="org.openpnp.machine.reference.ReferenceNozzleTip" id="NT1" name="NT1">
             <changer-start-location units="Millimeters" x="0.0" y="0.0" z="0.0" rotation="0.0"/>


### PR DESCRIPTION
# Description
Starting the implementation of a reusable CvPipeline configuration system as suggested in openpnp#843

Creating a new class Pipeline
-> includes a CvPipeline
-> includes a Camera
-> is saved to XML with an id and referenced by that

The actual implementations are in ReferenceBottomPipeline and ReferenceStripFeederPipeline as they load a specific default implementation. (ReferenceBottomPipeline is not used but shows the concept of having a bottom down camera)

This solves assigning the same pipeline configuration to multiple feeders. For now this is located in the ReferenceStripFeeder but should be moved up in the hierarchy

This basically also solves the issue with having multiple up cameras since a pipeline is now tied to a camera and thus could be used in job processing

This makes sense to me since the pipeline settings are camera dependent

# Justification
CvPipelines cannot be reused currently, see #843 

# Instructions for Use
Let OpenPnP create  a new machine.xml with the new config
Run OpenPNP
Pipelines are in the machine config under Vision -> Pipelines
Pipelines can be added by using the plus icon on top
Pipelines can then be used within ReferenceStripFeeder

# Implementation Details
1. How did you test the change?
Does not brake tests

2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)?

I hope so

3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing.

Yeah well not really an option not to touch them, but I was gentle

4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted.

works

@vonnieda Lets discuss if that makes sense, also the issue of the camera binding (no gui for that yet tough).
