### PR TITLE
set list length of combo boxes to 20 items.

### DIFF
--- a/src/main/java/org/openpnp/gui/JobPlacementsPanel.java
+++ b/src/main/java/org/openpnp/gui/JobPlacementsPanel.java
@@ -114,6 +114,7 @@ public class JobPlacementsPanel extends JPanel {
         captureAndPositionActionGroup.setEnabled(false);
 
         JComboBox<PartsComboBoxModel> partsComboBox = new JComboBox(new PartsComboBoxModel());
+        partsComboBox.setMaximumRowCount(20);
         partsComboBox.setRenderer(new IdentifiableListCellRenderer<Part>());
         JComboBox<Side> sidesComboBox = new JComboBox(Side.values());
         // Note we don't use Type.values() here because there are a couple Types that are only

--- a/src/main/java/org/openpnp/gui/MachineControlsPanel.java
+++ b/src/main/java/org/openpnp/gui/MachineControlsPanel.java
@@ -224,6 +224,7 @@ public class MachineControlsPanel extends JPanel {
                 new RowSpec[] {FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,}));
 
         comboBoxHeadMountable = new JComboBox();
+        comboBoxHeadMountable.setMaximumRowCount(20);
         comboBoxHeadMountable.addActionListener(new ActionListener() {
             @Override
             public void actionPerformed(ActionEvent e) {

--- a/src/main/java/org/openpnp/gui/PartsPanel.java
+++ b/src/main/java/org/openpnp/gui/PartsPanel.java
@@ -147,6 +147,7 @@ public class PartsPanel extends JPanel implements WizardContainer {
         searchTextField.setColumns(15);
 
         JComboBox packagesCombo = new JComboBox(new PackagesComboBoxModel());
+        packagesCombo.setMaximumRowCount(20);
         packagesCombo.setRenderer(new IdentifiableListCellRenderer<org.openpnp.model.Package>());
 
         JSplitPane splitPane = new JSplitPane();

--- a/src/main/java/org/openpnp/machine/reference/feeder/wizards/AbstractReferenceFeederConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/wizards/AbstractReferenceFeederConfigurationWizard.java
@@ -105,6 +105,7 @@ public abstract class AbstractReferenceFeederConfigurationWizard
                 FormSpecs.DEFAULT_ROWSPEC,}));
 
         comboBoxPart = new JComboBox();
+        comboBoxPart.setMaximumRowCount(20);
         try {
             comboBoxPart.setModel(new PartsComboBoxModel());
         }


### PR DESCRIPTION
# Description
Added more lines on parts combo boxes.

# Justification
It's easier to select with a bigger list.

# Instructions for Use
open a job or a leverFeeder
open the part combobox.

I would have been pleased to use a constant but I did not find any clue on where to put it.

