### PR TITLE
Feature/Rendering Quality on CameraView.

### DIFF
--- a/src/main/java/org/openpnp/gui/components/CameraViewPopupMenu.java
+++ b/src/main/java/org/openpnp/gui/components/CameraViewPopupMenu.java
@@ -33,6 +33,7 @@ import javax.swing.JOptionPane;
 import javax.swing.JPopupMenu;
 import javax.swing.JRadioButtonMenuItem;
 
+import org.openpnp.gui.components.CameraView.RenderingQuality;
 import org.openpnp.gui.components.reticle.CrosshairReticle;
 import org.openpnp.gui.components.reticle.FiducialReticle;
 import org.openpnp.gui.components.reticle.Reticle;
@@ -47,6 +48,7 @@ public class CameraViewPopupMenu extends JPopupMenu {
     private JMenu zoomIncMenu;
     private JMenu reticleMenu;
     private JMenu reticleOptionsMenu;
+    private JMenu renderingQualityMenu;
 
     public CameraViewPopupMenu(CameraView cameraView) {
         this.cameraView = cameraView;
@@ -54,6 +56,10 @@ public class CameraViewPopupMenu extends JPopupMenu {
         zoomIncMenu = createZoomIncMenu();
 
         add(zoomIncMenu);
+
+        renderingQualityMenu = createRenderingQualityMenu();
+
+        add(renderingQualityMenu);
 
         reticleMenu = createReticleMenu();
 
@@ -146,7 +152,54 @@ public class CameraViewPopupMenu extends JPopupMenu {
         
         return subMenu;
     }
-    
+
+    private JMenu createRenderingQualityMenu() {
+        JMenu subMenu = new JMenu("Rendering Quality");
+        ButtonGroup buttonGroup = new ButtonGroup();
+        JRadioButtonMenuItem menuItem;
+        
+        menuItem = new JRadioButtonMenuItem("Low Quality");
+        buttonGroup.add(menuItem);
+        if (cameraView.getRenderingQuality() == RenderingQuality.Low) {
+            menuItem.setSelected(true);
+        }
+        menuItem.addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                cameraView.setRenderingQuality(RenderingQuality.Low);
+            }
+        });
+        subMenu.add(menuItem);
+        
+        menuItem = new JRadioButtonMenuItem("High Quality");
+        buttonGroup.add(menuItem);
+        if (cameraView.getRenderingQuality() == RenderingQuality.High) {
+            menuItem.setSelected(true);
+        }
+        menuItem.addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                cameraView.setRenderingQuality(RenderingQuality.High);
+            }
+        });
+        subMenu.add(menuItem);
+        
+        menuItem = new JRadioButtonMenuItem("Highest Quality (best scale)");
+        buttonGroup.add(menuItem);
+        if (cameraView.getRenderingQuality() == RenderingQuality.BestScale) {
+            menuItem.setSelected(true);
+        }
+        menuItem.addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                cameraView.setRenderingQuality(RenderingQuality.BestScale);
+            }
+        });
+        subMenu.add(menuItem);
+        
+        return subMenu;
+    }
+
     private JMenu createReticleMenu() {
         JMenu menu = new JMenu("Reticle");
 


### PR DESCRIPTION
# Description
Added a Rendering Quality context menu to the Camera View: 

![CameraRenderingQuality2](https://user-images.githubusercontent.com/9963310/90915666-36cff800-e3e0-11ea-9203-eb0ec93f9057.gif)

# Justification
Lets you choose your preferred Rendering Quality setting. By making this a choice, you can still use the old way that might be faster on less powerful computers. 

# Instructions for Use

There are three choices:

1. The Low Quality setting is the default and works as before. The camera image is drawn with a simple pixel copying method. You get aliasing artifacts, as rows and columns of pixels are swallowed or duplicated. However, this is probably the fastest method.
2. The High Quality setting uses some method of sub-pixel super-sampling to create a better image. 
3. The Highest Quality setting uses the same method of sub-pixel super-sampling, but also scales the camera image the nearest best scale factor, i.e. the number of super-sampled pixels are constant. Some part of the image might be cropped or a black frame added. You can then adjust the CameraView size to this best scale. When zooming in this mode (with the mouse scroll wheel), it may take some patience until it snaps to the next best scale factor. 

![CameraRenderingQuality1](https://user-images.githubusercontent.com/9963310/90917202-b8c12080-e3e2-11ea-8adf-d1d69c85c66f.gif)

# Implementation Details
1. Tested with ImageCamera and real camera.
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. No changes in the `org.openpnp.spi` or `org.openpnp.model`.
4. Successfully ran `mvn test` before submitting the Pull Request. 
