### PR TITLE
Tweak error response exception message.

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/driver/GcodeDriver.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/GcodeDriver.java
@@ -803,7 +803,7 @@ public class GcodeDriver extends AbstractReferenceDriver implements Named, Runna
         }
         // If a command was specified and no confirmation was found it's a timeout error.
         if (command != null & foundError) {
-            throw new Exception("Controller raised an error: " + errorResponse);
+            throw new Exception("Error response from controller: " + errorResponse);
         }
         if (command != null && !found) {
             throw new Exception("Timeout waiting for response to " + command);


### PR DESCRIPTION
Reword to avoid common case of "error: error:" appearing in the dialog.

# Description
Cosmetic change to gcode error dialog text

# Justification
Avoids confusing "error: error:" text when ERROR_REGEX begins with "error:"

# Instructions for Use
N/A

# Implementation Details
String constant change only.
