### PR TITLE
Add ability to choose actuators between moves in the tool changer section

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/ReferenceNozzle.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceNozzle.java
@@ -552,8 +552,12 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
             MovableUtils.moveToLocationAtSafeZ(this, nt.getChangerEndLocation(), speed);
 
             if (changerEnabled) {
-                Logger.debug("{}.unloadNozzleTip(): moveTo Mid Location 2", getName());
+                Logger.debug("{}.unloadNozzleTip(): moveTo Mid Location 2000", getName());
                 moveTo(nt.getChangerMidLocation2(), nt.getChangerMid2ToEndSpeed() * speed);
+                
+                //changerActuatorPostStepOne(true);
+                Logger.debug("{}",nt.getChangerActuatorPostStepOne());
+                nt.setChangerActuatorPostStepOne(true);
 
                 Logger.debug("{}.unloadNozzleTip(): moveTo Mid Location", getName());
                 moveTo(nt.getChangerMidLocation(), nt.getChangerMidToMid2Speed() * speed);
@@ -724,7 +728,8 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
         }
         return false;
     }
-
+   
+    
     protected Actuator getVacuumActuator() throws Exception {
         Actuator actuator = getHead().getActuatorByName(vacuumActuatorName);
         if (actuator == null) {

--- a/src/main/java/org/openpnp/machine/reference/ReferenceNozzle.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceNozzle.java
@@ -438,8 +438,13 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
         if (this.nozzleTip == nozzleTip) {
             return;
         }
+        
 
         ReferenceNozzleTip nt = (ReferenceNozzleTip) nozzleTip;
+        
+        Actuator tcPostOneActuator = getHead().getActuatorByName(nt.getChangerActuatorPostStepOne());
+        Actuator tcPostTwoActuator = getHead().getActuatorByName(nt.getChangerActuatorPostStepTwo());
+        Actuator tcPostThreeActuator = getHead().getActuatorByName(nt.getChangerActuatorPostStepThree());
         
         if (!getCompatibleNozzleTips().contains(nt)) {
             throw new Exception("Can't load incompatible nozzle tip.");
@@ -474,15 +479,21 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
                 Logger.debug("{}.loadNozzleTip({}): moveTo Start Location",
                         new Object[] {getName(), nozzleTip.getName()});
                 MovableUtils.moveToLocationAtSafeZ(this, nt.getChangerStartLocation(), speed);
-
+                
+                tcPostOneActuator.actuate(true);
+                
                 Logger.debug("{}.loadNozzleTip({}): moveTo Mid Location",
                         new Object[] {getName(), nozzleTip.getName()});
                 moveTo(nt.getChangerMidLocation(), nt.getChangerStartToMidSpeed() * speed);
+                
+                tcPostTwoActuator.actuate(true);
 
                 Logger.debug("{}.loadNozzleTip({}): moveTo Mid Location 2",
                         new Object[] {getName(), nozzleTip.getName()});
                 moveTo(nt.getChangerMidLocation2(), nt.getChangerMidToMid2Speed() * speed);
 
+                tcPostThreeActuator.actuate(true);
+                
                 Logger.debug("{}.loadNozzleTip({}): moveTo End Location",
                         new Object[] {getName(), nozzleTip.getName()});
                 moveTo(nt.getChangerEndLocation(), nt.getChangerMid2ToEndSpeed() * speed);
@@ -527,7 +538,11 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
         }
 
         ReferenceNozzleTip nt = (ReferenceNozzleTip) nozzleTip;
-
+        
+        Actuator tcPostOneActuator = getHead().getActuatorByName(nt.getChangerActuatorPostStepOne());
+        Actuator tcPostTwoActuator = getHead().getActuatorByName(nt.getChangerActuatorPostStepTwo());
+        Actuator tcPostThreeActuator = getHead().getActuatorByName(nt.getChangerActuatorPostStepThree());
+        
         if (!nt.isUnloadedNozzleTipStandin()) {
             Logger.debug("{}.unloadNozzleTip(): Start", getName());
 
@@ -552,16 +567,23 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
             MovableUtils.moveToLocationAtSafeZ(this, nt.getChangerEndLocation(), speed);
 
             if (changerEnabled) {
+            	
+            	tcPostThreeActuator.actuate(true);
+            	
                 Logger.debug("{}.unloadNozzleTip(): moveTo Mid Location 2000", getName());
                 moveTo(nt.getChangerMidLocation2(), nt.getChangerMid2ToEndSpeed() * speed);
                 
-                //changerActuatorPostStepOne(true);
+                
                 Logger.debug("{}",nt.getChangerActuatorPostStepOne());
-                nt.setChangerActuatorPostStepOne(true);
+                
+                tcPostTwoActuator.actuate(true);
+                
 
                 Logger.debug("{}.unloadNozzleTip(): moveTo Mid Location", getName());
                 moveTo(nt.getChangerMidLocation(), nt.getChangerMidToMid2Speed() * speed);
-
+                
+                tcPostOneActuator.actuate(true);
+                
                 Logger.debug("{}.unloadNozzleTip(): moveTo Start Location", getName());
                 moveTo(nt.getChangerStartLocation(), nt.getChangerStartToMidSpeed() * speed);
                 moveToSafeZ(getHead().getMachine().getSpeed());

--- a/src/main/java/org/openpnp/machine/reference/ReferenceNozzle.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceNozzle.java
@@ -441,10 +441,12 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
         
 
         ReferenceNozzleTip nt = (ReferenceNozzleTip) nozzleTip;
-        
-        Actuator tcPostOneActuator = getHead().getActuatorByName(nt.getChangerActuatorPostStepOne());
-        Actuator tcPostTwoActuator = getHead().getActuatorByName(nt.getChangerActuatorPostStepTwo());
-        Actuator tcPostThreeActuator = getHead().getActuatorByName(nt.getChangerActuatorPostStepThree());
+       
+        // bert start
+        Actuator tcPostOneActuator = getMachine().getActuatorByName(nt.getChangerActuatorPostStepOne());
+        Actuator tcPostTwoActuator = getMachine().getActuatorByName(nt.getChangerActuatorPostStepTwo());
+        Actuator tcPostThreeActuator = getMachine().getActuatorByName(nt.getChangerActuatorPostStepThree());
+        // bert stop
         
         if (!getCompatibleNozzleTips().contains(nt)) {
             throw new Exception("Can't load incompatible nozzle tip.");
@@ -480,19 +482,31 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
                         new Object[] {getName(), nozzleTip.getName()});
                 MovableUtils.moveToLocationAtSafeZ(this, nt.getChangerStartLocation(), speed);
                 
-                tcPostOneActuator.actuate(true);
+                // bert start
+                if (tcPostOneActuator != null) {
+                    tcPostOneActuator.actuate(true);
+                }
+                // bert stop
                 
                 Logger.debug("{}.loadNozzleTip({}): moveTo Mid Location",
                         new Object[] {getName(), nozzleTip.getName()});
                 moveTo(nt.getChangerMidLocation(), nt.getChangerStartToMidSpeed() * speed);
                 
-                tcPostTwoActuator.actuate(true);
-
+                // bert start
+                if (tcPostTwoActuator !=null) {
+                    tcPostTwoActuator.actuate(true);
+                }
+                // bert stop
+                
                 Logger.debug("{}.loadNozzleTip({}): moveTo Mid Location 2",
                         new Object[] {getName(), nozzleTip.getName()});
                 moveTo(nt.getChangerMidLocation2(), nt.getChangerMidToMid2Speed() * speed);
 
-                tcPostThreeActuator.actuate(true);
+                // bert start
+                if (tcPostThreeActuator !=null) {
+                	tcPostThreeActuator.actuate(true);
+                }
+                //bert stop
                 
                 Logger.debug("{}.loadNozzleTip({}): moveTo End Location",
                         new Object[] {getName(), nozzleTip.getName()});
@@ -539,9 +553,9 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
 
         ReferenceNozzleTip nt = (ReferenceNozzleTip) nozzleTip;
         
-        Actuator tcPostOneActuator = getHead().getActuatorByName(nt.getChangerActuatorPostStepOne());
-        Actuator tcPostTwoActuator = getHead().getActuatorByName(nt.getChangerActuatorPostStepTwo());
-        Actuator tcPostThreeActuator = getHead().getActuatorByName(nt.getChangerActuatorPostStepThree());
+        Actuator tcPostOneActuator = getMachine().getActuatorByName(nt.getChangerActuatorPostStepOne());
+        Actuator tcPostTwoActuator = getMachine().getActuatorByName(nt.getChangerActuatorPostStepTwo());
+        Actuator tcPostThreeActuator = getMachine().getActuatorByName(nt.getChangerActuatorPostStepThree());
         
         if (!nt.isUnloadedNozzleTipStandin()) {
             Logger.debug("{}.unloadNozzleTip(): Start", getName());
@@ -568,21 +582,31 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
 
             if (changerEnabled) {
             	
-            	tcPostThreeActuator.actuate(true);
+            	// bert start
+                if (tcPostThreeActuator !=null) {
+                	tcPostThreeActuator.actuate(true);
+                }
+                //bert stop
             	
-                Logger.debug("{}.unloadNozzleTip(): moveTo Mid Location 2000", getName());
+                Logger.debug("{}.unloadNozzleTip(): moveTo Mid Location 2", getName());
                 moveTo(nt.getChangerMidLocation2(), nt.getChangerMid2ToEndSpeed() * speed);
                 
-                
-                Logger.debug("{}",nt.getChangerActuatorPostStepOne());
-                
-                tcPostTwoActuator.actuate(true);
+                                               
+                // bert start
+                if (tcPostTwoActuator !=null) {
+                    tcPostTwoActuator.actuate(true);
+                }
+                // bert stop
                 
 
                 Logger.debug("{}.unloadNozzleTip(): moveTo Mid Location", getName());
                 moveTo(nt.getChangerMidLocation(), nt.getChangerMidToMid2Speed() * speed);
                 
-                tcPostOneActuator.actuate(true);
+                // bert start
+                if (tcPostOneActuator != null) {
+                    tcPostOneActuator.actuate(true);
+                }
+                // bert stop
                 
                 Logger.debug("{}.unloadNozzleTip(): moveTo Start Location", getName());
                 moveTo(nt.getChangerStartLocation(), nt.getChangerStartToMidSpeed() * speed);

--- a/src/main/java/org/openpnp/machine/reference/ReferenceNozzleTip.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceNozzleTip.java
@@ -134,6 +134,18 @@ public class ReferenceNozzleTip extends AbstractNozzleTip {
 
     @Attribute(required = false)
     private boolean isPushAndDragAllowed = false;
+    
+    // berts stuff start
+    @Element(required = false)
+    protected String changerActuatorPostStepOne;
+
+    @Element(required = false)
+    protected String changerActuatorPostStepTwo;
+    
+    @Element(required = false)
+    protected String changerActuatorPostStepThree;
+    
+    //end bert
 
     public ReferenceNozzleTip() {
     }
@@ -285,6 +297,32 @@ public class ReferenceNozzleTip extends AbstractNozzleTip {
     public void setChangerMid2ToEndSpeed(double changerMid2ToEndSpeed) {
         this.changerMid2ToEndSpeed = changerMid2ToEndSpeed;
     }
+    
+    //bert start
+    public String getchangerActuatorPostStepOne() {
+        return changerActuatorPostStepOne;
+    }
+
+    public void setChangerActuatorPostStepOne(String changerActuatorPostStepOne) {
+        this.changerActuatorPostStepOne = changerActuatorPostStepOne;
+    }
+
+    public String getChangerActuatorPostStepTwo() {
+        return changerActuatorPostStepTwo;
+    }
+
+    public void setChangerActuatorPostStepTwo(String changerActuatorPostStepTwo) {
+        this.changerActuatorPostStepTwo = changerActuatorPostStepTwo;
+    }
+    
+    public String getChangerActuatorPostStepThree() {
+        return changerActuatorPostStepThree;
+    }
+
+    public void setChangerActuatorPostStepThree(String changerActuatorPostStepThree) {
+        this.changerActuatorPostStepThree = changerActuatorPostStepThree;
+    }
+    // bert stop
 
     public ReferenceNozzle getNozzleAttachedTo() {
         for (Head head : Configuration.get().getMachine().getHeads()) {

--- a/src/main/java/org/openpnp/machine/reference/ReferenceNozzleTip.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceNozzleTip.java
@@ -299,7 +299,7 @@ public class ReferenceNozzleTip extends AbstractNozzleTip {
     }
     
     //bert start
-    public String getchangerActuatorPostStepOne() {
+    public String getChangerActuatorPostStepOne() {
         return changerActuatorPostStepOne;
     }
 

--- a/src/main/java/org/openpnp/machine/reference/wizards/ReferenceNozzleTipToolChangerWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/wizards/ReferenceNozzleTipToolChangerWizard.java
@@ -22,6 +22,7 @@ package org.openpnp.machine.reference.wizards;
 import java.util.HashSet;
 import java.util.Set;
 
+import javax.swing.JComboBox;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JTextField;
@@ -31,11 +32,18 @@ import org.jdesktop.beansbinding.AutoBinding.UpdateStrategy;
 import org.openpnp.gui.components.ComponentDecorators;
 import org.openpnp.gui.components.LocationButtonsPanel;
 import org.openpnp.gui.support.AbstractConfigurationWizard;
+import org.openpnp.gui.support.ActuatorsComboBoxModel;
 import org.openpnp.gui.support.DoubleConverter;
 import org.openpnp.gui.support.LengthConverter;
 import org.openpnp.gui.support.MutableLocationProxy;
+//bert start
+import org.openpnp.machine.reference.ReferenceHead;
+//bert end
+import org.openpnp.machine.reference.ReferenceNozzle;
 import org.openpnp.machine.reference.ReferenceNozzleTip;
 import org.openpnp.model.Configuration;
+import org.openpnp.spi.Head;
+import org.pmw.tinylog.Logger;
 
 import com.jgoodies.forms.layout.ColumnSpec;
 import com.jgoodies.forms.layout.FormLayout;
@@ -77,7 +85,13 @@ public class ReferenceNozzleTipToolChangerWizard extends AbstractConfigurationWi
     private JLabel lblSpeed1_2;
     private JLabel lblSpeed2_3;
     private JLabel lblSpeed3_4;
-
+    // bert added
+    private JLabel label;
+    private JPanel panel;
+    private JComboBox tcPostOneComboBoxActuator;
+    private JComboBox tcPostTwoComboBoxActuator;
+    private JComboBox tcPostThreeComboBoxActuator;
+    // end of add
 
     public ReferenceNozzleTipToolChangerWizard(ReferenceNozzleTip nozzleTip) {
         this.nozzleTip = nozzleTip;
@@ -110,6 +124,37 @@ public class ReferenceNozzleTipToolChangerWizard extends AbstractConfigurationWi
         		FormSpecs.DEFAULT_ROWSPEC,
         		FormSpecs.DEFAULT_ROWSPEC,
         		FormSpecs.DEFAULT_ROWSPEC,}));
+        
+        
+        // Bert added this to put actuator combo box into changer
+        label = new JLabel("Post 1 Actuator");
+        panelChanger.add(label, "2, 5, right, center");
+        label = new JLabel("Post 2 Actuator");
+        panelChanger.add(label, "2, 7, right, center");
+        label = new JLabel("Post 3 Actuator");
+        panelChanger.add(label, "2, 9, right, center");
+        
+        Head head = null;
+        try {
+            head = Configuration.get().getMachine().getDefaultHead();
+        }
+        catch (Exception e) {
+            Logger.error(e, "Cannot determine default head of machine.");
+        }
+        
+        tcPostOneComboBoxActuator = new JComboBox();
+        tcPostOneComboBoxActuator.setModel(new ActuatorsComboBoxModel(head));
+        panelChanger.add(tcPostOneComboBoxActuator, "4, 5,");
+        
+        tcPostTwoComboBoxActuator = new JComboBox();
+        tcPostTwoComboBoxActuator.setModel(new ActuatorsComboBoxModel(head));
+        panelChanger.add(tcPostTwoComboBoxActuator, "4, 7");
+        
+        tcPostThreeComboBoxActuator = new JComboBox();
+        tcPostThreeComboBoxActuator.setModel(new ActuatorsComboBoxModel(head));
+        panelChanger.add(tcPostThreeComboBoxActuator, "4, 9");
+        
+        // end of bert added stuff
         
         lblX = new JLabel("X");
         panelChanger.add(lblX, "4, 2");
@@ -277,6 +322,12 @@ public class ReferenceNozzleTipToolChangerWizard extends AbstractConfigurationWi
                 lengthConverter);
         addWrappedBinding(changerEndLocation, "lengthZ", textFieldChangerEndZ, "text",
                 lengthConverter);
+        
+        // start bert
+        addWrappedBinding(nozzleTip, "changerActuatorPostStepOne", tcPostOneComboBoxActuator, "selectedItem");
+        addWrappedBinding(nozzleTip, "changerActuatorPostStepTwo", tcPostTwoComboBoxActuator, "selectedItem");
+        addWrappedBinding(nozzleTip, "changerActuatorPostStepThree", tcPostThreeComboBoxActuator, "selectedItem");
+        // end bert
         
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldChangerStartX);
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldChangerStartY);

--- a/src/main/java/org/openpnp/machine/reference/wizards/ReferenceNozzleTipToolChangerWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/wizards/ReferenceNozzleTipToolChangerWizard.java
@@ -43,6 +43,7 @@ import org.openpnp.machine.reference.ReferenceNozzle;
 import org.openpnp.machine.reference.ReferenceNozzleTip;
 import org.openpnp.model.Configuration;
 import org.openpnp.spi.Head;
+import org.openpnp.spi.Machine;
 import org.pmw.tinylog.Logger;
 
 import com.jgoodies.forms.layout.ColumnSpec;
@@ -126,35 +127,35 @@ public class ReferenceNozzleTipToolChangerWizard extends AbstractConfigurationWi
         		FormSpecs.DEFAULT_ROWSPEC,}));
         
         
-        // Bert added this to put actuator combo box into changer
+        // Bert start
         label = new JLabel("Post 1 Actuator");
         panelChanger.add(label, "2, 5, right, center");
         label = new JLabel("Post 2 Actuator");
         panelChanger.add(label, "2, 7, right, center");
         label = new JLabel("Post 3 Actuator");
         panelChanger.add(label, "2, 9, right, center");
-        
-        Head head = null;
+
+        Machine myMachine = null;
         try {
-            head = Configuration.get().getMachine().getDefaultHead();
+            myMachine = Configuration.get().getMachine();
         }
-        catch (Exception e) {
-            Logger.error(e, "Cannot determine default head of machine.");
+        catch (Exception e){
+        	Logger.error(e, "Cannot determine Name of machine.");
         }
         
         tcPostOneComboBoxActuator = new JComboBox();
-        tcPostOneComboBoxActuator.setModel(new ActuatorsComboBoxModel(head));
+        tcPostOneComboBoxActuator.setModel(new ActuatorsComboBoxModel(myMachine));
         panelChanger.add(tcPostOneComboBoxActuator, "4, 5,");
         
         tcPostTwoComboBoxActuator = new JComboBox();
-        tcPostTwoComboBoxActuator.setModel(new ActuatorsComboBoxModel(head));
+        tcPostTwoComboBoxActuator.setModel(new ActuatorsComboBoxModel(myMachine));
         panelChanger.add(tcPostTwoComboBoxActuator, "4, 7");
         
         tcPostThreeComboBoxActuator = new JComboBox();
-        tcPostThreeComboBoxActuator.setModel(new ActuatorsComboBoxModel(head));
+        tcPostThreeComboBoxActuator.setModel(new ActuatorsComboBoxModel(myMachine));
         panelChanger.add(tcPostThreeComboBoxActuator, "4, 9");
         
-        // end of bert added stuff
+        // bert stop
         
         lblX = new JLabel("X");
         panelChanger.add(lblX, "4, 2");
@@ -323,11 +324,11 @@ public class ReferenceNozzleTipToolChangerWizard extends AbstractConfigurationWi
         addWrappedBinding(changerEndLocation, "lengthZ", textFieldChangerEndZ, "text",
                 lengthConverter);
         
-        // start bert
+        // bert start
         addWrappedBinding(nozzleTip, "changerActuatorPostStepOne", tcPostOneComboBoxActuator, "selectedItem");
         addWrappedBinding(nozzleTip, "changerActuatorPostStepTwo", tcPostTwoComboBoxActuator, "selectedItem");
         addWrappedBinding(nozzleTip, "changerActuatorPostStepThree", tcPostThreeComboBoxActuator, "selectedItem");
-        // end bert
+        // bert stop
         
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldChangerStartX);
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldChangerStartY);

--- a/src/main/java/org/openpnp/machine/reference/wizards/ReferenceNozzleVacuumWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/wizards/ReferenceNozzleVacuumWizard.java
@@ -49,6 +49,8 @@ public class ReferenceNozzleVacuumWizard extends AbstractConfigurationWizard {
         this.nozzle = nozzle;
         createUi();
     }
+    
+    
     private void createUi() {
         
         CellConstraints cc = new CellConstraints();


### PR DESCRIPTION
# Read This First

To submit a Pull Request for OpenPnP you must use this template or it will not be accepted. 

Be sure to review the [Developers Guide](https://github.com/openpnp/openpnp/wiki/Developers-Guide)
and the [Contributing Guidelines](https://github.com/openpnp/openpnp/blob/develop/CONTRIBUTING.md).

Make your Pull Request as small as possible. Only include one bug or feature.

If you would like to add a new feature to OpenPnP that changes core or reference functionality,
please create a topic on the [discussion group](http://groups.google.com/group/openpnp) to discuss
the feature first. Also consider if your feature can be implemented as a new subclass of
a Reference class, or an entirely new class, instead of changing or adding to the Reference
class.

Fill out all the details below. All sections below are required. If they are not included your Pull Request
will not be accepted.

-----------------------------------------------------------------------

# Description
Three dropdowns are added to the tool changer GUI. These allow the user to choose (or not) actuators on the machine to fire between moves.

# Justification
There are users with machines that need more than just 4 simple moves to load/unload a nozzle tip. This is an attempt to make that available to machines that need more.

# Instructions for Use
To use it, simply create actuators on the machine that you want to have fire true between the step. Note the actuator will simply actuate (true) for the step. If you are turning a valve on/off, you will need to create an actuator for both. For instance 'valve on' can be one and 'valve off' could be the other. This is different then the normal toggle way we do it now with true/false.

# Implementation Details
I tested this in my install by choosing different actuators and watching the log to verify they are fired.
