### PR TITLE
Fix for bug #1017

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/driver/GcodeDriver.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/GcodeDriver.java
@@ -910,8 +910,14 @@ public class GcodeDriver extends AbstractReferenceDriver implements Named, Runna
              * If the command or regex is null we'll query the subdrivers. The first to respond
              * with a non-null value wins.
              */
+        	String val;
             for (ReferenceDriver driver : subDrivers) {
-                String val = driver.actuatorRead(actuator);
+                if (parameter == null) {
+                    val = driver.actuatorRead(actuator);
+                }
+                else {
+                    val = driver.actuatorRead(actuator, parameter);
+                }
                 if (val != null) {
                     return val;
                 }
@@ -921,7 +927,7 @@ public class GcodeDriver extends AbstractReferenceDriver implements Named, Runna
              * we've exhausted all the options to service the command, so throw an error.
              */
             if (parent == null) {
-                throw new Exception(String.format("Actuator \"%s\" read error: Driver configuration is missing ACTUATOR_READ_COMMAND or ACTUATOR_READ_REGEX.", actuator.getName()));
+                throw new Exception(String.format("Actuator \"%s\" read error: Driver configuration is missing ACTUATOR_READ_COMMAND or ACTUATOR_READ_WITH_DOUBLE_COMMAND or ACTUATOR_READ_REGEX.", actuator.getName()));
             }
             else {
                 return null;


### PR DESCRIPTION
# Description
Fixes bug #1017 where ACTUATOR_READ_WITH_DOUBLE_COMMAND fails for sub-drivers.

# Implementation Details
1. How did you test the change? Be descriptive. Untested code will not be accepted. Tested on live machine.
2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)? yes
3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing. n/a
4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted.  All tests passed
