### PR TITLE
Feature/allow full rotation in bottom vision

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/vision/ReferenceBottomVision.java
+++ b/src/main/java/org/openpnp/machine/reference/vision/ReferenceBottomVision.java
@@ -130,12 +130,18 @@ public class ReferenceBottomVision implements PartAlignment {
                 // the center of the camera to the located part.
                 offsets = VisionUtils.getPixelCenterOffsets(camera, rect.center.x, rect.center.y);
 
-                // OpenCV can only tell us the angle of the recognized rectangle in a   
+                double angleOffset = VisionUtils.getPixelAngle(camera, rect.angle) - wantedAngle;
+                // Most OpenCV Pipelines can only tell us the angle of the recognized rectangle in a   
                 // wrapping-around range of 0° .. 90° as it has no notion of which rectangle side 
                 // is which. We can assume that the part is never picked more than +/-45º rotated.
                 // So we change the range wrapping-around to -45° .. +45°. See angleNorm():
-                double angleOffset = angleNorm(VisionUtils.getPixelAngle(camera, rect.angle) - wantedAngle);
-                
+                if (partSettings.getMaxRotation() == MaxRotation.Adjust ) {
+                    angleOffset = angleNorm(angleOffset);
+                } else {
+                    // turning more than 180° in one direction makes no sense
+                    angleOffset = angleNorm(angleOffset, 180);
+                }
+
                 // When we rotate the nozzle later to compensate for the angle offset, the X, Y offsets 
                 // will change too, as the off-center part rotates around the nozzle axis.
                 // So we need to compensate for that.
@@ -203,11 +209,17 @@ public class ReferenceBottomVision implements PartAlignment {
             // the center of the camera to the located part.
             Location offsets = VisionUtils.getPixelCenterOffsets(camera, rect.center.x, rect.center.y);
 
-            // OpenCV can only tell us the angle of the recognized rectangle in a   
+            double angleOffset = VisionUtils.getPixelAngle(camera, rect.angle);
+            // Most OpenCV Pipelines can only tell us the angle of the recognized rectangle in a   
             // wrapping-around range of 0° .. 90° as it has no notion of which rectangle side 
             // is which. We can assume that the part is never picked more than +/-45º rotated.
             // So we change the range wrapping-around to -45° .. +45°. See angleNorm():
-            double angleOffset = angleNorm(VisionUtils.getPixelAngle(camera, rect.angle));
+            if (partSettings.getMaxRotation() == MaxRotation.Adjust ) {
+                angleOffset = angleNorm(angleOffset);
+            } else {
+                // turning more than 180° in one direction makes no sense
+                angleOffset = angleNorm(angleOffset, 180);
+            }
 
             // Set the angle on the offsets.
             offsets = offsets.derive(null, null, null, angleOffset);
@@ -417,6 +429,10 @@ public class ReferenceBottomVision implements PartAlignment {
     public enum PreRotateUsage {
         Default, AlwaysOn, AlwaysOff
     }
+    
+    public enum MaxRotation {
+        Adjust, Full
+    }
     @Root
     public static class PartSettings {
         @Attribute
@@ -424,6 +440,9 @@ public class ReferenceBottomVision implements PartAlignment {
         @Attribute(required = false)
         protected PreRotateUsage preRotateUsage = PreRotateUsage.Default;
 
+        @Attribute(required = false)
+        protected MaxRotation maxRotation = MaxRotation.Adjust;
+        
         @Element
         protected CvPipeline pipeline;
 
@@ -464,6 +483,14 @@ public class ReferenceBottomVision implements PartAlignment {
 
         public void setPipeline(CvPipeline pipeline) {
             this.pipeline = pipeline;
+        }
+        
+        public MaxRotation getMaxRotation() {
+            return maxRotation;
+        }
+
+        public void setMaxRotation(MaxRotation maxRotation) {
+            this.maxRotation = maxRotation;
         }
     }
 }

--- a/src/main/java/org/openpnp/machine/reference/vision/wizards/ReferenceBottomVisionPartConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/vision/wizards/ReferenceBottomVisionPartConfigurationWizard.java
@@ -14,7 +14,6 @@ import javax.swing.border.TitledBorder;
 import org.openpnp.gui.MainFrame;
 import org.openpnp.gui.support.AbstractConfigurationWizard;
 import org.openpnp.gui.support.MessageBoxes;
-import org.openpnp.machine.reference.ReferenceNozzleTip;
 import org.openpnp.machine.reference.vision.ReferenceBottomVision;
 import org.openpnp.machine.reference.vision.ReferenceBottomVision.PartSettings;
 import org.openpnp.model.LengthUnit;
@@ -42,7 +41,8 @@ public class ReferenceBottomVisionPartConfigurationWizard extends AbstractConfig
     private JCheckBox enabledCheckbox;
     private JCheckBox chckbxCenterAfterTest;
     private JComboBox comboBoxPreRotate;
-
+    private JComboBox comboBoxMaxRotation;
+    
     public ReferenceBottomVisionPartConfigurationWizard(ReferenceBottomVision bottomVision,
             Part part) {
         this.bottomVision = bottomVision;
@@ -61,6 +61,8 @@ public class ReferenceBottomVisionPartConfigurationWizard extends AbstractConfig
                 FormSpecs.RELATED_GAP_COLSPEC,
                 FormSpecs.DEFAULT_COLSPEC,},
             new RowSpec[] {
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
                 FormSpecs.RELATED_GAP_ROWSPEC,
                 FormSpecs.DEFAULT_ROWSPEC,
                 FormSpecs.RELATED_GAP_ROWSPEC,
@@ -124,6 +126,13 @@ public class ReferenceBottomVisionPartConfigurationWizard extends AbstractConfig
             }
         });
         panel.add(btnLoadDefault, "6, 8");
+        
+        JLabel lblMaxRotation = new JLabel("Rotation");
+        panel.add(lblMaxRotation, "2, 10, right, top");
+        
+        comboBoxMaxRotation = new JComboBox(ReferenceBottomVision.MaxRotation.values());
+        comboBoxMaxRotation.setToolTipText("Adjust for all parts, where only some minor offset is expected. Full for parts, where bottom vision detects pin 1");
+        panel.add(comboBoxMaxRotation, "4, 10, fill, default");
     }
 
     private void testAlignment() throws Exception {
@@ -212,5 +221,6 @@ public class ReferenceBottomVisionPartConfigurationWizard extends AbstractConfig
     public void createBindings() {
         addWrappedBinding(partSettings, "enabled", enabledCheckbox, "selected");
         addWrappedBinding(partSettings, "preRotateUsage", comboBoxPreRotate, "selectedItem");
+        addWrappedBinding(partSettings, "maxRotation", comboBoxMaxRotation, "selectedItem");
     }
 }


### PR DESCRIPTION
# Description
Introduced a new option for the parts, that the bottom Vision can not only adjust the angle (+-45°) but fully rotate the part (+-180°).
Added a option in the ReferenceBottomVision PartSettings (enum) and made that visible in the Wizzard. Default is "Adjust" => no change in behavior.
Also changed the call of the "angleNorm" function, depending on the setting.

# Justification
In some use cases (LoosePartFeeders, HeapFeeder) the orientation of a part can only be detected using the bottom vision. in that case it must be able to rotate freely if the part is polarized.

# Instructions for Use

in the ReferenceBottomVision Tab of a part select "Rotation = Full" and provide a vision pipeline, that return meaningfull results (e.g. using MatchParts).

# Implementation Details
1. How did you test the change? Yes and an other user.
2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)? yes
3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing. No changes
4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted. Run fine
