### PR TITLE
Feature/comms fail catch

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/driver/GcodeDriver.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/GcodeDriver.java
@@ -1047,7 +1047,14 @@ public class GcodeDriver extends AbstractReferenceDriver implements Named, Runna
                 command = unescape(command);
             }
             Logger.trace("[{}] >> {}", getCommunications().getConnectionName(), command);
-            getCommunications().writeLine(command);
+            try {
+                getCommunications().writeLine(command);
+            }
+            catch (IOException ex) {
+                Logger.error("Failed to write command: ", command);
+                disconnect();
+                Configuration.get().getMachine().setEnabled(false);
+            }
         }
 
         // Collect responses till we find one with the confirmation or we timeout. Return

--- a/src/main/java/org/openpnp/machine/reference/driver/GcodeDriver.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/GcodeDriver.java
@@ -1105,7 +1105,13 @@ public class GcodeDriver extends AbstractReferenceDriver implements Named, Runna
         while (!disconnectRequested) {
             String line;
             try {
-                line = getCommunications().readLine().trim();
+                line = getCommunications().readLine();
+                if (line == null) {
+                    // Line read failed eg. due to socket closure
+                    Logger.error("Failed to read gcode response");
+                    return;
+                }
+                line = line.trim();
             }
             catch (TimeoutException ex) {
                 continue;


### PR DESCRIPTION
# Description

With TCP communications and GCodeDriver, if the comms is lost due to the far end closing the socket, openPnP does not recover gracefully and requires a restart. This catches the command write and response read errors and correctly closes the connection. Since this is most likely a fatal error, the machine is disabled.

# Justification

This change is specific to GCodeDriver over TCP comms, so maybe a little specific. The change should be fairly unintrusive though.

# Instructions for Use

If the connection is broken, but then restored, the machine can be restarted and re-homed.

# Implementation Details

Tested using GCodeDriver via local socket to a gcode daemon.
There should be no coding style violations.
No changes to models or spi.
Maven tests do not cover this case, so are not affected.
