### PR TITLE
Apply in feeder dialog

### DIFF
--- a/src/main/java/org/openpnp/gui/FeedersPanel.java
+++ b/src/main/java/org/openpnp/gui/FeedersPanel.java
@@ -279,8 +279,9 @@ public class FeedersPanel extends JPanel implements WizardContainer {
 				    int j = 0;
 				    while ((j<configurationPanel.getComponentCount())) {
 				    	AbstractConfigurationWizard wizard = ((AbstractConfigurationWizard) configurationPanel.getComponent(j));
-				        if (wizard.isDirty())
+				        if (wizard.isDirty()) {
 							wizard.apply();
+				        }
 				        j++;
 				    }
 				    return false;

--- a/src/main/java/org/openpnp/gui/FeedersPanel.java
+++ b/src/main/java/org/openpnp/gui/FeedersPanel.java
@@ -219,10 +219,10 @@ public class FeedersPanel extends JPanel implements WizardContainer {
                 }
 
                 if (table.getSelectedRow() != priorRowIndex) {
-                    if (keepUnAppliedFeederConfigurationChanges()) {
+                	if (keepUnAppliedFeederConfigurationChanges()) {
                         table.setRowSelectionInterval(priorRowIndex, priorRowIndex);
                         return;
-                    }
+					}
                     priorRowIndex = table.getSelectedRow();
                     
                     Feeder feeder = getSelection();
@@ -267,19 +267,32 @@ public class FeedersPanel extends JPanel implements WizardContainer {
             i++;
         }
         if (feederConfigurationIsDirty && (priorFeeder != null)) {
-            int selection = JOptionPane.showOptionDialog(null,
-                    "Configuration changes to '" + priorFeeder.getName() + "' will be lost.  Do you want to proceed?",
+            int selection = JOptionPane.showConfirmDialog(null,
+                    priorFeeder.getName() + " changed.  Apply changes?",
                     "Warning!",
-                    JOptionPane.YES_NO_OPTION,
-                    JOptionPane.WARNING_MESSAGE,
-                    null,
-                    new String[]{"Yes", "No"},
-                    "No");
-            return (selection != JOptionPane.YES_OPTION);
+                    JOptionPane.YES_NO_CANCEL_OPTION,
+                    JOptionPane.QUESTION_MESSAGE,
+                    null
+                    );
+            switch (selection) {
+				case JOptionPane.YES_OPTION:
+				    int j = 0;
+				    while ((j<configurationPanel.getComponentCount())) {
+				    	AbstractConfigurationWizard wizard = ((AbstractConfigurationWizard) configurationPanel.getComponent(j));
+				        if (wizard.isDirty())
+							wizard.apply();
+				        j++;
+				    }
+				    return false;
+				case JOptionPane.NO_OPTION:
+					return false;
+				case JOptionPane.CANCEL_OPTION:
+				default:
+					return true;
+			}
         } else {
             return false;
         }
-        
     }
     
     @Subscribe

--- a/src/main/java/org/openpnp/gui/support/AbstractConfigurationWizard.java
+++ b/src/main/java/org/openpnp/gui/support/AbstractConfigurationWizard.java
@@ -188,4 +188,8 @@ public abstract class AbstractConfigurationWizard extends JPanel implements Wiza
     public Boolean isDirty() {
         return btnApply.isEnabled();
     }
+
+    public void apply() {
+        applyAction.actionPerformed(null);
+    }
 }


### PR DESCRIPTION

# Description
When a feeder property is dirty, changing the selected feeder by clicking on the list causes
a dialog ( "loose changes" or "cancel")

Changed behaviour to "xxx has changed. Apply changes? Yes / no / cancel"


# Justification
Much faster than doing "no", then "apply" then reclick on listview.

# Instructions for Use
Change a value in feeder's inspector, click in feeders' listview and see the magic.


# Implementation Details
1. How did you test the change? Be descriptive. Untested code will not be accepted.
trivial test.

2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)?

Yes

3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing.

No

4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted.

ok
