### PR TITLE
Feature / Enhanced Footprint Template Image Creation

### DIFF
--- a/src/main/java/org/openpnp/util/OpenCvUtils.java
+++ b/src/main/java/org/openpnp/util/OpenCvUtils.java
@@ -1,5 +1,11 @@
 package org.openpnp.util;
 
+import java.awt.Color;
+import java.awt.Graphics2D;
+import java.awt.RenderingHints;
+import java.awt.Shape;
+import java.awt.geom.AffineTransform;
+import java.awt.geom.Rectangle2D;
 import java.awt.image.BufferedImage;
 import java.awt.image.DataBufferByte;
 import java.io.File;
@@ -11,7 +17,6 @@ import java.util.List;
 
 import javax.imageio.ImageIO;
 
-import org.opencv.core.Core;
 import org.opencv.core.CvType;
 import org.opencv.core.Mat;
 import org.opencv.core.Point;
@@ -19,6 +24,7 @@ import org.opencv.core.Scalar;
 import org.opencv.core.Size;
 import org.opencv.imgproc.Imgproc;
 import org.openpnp.model.Configuration;
+import org.openpnp.model.Footprint;
 import org.openpnp.model.Length;
 import org.openpnp.model.Location;
 import org.openpnp.spi.Camera;
@@ -254,6 +260,93 @@ public class OpenCvUtils {
     private enum MinMaxState {
         BEFORE_INFLECTION,
         AFTER_INFLECTION
+    }
+
+    /**
+     * Draws a template image of the given footprint.  
+     * 
+     * @param camera The camera to get the pixel scale from.
+     * @param footprint Footprint to be drawn.
+     * @param topView Whether the body is drawn over the pads rather than vice versa. 
+     * @param padsColor Color of the pads. Pads are not drawn if null.
+     * @param bodyColor Color of the body. Body is not drawn if null.
+     * @param backgroundColor 
+     * @param marginFactor The margin around the Footprint, relative to its bounding rectangle.
+     * @param minimumMarginSize 
+     * @return
+     * @throws Exception
+     */
+    public static BufferedImage createFootprintTemplate(Camera camera, Footprint footprint, double rotation,
+            boolean topView, Color padsColor, Color bodyColor, Color backgroundColor, double marginFactor, int minimumMarginSize)
+                    throws Exception {
+        Location unitsPerPixel = camera.getUnitsPerPixel();
+
+        Shape shape = footprint.getShape();
+        Shape bodyShape = footprint.getBodyShape();
+        Shape padsShape = footprint.getPadsShape();
+
+        if (shape == null) {
+            throw new Exception(
+                    "Invalid footprint found, unable to create template for part match. See https://github.com/openpnp/openpnp/wiki/Fiducials.");
+        }
+
+        // Determine the scaling factor to go from Outline units to
+        // Camera units.
+        Length l = new Length(1, footprint.getUnits());
+        l = l.convertToUnits(unitsPerPixel.getUnits());
+        double unitScale = l.getValue();
+
+        // Create a transform to scale the Shape by
+        AffineTransform tx = new AffineTransform();
+
+        // First we scale by units to convert the units and then we scale
+        // by the camera X and Y units per pixels to get pixel locations.
+        tx.scale(unitScale, unitScale);
+        tx.scale(1.0 / unitsPerPixel.getX(), 1.0 / unitsPerPixel.getY());
+        tx.rotate(Math.toRadians(-rotation));
+
+        // Transform the Shape and draw it out.
+        shape = tx.createTransformedShape(shape);
+        bodyShape = tx.createTransformedShape(bodyShape);
+        padsShape = tx.createTransformedShape(padsShape);
+
+        Rectangle2D bounds = shape.getBounds2D();
+
+        if (bounds.getWidth() == 0 || bounds.getHeight() == 0) {
+            throw new Exception(
+                    "Invalid footprint found, unable to create template for part match. Width and height of pads must be greater than 0. See https://github.com/openpnp/openpnp/wiki/Fiducials.");
+        }
+
+        // Make the image bigger than the shape. This gives better
+        // recognition performance because it allows some border around the edges.
+        double width = Math.max(bounds.getWidth() * marginFactor, bounds.getWidth()+2*minimumMarginSize);
+        double height = Math.max(bounds.getHeight() * marginFactor, bounds.getHeight()+2*minimumMarginSize);
+        BufferedImage template =
+                new BufferedImage((int) width, (int) height, BufferedImage.TYPE_INT_ARGB);
+        Graphics2D g2d = (Graphics2D) template.getGraphics();
+        if (backgroundColor != null) {
+            g2d.setColor(backgroundColor);
+            g2d.fillRect(0, 0, (int) width, (int) height);
+        }
+
+        //g2d.setStroke(new BasicStroke(1f));
+        g2d.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+        // center the drawing
+        g2d.translate(width / 2.0, height / 2.0);
+        if (!topView && bodyColor != null) {
+            g2d.setColor(bodyColor);
+            g2d.fill(bodyShape);
+        }
+        if (padsColor != null) {
+            g2d.setColor(padsColor);
+            g2d.fill(padsShape);
+        }
+        if (topView && bodyColor != null) {
+            g2d.setColor(bodyColor);
+            g2d.fill(bodyShape);
+        }
+        g2d.dispose();
+        return template;
     }
 
     /**

--- a/src/main/java/org/openpnp/vision/pipeline/stages/CreateFootprintTemplateImage.java
+++ b/src/main/java/org/openpnp/vision/pipeline/stages/CreateFootprintTemplateImage.java
@@ -1,86 +1,97 @@
 package org.openpnp.vision.pipeline.stages;
 
-import java.awt.BasicStroke;
 import java.awt.Color;
-import java.awt.Graphics2D;
-import java.awt.RenderingHints;
-import java.awt.Shape;
-import java.awt.geom.AffineTransform;
-import java.awt.geom.Rectangle2D;
 import java.awt.image.BufferedImage;
 
 import org.openpnp.model.Footprint;
-import org.openpnp.model.Length;
-import org.openpnp.model.Location;
 import org.openpnp.spi.Camera;
 import org.openpnp.util.OpenCvUtils;
 import org.openpnp.vision.pipeline.CvPipeline;
 import org.openpnp.vision.pipeline.CvStage;
+import org.openpnp.vision.pipeline.Property;
 import org.openpnp.vision.pipeline.Stage;
+import org.openpnp.vision.pipeline.stages.convert.ColorConverter;
+import org.simpleframework.xml.Attribute;
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.convert.Convert;
 
 @Stage(description="Creates a template from the specified footprint and camera properties. The template is scaled to the camera's units.")
 public class CreateFootprintTemplateImage extends CvStage {
+
+    public enum FootprintView {
+        Fiducial,
+        TopView,
+        BottomView
+    }
+    @Attribute(required=false)
+    @Property(description = "Determines, how the footprint is drawn. Fiducial: only draws the pads, TopView: draws body over pads, "
+            + "BottomView: draws pads over body.")
+    private FootprintView footprintView = FootprintView.Fiducial;
+
+    @Element(required=false)
+    @Convert(ColorConverter.class)
+    @Property(description = "Color of the pads.")
+    private Color padsColor = Color.white; 
+
+    @Element(required=false)
+    @Convert(ColorConverter.class)
+    @Property(description = "Color of the body.")
+    private Color bodyColor = Color.black; 
+
+    @Element(required=false)
+    @Convert(ColorConverter.class)
+    @Property(description = "Color of the background.")
+    private Color backgroundColor = Color.black; 
+
+    public FootprintView getFootprintView() {
+        return footprintView;
+    }
+
+    public void setFootprintView(FootprintView footprintView) {
+        this.footprintView = footprintView;
+    }
+
+    public Color getPadsColor() {
+        return padsColor;
+    }
+
+    public void setPadsColor(Color padsColor) {
+        this.padsColor = padsColor;
+    }
+
+    public Color getBodyColor() {
+        return bodyColor;
+    }
+
+    public void setBodyColor(Color bodyColor) {
+        this.bodyColor = bodyColor;
+    }
+
+    public Color getBackgroundColor() {
+        return backgroundColor;
+    }
+
+    public void setBackgroundColor(Color backgroundColor) {
+        this.backgroundColor = backgroundColor;
+    }
+
     @Override
     public Result process(CvPipeline pipeline) throws Exception {
         Camera camera = (Camera) pipeline.getProperty("camera");
         Footprint footprint = (Footprint) pipeline.getProperty("footprint");
-        
+
         if (camera == null) {
             throw new Exception("Property \"camera\" is required.");
         }
         if (footprint == null) {
             throw new Exception("Property \"footprint\" is required.");
         }
-        
-        Location unitsPerPixel = camera.getUnitsPerPixel();
-        
-        Shape shape = footprint.getShape();
 
-        if (shape == null) {
-            throw new Exception(
-                    "Invalid footprint found, unable to create template for fiducial match. See https://github.com/openpnp/openpnp/wiki/Fiducials.");
-        }
-
-        // Determine the scaling factor to go from Outline units to
-        // Camera units.
-        Length l = new Length(1, footprint.getUnits());
-        l = l.convertToUnits(unitsPerPixel.getUnits());
-        double unitScale = l.getValue();
-
-        // Create a transform to scale the Shape by
-        AffineTransform tx = new AffineTransform();
-
-        // First we scale by units to convert the units and then we scale
-        // by the camera X and Y units per pixels to get pixel locations.
-        tx.scale(unitScale, unitScale);
-        tx.scale(1.0 / unitsPerPixel.getX(), 1.0 / unitsPerPixel.getY());
-
-        // Transform the Shape and draw it out.
-        shape = tx.createTransformedShape(shape);
-
-        Rectangle2D bounds = shape.getBounds2D();
-
-        if (bounds.getWidth() == 0 || bounds.getHeight() == 0) {
-            throw new Exception(
-                    "Invalid footprint found, unable to create template for fiducial match. Width and height of pads must be greater than 0. See https://github.com/openpnp/openpnp/wiki/Fiducials.");
-        }
-
-        // Make the image 50% bigger than the shape. This gives better
-        // recognition performance because it allows some border around the edges.
-        double width = bounds.getWidth() * 1.5;
-        double height = bounds.getHeight() * 1.5;
-        BufferedImage template =
-                new BufferedImage((int) width, (int) height, BufferedImage.TYPE_INT_ARGB);
-        Graphics2D g2d = (Graphics2D) template.getGraphics();
-
-        g2d.setStroke(new BasicStroke(1f));
-        g2d.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
-        g2d.setColor(Color.white);
-        // center the drawing
-        g2d.translate(width / 2, height / 2);
-        g2d.fill(shape);
-
-        g2d.dispose();
+        BufferedImage template = OpenCvUtils.createFootprintTemplate(camera, footprint, 0.0,
+                footprintView == FootprintView.TopView, 
+                padsColor, 
+                (footprintView == FootprintView.Fiducial ? null : bodyColor), 
+                backgroundColor, 1.5, 3);
 
         return new Result(OpenCvUtils.toMat(template));
     }


### PR DESCRIPTION
# Description

The `CreateFootprintTemplateImage` pipeline stage was refactored to extract the actual template image creation into a generic method of `OpenCvUtils`. Both the stage and the method were enhanced with new parameters and features.

The footprint image can now be colored to allow for full color template matching in difficult low contrast situations and for inverted (black on white) fiducials etc. 

![grafik](https://user-images.githubusercontent.com/9963310/89585400-13347b80-d83e-11ea-9e67-776c6f6bb4c9.png)

The stage was also enhanced to allow creating part templates as seen both from above and below and including the part body.

![grafik](https://user-images.githubusercontent.com/9963310/89585618-71615e80-d83e-11ea-9f0b-49a381bd7966.png)

# Justification

On the group users repeatedly asked for ways to recognize fiducials that have different colors and/or are negated (dark on bright). 

See also:
https://groups.google.com/g/openpnp/c/in0uHToytPo/m/fjw1fV_wBgAJ

The refactored method will be used in the upcoming "global axes" PR, where it is employed to improve the `SampleTestJob` unit test, i.e. to render parts in bottom vision and to recognize and validate pick and place locations with the `ImageCamera`. 

See here (the images):
https://groups.google.com/g/openpnp/c/bEVZvYoXO98/m/oS4SRmfIAwAJ

# Instructions for Use

Use the colors and the footprintView setting to render a template as you need it. As an example I created a color template that matches a difficult fiducial of a group user.  

![grafik](https://user-images.githubusercontent.com/9963310/89586939-dc139980-d840-11ea-8a99-8de76e223206.png)

![grafik](https://user-images.githubusercontent.com/9963310/89586964-eafa4c00-d840-11ea-8a17-3eb32cdf15a5.png)


# Implementation Details
1. The new stage was tested in the NullDriver machine, and a [group user supplied image](https://groups.google.com/g/openpnp/c/in0uHToytPo/m/fjw1fV_wBgAJ).  The extracted method was tested extensively in the upcoming PR.
2. I did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. I successfully ran `mvn test` before submitting the Pull Request. 
