### PR TITLE
Feature/Advanced Motion Control  - Update 2

### DIFF
--- a/src/main/java/org/openpnp/gui/components/CameraView.java
+++ b/src/main/java/org/openpnp/gui/components/CameraView.java
@@ -1615,9 +1615,10 @@ public class CameraView extends JComponent implements CameraListener {
     private MouseWheelListener mouseWheelListener = new MouseWheelListener() {
         @Override
         public void mouseWheelMoved(MouseWheelEvent e) {
-            zoom -= e.getPreciseWheelRotation() * Math.max(zoomIncPerMouseWheelTick,
+            double zoomInc = Math.max(zoomIncPerMouseWheelTick,
                     // When best-scale is selected, we can only zoom by 1.0 or faster.
-                    renderingQuality == RenderingQuality.BestScale ? 1.0 : 0); 
+                    renderingQuality == RenderingQuality.BestScale ? 1.0 : 0);
+            zoom = (Math.round(zoom/zoomInc) - e.getPreciseWheelRotation()) * zoomInc; 
             zoom = Math.max(zoom, 1.0d);
             zoom = Math.min(zoom, 100d);
             calculateScalingData();

--- a/src/main/java/org/openpnp/machine/neoden4/NeoDen4Driver.java
+++ b/src/main/java/org/openpnp/machine/neoden4/NeoDen4Driver.java
@@ -385,7 +385,7 @@ public class NeoDen4Driver extends AbstractReferenceDriver {
     }
 
     @Override
-    public AxesLocation getMomentaryLocation(long timeout) throws Exception {
+    public AxesLocation getReportedLocation(long timeout) throws Exception {
         // TODO: if the driver can do it, please implement. 
         throw new Exception("Not supported in this driver");
     }

--- a/src/main/java/org/openpnp/machine/reference/HttpActuator.java
+++ b/src/main/java/org/openpnp/machine/reference/HttpActuator.java
@@ -47,7 +47,7 @@ public class HttpActuator extends ReferenceActuator {
     public void actuate(boolean on) throws Exception {
         Logger.debug("{}.actuate({})", getName(), on);
         if (isCoordinatedBeforeActuate()) {
-            coordinateWithMachine();
+            coordinateWithMachine(false);
         }
         // getDriver().actuate(this, on);
         URL obj = null;
@@ -84,7 +84,7 @@ public class HttpActuator extends ReferenceActuator {
         this.on = on;
 
         if (isCoordinatedAfterActuate()) {
-            coordinateWithMachine();
+            coordinateWithMachine(true);
         }
         getMachine().fireMachineHeadActivity(head);
     }

--- a/src/main/java/org/openpnp/machine/reference/ReferenceActuator.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceActuator.java
@@ -80,11 +80,11 @@ public class ReferenceActuator extends AbstractActuator implements ReferenceHead
     public void actuate(boolean on) throws Exception {
         Logger.debug("{}.actuate({})", getName(), on);
         if (isCoordinatedBeforeActuate()) {
-            coordinateWithMachine();
+            coordinateWithMachine(false);
         }
         getDriver().actuate(this, on);
         if (isCoordinatedAfterActuate()) {
-            coordinateWithMachine();
+            coordinateWithMachine(true);
         }
         getMachine().fireMachineHeadActivity(head);
     }
@@ -98,11 +98,11 @@ public class ReferenceActuator extends AbstractActuator implements ReferenceHead
     public void actuate(double value) throws Exception {
         Logger.debug("{}.actuate({})", getName(), value);
         if (isCoordinatedBeforeActuate()) {
-            coordinateWithMachine();
+            coordinateWithMachine(false);
         }
         getDriver().actuate(this, value);
         if (isCoordinatedAfterActuate()) {
-            coordinateWithMachine();
+            coordinateWithMachine(true);
         }
         getMachine().fireMachineHeadActivity(head);
     }
@@ -111,11 +111,11 @@ public class ReferenceActuator extends AbstractActuator implements ReferenceHead
     public void actuate(String value) throws Exception {
         Logger.debug("{}.actuate({})", getName(), value);
         if (isCoordinatedBeforeActuate()) {
-            coordinateWithMachine();
+            coordinateWithMachine(false);
         }
         getDriver().actuate(this, value);
         if (isCoordinatedAfterActuate()) {
-            coordinateWithMachine();
+            coordinateWithMachine(true);
         }
         getMachine().fireMachineHeadActivity(head);
     }
@@ -123,12 +123,12 @@ public class ReferenceActuator extends AbstractActuator implements ReferenceHead
     @Override
     public String read() throws Exception {
         if (isCoordinatedBeforeRead()) {
-            coordinateWithMachine();
+            coordinateWithMachine(false);
         }
         String value = getDriver().actuatorRead(this);
         Logger.debug("{}.read(): {}", getName(), value);
         if (isCoordinatedAfterActuate()) {
-            coordinateWithMachine();
+            coordinateWithMachine(true);
         }
         getMachine().fireMachineHeadActivity(head);
         return value;
@@ -137,7 +137,7 @@ public class ReferenceActuator extends AbstractActuator implements ReferenceHead
     @Override
     public String read(double parameter) throws Exception {
         if (isCoordinatedBeforeRead()) {
-            coordinateWithMachine();
+            coordinateWithMachine(false);
         }
         String value = getDriver().actuatorRead(this, parameter);
         Logger.debug("{}.readWithDouble({}): {}", getName(), parameter, value);

--- a/src/main/java/org/openpnp/machine/reference/ScriptActuator.java
+++ b/src/main/java/org/openpnp/machine/reference/ScriptActuator.java
@@ -26,26 +26,26 @@ public class ScriptActuator extends ReferenceActuator {
     @Override
     public void actuate(boolean on) throws Exception {
         if (isCoordinatedBeforeActuate()) {
-            coordinateWithMachine();
+            coordinateWithMachine(false);
         }
         Map<String, Object> globals = new HashMap<>();
         globals.put("actuateBoolean", on);
         this.execute(globals);
         if (isCoordinatedAfterActuate()) {
-            coordinateWithMachine();
+            coordinateWithMachine(true);
         }
     }
 
     @Override
     public void actuate(double value) throws Exception {
         if (isCoordinatedBeforeActuate()) {
-            coordinateWithMachine();
+            coordinateWithMachine(false);
         }
         Map<String, Object> globals = new HashMap<>();
         globals.put("actuateDouble", value);
         this.execute(globals);
         if (isCoordinatedAfterActuate()) {
-            coordinateWithMachine();
+            coordinateWithMachine(true);
         }
     }
 

--- a/src/main/java/org/openpnp/machine/reference/axis/wizards/ReferenceControllerAxisConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/axis/wizards/ReferenceControllerAxisConfigurationWizard.java
@@ -544,6 +544,17 @@ public class ReferenceControllerAxisConfigurationWizard extends AbstractAxisConf
         btnCaptureSoftLimitHigh.setVisible(!showRotationSettings);
         btnPositionSoftLimitLow.setVisible(!showRotationSettings);
         btnPositionSoftLimitHigh.setVisible(!showRotationSettings);
+
+        lblSafeZoneLow.setVisible(!showRotationSettings);
+        lblSafeZoneHigh.setVisible(!showRotationSettings);
+        safeZoneLow.setVisible(!showRotationSettings);
+        safeZoneHigh.setVisible(!showRotationSettings);
+        safeZoneLowEnabled.setVisible(!showRotationSettings);
+        safeZoneHighEnabled.setVisible(!showRotationSettings);
+        btnCaptureSafeZoneLow.setVisible(!showRotationSettings);
+        btnCaptureSafeZoneHigh.setVisible(!showRotationSettings);
+        btnPositionSafeZoneLow.setVisible(!showRotationSettings);
+        btnPositionSafeZoneHigh.setVisible(!showRotationSettings);
     }
 
     @Override

--- a/src/main/java/org/openpnp/machine/reference/driver/GcodeAsyncDriver.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/GcodeAsyncDriver.java
@@ -297,8 +297,8 @@ public class GcodeAsyncDriver extends GcodeDriver {
     public void waitForCompletion(ReferenceHeadMountable hm, 
             CompletionType completionType) throws Exception {
         waitedForCommands = true;
-        if (completionType != CompletionType.WaitForStillstandIndefinitely 
-                && !isMotionPending()) {
+        if (!(completionType.isUnconditionalCoordination() 
+                || isMotionPending())) {
             return;
         }
         // Issue the M400 in the super class.
@@ -307,7 +307,7 @@ public class GcodeAsyncDriver extends GcodeDriver {
         if (completionType.isWaitingForDrivers()) {
             // Explicitly wait for the controller's acknowledgment here. 
             // This is signaled with a position report.
-            getMomentaryLocation(
+            getReportedLocation(
                 completionType == CompletionType.WaitForStillstandIndefinitely ?
                 -1 : getTimeoutAtMachineSpeed());
         }

--- a/src/main/java/org/openpnp/machine/reference/driver/NullDriver.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/NullDriver.java
@@ -138,7 +138,7 @@ public class NullDriver extends AbstractDriver {
     }
 
     @Override
-    public AxesLocation getMomentaryLocation(long timeout) throws Exception {
+    public AxesLocation getReportedLocation(long timeout) throws Exception {
         ReferenceMachine machine = (ReferenceMachine) Configuration.get().getMachine();
         double now = NanosecondTime.getRuntimeSeconds();
         Motion motion = machine.getMotionPlanner()

--- a/src/main/java/org/openpnp/model/Motion.java
+++ b/src/main/java/org/openpnp/model/Motion.java
@@ -984,7 +984,7 @@ public class Motion {
             double t2 = i*dt;
             boolean special = (i == numSteps);
             // Snap to a any special interval.
-            while (!motionIntervals.isEmpty() && motionIntervals.first() < t2+dt) {
+            while (!motionIntervals.isEmpty() && motionIntervals.first() <= t2+dt*.5) {
                 t2 = motionIntervals.first();
                 motionIntervals.remove(t2);
                 special = true;

--- a/src/main/java/org/openpnp/spi/Driver.java
+++ b/src/main/java/org/openpnp/spi/Driver.java
@@ -93,7 +93,7 @@ import org.openpnp.spi.MotionPlanner.CompletionType;
      * @return
      * @throws Exception
      */
-    public AxesLocation getMomentaryLocation(long timeout) throws Exception;
+    public AxesLocation getReportedLocation(long timeout) throws Exception;
 
     /**
      * @return true if a motion is still assumed to be pending, i.e. waitForCompletion() has not yet been called.  

--- a/src/main/java/org/openpnp/spi/MotionPlanner.java
+++ b/src/main/java/org/openpnp/spi/MotionPlanner.java
@@ -142,18 +142,30 @@ public interface MotionPlanner extends PropertySheetHolder {
          */
         WaitForStillstand,
         
+        
         /**
-         * Wait forever.
+         * Like WaitForStillStand but the wait will also be done, if no motion is thought to be pending (used when it is though 
+         * that the machine might have moved through custom Actuator Gcode (Contract Z Probing is one example). 
+         */
+        WaitForUnconditionalCoordination,
+        
+        /**
+         * Like WaitForFullCoordination but wait "forever".
          */
         WaitForStillstandIndefinitely;
 
         public boolean isEnforcingStillstand() {
-            return isWaitingForDrivers() || this == CommandStillstand;
+            return this.ordinal() >= CommandStillstand.ordinal();
         }
 
         public boolean isWaitingForDrivers() {
-            return this == WaitForStillstand || this == WaitForStillstandIndefinitely;
+            return this.ordinal() >= WaitForStillstand.ordinal();
         }
+
+        public boolean isUnconditionalCoordination() {
+            return this.ordinal() >= WaitForUnconditionalCoordination.ordinal();
+        }
+
     }
 
     /**

--- a/src/main/java/org/openpnp/spi/base/AbstractActuator.java
+++ b/src/main/java/org/openpnp/spi/base/AbstractActuator.java
@@ -100,14 +100,17 @@ public abstract class AbstractActuator extends AbstractHeadMountable implements 
         return null;
     }
 
-    protected void coordinateWithMachine() throws Exception {
-        Configuration.get().getMachine().getMotionPlanner().waitForCompletion(null, CompletionType.WaitForStillstand);
+    protected void coordinateWithMachine(boolean unconditional) throws Exception {
+        Configuration.get().getMachine().getMotionPlanner()
+        .waitForCompletion(null, unconditional ? 
+                CompletionType.WaitForUnconditionalCoordination
+                : CompletionType.WaitForStillstand);
     }
 
     @Override
     public String read() throws Exception {
         if (isCoordinatedBeforeRead()) {
-            coordinateWithMachine();
+            coordinateWithMachine(false);
         }
         return null;
     }

--- a/src/test/java/org/openpnp/machine/reference/driver/test/TestDriver.java
+++ b/src/test/java/org/openpnp/machine/reference/driver/test/TestDriver.java
@@ -42,8 +42,8 @@ public class TestDriver extends AbstractDriver implements Driver {
     }
 
     @Override
-    public AxesLocation getMomentaryLocation(long timeout) throws Exception {
-        return delegate.getMomentaryLocation(-1);
+    public AxesLocation getReportedLocation(long timeout) throws Exception {
+        return delegate.getReportedLocation(-1);
     }
 
     @Override
@@ -94,7 +94,7 @@ public class TestDriver extends AbstractDriver implements Driver {
         }
  
         @Override
-        public AxesLocation getMomentaryLocation(long timeout) throws Exception {
+        public AxesLocation getReportedLocation(long timeout) throws Exception {
             return null;
         }
 


### PR DESCRIPTION
# Description
These are some refinements and bugfixes for #1061, #1065.

* Extensive tests on the machine.
* Contact Z-Probing remodeled for custom Gcode M114 or GcodeAsyncDriver's reported Locations
* Bug-fix in interpolation when special interval snapping would exactly match the next interval.
* Correct graphical rendition of "dithering" in motion interpolation, i.e. when one axis is moving so little that some of its interpolation steps collapse to zero. See the discussion [in Section "Interpolation Step Feed-rate Issue" in the blog](https://makr.zone/smoothieware-new-firmware-for-pnp/500/). 

![grafik](https://user-images.githubusercontent.com/9963310/96366662-456d2e00-1149-11eb-8488-01af14a58f4a.png)


# Justification
Best possible testing version. ;-)

# Instructions for Use
Download the testing version

- https://openpnp.org/test-downloads/

Follow the instructions of the Wiki documentation:

- https://github.com/openpnp/openpnp/wiki/Advanced-Motion-Control
- https://github.com/openpnp/openpnp/wiki/GcodeAsyncDriver
- https://github.com/openpnp/openpnp/wiki/Motion-Planner
- https://github.com/openpnp/openpnp/wiki/Machine-Axes
- https://github.com/openpnp/openpnp/wiki/Backlash-Compensation
- https://github.com/openpnp/openpnp/wiki/Transformed-Axes
- https://github.com/openpnp/openpnp/wiki/Linear-Transformed-Axes
- https://github.com/openpnp/openpnp/wiki/Mapping-Axes

# Implementation Details
1. Extensive tests on the machine. Contact probing. Runout calibration. Provoking "dithering".
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. Driver `getMomentaryLocation()` in `org.openpnp.spi` renamed to `getReportedLocation()` as this is now a more accurate name.
4. Did run `mvn test` before submitting the Pull Request. 
