### PR TITLE
allow auto assign known parts

### DIFF
--- a/src/main/java/org/openpnp/gui/importer/KicadPosImporter.java
+++ b/src/main/java/org/openpnp/gui/importer/KicadPosImporter.java
@@ -67,7 +67,7 @@ public class KicadPosImporter implements BoardImporter {
         return board;
     }
 
-    static List<Placement> parseFile(File file, Side side, boolean createMissingParts, 
+    static List<Placement> parseFile(File file, Side side, boolean assignParts,  boolean createMissingParts, 
     		boolean useOnlyValueAsPartId)
             throws Exception {
         BufferedReader reader =
@@ -129,7 +129,7 @@ public class KicadPosImporter implements BoardImporter {
             placement.setLocation(new Location(LengthUnit.Millimeters, placementX, placementY, 0,
                     placementRotation));
             Configuration cfg = Configuration.get();
-            if (cfg != null && createMissingParts) {
+            if (cfg != null && assignParts) {
                 String partId;
                 if(useOnlyValueAsPartId == true) {
                 	partId = partValue;
@@ -137,7 +137,9 @@ public class KicadPosImporter implements BoardImporter {
                 	partId = pkgName + "-" + partValue;
                 }
                 Part part = cfg.getPart(partId);
-                if (part == null) {
+                if (part != null) {
+                    placement.setPart(part);
+                } else if (createMissingParts) {
                     part = new Part(partId);
                     Package pkg = cfg.getPackage(pkgName);
                     if (pkg == null) {
@@ -145,11 +147,9 @@ public class KicadPosImporter implements BoardImporter {
                         cfg.addPackage(pkg);
                     }
                     part.setPackage(pkg);
-
                     cfg.addPart(part);
+                    placement.setPart(part);
                 }
-                placement.setPart(part);
-
             }
 
             placement.setSide(side);

--- a/src/main/java/org/openpnp/gui/importer/KicadPosImporterDialog.java
+++ b/src/main/java/org/openpnp/gui/importer/KicadPosImporterDialog.java
@@ -48,7 +48,7 @@ class KicadPosImporterDialog extends JDialog {
     private final Action cancelAction = new SwingAction_3();
     private JCheckBox chckbxCreateMissingParts;
     private JCheckBox chckbxUseValueOnlyAsPartId;
-
+    private JCheckBox chckbxAssignParts;
     public KicadPosImporterDialog(KicadPosImporter kicadPosImporter, Frame parent) {
         super(parent, KicadPosImporter.DESCRIPTION, true);
         importer = kicadPosImporter;
@@ -94,21 +94,27 @@ class KicadPosImporterDialog extends JDialog {
         panel_1.setLayout(new FormLayout(new ColumnSpec[] {
                 FormSpecs.RELATED_GAP_COLSPEC,
                 FormSpecs.DEFAULT_COLSPEC,},
-            new RowSpec[] {
-                FormSpecs.RELATED_GAP_ROWSPEC,
-                FormSpecs.DEFAULT_ROWSPEC,
-                FormSpecs.RELATED_GAP_ROWSPEC,
-                FormSpecs.DEFAULT_ROWSPEC,}));
-                
-                        chckbxCreateMissingParts = new JCheckBox("Create Missing Parts");
-                        chckbxCreateMissingParts.setSelected(false);
-                        chckbxCreateMissingParts.setToolTipText("PartId = 'Package'-'Value'");
-                        panel_1.add(chckbxCreateMissingParts, "2, 2");
-        
-                chckbxUseValueOnlyAsPartId = new JCheckBox("Use only Value as PartId");
-                chckbxUseValueOnlyAsPartId.setSelected(false);
-                chckbxUseValueOnlyAsPartId.setToolTipText("Check this, if Value is unique (e.g. company internal part number)");
-                panel_1.add(chckbxUseValueOnlyAsPartId, "2, 4");
+                new RowSpec[] {
+                        FormSpecs.RELATED_GAP_ROWSPEC,
+                        FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC,
+                        FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC,
+                        FormSpecs.DEFAULT_ROWSPEC,}));
+
+        chckbxAssignParts = new JCheckBox("Assign Parts");
+        chckbxAssignParts.setSelected(true);
+        panel_1.add(chckbxAssignParts, "2, 2");
+
+        chckbxCreateMissingParts = new JCheckBox("Create Missing Parts");
+        chckbxCreateMissingParts.setSelected(false);
+        chckbxCreateMissingParts.setToolTipText("PartId = 'Package'-'Value'");
+        panel_1.add(chckbxCreateMissingParts, "2, 4");
+
+        chckbxUseValueOnlyAsPartId = new JCheckBox("Use only Value as PartId");
+        chckbxUseValueOnlyAsPartId.setSelected(false);
+        chckbxUseValueOnlyAsPartId.setToolTipText("Check this, if Value is unique (e.g. company internal part number)");
+        panel_1.add(chckbxUseValueOnlyAsPartId, "2, 6");
 
         JSeparator separator = new JSeparator();
         getContentPane().add(separator);
@@ -196,11 +202,13 @@ class KicadPosImporterDialog extends JDialog {
             try {
                 if (KicadPosImporterDialog.this.importer.topFile.exists()) {
                     placements.addAll(KicadPosImporter.parseFile(KicadPosImporterDialog.this.importer.topFile, Side.Top,
+                            chckbxAssignParts.isSelected(),
                             chckbxCreateMissingParts.isSelected(), 
                             chckbxUseValueOnlyAsPartId.isSelected()));
                 }
                 if (KicadPosImporterDialog.this.importer.bottomFile.exists()) {
                     placements.addAll(KicadPosImporter.parseFile(KicadPosImporterDialog.this.importer.bottomFile, Side.Bottom,
+                            chckbxAssignParts.isSelected(),
                             chckbxCreateMissingParts.isSelected(), 
                             chckbxUseValueOnlyAsPartId.isSelected()));
                 }


### PR DESCRIPTION
# Description
Until now importing a kicad.pos file you had the choice between importing only the positions or import the positions, assign existing parts and if parts does not exist automatically create a new part.
This change allows (default on) assigning only existing parts.

# Justification
I think the use case where only existing parts should be imported is not so uncommon.

# Instructions for Use
Just import the .pos file.
If automatic assignment is not wanted, uncheck the checkbox in the import dialog.
Other check-boxes work unchanged.

# Implementation Details
1. How did you test the change? Unittest and existing .pos
2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)? Yes
3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing. No changes
4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted. ok
