### PR TITLE
Factorize Communication code

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/driver/ReferenceDriverCommunications.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/ReferenceDriverCommunications.java
@@ -55,11 +55,58 @@ public abstract class ReferenceDriverCommunications {
 
     abstract public String getConnectionName();
 
-    abstract public String readLine() throws TimeoutException, IOException;
-    abstract public void writeLine(String data) throws IOException;
+    abstract public void writeBytes(byte[] data) throws IOException;
 
     abstract public int read() throws TimeoutException, IOException;
-    abstract public void write(int d) throws IOException;
+
+    /**
+     * Read a line from the input stream. Blocks for the default timeout. If the read times out a
+     * TimeoutException is thrown. Any other failure to read results in an IOExeption;
+     *
+     * @return
+     * @throws TimeoutException
+     * @throws IOException
+     */
+    public String readLine() throws TimeoutException, IOException {
+        return readUntil("\r\n");
+    }
+
+    public void writeLine(String data) throws IOException {
+        writeBytes(data.getBytes());
+        writeBytes(getLineEndingType().getLineEnding().getBytes());
+    }
+
+    /**
+     * Read the input stream until one of the characters is found. Blocks for the default timeout. If the read times out
+     * a TimeoutException is thrown. Any other failure to read results in an IOExeption;
+     *
+     * @param characters list of ending characters
+     * @return
+     * @throws TimeoutException
+     * @throws IOException
+     */
+    public String readUntil(String characters) throws TimeoutException, IOException {
+        StringBuffer line = new StringBuffer();
+        while (true) {
+            int ch = read();
+            if (ch == -1) {
+                return null;
+            }
+            else if (characters.indexOf((char)ch) >= 0) {
+                if (line.length() > 0) {
+                    return line.toString();
+                }
+            }
+            else {
+                line.append((char) ch);
+            }
+        }
+    }
+
+    public void write(int d) throws IOException {
+        byte[] b = new byte[] { (byte) d };
+        writeBytes(b);
+    }
     
     public void setLineEndingType(LineEndingType lineEndingType) {
         this.lineEndingType = lineEndingType;

--- a/src/main/java/org/openpnp/machine/reference/driver/SerialPortCommunications.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/SerialPortCommunications.java
@@ -136,43 +136,6 @@ public class SerialPortCommunications extends ReferenceDriverCommunications {
         return portNames.toArray(new String[] {});
     }
 
-    /**
-     * Read a line from the serial port. Blocks for the default timeout. If the read times out a
-     * TimeoutException is thrown. Any other failure to read results in an IOExeption;
-     * 
-     * @return
-     * @throws TimeoutException
-     * @throws IOException
-     */
-    public String readLine() throws TimeoutException, IOException {
-        StringBuffer line = new StringBuffer();
-        while (true) {
-            int ch = read();
-            if (ch == '\n' || ch == '\r') {
-                if (line.length() > 0) {
-                    return line.toString();
-                }
-            }
-            else {
-                line.append((char) ch);
-            }
-        }
-    }
-
-    public void writeLine(String data) throws IOException
-    {
-        byte[] b = data.getBytes();
-        int l = serialPort.writeBytes(b, b.length);
-        if (l == -1) {
-            throw new IOException("Write error.");
-        }
-        b = getLineEndingType().getLineEnding().getBytes();
-        l = serialPort.writeBytes(b, b.length);
-        if (l == -1) {
-            throw new IOException("Write error.");
-        }
-    }
-
     public int read() throws TimeoutException, IOException {
         byte[] b = new byte[1];
         int l = serialPort.readBytes(b, 1);
@@ -184,14 +147,14 @@ public class SerialPortCommunications extends ReferenceDriverCommunications {
         }
         return b[0];
     }
-    
-    public void write(int d) throws IOException {
-        byte[] b = new byte[] { (byte) d };
-        int l = serialPort.writeBytes(b, 1);
+
+    public void writeBytes(byte[] data) throws IOException {
+        int l = serialPort.writeBytes(data, data.length);
         if (l == -1) {
             throw new IOException("Write error.");
         }
     }
+
 
     public String getConnectionName() {
         return "serial://" + portName;

--- a/src/main/java/org/openpnp/machine/reference/driver/TcpCommunications.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/TcpCommunications.java
@@ -50,51 +50,6 @@ public class TcpCommunications extends ReferenceDriverCommunications {
         return "tcp://" + ipAddress + ":" + port;
     }
 
-    /**
-     * Read a line from the socket. Blocks for the default timeout. If the read times out a
-     * TimeoutException is thrown. Any other failure to read results in an IOExeption;
-     * 
-     * @return
-     * @throws TimeoutException
-     * @throws IOException
-     */
-    public String readLine() throws TimeoutException, IOException {
-        StringBuffer line = new StringBuffer();
-        while (true) {
-            try {
-                int ch = input.read();
-                if (ch == -1) {
-                    return null;
-                }
-                else if (ch == '\n' || ch == '\r') {
-                    if (line.length() > 0) {
-                        return line.toString();
-                    }
-                }
-                else {
-                    line.append((char) ch);
-                }
-            }
-            catch (IOException ex) {
-                if (ex.getCause() instanceof SocketTimeoutException) {
-                    throw new TimeoutException(ex.getMessage());
-                }
-                throw ex;
-            }
-        }
-    }
-
-    public void writeLine(String data) throws IOException
-    {
-        try {
-            output.write(data.getBytes());
-            output.write(getLineEndingType().getLineEnding().getBytes());
-        }
-        catch (IOException ex) {
-            throw ex;
-        }
-    }
-    
     public int read() throws TimeoutException, IOException {
         try {
             return input.read();
@@ -106,9 +61,15 @@ public class TcpCommunications extends ReferenceDriverCommunications {
             throw ex;
         }
     }
-    
+
+    @Override
     public void write(int d) throws IOException {
         output.write(d);
+    }
+
+    @Override
+    public void writeBytes(byte[] data) throws IOException {
+        output.write(data);
     }
 
     public String getIpAddress() {


### PR DESCRIPTION
# Description
Factorize serial and tcp serial communication using primitive read/write functions

# Justification
writeLine and readLine are duplicated code which can be factorized using simple abstract read and writeBytes function.

# Implementation Details
Tested over a simple query/reply protocol