### PR TITLE
Fix/Global Axes Bug-Fixes 2

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/axis/ReferenceControllerAxis.java
+++ b/src/main/java/org/openpnp/machine/reference/axis/ReferenceControllerAxis.java
@@ -219,6 +219,11 @@ public class ReferenceControllerAxis extends AbstractControllerAxis {
             return getAccelerationPerSecond2().convertToUnits(AxesLocation.getUnits()).getValue();
         }
         else if (order == 3) {
+            if (getDriver() != null 
+                    && getDriver().getMotionControlType().isConstantAcceleration()) {
+                // Suppress any jerk setting in constant acceleration motion control.
+                return 0;
+            }
             return getJerkPerSecond3().convertToUnits(AxesLocation.getUnits()).getValue();
         }
         return 0;

--- a/src/main/java/org/openpnp/machine/reference/driver/AbstractReferenceDriver.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/AbstractReferenceDriver.java
@@ -5,6 +5,8 @@ import java.io.IOException;
 import org.openpnp.gui.support.PropertySheetWizardAdapter;
 import org.openpnp.gui.support.Wizard;
 import org.openpnp.machine.reference.ReferenceDriver;
+import org.openpnp.machine.reference.SimulationModeMachine;
+import org.openpnp.machine.reference.SimulationModeMachine.SimulationMode;
 import org.openpnp.machine.reference.driver.SerialPortCommunications.DataBits;
 import org.openpnp.machine.reference.driver.SerialPortCommunications.FlowControl;
 import org.openpnp.machine.reference.driver.SerialPortCommunications.Parity;
@@ -22,6 +24,9 @@ public abstract class AbstractReferenceDriver extends AbstractDriver implements 
 
     @Element(required = false)
     protected TcpCommunications tcp = new TcpCommunications();
+    
+    @Element(required = false)
+    protected SimulatedCommunications simulated = new SimulatedCommunications();
 
     @Attribute(required = false, name = "communications")
     protected String communicationsType = "serial";
@@ -122,6 +127,11 @@ public abstract class AbstractReferenceDriver extends AbstractDriver implements 
     }
     
     public ReferenceDriverCommunications getCommunications() {
+        SimulationModeMachine machine = SimulationModeMachine.getSimulationModeMachine();
+        if (machine != null && machine.getSimulationMode() != SimulationMode.Off) {
+            simulated.setDriver(this);
+            return simulated;
+        }
         switch (communicationsType) {
             case "serial": {
                 return serial;

--- a/src/main/java/org/openpnp/machine/reference/driver/AbstractReferenceDriver.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/AbstractReferenceDriver.java
@@ -19,6 +19,9 @@ import org.simpleframework.xml.Element;
 import org.simpleframework.xml.core.Commit;
 
 public abstract class AbstractReferenceDriver extends AbstractDriver implements ReferenceDriver {
+    @Attribute(required = false)
+    protected MotionControlType motionControlType = MotionControlType.ToolpathFeedRate; 
+
     @Element(required = false)
     protected SerialPortCommunications serial = new SerialPortCommunications();
 
@@ -100,7 +103,16 @@ public abstract class AbstractReferenceDriver extends AbstractDriver implements 
     }
     
     public abstract void disconnect() throws Exception;
-    
+
+    @Override
+    public MotionControlType getMotionControlType() {
+        return motionControlType;
+    }
+
+    public void setMotionControlType(MotionControlType motionControlType) {
+        this.motionControlType = motionControlType;
+    }
+
     public String getCommunicationsType() {
         return communicationsType;
     }

--- a/src/main/java/org/openpnp/machine/reference/driver/GcodeDriver.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/GcodeDriver.java
@@ -463,7 +463,7 @@ public class GcodeDriver extends AbstractReferenceDriver implements Named, Runna
             throws Exception {
         // Get the axes that are actually moving.
         AxesLocation location = motion.getMovingAxesTargetLocation(this);
-        double feedRate = motion.getFeedRatePerMinute(this);
+        Double feedRate = motion.getFeedRatePerMinute(this);
         Double acceleration = motion.getAccelerationPerSecond2(this);
         Double jerk = motion.getJerkPerSecond3(this);
 
@@ -483,7 +483,8 @@ public class GcodeDriver extends AbstractReferenceDriver implements Named, Runna
         command = substituteVariable(command, "Id", hm.getId());
         command = substituteVariable(command, "Name", hm.getName());
         command = substituteVariable(command, "FeedRate", feedRate);
-        command = substituteVariable(command, "BacklashFeedRate", enableBacklash ? feedRate * backlashFeedRateFactor : feedRate);
+        command = substituteVariable(command, "BacklashFeedRate", feedRate == null ? null : 
+            (enableBacklash ? feedRate * backlashFeedRateFactor : feedRate));
         command = substituteVariable(command, "Acceleration", acceleration);
         command = substituteVariable(command, "Jerk", jerk);
         

--- a/src/main/java/org/openpnp/machine/reference/driver/GcodeDriver.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/GcodeDriver.java
@@ -229,11 +229,16 @@ public class GcodeDriver extends AbstractReferenceDriver implements Named, Runna
     public void createDefaults() throws Exception {
         createAxisMappingDefaults((ReferenceMachine) Configuration.get().getMachine());
 
+        createDefaultCommands();
+    }
+
+    public void createDefaultCommands() {
         commands = new ArrayList<>();
         commands.add(new Command(null, CommandType.COMMAND_CONFIRM_REGEX, "^ok.*"));
         commands.add(new Command(null, CommandType.CONNECT_COMMAND, "G21 ; Set millimeters mode\nG90 ; Set absolute positioning mode\nM82 ; Set absolute mode for extruder"));
         commands.add(new Command(null, CommandType.HOME_COMMAND, "G28 ; Home all axes"));
-        commands.add(new Command(null, CommandType.MOVE_TO_COMMAND, "G0 {XL}{X:%.4f} {YL}{Y:%.4f} {ZL}{Z:%.4f} {RotationL}{Rotation:%.4f} F{FeedRate:%.0f} ; Send standard Gcode move"));
+        commands.add(new Command(null, CommandType.SET_GLOBAL_OFFSETS_COMMAND, "G92 {XL}{X:%.4f} {YL}{Y:%.4f} {ZL}{Z:%.4f} {RotationL}{Rotation:%.4f} ; Reset current position to given coordinates"));
+        commands.add(new Command(null, CommandType.MOVE_TO_COMMAND, "{Acceleration:M204 S%.1f} G0 {XL}{X:%.4f} {YL}{Y:%.4f} {ZL}{Z:%.4f} {RotationL}{Rotation:%.4f} {FeedRate:F%.1f} ; Send standard Gcode move"));
         commands.add(new Command(null, CommandType.MOVE_TO_COMPLETE_COMMAND, "M400 ; Wait for moves to complete before returning"));
     }
 

--- a/src/main/java/org/openpnp/machine/reference/driver/GcodeDriver.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/GcodeDriver.java
@@ -323,14 +323,16 @@ public class GcodeDriver extends AbstractReferenceDriver implements Named, Runna
         homeLocation.setToDriverCoordinates(this);
     }
 
-    protected List<String> getAxisVariables(ReferenceMachine machine) {
+    public List<String> getAxisVariables(ReferenceMachine machine) {
         List<String> variables = new ArrayList<>();
         if (usingLetterVariables) {
             for (org.openpnp.spi.Axis axis : machine.getAxes()) {
                 if (axis instanceof ControllerAxis) {
-                    String letter =((ControllerAxis) axis).getLetter(); 
-                    if (letter != null && !letter.isEmpty()) {
-                        variables.add(letter);
+                    if (((ControllerAxis) axis).getDriver() == this) {
+                        String letter = ((ControllerAxis) axis).getLetter(); 
+                        if (letter != null && !letter.isEmpty()) {
+                            variables.add(letter);
+                        }
                     }
                 }
             }

--- a/src/main/java/org/openpnp/machine/reference/driver/NullDriver.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/NullDriver.java
@@ -238,4 +238,9 @@ public class NullDriver extends AbstractDriver implements ReferenceDriver {
     public boolean isUsingLetterVariables() {
         return false;
     }
+
+    @Override
+    public MotionControlType getMotionControlType() {
+        return MotionControlType.Full3rdOrderControl;
+    }
 }

--- a/src/main/java/org/openpnp/machine/reference/driver/NullDriver.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/NullDriver.java
@@ -44,9 +44,8 @@ import org.pmw.tinylog.Logger;
 import org.simpleframework.xml.Attribute;
 
 /**
- * An example of the simplest possible driver that can support multiple heads. This driver maintains
- * a set of coordinates for each Head that it is asked to handle and simply logs all commands sent
- * to it.
+ * An example of the simplest possible driver. This driver maintains a set of coordinates for each Axis
+ * that it is asked to handle and simply logs all commands sent to it.
  */
 public class NullDriver extends AbstractDriver implements ReferenceDriver {
 

--- a/src/main/java/org/openpnp/machine/reference/driver/SimulatedCommunications.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/SimulatedCommunications.java
@@ -1,0 +1,122 @@
+package org.openpnp.machine.reference.driver;
+
+import java.io.BufferedReader;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.Socket;
+import java.net.SocketTimeoutException;
+import java.util.concurrent.TimeoutException;
+
+import org.openpnp.machine.reference.ReferenceDriver;
+import org.openpnp.machine.reference.driver.ReferenceDriverCommunications.LineEndingType;
+import org.openpnp.util.GcodeServer;
+import org.simpleframework.xml.Attribute;
+
+/**
+ * A base class for basic TCP based Drivers. Includes functions for connecting,
+ * disconnecting, reading and sending lines.
+ */
+public class SimulatedCommunications extends ReferenceDriverCommunications {
+    protected Socket clientSocket;
+    protected BufferedReader input;
+    protected DataOutputStream output;
+
+    protected GcodeServer gcodeServer;
+    private ReferenceDriver driver;
+
+    public synchronized void connect() throws Exception {
+        disconnect();
+        clientSocket = new Socket("localhost", getGcodeServer().getListenerPort());
+        input = new BufferedReader(new InputStreamReader(clientSocket.getInputStream()));
+        output = new DataOutputStream(clientSocket.getOutputStream());
+    }
+
+    public synchronized void disconnect() throws Exception {
+        if (clientSocket != null && clientSocket.isBound()) {
+            clientSocket.close();
+            input = null;
+            output = null;
+            clientSocket = null;
+            gcodeServer = null;
+        }
+    }
+
+    public String getConnectionName(){
+        return "simulated: "+(gcodeServer == null ? "off" : "port "+gcodeServer.getListenerPort());
+    }
+
+    public GcodeServer getGcodeServer() throws Exception {
+        if (gcodeServer == null) {
+            gcodeServer = new GcodeServer();
+        }
+        gcodeServer.setDriver(driver);
+        return gcodeServer;
+    }
+
+    /**
+     * Read a line from the socket. Blocks for the default timeout. If the read times out a
+     * TimeoutException is thrown. Any other failure to read results in an IOExeption;
+     * 
+     * @return
+     * @throws TimeoutException
+     * @throws IOException
+     */
+    public String readLine() throws TimeoutException, IOException {
+        StringBuffer line = new StringBuffer();
+        while (true) {
+            try {
+                int ch = input.read();
+                if (ch == -1) {
+                    return null;
+                }
+                else if (ch == '\n' || ch == '\r') {
+                    if (line.length() > 0) {
+                        return line.toString();
+                    }
+                }
+                else {
+                    line.append((char) ch);
+                }
+            }
+            catch (IOException ex) {
+                if (ex.getCause() instanceof SocketTimeoutException) {
+                    throw new TimeoutException(ex.getMessage());
+                }
+                throw ex;
+            }
+        }
+    }
+
+    public void writeLine(String data) throws IOException
+    {
+        try {
+            output.write(data.getBytes());
+            output.write(getLineEndingType().getLineEnding().getBytes());
+        }
+        catch (IOException ex) {
+            throw ex;
+        }
+    }
+    
+    public int read() throws TimeoutException, IOException {
+        try {
+            return input.read();
+        }
+        catch (IOException ex) {
+            if (ex.getCause() instanceof SocketTimeoutException) {
+                throw new TimeoutException(ex.getMessage());
+            }
+            throw ex;
+        }
+    }
+    
+    public void write(int d) throws IOException {
+        output.write(d);
+    }
+
+    public void setDriver(ReferenceDriver driver) {
+        this.driver = driver;
+    }
+}
+

--- a/src/main/java/org/openpnp/machine/reference/driver/wizards/GcodeDriverGcodes.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/wizards/GcodeDriverGcodes.java
@@ -132,17 +132,29 @@ public class GcodeDriverGcodes extends AbstractConfigurationWizard {
         importExportPanel.setBorder(new TitledBorder(null, "Import / Export", TitledBorder.LEADING,
                 TitledBorder.TOP, null, null));
         contentPanel.add(importExportPanel);
-        importExportPanel.setLayout(new FormLayout(
-                new ColumnSpec[] {FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,
-                        FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,},
-                new RowSpec[] {FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
-                        FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,}));
+        importExportPanel.setLayout(new FormLayout(new ColumnSpec[] {
+                FormSpecs.RELATED_GAP_COLSPEC,
+                FormSpecs.DEFAULT_COLSPEC,
+                FormSpecs.RELATED_GAP_COLSPEC,
+                FormSpecs.DEFAULT_COLSPEC,},
+            new RowSpec[] {
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,}));
 
         JButton btnExportGcodeProfile = new JButton(exportProfileAction);
         importExportPanel.add(btnExportGcodeProfile, "2, 2");
 
         JButton btnCopyGcodeProfile = new JButton(copyProfileToClipboardAction);
         importExportPanel.add(btnCopyGcodeProfile, "2, 4");
+        
+        JButton btnResetToDefaults = new JButton(resetToDefaultAction);
+        importExportPanel.add(btnResetToDefaults, "2, 8");
 
         headMountableChanged();
         commandTypeChanged();
@@ -367,6 +379,32 @@ public class GcodeDriverGcodes extends AbstractConfigurationWizard {
             }
             catch (Exception e) {
                 MessageBoxes.errorBox(MainFrame.get(), "Paste Failed", e);
+            }
+        }
+    };
+    public final Action resetToDefaultAction = new AbstractAction() {
+        {
+            putValue(SMALL_ICON, Icons.delete);
+            putValue(NAME, "Reset to defaults");
+            putValue(SHORT_DESCRIPTION, "Reset the Gcode profile to the default.");
+        }
+
+        @Override
+        public void actionPerformed(ActionEvent arg0) {
+            try {
+                int ret = JOptionPane.showConfirmDialog(getTopLevelAncestor(),
+                        "This will delete all your Gcode and reset it to minimal defaults.\n"
+                        + "Are you absolutely sure?", 
+                        "Reset to defaults",
+                        JOptionPane.YES_NO_OPTION,
+                        JOptionPane.WARNING_MESSAGE);
+                if (ret == JOptionPane.YES_OPTION) {
+                    driver.createDefaultCommands();
+                    resetAction.actionPerformed(arg0);
+                }
+            }
+            catch (Exception e) {
+                MessageBoxes.errorBox(MainFrame.get(), "Reset Failed", e);
             }
         }
     };

--- a/src/main/java/org/openpnp/machine/reference/driver/wizards/GcodeDriverSettings.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/wizards/GcodeDriverSettings.java
@@ -35,6 +35,7 @@ import org.openpnp.model.Configuration;
 import org.openpnp.model.LengthUnit;
 import org.openpnp.spi.Actuator;
 import org.openpnp.spi.Camera;
+import org.openpnp.spi.Driver.MotionControlType;
 import org.openpnp.spi.HeadMountable;
 import org.openpnp.spi.Nozzle;
 import org.simpleframework.xml.Serializer;
@@ -72,67 +73,76 @@ public class GcodeDriverSettings extends AbstractConfigurationWizard {
                 FormSpecs.RELATED_GAP_ROWSPEC,
                 FormSpecs.DEFAULT_ROWSPEC,
                 FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
                 FormSpecs.DEFAULT_ROWSPEC,}));
         
+        JLabel lblMotionControlType = new JLabel("Motion Control Type");
+        lblMotionControlType.setToolTipText("<html>\r\n<p>Determines how the OpenPnP MotionPlanner will plan the motion and how it will talk <br/>\r\nto the controller:</p>\r\n<ul>\r\n<li><strong>ToolpathFeedRate:</strong><br/>\r\nApply the nominal driver feed-rate limit multiplied by the speed factor to the tool-path.<br/>\r\nThe driver feed-rate must be specified. No acceleration control is applied.</li>\r\n<li><strong>EuclideanAxisLimits:</strong><br/>\r\nApply axis feed-rate, acceleration and jerk limits multiplied by the proper speed factors. <br/>\r\nThe Euclidean Metric is calculated to allow the machine to run faster in a diagonal.<br/>\r\nAll profile motion control is left to the controller. </li>  \r\n<li><strong>ConstantAcceleration:</strong><br/>\r\nApply motion planning assuming a controller with constant acceleration motion control. </li>\r\n<li><strong>SimpleSCurve:</strong><br/>\r\nApply motion planning assuming a controller with simplified S-Curve motion control. <br/>\r\nSimplified S-Curves have no constant acceleration phase, only jerk phases (e.g. TinyG, Marlin).</li>\r\n<li><strong>Full3rdOrderControl:</strong><br/>\r\nApply motion planning assuming a controller with full 3rd order motion control.</li> \r\n</html>");
+        settingsPanel.add(lblMotionControlType, "2, 2, right, default");
+        
+        motionControlType = new JComboBox(MotionControlType.values());
+        settingsPanel.add(motionControlType, "4, 2, 5, 1, fill, default");
+        
         JLabel lblUnits = new JLabel("Units");
-        settingsPanel.add(lblUnits, "6, 2, right, default");
+        settingsPanel.add(lblUnits, "6, 4, right, default");
         
         unitsCb = new JComboBox(LengthUnit.values());
-        settingsPanel.add(unitsCb, "8, 2, fill, default");
+        settingsPanel.add(unitsCb, "8, 4, fill, default");
         
         JLabel lblMaxFeedRate = new JLabel("Max Feed Rate [/min]");
         lblMaxFeedRate.setToolTipText("<html><p>Maximum tool-path feed-rate in driver units per minute. </p>\r\n<p>Set to 0 to disable and only use axis feed-rate limits. Diagonal moves will then be faster. </p>\r\n</html>");
-        settingsPanel.add(lblMaxFeedRate, "6, 4, right, default");
+        settingsPanel.add(lblMaxFeedRate, "6, 6, right, default");
         
         maxFeedRateTf = new JTextField();
-        settingsPanel.add(maxFeedRateTf, "8, 4, fill, default");
+        settingsPanel.add(maxFeedRateTf, "8, 6, fill, default");
         maxFeedRateTf.setColumns(5);
         
         JLabel lblCommandTimeoutms = new JLabel("Command Timeout [ms]");
-        settingsPanel.add(lblCommandTimeoutms, "2, 2, right, default");
+        settingsPanel.add(lblCommandTimeoutms, "2, 4, right, default");
         
         commandTimeoutTf = new JTextField();
-        settingsPanel.add(commandTimeoutTf, "4, 2, fill, default");
+        settingsPanel.add(commandTimeoutTf, "4, 4, fill, default");
         commandTimeoutTf.setColumns(10);
         
         JLabel lblConnectWaitTime = new JLabel("Connect Wait Time [ms]");
-        settingsPanel.add(lblConnectWaitTime, "2, 4, right, default");
+        settingsPanel.add(lblConnectWaitTime, "2, 6, right, default");
         
         connectWaitTimeTf = new JTextField();
-        settingsPanel.add(connectWaitTimeTf, "4, 4, fill, default");
+        settingsPanel.add(connectWaitTimeTf, "4, 6, fill, default");
         connectWaitTimeTf.setColumns(10);
         
         JLabel lblBacklashFeedSpeedFactor = new JLabel("Backlash Feed Rate Factor");
-        settingsPanel.add(lblBacklashFeedSpeedFactor, "2, 6, right, default");
+        settingsPanel.add(lblBacklashFeedSpeedFactor, "2, 8, right, default");
         
         backlashFeedRateFactorTf = new JTextField();
-        settingsPanel.add(backlashFeedRateFactorTf, "4, 6, fill, default");
+        settingsPanel.add(backlashFeedRateFactorTf, "4, 8, fill, default");
         backlashFeedRateFactorTf.setColumns(10);
         
         JLabel lblBackslashEscapedCharacters = new JLabel("Backslash Escaped Characters?");
         lblBackslashEscapedCharacters.setToolTipText("Allows insertion of unicode characters into Gcode strings as \\uxxxx "
                 + "where xxxx is four hexidecimal characters.  Also permits \\t for tab, \\b for backspace, \\n for line "
                 + "feed, \\r for carriage return, and \\f for form feed.");
-        settingsPanel.add(lblBackslashEscapedCharacters, "2, 8, right, default");
+        settingsPanel.add(lblBackslashEscapedCharacters, "2, 10, right, default");
         
         backslashEscapedCharacters = new JCheckBox("");
         backslashEscapedCharacters.setToolTipText("Allows insertion of unicode characters into Gcode strings as \\uxxxx "
                 + "where xxxx is four hexidecimal characters.  Also permits \\t for tab, \\b for backspace, \\n for line "
                 + "feed, \\r for carriage return, and \\f for form feed.");
-        settingsPanel.add(backslashEscapedCharacters, "4, 8");
+        settingsPanel.add(backslashEscapedCharacters, "4, 10");
         
         JLabel lblLetterVariables = new JLabel("Letter Variables?");
         lblLetterVariables.setToolTipText("Axis variables in Gcode are named using the Axis Letters rather than the Axis Type.");
-        settingsPanel.add(lblLetterVariables, "6, 8, right, default");
+        settingsPanel.add(lblLetterVariables, "6, 10, right, default");
         
         letterVariables = new JCheckBox("");
-        settingsPanel.add(letterVariables, "8, 8");
+        settingsPanel.add(letterVariables, "8, 10");
         
         JLabel lblAllowPremoveCommands = new JLabel("Allow Pre-Move Commands?");
-        settingsPanel.add(lblAllowPremoveCommands, "2, 10, right, default");
+        settingsPanel.add(lblAllowPremoveCommands, "2, 12, right, default");
         
         supportingPreMove = new JCheckBox("");
-        settingsPanel.add(supportingPreMove, "4, 10");
+        settingsPanel.add(supportingPreMove, "4, 12");
     }
 
     @Override
@@ -142,6 +152,7 @@ public class GcodeDriverSettings extends AbstractConfigurationWizard {
                 new DoubleConverter(Configuration.get().getLengthDisplayFormat());
         DoubleConverter doubleConverterFine = new DoubleConverter("%f");
         
+        addWrappedBinding(driver, "motionControlType", motionControlType, "selectedItem");
         addWrappedBinding(driver, "units", unitsCb, "selectedItem");
         addWrappedBinding(driver, "maxFeedRate", maxFeedRateTf, "text", intConverter);
         addWrappedBinding(driver, "backlashFeedRateFactor", backlashFeedRateFactorTf, "text", doubleConverter);
@@ -283,6 +294,7 @@ public class GcodeDriverSettings extends AbstractConfigurationWizard {
             }
         }
     };
+    private JComboBox motionControlType;
     private JTextField maxFeedRateTf;
     private JTextField backlashFeedRateFactorTf;
     private JTextField commandTimeoutTf;

--- a/src/main/java/org/openpnp/model/MotionProfile.java
+++ b/src/main/java/org/openpnp/model/MotionProfile.java
@@ -147,7 +147,7 @@ public class MotionProfile {
         return a[segment];
     }
     public double getJerk(int segment) {
-        return a[segment];
+        return j[segment];
     }
 
 
@@ -1032,7 +1032,6 @@ public class MotionProfile {
         }
         if (leadProfile != null) {
             leadProfile.assertSolved();
-            // Can't use bestDist, need it signed.
             coordinateProfilesToLead(profiles, leadProfile);
         }
     }

--- a/src/main/java/org/openpnp/spi/Driver.java
+++ b/src/main/java/org/openpnp/spi/Driver.java
@@ -12,12 +12,53 @@ import org.openpnp.model.Named;
  * while the ReferenceDriver interface holds the interface used for the ReferenceMachine.  
  */
 public interface Driver extends Identifiable, Named, Closeable, WizardConfigurable, PropertySheetHolder {
-
     LengthUnit getUnits();
 
     boolean isSupportingPreMove();
 
     boolean isUsingLetterVariables();
 
+    /**
+     * The MotionControlType determines how the OpenPnP MotionPlanner will do its planning and how it will talk 
+     * to the controller. 
+     *
+     */
+    public enum MotionControlType {
+        /**
+         * Apply the nominal driver feed-rate limit multiplied by the speed factor to the tool-path. 
+         * The driver feed-rate must be specified. No acceleration control is applied. 
+         */
+        ToolpathFeedRate,
+        /**
+         * Apply axis feed-rate, acceleration and jerk limits multiplied by the proper speed factors. 
+         * The Euclidean Metric is calculated to allow the machine to run faster in a diagonal.
+         * All profile motion control is left to the controller.   
+         */
+        EuclideanAxisLimits,
+        /**
+         * Apply motion planning assuming a controller with constant acceleration motion control. 
+         */
+        ConstantAcceleration,
+        /**
+         * Apply motion planning assuming a controller with simplified S-Curve motion control. 
+         * Simplified S-Curves have no constant acceleration phase, only jerk phases (e.g. TinyG, Marlin). 
+         */
+        SimpleSCurve,
+
+        //TODO: Simulated3rdOrderControl,
+
+        /**
+         * Apply motion planning assuming a controller with full 3rd order motion control. 
+         */
+        Full3rdOrderControl;
+
+        public boolean isConstantAcceleration() {
+            return this == ToolpathFeedRate || this == ConstantAcceleration;
+        }
+    }
+
+    MotionControlType getMotionControlType();
+
     Length getFeedRatePerSecond();
+
 }

--- a/src/main/java/org/openpnp/util/GcodeServer.java
+++ b/src/main/java/org/openpnp/util/GcodeServer.java
@@ -4,14 +4,36 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.ServerSocket;
 import java.net.Socket;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.TreeMap;
+
+import org.openpnp.machine.reference.ReferenceDriver;
+import org.openpnp.machine.reference.SimulationModeMachine;
+import org.openpnp.model.AxesLocation;
+import org.openpnp.model.Location;
+import org.openpnp.model.Motion;
+import org.openpnp.model.Motion.MotionOption;
+import org.openpnp.spi.Axis;
+import org.openpnp.spi.ControllerAxis;
+import org.pmw.tinylog.Logger;
 
 public class GcodeServer extends Thread {
     final Map<String, String> commandResponses = new HashMap<>();
     final ServerSocket serverSocket;
-    
-    
+    ReferenceDriver driver;
+    SimulationModeMachine machine;
+    /**
+     * The simulated visual homing offsets are applied to what the simulated down camera sees.
+     * Works like Gcode G92. Initialized with the SimulationModeMachine.getHomingError() on homing.
+     */
+    private AxesLocation homingOffsets = new AxesLocation();
+
+    protected TreeMap<Double, Motion> motionPlan = new TreeMap<Double, Motion>();
+
+
     /**
      * Create a GcodeServer listening on the given port.
      * @param port
@@ -23,7 +45,7 @@ public class GcodeServer extends Thread {
         thread.setDaemon(false);
         thread.start();
     }
-    
+
     /**
      * Create a GcodeServer listening on a random port. The chosen port can be
      * retrived by calling GcodeServer.getListenerPort().
@@ -32,24 +54,33 @@ public class GcodeServer extends Thread {
     public GcodeServer() throws Exception {
         this(0);
     }
-    
+
     public int getListenerPort() {
         return serverSocket.getLocalPort();
     }
-    
+
+    public ReferenceDriver getDriver() {
+        return driver;
+    }
+
+    public void setDriver(ReferenceDriver driver) {
+        this.machine = SimulationModeMachine.getSimulationModeMachine();
+        this.driver = driver;
+    }
+
     public void addCommandResponse(String command, String response) {
         commandResponses.put(command, response);
     }
-    
+
     public void shutdown() {
         try {
             serverSocket.close();
         }
         catch (Exception e) {
-            
+
         }
     }
-    
+
     public void run() {
         while (!serverSocket.isClosed()) {
             try {
@@ -60,18 +91,57 @@ public class GcodeServer extends Thread {
             }
         }
     }
-    
+
+    enum Gcode {
+        // See http://linuxcnc.org/docs/2.4/html/gcode_overview.html#sec:Modal-Groups
+        G0(1), G1(1), G2(1), G3(1), G33(1), G38(1), G73(1), G76(1), G80(1), G81(1),
+           G82(1), G83(1), G84(1), G85(1), G86(1), G87(1), G88(1), G89(1),
+        G17(2), G18(2), G19(2),
+        G7(3), G8(3),
+        G90(4), G91(4),
+        G93(5), G94(5),
+        G20(6), G21(6),
+        G40(7), G41(7), G42(7),
+        G43(8), G49(8),
+        G98(9), G99(9),
+        G54(10), G55(10), G56(10), G57(10), G58(10), G59(10), 
+        M0(11), M1(11), M2(11), M30(11), M60(11),
+        M6(12), Tn(12),  
+        M3(13), M4(13), M5(13),
+        M7(14), M8(14), M9(14),
+        M48(15), M49(15),
+        O(16),
+        G4(0), G10(0), G28(0), G30(0), G53(0), G92(0), M1nn(0), 
+        // Smoothie plus
+        M204(12),
+        M400(0);
+
+        private int modalGroup;
+        Gcode(int modalGroup) {
+            this.modalGroup = modalGroup;
+        }
+        public int getModalGroup() {
+            return modalGroup;
+        }
+    }
+
     class Worker extends Thread {
         final Socket socket;
         final InputStream input;
         final OutputStream output;
-        
+        private AxesLocation machineLocation;
+        private double feedRate;
+        private double acceleration;
+        private double jerk;
+        private double unit = 1.0; // 1.0 --> mm or 25.4 --> inch
+        private boolean absolute = true;
+
         public Worker(Socket socket) throws Exception {
             this.socket = socket;
             input = socket.getInputStream();
             output = socket.getOutputStream();
         }
-        
+
         String read() throws Exception {
             StringBuffer line = new StringBuffer();
             while (true) {
@@ -89,25 +159,33 @@ public class GcodeServer extends Thread {
                 }
             }
         }
-        
-        
+
         void write(String s) throws Exception {
             output.write((s + "\n").getBytes("UTF8"));
         }
-        
+
         public void run() {
             while (true) {
                 try {
-                    String input = read().trim();
-                    String response = commandResponses.get(input);
-                    if (response != null) {
-                        write(response);
-                    }
-                    else {
-                        write("error:unknown command");
+                    String input = read();
+                    if (input != null) {
+                        // Canned responses.
+                        String response = null;
+                        response = commandResponses.get(input.trim());
+                        if (response != null) {
+                            write(response);
+                        }
+                        else if (driver != null) {
+                            // No canned responses. Try to interpret.
+                            interpretGcode(input);
+                        }
+                        else {    
+                            write("error:unknown command");
+                        }
                     }
                 }
                 catch (Exception e) {
+                    Logger.error(e);
                     break;
                 }
             }
@@ -127,9 +205,419 @@ public class GcodeServer extends Thread {
             catch (Exception e) {
             }
         }
+
+
+        protected class GcodeWord {
+            final char letter;
+            int number = 0;
+            int signum = 0;
+            int digits = 0;
+            int decimal = 0;
+            String comment = "";
+            private Gcode code;
+
+
+            int getNumberIntegral() {
+                return number/decimal;
+            }
+            int getNumberFraction() {
+                return number % decimal;
+            }
+            double getNumberDouble() {
+                return signum*((double)number)/decimal;
+            }
+
+            public GcodeWord(char letter) {
+                super();
+                this.letter = letter;
+            }
+
+            public void recognizeCode() {
+                if (decimal == 0) {
+                    decimal = 1;
+                }
+
+                if (letter == 'T') {
+                    this.code = Gcode.Tn;
+                }
+                else if (letter == 'O') {
+                    this.code = Gcode.O;
+                }
+                else if (letter == 'M' && getNumberIntegral()/100 == 1) {
+                    this.code = Gcode.M1nn;
+                }
+                else {
+                    String codeName = ((Character)letter).toString()+getNumberIntegral();
+                    for (Gcode code : Gcode.values()) {
+                        if (code.toString().equals(codeName)) {
+                            this.code = code;
+                        }
+                    }
+                }
+            }
+            public int getModalGroup() {
+                return code != null ? code.modalGroup : -1;   
+            }
+        }
+
+        public void interpretGcode(String input) throws Exception {
+            GcodeWord currentWord = null;
+            int col = 0;
+            boolean insideComment = false;
+            List<GcodeWord> commandWords = new ArrayList<>();
+            for (char ch : input.toCharArray()) {
+                col++;
+                if (ch == ' ') {
+                    continue;
+                }
+                else if (ch == '(') {
+                    if (insideComment) {
+                        throw new Exception("Nested comment at "+col+": "+input);
+                    }
+                    insideComment = true;
+                    if (currentWord != null) {
+                        currentWord.comment = "";
+                    }
+                }
+                else if (ch == ')') {
+                    if (!insideComment) {
+                        throw new Exception("Mismatched comment at "+col+": "+input);
+                    }
+                    insideComment = true;
+                }
+                else if (insideComment) {
+                    if (currentWord != null) {
+                        currentWord.comment += ch;
+                    }
+                    continue;
+                }
+                else if (ch == ';') {
+                    break;
+                }
+                else if (Character.toUpperCase(ch) >= 'A' && Character.toUpperCase(ch) <= 'Z') {
+                    commandWords = handleGcodeWord(currentWord, commandWords);
+                    currentWord = new GcodeWord(Character.toUpperCase(ch));
+                }
+                else if (currentWord == null) {
+                    // the remaining character are only allowed inside a word 
+                    throw new Exception("Syntax error at col "+col+" '"+ch+"' unexpected: "+input);
+                }
+                else if (ch == '+') {
+                    if (currentWord.signum != 0) {
+                        throw new Exception("Syntax error at col "+col+" '"+ch+"' unexpected: "+input);
+                    }
+                    currentWord.signum = +1;
+                }
+                else if (ch == '-') {
+                    if (currentWord.signum != 0) {
+                        throw new Exception("Syntax error at col "+col+" '"+ch+"' unexpected: "+input);
+                    }
+                    currentWord.signum = -1;
+                }
+                else if (ch >= '0' && ch <= '9') {
+                    currentWord.number *= 10;
+                    currentWord.number += (int)(ch - '0');
+                    currentWord.decimal *= 10;
+                    if (currentWord.signum == 0) {
+                        currentWord.signum = 1;
+                    }
+                }
+                else if (ch == '.') {
+                    if (currentWord.decimal != 0) {
+                        throw new Exception("Syntax error at col "+col+" '"+ch+"' unexpected: "+input);
+                    }
+                    currentWord.decimal = 1;
+                    if (currentWord.signum == 0) {
+                        currentWord.signum = 1;
+                    }
+                }
+            }
+            commandWords = handleGcodeWord(currentWord, commandWords);
+            simulateGcode(commandWords);
+        }
+
+        public List<GcodeWord> handleGcodeWord(GcodeWord currentWord,
+                List<GcodeWord> commandWords) throws Exception {
+            if (currentWord != null) {
+                // Finish the last word.
+                currentWord.recognizeCode();
+                int modalGroup = currentWord.getModalGroup();
+                if (modalGroup != -1) {
+                    for (GcodeWord word : commandWords) {
+                        if (word.getModalGroup() == modalGroup) {
+                            // This is the same modal group, therefore a new command is begun. 
+                            // Note, this is strictly speaking not standard RS274/NGC G-code but as many controllers do it, we must cope with it.
+                            // See http://linuxcnc.org/docs/2.4/html/gcode_overview.html#r1_10
+                            simulateGcode(commandWords);
+                            // Begin a new command.
+                            commandWords = new ArrayList<>();
+                            break;
+                        }
+                    }
+                }
+                // Add the finished Word to the command.
+                commandWords.add(currentWord);
+            }
+            return commandWords;
+        }
+
+        GcodeWord getLetterWord(char letter, List<GcodeWord> commandWords) {
+            for (GcodeWord word : commandWords) {
+                if (word.letter == letter) {
+                    return word;
+                }
+            }
+            return null;
+        }
+
+        GcodeWord getCodeWord(Gcode code, List<GcodeWord> commandWords) {
+            for (GcodeWord word : commandWords) {
+                if (word.code == code) {
+                    return word;
+                }
+            }
+            return null;
+        }
+
+        public String toString(List<GcodeWord> commandWords) {
+            StringBuilder regurg = new StringBuilder();
+            for (GcodeWord word : commandWords) {
+                regurg.append(word.letter);
+                if (word.signum < 0) {
+                    regurg.append('-');
+                }
+                regurg.append(word.getNumberIntegral());
+                if (word.getNumberFraction() != 0) {
+                    regurg.append('.');
+                    regurg.append(word.getNumberFraction());
+                }
+                regurg.append(' ');
+            }
+            return regurg.toString();
+        }
+
+        /**
+         * A very crude simulation of some known G-code commands. 
+         * 
+         * @param commandWords
+         * @throws Exception 
+         */
+        private void simulateGcode(List<GcodeWord> commandWords) throws Exception {
+            if (!commandWords.isEmpty()) {
+
+                
+                Logger.debug(toString(commandWords));
+                
+                // Order of execution
+                //
+                // See http://linuxcnc.org/docs/2.4/html/gcode_overview.html#sec:Order-of-Execution
+                //    1.  Comment (including message)
+                //    2.  Set feed rate mode (G93, G94). 
+                //    3.  Set feed rate (F). 
+                //    4.  Set spindle speed (S). 
+                //    5.  Select tool (T). 
+                //    6.  Change tool (M6).
+                //    7.  Spindle on or off (M3, M4, M5).
+                //    8.  Coolant on or off (M7, M8, M9).
+                //    9.  Enable or disable overrides (M48, M49). 
+                //    10. Dwell (G4). 
+                //    11. Set active plane (G17, G18, G19). 
+                //    12. Set length units (G20, G21).
+                //    13. Cutter radius compensation on or off (G40, G41, G42) 
+                //    14. Cutter length compensation on or off (G43, G49) 
+                //    15. Coordinate system selection (G54, G55, G56, G57, G58, G59, G59.1, G59.2, G59.3). 
+                //    16. Set path control mode (G61, G61.1, G64)
+                //    17. Set distance mode (G90, G91). 
+                //    18. Set retract mode (G98, G99).
+                //    19. Go to reference location (G28, G30) or change coordinate system data (G10) or set axis offsets (G92, G92.1, G92.2, G94). 
+                //    20. Perform motion (G0 to G3, G33, G73, G76, G80 to G89), as modified (possibly) by G53. 
+                //    21. Stop (M0, M1, M2, M30, M60).
+
+                if (machineLocation == null) {
+                    machineLocation = new AxesLocation(machine).drivenBy(getDriver());
+                }
+                // Get some general params.
+                GcodeWord sWord = getLetterWord('S', commandWords);
+                GcodeWord pWord = getLetterWord('P', commandWords);
+                AxesLocation axesLocation = machineLocation;
+                AxesLocation axesGiven = AxesLocation.zero;
+                for (Axis axis : machine.getAxes()) {
+                    if (axis instanceof ControllerAxis) {
+                        if (((ControllerAxis) axis).getDriver() == getDriver()) {
+                            String letter = ((ControllerAxis) axis).getLetter(); 
+                            if (letter.isEmpty() || letter.length() > 1) {
+                                throw new Exception("Invalid letter on axis "+axis.getName());
+                            }
+                            GcodeWord axisWord = getLetterWord(letter.toCharArray()[0], commandWords);
+                            if (axisWord != null) {
+                                if (absolute) {
+                                    axesLocation = axesLocation.put(new AxesLocation(axis, axisWord.getNumberDouble()*unit));
+                                }
+                                else {
+                                    axesLocation = axesLocation.add(new AxesLocation(axis, axisWord.getNumberDouble()*unit));
+                                }
+                                axesGiven = axesGiven.put(new AxesLocation(axis, axisWord.getNumberDouble()*unit));
+                            }
+                        }
+                    }
+                }
+
+                // Feed rate
+                GcodeWord fWord = getLetterWord('F', commandWords);
+                if (fWord != null) {
+                    feedRate = fWord.getNumberDouble()*unit/60; // convert per second
+                }
+                
+                // Acceleration
+                GcodeWord m204Word = getCodeWord(Gcode.M204, commandWords);
+                if (m204Word != null && sWord != null) {
+                    acceleration = sWord.getNumberDouble()*unit;
+                }
+
+                // Compute the wait or dwell time. Start with the motion plan completion time. 
+                int dwellMilliseconds = (motionPlan.isEmpty() ? 
+                        0 : (int)Math.max(0, (motionPlan.lastKey() - NanosecondTime.getRuntimeSeconds())*1000));
+                //Logger.debug("Motion ongoing for +"+dwellMilliseconds+" ms, lastKey = "+(motionPlan.isEmpty() ? 0 : motionPlan.lastKey())+", now="+NanosecondTime.getRuntimeSeconds());
+                boolean doDwell = false;
+                GcodeWord g4Word = getCodeWord(Gcode.G4, commandWords);
+                GcodeWord m400Word = getCodeWord(Gcode.M400, commandWords);
+                
+                // Dwell command
+                if (g4Word != null) {
+                    if (pWord != null) {
+                        dwellMilliseconds += pWord.getNumberIntegral();
+                    }
+                    if (sWord != null) {
+                        dwellMilliseconds += (int)(sWord.getNumberDouble()*1000);
+                    }
+                    doDwell = true;
+                }
+                
+                // Wait for completion command.
+                if (m400Word != null) {
+                    doDwell = true;
+                }
+                
+
+                // Set global offsets. 
+                GcodeWord g92Word = getCodeWord(Gcode.G92, commandWords);
+                if (g92Word != null) {
+                    homingOffsets = axesLocation.subtract(machineLocation).add(homingOffsets);
+                    machineLocation = axesLocation;
+                    doDwell = true;
+                }
+
+                // Set unit. 
+                GcodeWord g21Word = getCodeWord(Gcode.G21, commandWords);
+                GcodeWord g20Word = getCodeWord(Gcode.G20, commandWords);
+                if (g21Word != null) {
+                    // Millimeters
+                    unit = 1.0;
+                }
+                if (g20Word != null) {
+                    // Inches
+                    unit = 25.4;
+                }
+
+                GcodeWord g90Word = getCodeWord(Gcode.G90, commandWords);
+                GcodeWord g91Word = getCodeWord(Gcode.G91, commandWords);
+                if (g90Word != null) {
+                    // Absolute mode.
+                    absolute = true;
+                }
+                if (g91Word != null) {
+                    // Relative mode.
+                    absolute = false;
+                }
+
+                
+                if (doDwell && dwellMilliseconds > 0) {
+                    // There is a command, that waits for completion/dwells.
+                    if (dwellMilliseconds > 10000) {
+                        // Be reasonable
+                        Logger.warn("Dwell time limited to 10s from "+(dwellMilliseconds/1000.)+"s");
+                        dwellMilliseconds = 10000;
+                    }
+                    Logger.trace("Waiting "+dwellMilliseconds+"ms");
+                    Thread.sleep(dwellMilliseconds);
+                    
+                    // Remove old stuff.
+                    double time = NanosecondTime.getRuntimeSeconds() - 30;
+                    while (motionPlan.isEmpty() == false && motionPlan.firstKey() < time) {
+                        motionPlan.remove(motionPlan.firstKey());
+                    }
+                }
+
+                // Motion.
+                GcodeWord g0Word = getCodeWord(Gcode.G0, commandWords);
+                GcodeWord g1Word = getCodeWord(Gcode.G1, commandWords);
+                GcodeWord g28Word = getCodeWord(Gcode.G28, commandWords);
+                if (g0Word != null || g1Word != null || g28Word != null) {
+                    double speed = 1.0;
+                    if (g28Word != null) {
+                        // Handle homing like a move. 
+                        // But restore the simulated homing error.
+                        Location homingError = machine.getHomingError();
+                        homingOffsets = new AxesLocation(machine, getDriver(), (axis) 
+                                -> (axis.getType() == Axis.Type.X ? homingError.getLengthX() :
+                                    axis.getType() == Axis.Type.Y ? homingError.getLengthY() : 
+                                        null));
+                        // Make it slower.
+                        speed = 0.5;
+                        if (axesGiven.isEmpty()) {
+                            // G28 has not axes, use preset homing coordinates.
+                            axesLocation = new AxesLocation(machineLocation.getAxes(getDriver()), (a) -> a.getHomeCoordinate());
+                        }
+                        else {
+                            // If we're in relative mode, we still want this absolute.
+                            axesLocation = machineLocation.put(axesGiven);
+                        }
+                    }
+                    // Create the motion.
+                    Motion motion = new Motion(null, machineLocation, axesLocation, speed, 
+                            feedRate, acceleration, jerk,
+                            (g0Word != null ? MotionOption.UncoordinatedMotion.flag() : 0));
+                    double t = NanosecondTime.getRuntimeSeconds();
+                    if (motionPlan.isEmpty() == false && motionPlan.lastKey() > t) {
+                        // Append to a plan that is still running. 
+                        t = motionPlan.lastKey();
+                    }
+                    // Put into timed plan.
+                    t += motion.getTime();
+                    Logger.debug("move takes "+(motion.getTime()*1000)+" ms");
+                    motionPlan.put(t, motion);
+                    // Store new location.
+                    machineLocation = machineLocation.put(axesLocation);
+                }
+
+                // Standard response.
+                write("ok");
+            }
+        }
     }
-    
-    
+
+    public synchronized Motion getMomentaryMotion(double time) {
+        Map.Entry<Double, Motion> entry1 = motionPlan.higherEntry(time);
+        if (entry1 != null) {
+            // Return the current motion.
+            Motion motion = entry1.getValue();
+            return motion;
+        }
+        else {
+            // Nothing in the plan or machine stopped before this time, just get the current axes location.
+            AxesLocation currentLocation = new AxesLocation(machine); 
+            Motion motion = new Motion( 
+                    null, 
+                    currentLocation,
+                    currentLocation,
+                    1.0,
+                    MotionOption.Stillstand);
+            // Anchor it in real-time.
+            motion.setPlannedTime1(time);
+            return motion;
+        }
+    }
+
     public static void main(String[] args) throws Exception {
         GcodeServer server = new GcodeServer();
     }

--- a/src/test/java/AdvancedMotionTest.java
+++ b/src/test/java/AdvancedMotionTest.java
@@ -158,7 +158,7 @@ public class AdvancedMotionTest {
 
         testProfileCase(message, profile, expectedError);
         testProfileCase(message+" (reverse)", profileRev, expectedError);
-        testProfileCase(message+" (constant aceleration)", profileConstantAcc, expectedError);
+        testProfileCase(message+" (constant acceleration)", profileConstantAcc, expectedError);
         System.out.println(" ");
     }
 

--- a/src/test/java/AdvancedMotionTest.java
+++ b/src/test/java/AdvancedMotionTest.java
@@ -5,6 +5,7 @@ import org.junit.Test;
 import org.openpnp.model.MotionProfile;
 import org.openpnp.model.MotionProfile.ErrorState;
 import org.openpnp.model.MotionProfile.ProfileOption;
+import org.openpnp.spi.Driver.MotionControlType;
 
 public class AdvancedMotionTest {
 
@@ -123,10 +124,10 @@ public class AdvancedMotionTest {
         MotionProfile profile2 = new MotionProfile(
                 0, 400, 0, -20, 0, -100,
                 0, 1000, 
-                profile.getProfileVelocity(), 
-                profile.getProfileEntryAcceleration(), 
-                profile.getProfileExitAcceleration(),
-                profile.getProfileJerk(),
+                profile.getProfileVelocity(MotionControlType.Full3rdOrderControl), 
+                profile.getProfileEntryAcceleration(MotionControlType.Full3rdOrderControl), 
+                profile.getProfileExitAcceleration(MotionControlType.Full3rdOrderControl),
+                profile.getProfileJerk(MotionControlType.Full3rdOrderControl),
                 0.0, Double.POSITIVE_INFINITY, 0);
         testProfile("recheck solution", profile2, null);
     }
@@ -156,9 +157,22 @@ public class AdvancedMotionTest {
                 profile.getTimeMin(), profile.getTimeMax(), 
                 profile.getOptions());
 
+        MotionProfile profileSimpleSCurve = new MotionProfile(
+                profile.getLocation(0), profile.getLocation(MotionProfile.segments), 
+                profile.getVelocity(0), profile.getVelocity(MotionProfile.segments),  
+                0, 0,
+                profile.getLocationMin(), profile.getLocationMax(),
+                profile.getVelocityMax(), 
+                profile.getEntryAccelerationMax(), 
+                profile.getExitAccelerationMax(),
+                profile.getJerkMax(),
+                profile.getTimeMin(), profile.getTimeMax(), 
+                profile.getOptions() | ProfileOption.SimplifiedSCurve.flag());
+
         testProfileCase(message, profile, expectedError);
         testProfileCase(message+" (reverse)", profileRev, expectedError);
         testProfileCase(message+" (constant acceleration)", profileConstantAcc, expectedError);
+        testProfileCase(message+" (simplified S-Curve)", profileSimpleSCurve, expectedError);
         System.out.println(" ");
     }
 

--- a/src/test/java/org/openpnp/machine/reference/driver/test/TestDriver.java
+++ b/src/test/java/org/openpnp/machine/reference/driver/test/TestDriver.java
@@ -16,6 +16,7 @@ import org.openpnp.model.LengthUnit;
 import org.openpnp.model.Motion;
 import org.openpnp.spi.MotionPlanner.CompletionType;
 import org.openpnp.spi.PropertySheetHolder;
+import org.openpnp.spi.Driver.MotionControlType;
 import org.openpnp.spi.base.AbstractDriver;
 import org.simpleframework.xml.Attribute;
 
@@ -153,6 +154,11 @@ public class TestDriver extends AbstractDriver implements ReferenceDriver {
         }
 
         @Override
+        public MotionControlType getMotionControlType() {
+            return MotionControlType.Full3rdOrderControl;
+        }
+
+        @Override
         public LengthUnit getUnits() {
             return LengthUnit.Millimeters;
         }
@@ -181,6 +187,11 @@ public class TestDriver extends AbstractDriver implements ReferenceDriver {
             return null;
         }
    }
+
+    @Override
+    public MotionControlType getMotionControlType() {
+        return MotionControlType.Full3rdOrderControl;
+    }
 
     @Override
     public LengthUnit getUnits() {


### PR DESCRIPTION
# Description

This is the second round of bug-fixes for #1035.

Integrated `GcodeServer `into  `SimulationModeMachine`. Implemented basic G-code parser (work in progress). This allows testing of user `machine.xml` with multi-nozzle, multi-driver machines etc.
![grafik](https://user-images.githubusercontent.com/9963310/90826797-62e56d80-e33b-11ea-83b1-6b025f03eb93.png)

Implemented `MotionControlType` to determine how OpenPnP plans the motion profiles and how it talks to controllers.
![grafik](https://user-images.githubusercontent.com/9963310/90837120-5b30c380-e351-11ea-8a54-2dce63a41397.png)

Various bug fixes. 

# Justification
See user group.

# Instructions for Use
The `SimulationModeMachine` can be activated by exiting OpenPnP, then replacing `ReferenceMachine` with `SimulationModeMachine` at the top of the `.xml`.

Restart OpenPnP and go to the Simulation Mode Wizard in the machine. Choose one of the Simulation modes:
![grafik](https://user-images.githubusercontent.com/9963310/90837251-cf6b6700-e351-11ea-949d-a3437ce58826.png)

Enable the machine. The connections will now be simulated with GcodeServers (one per Controller). 

`MotionControlType` is described in the tooltip, see screen shot above. 

# Implementation Details
1. Tested in the Null Machine. No Machine tests yet. 
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. Minor change in the `org.openpnp.spi` package (Driver).
4. Succesfully ran `mvn test` before submitting the Pull Request.
