### PR TITLE
Update SlotSchultzFeederConfigurationWizard.java

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/feeder/wizards/SlotSchultzFeederConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/wizards/SlotSchultzFeederConfigurationWizard.java
@@ -183,10 +183,15 @@ public class SlotSchultzFeederConfigurationWizard
         flowLayout_1.setAlignment(FlowLayout.LEFT);
         whateverPanel.add(panel_1, "12, 2");
         
-        JButton newFeederBtn = new JButton(newFeederAction);
-        panel_1.add(newFeederBtn);
+        JButton loadFeederBtn = new JButton(loadFeederAction);
+        loadFeederBtn.setToolTipText("Load installed feeder to slot.");
+        panel_1.add(loadFeederBtn);
+        
+//        JButton newFeederBtn = new JButton(newFeederAction);
+//        panel_1.add(newFeederBtn);
         
         JButton deleteFeederBtn = new JButton(deleteFeederAction);
+        deleteFeederBtn.setToolTipText("Remove selected feeder from database.");
         panel_1.add(deleteFeederBtn);
         
         JLabel lblPickRetryCount = new JLabel("Pick Retry Count");
@@ -644,7 +649,32 @@ public class SlotSchultzFeederConfigurationWizard
 
     }
     
-    private Action newFeederAction = new AbstractAction("New") {
+    private Action loadFeederAction = new AbstractAction("Load") {
+        @Override
+        public void actionPerformed(ActionEvent e) {
+            Bank bank = (Bank) bankCb.getSelectedItem();
+            Feeder f = new Feeder(idText.getText());
+            Feeder item;
+            int i;
+            for (i = 1; i < feederCb.getItemCount(); i++) {
+            	item = (Feeder) feederCb.getItemAt(i);
+            	if (item.getName().equals(f.getName()))  {
+            		feederCb.setSelectedIndex(i);
+            		break;
+            	}
+            }
+            if (i == feederCb.getItemCount()) {	  // list did not contain feeder, so create it
+				Logger.warn("No feeder {} exists in bank, so creating new.", f);
+                bank.getFeeders().add(f);
+                feederCb.addItem(f);
+                feederCb.setSelectedItem(f);
+            	xOffsetTf.setText("-5");		// set default offsets for new feeder
+            	yOffsetTf.setText("-30");
+            }
+        }
+    };
+
+/*    private Action newFeederAction = new AbstractAction("New") {
         @Override
         public void actionPerformed(ActionEvent e) {
             Bank bank = (Bank) bankCb.getSelectedItem();
@@ -652,9 +682,12 @@ public class SlotSchultzFeederConfigurationWizard
             bank.getFeeders().add(f);
             feederCb.addItem(f);
             feederCb.setSelectedItem(f);
+        	xOffsetTf.setText("-5");		// set default offsets for new feeder
+        	yOffsetTf.setText("-30");
         }
     };
-
+*/
+    
     private Action deleteFeederAction = new AbstractAction("Delete") {
         @Override
         public void actionPerformed(ActionEvent e) {


### PR DESCRIPTION
# Description
Changed the "New" button to "Load" to make it easier to load the installed feeder to the slot.  Previously it had to be selected from the combo box list.
If the installed feeder is not in the database, it will be created.

# Justification
Improve useability of SlotSchultzFeeder

# Instructions for Use
When a feeder is changed in a slot, press the "Load" button to load the feeder information from the database.

# Implementation Details
1. How did you test the change? Tested on my machine
2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)? Yes
3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing. N/A
4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted. All tests passed.
