### PR TITLE
Fix / Various assorted bugfixes broken out

### DIFF
--- a/src/main/java/org/openpnp/gui/MachineSetupPanel.java
+++ b/src/main/java/org/openpnp/gui/MachineSetupPanel.java
@@ -29,6 +29,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Enumeration;
+import java.util.HashMap;
 import java.util.List;
 import java.util.prefs.Preferences;
 
@@ -90,7 +91,7 @@ public class MachineSetupPanel extends JPanel implements WizardContainer {
      */
     private boolean disableLastSelectedListener = false;
     private Object lastSelectedNode = null;
-    private int lastSelectedTabIndex = 0;
+    private HashMap<Class, Integer> lastSelectedTabIndex = new HashMap<>();
 
     public MachineSetupPanel() {
         setLayout(new BorderLayout(0, 0));
@@ -159,10 +160,12 @@ public class MachineSetupPanel extends JPanel implements WizardContainer {
         
         tabbedPane.addChangeListener(new ChangeListener() {
             public void stateChanged(ChangeEvent e) {
-                if (disableLastSelectedListener) {
-                    return;
+                if (lastSelectedNode != null) {
+                    if (disableLastSelectedListener) {
+                        return;
+                    }
+                    lastSelectedTabIndex.put(lastSelectedNode.getClass(), tabbedPane.getSelectedIndex());
                 }
-                lastSelectedTabIndex = tabbedPane.getSelectedIndex();
             }
         });
 
@@ -203,9 +206,11 @@ public class MachineSetupPanel extends JPanel implements WizardContainer {
                                 }
                             }
                             
-                            if (lastSelectedNode != null) {
-                                if (lastSelectedNode.getClass().equals(node.obj.getClass())) {
-                                    tabbedPane.setSelectedIndex(lastSelectedTabIndex);
+                            if (node.obj != null) {
+                                if (lastSelectedTabIndex.get(node.obj.getClass()) != null) {
+                                    // Sometimes when clicking around quickly, the lastSelectedTabIndex update seems to be wrong, 
+                                    // resulting in an IndexOutOfBoundsException. Therefore we check the tab count too. This covers variable per class Wizards too. 
+                                    tabbedPane.setSelectedIndex(Math.min(tabbedPane.getTabCount()-1, lastSelectedTabIndex.get(node.obj.getClass())));
                                 }
                             }
                             

--- a/src/main/java/org/openpnp/machine/reference/ReferencePnpJobProcessor.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferencePnpJobProcessor.java
@@ -1053,17 +1053,17 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
                         totalPartsPlaced,
                         df.format(dtSec), 
                         df.format(totalPartsPlaced / (dtSec / 3600.0)));
+
+                Logger.info("Errored Placements:");
+                for (JobPlacement jobPlacement : erroredPlacements) {
+                    Logger.info("{}: {}", jobPlacement, jobPlacement.getError().getMessage());
+                }
             }
             else {
                 fireTextStatus("Job finished without error, placed %s parts in %s sec. (%s CPH)", 
                         totalPartsPlaced,
                         df.format(dtSec), 
                         df.format(totalPartsPlaced / (dtSec / 3600.0)));
-            }
-            
-            Logger.info("Errored Placements:");
-            for (JobPlacement jobPlacement : erroredPlacements) {
-                Logger.info("{}: {}", jobPlacement, jobPlacement.getError().getMessage());
             }
 
             return null;

--- a/src/main/java/org/openpnp/machine/reference/camera/wizards/OpenPnpCaptureCameraConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/camera/wizards/OpenPnpCaptureCameraConfigurationWizard.java
@@ -48,9 +48,6 @@ import com.jgoodies.forms.layout.ColumnSpec;
 import com.jgoodies.forms.layout.FormLayout;
 import com.jgoodies.forms.layout.FormSpecs;
 import com.jgoodies.forms.layout.RowSpec;
-import javax.swing.SwingConstants;
-import javax.swing.JTextArea;
-import javax.swing.UIManager;
 
 @SuppressWarnings("serial")
 public class OpenPnpCaptureCameraConfigurationWizard extends AbstractConfigurationWizard {

--- a/src/main/java/org/openpnp/machine/reference/feeder/BlindsFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/BlindsFeeder.java
@@ -45,15 +45,11 @@ import org.openpnp.ConfigurationListener;
 import org.openpnp.gui.MainFrame;
 import org.openpnp.gui.support.Wizard;
 import org.openpnp.machine.reference.ReferenceFeeder;
-import org.openpnp.machine.reference.ReferenceMachine;
-import org.openpnp.machine.reference.ReferenceNozzleTip;
-import org.openpnp.machine.reference.driver.GcodeDriver;
 import org.openpnp.machine.reference.feeder.wizards.BlindsFeederConfigurationWizard;
 import org.openpnp.model.Configuration;
 import org.openpnp.model.Length;
 import org.openpnp.model.LengthUnit;
 import org.openpnp.model.Location;
-import org.openpnp.model.Part;
 import org.openpnp.model.Point;
 import org.openpnp.spi.Camera;
 import org.openpnp.spi.Feeder;
@@ -1292,28 +1288,6 @@ public class BlindsFeeder extends ReferenceFeeder {
                 throw new Exception("Feeder " + getName() + ": current nozzle tip "+nozzleTip.getId()+
                         " has push diameter not set. Check the nozzle tip configuration.");
             }
-            
-            // HACK: get backlash compensation from GcodeDriver. No point in adding a general interface as this 
-            // should not be on the driver in the first place.
-            Length backlashOffset = new Length(0.0, getFiducial2Location().getUnits());
-            double backlashOpen = 0.0;
-            double backlashClose = 0.0;
-            ReferenceMachine referenceMachine;
-            if (Configuration.get().getMachine() instanceof ReferenceMachine) {
-                referenceMachine = (ReferenceMachine)Configuration.get().getMachine();
-                if (referenceMachine.getDriver() instanceof GcodeDriver) {
-                    GcodeDriver gcodeDriver = (GcodeDriver)referenceMachine.getDriver();
-                    Location backlashVector = new Location(gcodeDriver.getUnits(), 
-                            gcodeDriver.getBacklashOffsetX(), 
-                            gcodeDriver.getBacklashOffsetY(), 
-                            0.0, 0.0);
-                    Location unitVectorX =  getFiducial1Location().unitVectorTo(getFiducial2Location());
-                    // dot product is backlash offset perpendicularly projected onto the feeder X axis 
-                    backlashOffset = unitVectorX.dotProduct(backlashVector);
-                    backlashOpen = backlashOffset.getValue() > 0.0 ? 1.0 : 0.0;
-                    backlashClose = backlashOffset.getValue() < 0.0 ? 1.0 : 0.0;
-                }
-            }
 
             assertCalibration();
 
@@ -1323,23 +1297,19 @@ public class BlindsFeeder extends ReferenceFeeder {
                         edgeOpenDistance.multiply(-1.0)
                         .subtract(sprocketPitch.multiply(0.5)) // go half sprocket too far back
                         .subtract(nozzleTipDiameter.multiply(0.5))
-                        .subtract(backlashOffset.multiply(backlashOpen))
                         : 
                             edgeClosedDistance
                             .add(tapeLength) 
                             .add(sprocketPitch.multiply(0.5)) // go half sprocket too far
                             .add(nozzleTipDiameter.multiply(0.5)))
-                            .subtract(backlashOffset.multiply(backlashClose))
                         .convertToUnits(location.getUnits());
                 Length feederX1 = (openState ? 
                         edgeOpenDistance.multiply(-1.0)
-                        .subtract(nozzleTipDiameter.multiply(0.5)) 
-                        .subtract(backlashOffset.multiply(backlashOpen))
+                        .subtract(nozzleTipDiameter.multiply(0.5))
                         : 
                             edgeClosedDistance
                             .add(tapeLength)
                             .add(nozzleTipDiameter.multiply(0.5)))
-                            .subtract(backlashOffset.multiply(backlashClose))
                         .convertToUnits(location.getUnits());
                 Length feederY = pocketCenterline
                         .convertToUnits(location.getUnits());

--- a/src/main/java/org/openpnp/machine/reference/feeder/ReferenceDragFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/ReferenceDragFeeder.java
@@ -279,9 +279,6 @@ public class ReferenceDragFeeder extends ReferenceFeeder {
         // Move the camera to be in focus over the pick location.
         // head.moveTo(head.getX(), head.getY(), z, head.getC());
 
-        // Settle the camera
-        Thread.sleep(camera.getSettleTimeMs());
-
         VisionProvider visionProvider = camera.getVisionProvider();
 
         Rectangle aoi = getVision().getAreaOfInterest();

--- a/src/main/java/org/openpnp/machine/reference/feeder/ReferenceLeverFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/ReferenceLeverFeeder.java
@@ -234,9 +234,6 @@ public class ReferenceLeverFeeder extends ReferenceFeeder {
         // Move the camera to be in focus over the pick location.
         // head.moveTo(head.getX(), head.getY(), z, head.getC());
 
-        // Settle the camera
-        Thread.sleep(camera.getSettleTimeMs());
-
         VisionProvider visionProvider = camera.getVisionProvider();
 
         Rectangle aoi = getVision().getAreaOfInterest();

--- a/src/main/java/org/openpnp/machine/reference/feeder/ReferenceStripFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/ReferenceStripFeeder.java
@@ -329,8 +329,10 @@ public class ReferenceStripFeeder extends ReferenceFeeder {
     }
 
     public void setReferenceHoleLocation(Location referenceHoleLocation) {
+        Object oldValue = this.referenceHoleLocation;
         this.referenceHoleLocation = referenceHoleLocation;
         visionLocation = null;
+        firePropertyChange("referenceHoleLocation", oldValue, referenceHoleLocation);
     }
 
     public Location getLastHoleLocation() {
@@ -338,8 +340,10 @@ public class ReferenceStripFeeder extends ReferenceFeeder {
     }
 
     public void setLastHoleLocation(Location lastHoleLocation) {
+        Object oldValue = this.lastHoleLocation;
         this.lastHoleLocation = lastHoleLocation;
         visionLocation = null;
+        firePropertyChange("lastHoleLocation", oldValue, lastHoleLocation);
     }
 
     public Length getHoleDiameter() {

--- a/src/main/java/org/openpnp/machine/reference/vision/OpenCvVisionProvider.java
+++ b/src/main/java/org/openpnp/machine/reference/vision/OpenCvVisionProvider.java
@@ -82,7 +82,7 @@ public class OpenCvVisionProvider implements VisionProvider {
      * @return
      */
     public List<TemplateMatch> getTemplateMatches(BufferedImage template) {
-        BufferedImage image = camera.capture();
+        BufferedImage image = camera.settleAndCapture();
 
         // Convert the camera image and template image to the same type. This
         // is required by the cvMatchTemplate call.
@@ -149,7 +149,7 @@ public class OpenCvVisionProvider implements VisionProvider {
     @Override
     public Point[] locateTemplateMatches(int roiX, int roiY, int roiWidth, int roiHeight, int coiX,
             int coiY, BufferedImage templateImage_) throws Exception {
-        BufferedImage cameraImage_ = camera.capture();
+        BufferedImage cameraImage_ = camera.settleAndCapture();
 
         // Convert the camera image and template image to the same type. This
         // is required by the cvMatchTemplate call.

--- a/src/main/java/org/openpnp/spi/Camera.java
+++ b/src/main/java/org/openpnp/spi/Camera.java
@@ -121,14 +121,4 @@ public interface Camera extends HeadMountable, WizardConfigurable,
      * @return
      */
     public int getHeight();
-
-    /**
-     * Get the time in milliseconds that the Camera should be allowed to settle before images are
-     * captured for vision operations.
-     * 
-     * @return
-     */
-    public long getSettleTimeMs();
-
-    public void setSettleTimeMs(long settleTimeMs);
 }

--- a/src/main/java/org/openpnp/vision/pipeline/stages/DrawTemplateMatches.java
+++ b/src/main/java/org/openpnp/vision/pipeline/stages/DrawTemplateMatches.java
@@ -2,6 +2,7 @@ package org.openpnp.vision.pipeline.stages;
 
 import java.awt.Color;
 import java.util.List;
+import java.util.Locale;
 
 import org.opencv.core.Mat;
 import org.opencv.core.Scalar;
@@ -65,7 +66,7 @@ public class DrawTemplateMatches extends CvStage {
             Scalar color = FluentCv.colorToScalar(color_);
             Imgproc.rectangle(mat, new org.opencv.core.Point(x, y),
                     new org.opencv.core.Point(x + width, y + height), color);
-            Imgproc.putText(mat, "" + score, new org.opencv.core.Point(x + width, y + height),
+            Imgproc.putText(mat, String.format(Locale.US, "%.3f", score), new org.opencv.core.Point(x + width, y + height),
                     Imgproc.FONT_HERSHEY_PLAIN, 1.0, color);
         }
 

--- a/src/test/java/SampleJobTest.java
+++ b/src/test/java/SampleJobTest.java
@@ -12,6 +12,7 @@ import org.openpnp.machine.reference.driver.NullDriver;
 import org.openpnp.model.Configuration;
 import org.openpnp.model.Job;
 import org.openpnp.spi.Camera;
+import org.openpnp.spi.base.AbstractCamera;
 
 import com.google.common.io.Files;
 
@@ -40,8 +41,10 @@ public class SampleJobTest {
         NullDriver driver = (NullDriver) machine.getDriver();
         driver.setFeedRateMmPerMinute(0);
 
-        Camera camera = machine.getDefaultHead().getDefaultCamera();
+        AbstractCamera camera = (AbstractCamera)machine.getDefaultHead().getDefaultCamera();
+        camera.setSettleMethod(AbstractCamera.SettleMethod.FixedTime);
         camera.setSettleTimeMs(0);
+
         // File videoFile = new File("target");
         // videoFile = new File(videoFile, "SampleJobTest.mp4");
         // MpegEncodingCameraListener encoder = new MpegEncodingCameraListener(videoFile);

--- a/src/test/java/VisionUtilsTest.java
+++ b/src/test/java/VisionUtilsTest.java
@@ -201,16 +201,6 @@ public class VisionUtilsTest {
         }
 
         @Override
-        public long getSettleTimeMs() {
-            return 0;
-        }
-
-        @Override
-        public void setSettleTimeMs(long settleTimeMs) {
-
-        }
-
-        @Override
         public void moveTo(Location location, MoveToOption... options) throws Exception {
             moveTo(location, getHead().getMachine().getSpeed(), options);
         }


### PR DESCRIPTION
# Description

In the course of developing and testing the upcoming "Global Axes" PR, I found some bugs and cleaned up some code. These are now broken out in this PR to reduce the size of the upcoming PR.

## Machine Setup Panel

When changing objects in the Machine Setup Panel, the currently opened Wizard Tab is re-selected if the new object has the same class. Due to some race condition, if you click around quickly, this sometimes throws an index out of bounds exception, leaving the Panel in a half crashed way, with redraw issues, permanently. There were various reports in the group, etc.. 

This is fixed and enhanced in this PR: The Panel now remembers which Wizard Tab is selected for which class. Changing between objects will reliably re-select the tab. As it is stored per class, it will now remember the tab even if you visit other classes' objects in between. 

This should solve #961.

## Errored Placements

During (extensive!) testing I was repeatedly irritated by the message "Errored Placements". This message is issued even if there are **none**. This is now remedied. 

## Unnecessary imports

Unnecessary imports in `OpenPnpCaptureCameraConfigurationWizard` were removed. 

## Backlash Compensation correction in BlindsFeeder removed

Realizing that a properly calibrated Backlash Compensation should only take up slack/play of the belt/actuator but should **not** actually physically move the Nozzle (at least not significantly), I removed the corresponding correction in (my own #936) `BlindsFeeder`. 

## Camera Settling lose Ends

Having reworked Camera Settling in #995, I now stumbled over some code that still used the old (positive) settle time in a `Thread.sleep()` to assume a settled camera. If the user selects one of the advanced Settle Methods, the fixed settle time is no longer part of the settings (hidden on the GUI) and may be inadequate. Even before my PR, negative settle times for auto-settling would not have worked. 

Therefore, I removed the settle timeout getter/setter from the `Camera` interface, removed `Thread.sleep()` calls from `ReferenceLeverFeeder` and `ReferenceDragFeeder` and changed the `OpenCvVisionProvider` methods to use `camera.settleAndCapture()` instead of `camera.capture()`. 

Similarly, I changed `SampleJobTest` to properly use the `AbstractCamera` and set the `FixedTime` method and settle time (to 0ms,  the unit test does this to speed up simulation). 

## Firing Property Changes in ReferenceStripFeeder Reference/Last Hole Setters

Missing property change firing led to lost updates if a `ReferenceStripFeeder` is loaded/modified in the Wizard and operated at the same time. This is now fixed. Unfortunately, I don't remember the exact scenario how to reproduce (but it was nasty to diagnose). 

## Formatting DrawTemplateMatches Scores

`DrawTemplateMatches` score numbers were previously printed with full double precision. They are now formatted with reasonable 3 decimal digits. 

# Justification

All these bugs and issues were encountered during rework of the global axis handling and most importantly when testing the GUI and adapting existing and creating new unit test.  

# Instructions for Use

There is no user action needed to enable or control these fixes. Just use the features described above as before and observe.

# Implementation Details
1. Most of these changes were tested using the unit tests or the GUI with the `NullDriver` machine. `BlindsFeeder` changes were tested on the machine (albeit in the context of an early stage of the upcoming PR). The only missing tests are the `ReferenceLeverFeeder` and `ReferenceDragFeeder` camera settling due to not having these on my machine. However, the code changes are simple and I carefully looked at how the pipeline does it. I hope this is acceptable, not least under the premise that `OpenCvVisionProvider` methods are actually deprecated.  
2. I did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. Changes in the `org.openpnp.spi.Camera` interface as described.
4. Succesfully ran `mvn test` before submitting the Pull Request. 
