### PR TITLE
Added possibility to disable ContactProbeNozzle actuator temporarily..

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/ContactProbeNozzle.java
+++ b/src/main/java/org/openpnp/machine/reference/ContactProbeNozzle.java
@@ -48,6 +48,7 @@ public class ContactProbeNozzle extends ReferenceNozzle {
 
     @Element(required = false)
     private String contactProbeActuatorName = "";
+    private boolean isDisabled;
 
     @Override
     public PropertySheet[] getPropertySheets() {
@@ -68,7 +69,9 @@ public class ContactProbeNozzle extends ReferenceNozzle {
 
         // First probe down from current position above the part until the probe sensor
         // is triggered.
-        actuateContactProbe(true);
+		if (!isDisabled) {
+			actuateContactProbe(true);
+		}
         // Now call the default pick() which usually just turns on the vacuum.
         super.pick(part);
         // Retract from probing i.e. until the probe sensor is released.
@@ -97,7 +100,9 @@ public class ContactProbeNozzle extends ReferenceNozzle {
 
         // First probe down from current position above the PCB until the probe sensor
         // is triggered.
-        actuateContactProbe(true);
+		if (!isDisabled) {
+			actuateContactProbe(true);
+		}
         // Now call the default place() which usually just turns off the vacuum.
         super.place();
         // Retract from probing i.e. until the probe sensor is released.
@@ -124,6 +129,10 @@ public class ContactProbeNozzle extends ReferenceNozzle {
     protected void actuateContactProbe(boolean on) throws Exception {
         getContactProbeActuator().actuate(on);
     }
+    
+	public void disableContactProbeActuator(boolean set) {
+		isDisabled = set;
+	}
 
     public String getContactProbeActuatorName() {
         return contactProbeActuatorName;


### PR DESCRIPTION
to avoid probing with every pick and place command by scripting.

# Description
A ContactProbeNozzle probes with every pick an place command. If one will avoid these we can now set a flag by script. If not set the machine behaves as before.

# Justification
Probing has an impact on speed and can cause errors. Probing with discard devices e.q. makes no sense.

# Instructions for Use
Setup a ContactProbeNozzle for your machine as descriped here in detail https://github.com/openpnp/openpnp/pull/859.
After that the machine will probe with every pick and place command. To avoid these for certain action we can use https://github.com/openpnp/openpnp/wiki/Scripting. Job.BeforeDiscard.js to disable and Job.AfterDiscard.js to enable e.g. with discard devices action. The script could be similar to this example:

Job.BeforeDiscard.js:

	// Import some OpenPnP classes we'll use to disable probing
	var imports = new JavaImporter(org.openpnp.spi.machine);
	var head = machine.getHead("H1");   // Your machine head's name
	var nozzle = head.getNozzle("N1");   // Your machine nozzle's name
	print("##################################################################");
	nozzle.disableContactProbeActuator(true);   // We disable probing
	print("##################################################################");

The same code in a Job.AfterDiscard.js but with:

	nozzle.disableContactProbeActuator(false);   // We enable probing


# Implementation Details
1. I made several tests with my machine and run the virtual job of OpenPnP
2. I did follow the coding style.
3. No changes were made in the org.openpnp.spi or org.openpnp.model packages. 
4. After downgrade to JDK 11.0.2  (before machine.xml was not found) the maven test run without error.
