### PR TITLE
Update javassist to latest version (3.27.0-GA)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -146,9 +146,9 @@
 			<version>1.4.9</version>
 		</dependency>
 		<dependency>
-			<groupId>javassist</groupId>
+			<groupId>org.javassist</groupId>
 			<artifactId>javassist</artifactId>
-			<version>3.12.1.GA</version>
+			<version>3.27.0-GA</version>
 		</dependency>
 		<dependency>
 			<groupId>org.jdesktop</groupId>


### PR DESCRIPTION

# Description
Updates javassist to latest version.

# Justification
This allows the beansBinding speedup patch to work on at least JDK11. Without this UI wizards are slow to generate on this java version.

# Instructions for Use
N/A

# Implementation Details
Tested on x86_64 Linux and aarch64 Linux. Wizards appear quickly.
Coding style N/A (minor change to pom.xml only)
No java code changes.
mvn tests continue to pass.

Javasssist is only used in monkeyPatchBeansBinding which fails under jdk11 without this update.
javassist is a top level dependency and pulls in no other dependencies.