### PR TITLE
a feeder in feeder's list is grayed out if no active placement uses it.

### DIFF
--- a/src/main/java/org/openpnp/gui/JobPanel.java
+++ b/src/main/java/org/openpnp/gui/JobPanel.java
@@ -784,6 +784,7 @@ public class JobPanel extends JPanel {
                     existingBoard.addSolderPastePad(pad);
                 }
                 jobPlacementsPanel.setBoardLocation(getSelection());
+                frame.getFeedersTab().updateView();
             }
         }
         catch (Exception e) {
@@ -822,6 +823,7 @@ public class JobPanel extends JPanel {
                 Job job = configuration.loadJob(file);
                 setJob(job);
                 addRecentJob(file);
+                frame.getFeedersTab().updateView();
             }
             catch (Exception e) {
                 e.printStackTrace();
@@ -1538,6 +1540,7 @@ public class JobPanel extends JPanel {
                 Job job = configuration.loadJob(file);
                 setJob(job);
                 addRecentJob(file);
+                frame.getFeedersTab().updateView();
             }
             catch (Exception e) {
                 e.printStackTrace();


### PR DESCRIPTION
Description
A feeder in feeder's list is grayed out if no active placement uses it.

Justification
I have 30 feeders on my machine, all full.
When I start a new job, I need to add new parts. Therefore, I need to empty one feeder and of course one that will not
be used by the new job. Today there's no fast way to find unused feeders.

Instructions for Use
Open new session.
go to feeders panels, there are all grayed out.
open a job -> feeders that are in used by the job are white.
Check uncheck placements / boardslocation, see the result in feeder's panel

This is documentation for a user, not for a developer.

Implementation Details
How did you test the change? Be descriptive. Untested code will not be accepted.
manual gui tests.

Did you follow the coding style?
I think.

If you made changes in the org.openpnp.spi or org.openpnp.model packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing.
No

Be sure to run mvn test before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted.
Does not run on my machine, "java.lang.Exception: Error while reading machine.xml (null)" . gitHub will do it for me...