### PR TITLE
Feature / Better manual Nozzle Tip Change

### DIFF
--- a/src/main/java/org/openpnp/gui/FeedersPanel.java
+++ b/src/main/java/org/openpnp/gui/FeedersPanel.java
@@ -523,62 +523,72 @@ public class FeedersPanel extends JPanel implements WizardContainer {
             UiUtils.submitUiMachineTask(() -> {
                 Feeder feeder = getSelection();
 
-                // Simulate a "one feeder" job, prepare the feeder.
-                if (feeder.getJobPreparationLocation() != null) {
-                    feeder.prepareForJob(true);
-                }
-                feeder.prepareForJob(false);
-
-                // Check the nozzle tip package compatibility.
-                Nozzle nozzle = MainFrame.get().getMachineControls().getSelectedNozzle();
-                org.openpnp.model.Package packag = feeder.getPart().getPackage();
-                if (nozzle.getNozzleTip() == null || 
-                        !packag.getCompatibleNozzleTips().contains(nozzle.getNozzleTip())) {
-                    // Wrong nozzle tip, try find one that works.
-                    boolean resolved = false;
-                    if (nozzle.isNozzleTipChangedOnManualFeed()) {
-                        for (NozzleTip nozzleTip : packag.getCompatibleNozzleTips()) {
-                            if (nozzle.getCompatibleNozzleTips().contains(nozzleTip)) {
-                                // Found a compatible one.
-                                nozzle.loadNozzleTip(nozzleTip);
-                                resolved = true;
-                                break;
-                            }
-                        }
-                    }
-                    if (nozzle.getNozzleTip() == null) {
-                        throw new Exception("Can't pick, no nozzle tip loaded on nozzle "+nozzle.getName()+". "
-                                +"You may want to enable automatic nozzle tip change on manual feed on the Nozzle / Tool Changer.");
-                    }
-                    else if (! resolved) {
-                        throw new Exception("Can't pick, loaded nozzle tip "+
-                                nozzle.getNozzleTip().getName()+" is not compatible with package "+packag.getId()+". "
-                                +"You may want to enable automatic nozzle tip change on manual feed on the Nozzle / Tool Changer.");
-                    }
-                }
-
-                // Perform the feed.
-                nozzle.moveToSafeZ();
-                feeder.feed(nozzle);
-
-                // Go to the pick location and pick.
-                Location pickLocation = feeder.getPickLocation();
-                MovableUtils.moveToLocationAtSafeZ(nozzle, pickLocation);
-                nozzle.pick(feeder.getPart());
-                nozzle.moveToSafeZ();
-
-                // After the pick. 
-                feeder.postPick(nozzle);
-
-                // Perform the vacuum check, if enabled.
-                if (nozzle.isPartOnEnabled(Nozzle.PartOnStep.AfterPick)) {
-                    if(!nozzle.isPartOn()) {
-                        throw new JobProcessorException(nozzle, "No part detected.");
-                    }
-                }
+                pickFeeder(feeder);
             });
         }
     };
+
+    public static void pickFeeder(Feeder feeder) throws Exception, JobProcessorException {
+        // Simulate a "one feeder" job, prepare the feeder.
+        if (feeder.getJobPreparationLocation() != null) {
+            feeder.prepareForJob(true);
+        }
+        feeder.prepareForJob(false);
+
+        // Check the nozzle tip package compatibility.
+        Nozzle nozzle = MainFrame.get().getMachineControls().getSelectedNozzle();
+        org.openpnp.model.Package packag = feeder.getPart().getPackage();
+        if (nozzle.getNozzleTip() == null || 
+                !packag.getCompatibleNozzleTips().contains(nozzle.getNozzleTip())) {
+            // Wrong nozzle tip, try find one that works.
+            boolean resolved = false;
+            if (nozzle.isNozzleTipChangedOnManualFeed()) {
+                for (NozzleTip nozzleTip : packag.getCompatibleNozzleTips()) {
+                    if (nozzle.getCompatibleNozzleTips().contains(nozzleTip)) {
+                        // Found a compatible one. Unload and load like the JobProcessor.
+                        nozzle.unloadNozzleTip();
+                        nozzle.loadNozzleTip(nozzleTip);
+                        resolved = true;
+                        break;
+                    }
+                }
+            }
+            if (nozzle.getNozzleTip() == null) {
+                throw new Exception("Can't pick, no nozzle tip loaded on nozzle "+nozzle.getName()+". "
+                        +"You may want to enable automatic nozzle tip change on manual feed on the Nozzle / Tool Changer.");
+            }
+            else if (! resolved) {
+                throw new Exception("Can't pick, loaded nozzle tip "+
+                        nozzle.getNozzleTip().getName()+" is not compatible with package "+packag.getId()+". "
+                        +"You may want to enable automatic nozzle tip change on manual feed on the Nozzle / Tool Changer.");
+            }
+        }
+
+        // Like in the JobProcessor, make sure it is calibrated.
+        if (!nozzle.isCalibrated()) {
+            nozzle.calibrate();
+        }
+
+        // Perform the feed.
+        nozzle.moveToSafeZ();
+        feeder.feed(nozzle);
+
+        // Go to the pick location and pick.
+        Location pickLocation = feeder.getPickLocation();
+        MovableUtils.moveToLocationAtSafeZ(nozzle, pickLocation);
+        nozzle.pick(feeder.getPart());
+        nozzle.moveToSafeZ();
+
+        // After the pick. 
+        feeder.postPick(nozzle);
+
+        // Perform the vacuum check, if enabled.
+        if (nozzle.isPartOnEnabled(Nozzle.PartOnStep.AfterPick)) {
+            if(!nozzle.isPartOn()) {
+                throw new JobProcessorException(nozzle, "No part detected.");
+            }
+        }
+    }
 
     public Action moveCameraToPickLocation = new AbstractAction() {
         {

--- a/src/main/java/org/openpnp/gui/FeedersPanel.java
+++ b/src/main/java/org/openpnp/gui/FeedersPanel.java
@@ -555,12 +555,12 @@ public class FeedersPanel extends JPanel implements WizardContainer {
             }
             if (nozzle.getNozzleTip() == null) {
                 throw new Exception("Can't pick, no nozzle tip loaded on nozzle "+nozzle.getName()+". "
-                        +"You may want to enable automatic nozzle tip change on manual feed on the Nozzle / Tool Changer.");
+                        +"You may want to enable automatic nozzle tip change on manual pick on the Nozzle / Tool Changer.");
             }
             else if (! resolved) {
                 throw new Exception("Can't pick, loaded nozzle tip "+
                         nozzle.getNozzleTip().getName()+" is not compatible with package "+packag.getId()+". "
-                        +"You may want to enable automatic nozzle tip change on manual feed on the Nozzle / Tool Changer.");
+                        +"You may want to enable automatic nozzle tip change on manual pick on the Nozzle / Tool Changer.");
             }
         }
 

--- a/src/main/java/org/openpnp/gui/PartsPanel.java
+++ b/src/main/java/org/openpnp/gui/PartsPanel.java
@@ -346,7 +346,6 @@ public class PartsPanel extends JPanel implements WizardContainer {
         @Override
         public void actionPerformed(ActionEvent arg0) {
             UiUtils.submitUiMachineTask(() -> {
-                Nozzle nozzle = MainFrame.get().getMachineControls().getSelectedNozzle();
                 Part part = getSelection();
                 Feeder feeder = null;
                 // find a feeder to feed
@@ -358,13 +357,8 @@ public class PartsPanel extends JPanel implements WizardContainer {
                 if (feeder == null) {
                     throw new Exception("No valid feeder found for " + part.getId());
                 }
-                // feed the chosen feeder
-                feeder.feed(nozzle);
-                // pick the part
-                Location pickLocation = feeder.getPickLocation();
-                MovableUtils.moveToLocationAtSafeZ(nozzle, pickLocation);
-                nozzle.pick(part);
-                nozzle.moveToSafeZ();
+                // Perform the whole Job like pick cycle as in the FeedersPanel. 
+                FeedersPanel.pickFeeder(feeder);
             });
         }
     };

--- a/src/main/java/org/openpnp/machine/reference/ReferenceNozzle.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceNozzle.java
@@ -456,11 +456,12 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
             // Nozzle tip is on different nozzle - unload it from there first.  
             nt.getNozzleAttachedTo().unloadNozzleTip();
         }
-        
-        if (changerEnabled) {
-            unloadNozzleTip();
-            if (!nt.isUnloadedNozzleTipStandin()) {
 
+        unloadNozzleTip();
+
+        double speed = getHead().getMachine().getSpeed();
+        if (!nt.isUnloadedNozzleTipStandin()) {
+            if (changerEnabled) {
                 Logger.debug("{}.loadNozzleTip({}): Start", getName(), nozzleTip.getName());
 
                 try {
@@ -469,14 +470,12 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
                     globals.put("nozzle", this);
                     globals.put("nozzleTip", nt);
                     Configuration.get()
-                                 .getScripting()
-                                 .on("NozzleTip.BeforeLoad", globals);
+                    .getScripting()
+                    .on("NozzleTip.BeforeLoad", globals);
                 }
                 catch (Exception e) {
                     Logger.warn(e);
                 }
-
-                double speed = getHead().getMachine().getSpeed();
 
                 Logger.debug("{}.loadNozzleTip({}): moveTo Start Location",
                         new Object[] {getName(), nozzleTip.getName()});
@@ -504,18 +503,20 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
 
                 // bert start
                 if (tcPostThreeActuator !=null) {
-                	tcPostThreeActuator.actuate(true);
+                    tcPostThreeActuator.actuate(true);
                 }
                 //bert stop
-                
-                Logger.debug("{}.loadNozzleTip({}): moveTo End Location",
-                        new Object[] {getName(), nozzleTip.getName()});
-                moveTo(nt.getChangerEndLocation(), nt.getChangerMid2ToEndSpeed() * speed);
-                moveToSafeZ(getHead().getMachine().getSpeed());
+            }
 
-                Logger.debug("{}.loadNozzleTip({}): Finished",
-                        new Object[] {getName(), nozzleTip.getName()});
+            Logger.debug("{}.loadNozzleTip({}): moveTo End Location",
+                    new Object[] {getName(), nozzleTip.getName()});
+            moveTo(nt.getChangerEndLocation(), nt.getChangerMid2ToEndSpeed() * speed);
+            moveToSafeZ(getHead().getMachine().getSpeed());
 
+            Logger.debug("{}.loadNozzleTip({}): Finished",
+                    new Object[] {getName(), nozzleTip.getName()});
+
+            if (changerEnabled) {
                 try {
                     Map<String, Object> globals = new HashMap<>();
                     globals.put("head", getHead());
@@ -532,17 +533,30 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
 
         this.nozzleTip = nt;
         currentNozzleTipId = nozzleTip.getId();
+        firePropertyChange("nozzleTip", null, getNozzleTip());
+        ((ReferenceMachine) head.getMachine()).fireMachineHeadActivity(head);
+
+        if (!nt.isUnloadedNozzleTipStandin()) {
+            if (!changerEnabled) {
+                if (this.nozzleTip.getCalibration().isRecalibrateOnNozzleTipChangeNeeded(this) 
+                        || this.nozzleTip.getCalibration().isRecalibrateOnNozzleTipChangeInJobNeeded(this)) {
+                    Logger.debug("{}.loadNozzleTip() nozzle tip {} calibration reset", getName(), this.nozzleTip.getName());
+                    // can't automatically recalibrate with manual change - reset() for now
+                    this.nozzleTip.getCalibration().reset(this);
+                }
+                throw new Exception("Manual NozzleTip "+nt.getName()+" load on Nozzle "+getName()+" required!");
+            }
+        }
+
         if (this.nozzleTip.getCalibration().isRecalibrateOnNozzleTipChangeNeeded(this)) {
             Logger.debug("{}.loadNozzleTip() nozzle tip {} calibration needed", getName(), this.nozzleTip.getName());
             this.nozzleTip.getCalibration().calibrate(this);
         }
         else if (this.nozzleTip.getCalibration().isRecalibrateOnNozzleTipChangeInJobNeeded(this)) {
             Logger.debug("{}.loadNozzleTip() nozzle tip {} calibration reset", getName(), this.nozzleTip.getName());
-            // is will be recalibrated by the job - just reset() for now
+            // it will be recalibrated by the job - just reset() for now
             this.nozzleTip.getCalibration().reset(this);
         }
-        firePropertyChange("nozzleTip", null, getNozzleTip());
-        ((ReferenceMachine) head.getMachine()).fireMachineHeadActivity(head);
     }
 
     @Override
@@ -634,7 +648,7 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
         ((ReferenceMachine) head.getMachine()).fireMachineHeadActivity(head);
 
         if (!changerEnabled) {
-            throw new Exception("Manual NozzleTip change required!");
+            throw new Exception("Manual NozzleTip "+nt.getName()+" unload from Nozzle "+getName()+" required!");
         }
         // May need to calibrate the "unloaded" nozzle tip stand-in i.e. the naked nozzle tip holder. 
         ReferenceNozzleTip calibrationNozzleTip = this.getCalibrationNozzleTip();

--- a/src/main/java/org/openpnp/machine/reference/wizards/ReferenceNozzleToolChangerWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/wizards/ReferenceNozzleToolChangerWizard.java
@@ -74,7 +74,7 @@ public class ReferenceNozzleToolChangerWizard extends AbstractConfigurationWizar
         chckbxChangerEnabled = new JCheckBox("");
         panelChanger.add(chckbxChangerEnabled, "4, 2");
         
-        lblChangeOnManual = new JLabel("Change On Manual Feed?");
+        lblChangeOnManual = new JLabel("Change On Manual Pick?");
         panelChanger.add(lblChangeOnManual, "2, 4, right, default");
         
         chckbxChangeOnManualFeed = new JCheckBox("");


### PR DESCRIPTION
# Description

## Intro
For machines that have no automatic nozzle tip changer, one can disable the automatic changer on the nozzle:

![Nozzle Tool Changer Settings](https://user-images.githubusercontent.com/9963310/95017556-42a70f00-065a-11eb-8520-8ac62c8aafa6.png)

OpenPnP will then only use the **Last Location** of the Nozzle Tip Tool Changer setup. A user can just capture a location that is convenient to manually load/unload Nozzle Tips:

![Tool Changer Last Location](https://user-images.githubusercontent.com/9963310/95016614-5b142b00-0654-11eb-927b-a955fd4a044d.png)

## Better Unload/Load Messages
This PR improves the usability by naming the nozzle and nozzle tip in the messages. Furthermore, the nozzle is now moved to the **Last Location** and the message shown for _both_ the unload _and_ the load operation (formerly only unload):

![Unload](https://user-images.githubusercontent.com/9963310/95016645-90207d80-0654-11eb-945c-88855120b8c6.png)

![Unload](https://user-images.githubusercontent.com/9963310/95016651-96165e80-0654-11eb-8863-cf1cc9ae24ce.png)

This now also works, if no nozzle tip was loaded to begin with. 

When these Messages are shown, the current Job or GUI action is aborted. The user needs to resume the Job or re-execute the GUI action (this in itself is not new). However, because the unload / load now shows two separate Messages, a user will have to do this one _more_ time. 

In return, the needed intervention is now very clear, with the nozzle tip and nozzle clearly named in the message. The danger of confusing nozzle tips, nozzles, or a separate unload from a combined unload/load operation is significantly reduced. 

## Usage through the Load and Unload Buttons
As a consequence, this now works with both the GUI buttons (formerly only unload worked):

![grafik](https://user-images.githubusercontent.com/9963310/95017176-0d99bd00-0658-11eb-9a17-11bbd320b6d3.png)

## Usage through the Pick Buttons
When used manually from the GUI, the pick buttons
![Pick Button](https://user-images.githubusercontent.com/9963310/95016721-1341d380-0655-11eb-858d-183ef37836bd.png)
now behave more like the JobProcessor and will now also calibrate a nozzle tip, when manually loaded. 

## Internals
The `PartsPanel` will now use the same refactored `FeederPanels.pickFeeder` function for a more job-like behavior. See also #942 .

The `FeedersPanel.pickFeeder` function now includes explicit nozzle tip calibration as in a job, to make sure calibration is done even after interruption due to manual change. 

Also changed the label of the "Change On Manual Feed?" option to "Change On Manual Pick?", as this is actually more accurate (my own mistake from #942).

Because of indentation, it is recommended to look at the diff with whitespace changes suppressed.

# Justification
See also:
https://groups.google.com/g/openpnp/c/AoED-hR5hTo/m/6gbKnic1BwAJ

# Instructions for Use
See the Description above.

# Implementation Details
1. Tested this in the NullDriver machine. From the GUI and in Jobs. Including different triggers for nozzle tip calibration. Used part incompatible nozzle tips to prompt automatic nozzle tip change both from a Job and from the GUI (using the Change on Manual Pick option).
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. Successful `mvn test` before submitting the Pull Request. 
