### PR TITLE
Feature / Advanced Motion Control - Update 5

### DIFF
--- a/src/main/java/org/openpnp/gui/components/SimpleGraphView.java
+++ b/src/main/java/org/openpnp/gui/components/SimpleGraphView.java
@@ -52,6 +52,8 @@ public class SimpleGraphView extends JComponent implements MouseMotionListener, 
     private Integer xMouse;
     private Integer yMouse;
     private Double selectedX;
+    private int displayCycle = -1;//all displayed
+    private int displayCycleMask;
 
     public SimpleGraphView() {
         addMouseMotionListener(this);
@@ -67,6 +69,17 @@ public class SimpleGraphView extends JComponent implements MouseMotionListener, 
     }
     public void setGraph(SimpleGraph graph) {
         this.graph = graph;
+        displayCycleMask = 0;
+        if (graph != null) {
+            for (DataScale dataScale : graph.getDataScales()) {
+                for (DataRow dataRow : dataScale.getDataRows()) {
+                    if (dataRow.size() >= 2) {
+                        displayCycleMask |= dataRow.getDisplayCycleMask();
+                    }
+                }
+            }
+        }
+        displayCycle = displayCycleMask;
         repaint();
     }
 
@@ -101,6 +114,7 @@ public class SimpleGraphView extends JComponent implements MouseMotionListener, 
     public void paintComponent(Graphics g) {
         super.paintComponent(g);
         Graphics2D g2d = (Graphics2D) g;
+        g2d.setRenderingHint(RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_QUALITY);
         g2d.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
 
         Font font = getFont();
@@ -115,6 +129,12 @@ public class SimpleGraphView extends JComponent implements MouseMotionListener, 
             for (DataScale dataScale : graph.getDataScales()) {
                 Point2D.Double min = graph.getMinimum(dataScale);
                 Point2D.Double max = graph.getMaximum(dataScale);
+                if (dataScale.isSymmetricIfSigned()) {
+                    if (min != null && max != null && min.y < 0.0 && max.y > 0) {
+                        max.y = Math.max(max.y, -min.y);
+                        min.y = Math.min(-max.y, min.y);
+                    }
+                }
                 if (min != null && max != null && (max.y-min.y) > 0.0 && (max.x-min.x) > 0.0) {
                     double xOrigin = (w-1)*graph.getRelativePaddingLeft();
                     double xScale = (w-1)*(1.0-graph.getRelativePaddingLeft()-graph.getRelativePaddingRight())/(max.x-min.x);
@@ -219,25 +239,59 @@ public class SimpleGraphView extends JComponent implements MouseMotionListener, 
                             }
                         }
                     }
+                    // Draw the actual curves.
                     for (DataRow dataRow : dataScale.getDataRows()) {
-                        Set<Double> xAxis = dataRow.getXAxis();
-                        if (xAxis != null) {
-                            double y0 = Double.NaN;
-                            double x0 = Double.NaN;
-                            // Draw the actual curves.
-                            g2d.setColor(dataRow.getColor());
-                            for (double x : xAxis) {
-                                double y = dataRow.getDataPoint(x);
-                                if (!Double.isNaN(x0)) {
-                                    g2d.drawLine((int)(xOrigin+(x0-min.x)*xScale), (int)(yOrigin-(y0-min.y)*yScale), 
-                                            (int)(xOrigin+(x-min.x)*xScale), (int)(yOrigin-(y-min.y)*yScale));
+                        if ((dataRow.getDisplayCycleMask() & displayCycle) != 0) {
+                            Set<Double> xAxis = dataRow.getXAxis();
+                            if (xAxis != null) {
+                                // Convert to pixel coordinates
+                                int size = dataRow.size();
+                                if (size >= 2) {
+                                    double [] xfPlot = new double [size]; 
+                                    double [] yfPlot = new double [size];
+                                    int i = 0;
+                                    for (double x : xAxis) {
+                                        double y = dataRow.getDataPoint(x);
+                                        xfPlot[i] = xOrigin+(x-min.x)*xScale; 
+                                        yfPlot[i] = yOrigin-(y-min.y)*yScale;
+                                        i++;
+                                    }
+                                    // Analyze the curve and only plot relevant curve points.
+                                    int [] xPlot = new int [size]; 
+                                    int [] yPlot = new int [size];
+                                    int s = 0;
+                                    // Always add first point.
+                                    xPlot[s] = (int) xfPlot[0];
+                                    yPlot[s] = (int) yfPlot[0];
+                                    s++;
+                                    for (i = 1; i < size-1; i++) {
+                                        double dx0 = xfPlot[i]-xfPlot[i-1];
+                                        double dy0 = yfPlot[i]-yfPlot[i-1];
+                                        double dx1 = xfPlot[i+1]-xfPlot[i];
+                                        double dy1 = yfPlot[i+1]-yfPlot[i];
+                                        double n0 = Math.sqrt(dx0*dx0+dy0*dy0); 
+                                        double n1 = Math.sqrt(dx1*dx1+dy1*dy1); 
+                                        double cosine = ((dx0*dx1) + (dy0*dy1))/n0/n1;
+                                        if (cosine < 0.99 
+                                                || Math.abs(xfPlot[i]-xPlot[s-1]) > 12 || Math.abs(yfPlot[i]-yPlot[s-1]) > 1.5) {
+                                            // Corner point or relevant change.
+                                            xPlot[s] = (int) xfPlot[i];
+                                            yPlot[s] = (int) yfPlot[i];
+                                            s++;
+                                        }
+                                    }
+                                    // Always add last point.
+                                    xPlot[s] = (int) xfPlot[size-1];
+                                    yPlot[s] = (int) yfPlot[size-1];
+                                    s++;
+                                    // Draw as polyline.
+                                    g2d.setColor(dataRow.getColor());
+                                    g2d.drawPolyline(xPlot, yPlot, s);
+                                    if (selectedX != null) {
+                                        drawYIndicator(g2d, dfm, fontAscent, w, min, max, yOrigin, yScale, yUnit, 
+                                                dataRow.getInterpolated(selectedX), dataRow.getColor());
+                                    }
                                 }
-                                x0 = x;
-                                y0 = y;
-                            }
-                            if (selectedX != null) {
-                                drawYIndicator(g2d, dfm, fontAscent, w, min, max, yOrigin, yScale, yUnit, 
-                                        dataRow.getInterpolated(selectedX), dataRow.getColor());
                             }
                         }
                     }
@@ -289,6 +343,13 @@ public class SimpleGraphView extends JComponent implements MouseMotionListener, 
     }
     @Override
     public void mouseClicked(MouseEvent e) {
+        if (displayCycleMask != 0) {
+            displayCycle--;
+            while ((displayCycle & displayCycleMask) == 0) {
+                displayCycle--;
+            }
+        }
+        repaint();
     }
     @Override
     public void mousePressed(MouseEvent e) {

--- a/src/main/java/org/openpnp/machine/reference/driver/wizards/GcodeAsyncDriverSettings.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/wizards/GcodeAsyncDriverSettings.java
@@ -19,6 +19,10 @@ import com.jgoodies.forms.layout.ColumnSpec;
 import com.jgoodies.forms.layout.FormLayout;
 import com.jgoodies.forms.layout.FormSpecs;
 import com.jgoodies.forms.layout.RowSpec;
+import java.awt.Component;
+import javax.swing.Box;
+import java.awt.event.ItemListener;
+import java.awt.event.ItemEvent;
 
 public class GcodeAsyncDriverSettings extends AbstractConfigurationWizard {
     private final GcodeDriver driver;
@@ -28,6 +32,7 @@ public class GcodeAsyncDriverSettings extends AbstractConfigurationWizard {
     private JTextField interpolationMaxSteps;
     private JTextField junctionDeviation;
     private JTextField interpolationJerkSteps;
+    private JCheckBox reportedLocationConfirmation;
 
     public GcodeAsyncDriverSettings(GcodeAsyncDriver driver) {
         this.driver = driver;
@@ -45,6 +50,8 @@ public class GcodeAsyncDriverSettings extends AbstractConfigurationWizard {
                 FormSpecs.RELATED_GAP_COLSPEC,
                 FormSpecs.DEFAULT_COLSPEC,},
             new RowSpec[] {
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
                 FormSpecs.RELATED_GAP_ROWSPEC,
                 FormSpecs.DEFAULT_ROWSPEC,}));
         JPanel interpolationPanel = new JPanel();
@@ -126,7 +133,28 @@ public class GcodeAsyncDriverSettings extends AbstractConfigurationWizard {
         settingsPanel.add(lblConfirmationFlowControl, "2, 2, right, default");
 
         confirmationFlowControl = new JCheckBox("");
+        confirmationFlowControl.addItemListener(new ItemListener() {
+            public void itemStateChanged(ItemEvent e) {
+                if (!confirmationFlowControl.isSelected()) {
+                    reportedLocationConfirmation.setSelected(true);
+                }
+            }
+        });
         settingsPanel.add(confirmationFlowControl, "4, 2");
+
+        JLabel lblRequestLocation = new JLabel("Location Confirmation?");
+        lblRequestLocation.setToolTipText("<html>Request the controller to report the location after a motion has completed.<br/>\r\nIf it has changed, the internal OpenPnP location is updated. The location report is <br/>\r\nalso used to synchronize OpenPnP when confirmation flow control is disabled.<br/>\r\nAt least on of the two options need to be enabled. Location Confirmation allows<br/>\r\nmore extensive asynchronous operation. \r\n</html>\r\n");
+        settingsPanel.add(lblRequestLocation, "2, 4, right, default");
+
+        reportedLocationConfirmation = new JCheckBox("");
+        reportedLocationConfirmation.addItemListener(new ItemListener() {
+            public void itemStateChanged(ItemEvent e) {
+                if (!reportedLocationConfirmation.isSelected()) {
+                    confirmationFlowControl.setSelected(true);
+                }
+            }
+        });
+        settingsPanel.add(reportedLocationConfirmation, "4, 4");
 
     }
 
@@ -138,6 +166,7 @@ public class GcodeAsyncDriverSettings extends AbstractConfigurationWizard {
         LengthConverter lengthConverter = new LengthConverter();
 
         addWrappedBinding(driver, "confirmationFlowControl", confirmationFlowControl, "selected");
+        addWrappedBinding(driver, "reportedLocationConfirmation", reportedLocationConfirmation, "selected");
         addWrappedBinding(driver, "interpolationMaxSteps", interpolationMaxSteps, "text", intConverter);
         addWrappedBinding(driver, "interpolationJerkSteps", interpolationJerkSteps, "text", intConverter);
         addWrappedBinding(driver, "interpolationTimeStep", interpolationTimeStep, "text", doubleConverterFine);

--- a/src/main/java/org/openpnp/machine/reference/driver/wizards/GcodeDriverSettings.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/wizards/GcodeDriverSettings.java
@@ -52,6 +52,7 @@ import javax.swing.JButton;
 import java.awt.SystemColor;
 import java.awt.event.ActionListener;
 import java.awt.Font;
+import javax.swing.SwingConstants;
 
 public class GcodeDriverSettings extends AbstractConfigurationWizard {
     private final GcodeDriver driver;
@@ -91,7 +92,11 @@ public class GcodeDriverSettings extends AbstractConfigurationWizard {
                 FormSpecs.RELATED_GAP_ROWSPEC,
                 FormSpecs.DEFAULT_ROWSPEC,
                 FormSpecs.RELATED_GAP_ROWSPEC,
-                RowSpec.decode("default:grow"),}));
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,}));
         
         JLabel lblMotionControlType = new JLabel("Motion Control Type");
         lblMotionControlType.setToolTipText("<html>\r\n<p>Determines how the OpenPnP MotionPlanner will plan the motion and how it will talk <br/>\r\nto the controller:</p>\r\n<ul>\r\n\r\n<li><strong>ToolpathFeedRate:</strong><br/>\r\nApply the nominal driver feed-rate limit multiplied by the speed factor to the tool-path.<br/>\r\nThe driver feed-rate must be specified. No acceleration control is applied.</li>\r\n\r\n<li><strong>EuclideanAxisLimits:</strong><br/>\r\nApply axis feed-rate, acceleration and jerk limits multiplied by the proper speed factors. <br/>\r\nThe Euclidean Metric is calculated to allow the machine to run faster in a diagonal.<br/>\r\nOpenPnP only sets the speed factor maximum, ramping up and down the speed is <br/>\r\nentirely left to the controller. </li>  \r\n\r\n<li><strong>ConstantAcceleration:</strong><br/>\r\nApply motion planning assuming a controller with constant acceleration motion control. </li>\r\n\r\n<li><strong>ModeratedConstantAcceleration:</strong><br/>\r\nApply motion planning assuming a controller with constant acceleration motion control but<br/>\r\nmoderate the acceleration and velocity to resemble those of 3rd order control, resulting<br/>\r\nin a move that takes the same amount of time and has similar average acceleration. <br/>\r\nThis will already reduce vibrations a bit.</li>\r\n\r\n<li><strong>SimpleSCurve:</strong><br/>\r\nApply motion planning assuming a controller with simplified S-Curve motion control. <br/>\r\nSimplified S-Curves have no constant acceleration phase, only jerk phases (e.g. TinyG, Marlin).</li>\r\n\r\n<li><strong>Simulated3rdOrderControl:</strong><br/>\r\nApply motion planning assuming a controller with constant acceleration motion control but<br/>\r\nsimulating 3rd order control with time step interpolation. </li> \r\n\r\n<li><strong>Full3rdOrderControl:</strong><br/>\r\nApply motion planning assuming a controller with full 3rd order motion control.</li> \r\n\r\n</html>");
@@ -193,16 +198,24 @@ public class GcodeDriverSettings extends AbstractConfigurationWizard {
         
         detectedFirmware = new JTextArea();
         detectedFirmware.setForeground(SystemColor.textInactiveText);
+        detectedFirmware.setBackground(SystemColor.control);
         detectedFirmware.setWrapStyleWord(true);
         detectedFirmware.setLineWrap(true);
         detectedFirmware.setEditable(false);
         detectedFirmware.setFont(new Font("Dialog", Font.PLAIN, 11));
-        detectedFirmware.setBackground(SystemColor.control);
-        detectedFirmware.setEditable(false);
-        settingsPanel.add(detectedFirmware, "4, 16, 7, 3, fill, fill");
+        settingsPanel.add(detectedFirmware, "4, 16, 7, 5, fill, fill");
         
         JLabel label = new JLabel(" ");
         settingsPanel.add(label, "2, 18");
+        
+        reportedAxes = new JTextArea();
+        reportedAxes.setForeground(SystemColor.textInactiveText);
+        reportedAxes.setBackground(SystemColor.control);
+        reportedAxes.setWrapStyleWord(true);
+        reportedAxes.setLineWrap(true);
+        reportedAxes.setEditable(false);
+        reportedAxes.setFont(new Font("Dialog", Font.PLAIN, 11));
+        settingsPanel.add(reportedAxes, "4, 22, 7, 1, fill, fill");
     }
 
     @Override
@@ -224,6 +237,7 @@ public class GcodeDriverSettings extends AbstractConfigurationWizard {
         addWrappedBinding(driver, "usingLetterVariables", letterVariables, "selected");
         addWrappedBinding(driver, "loggingGcode", loggingGcode, "selected");
         addWrappedBinding(driver, "detectedFirmware", detectedFirmware, "text");
+        addWrappedBinding(driver, "reportedAxes", reportedAxes, "text");
         
         ComponentDecorators.decorateWithAutoSelect(maxFeedRateTf);
         ComponentDecorators.decorateWithAutoSelect(commandTimeoutTf);
@@ -372,6 +386,8 @@ public class GcodeDriverSettings extends AbstractConfigurationWizard {
     private JCheckBox loggingGcode;
 
     private JTextArea detectedFirmware;
+
+    private JTextArea reportedAxes;
 
     static class HeadMountableItem {
         private HeadMountable hm;

--- a/src/main/java/org/openpnp/machine/reference/driver/wizards/ReferenceAdvancedMotionPlannerConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/wizards/ReferenceAdvancedMotionPlannerConfigurationWizard.java
@@ -52,6 +52,12 @@ import com.jgoodies.forms.layout.FormSpecs;
 import com.jgoodies.forms.layout.RowSpec;
 import javax.swing.UIManager;
 import java.awt.Color;
+import javax.swing.SwingConstants;
+import org.jdesktop.beansbinding.BeanProperty;
+import org.jdesktop.beansbinding.AutoBinding;
+import org.jdesktop.beansbinding.Bindings;
+import java.awt.event.ItemListener;
+import java.awt.event.ItemEvent;
 
 @SuppressWarnings("serial")
 public class ReferenceAdvancedMotionPlannerConfigurationWizard extends AbstractConfigurationWizard {
@@ -100,6 +106,20 @@ public class ReferenceAdvancedMotionPlannerConfigurationWizard extends AbstractC
     private JLabel lblRetime;
     private JCheckBox interpolationRetiming;
     private JPanel panel_1;
+    private JCheckBox startLocationEnabled;
+    private JCheckBox mid1LocationEnabled;
+    private JCheckBox mid2LocationEnabled;
+    private JCheckBox endLocationEnabled;
+    private JCheckBox toMid1SafeZ;
+    private JLabel lblSafeZ;
+    private JLabel lblSafeZ_1;
+    private JLabel lblSafeZ_2;
+    private JCheckBox toMid2SafeZ;
+    private JCheckBox toEndSafeZ;
+    private JLabel lblEnabled;
+    private JLabel lblCaution1;
+    private JLabel lblCaution2;
+    private JLabel lblCaution3;
 
 
     public ReferenceAdvancedMotionPlannerConfigurationWizard(ReferenceAdvancedMotionPlanner motionPlanner) {
@@ -165,7 +185,9 @@ public class ReferenceAdvancedMotionPlannerConfigurationWizard extends AbstractC
                 FormSpecs.RELATED_GAP_COLSPEC,
                 FormSpecs.DEFAULT_COLSPEC,
                 FormSpecs.RELATED_GAP_COLSPEC,
-                FormSpecs.DEFAULT_COLSPEC,
+                ColumnSpec.decode("max(25dlu;default)"),
+                FormSpecs.RELATED_GAP_COLSPEC,
+                ColumnSpec.decode("max(25dlu;default)"),
                 FormSpecs.RELATED_GAP_COLSPEC,
                 FormSpecs.DEFAULT_COLSPEC,
                 FormSpecs.RELATED_GAP_COLSPEC,
@@ -174,17 +196,30 @@ public class ReferenceAdvancedMotionPlannerConfigurationWizard extends AbstractC
                 FormSpecs.DEFAULT_COLSPEC,
                 FormSpecs.RELATED_GAP_COLSPEC,
                 FormSpecs.DEFAULT_COLSPEC,},
-                new RowSpec[] {
-                        FormSpecs.RELATED_GAP_ROWSPEC,
-                        FormSpecs.DEFAULT_ROWSPEC,
-                        FormSpecs.RELATED_GAP_ROWSPEC,
-                        FormSpecs.DEFAULT_ROWSPEC,
-                        FormSpecs.DEFAULT_ROWSPEC,
-                        FormSpecs.DEFAULT_ROWSPEC,
-                        FormSpecs.DEFAULT_ROWSPEC,
-                        FormSpecs.DEFAULT_ROWSPEC,
-                        FormSpecs.DEFAULT_ROWSPEC,
-                        FormSpecs.DEFAULT_ROWSPEC,}));
+            new RowSpec[] {
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.LINE_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.LINE_GAP_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.LINE_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.UNRELATED_GAP_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,}));
 
         Machine myMachine = null;
         try {
@@ -193,137 +228,197 @@ public class ReferenceAdvancedMotionPlannerConfigurationWizard extends AbstractC
         catch (Exception e){
             Logger.error(e, "Cannot determine Name of machine.");
         }
+        
+        lblEnabled = new JLabel("Enabled?");
+        panel.add(lblEnabled, "4, 2");
 
         lblX = new JLabel("X");
-        panel.add(lblX, "4, 2, center, default");
+        panel.add(lblX, "6, 2, center, default");
 
         lblY = new JLabel("Y");
-        panel.add(lblY, "6, 2, center, default");
+        panel.add(lblY, "8, 2, center, default");
 
         lblZ = new JLabel("Z");
-        panel.add(lblZ, "8, 2, center, default");
+        panel.add(lblZ, "10, 2, center, default");
 
         lblRotation = new JLabel("Rotation");
-        panel.add(lblRotation, "10, 2, center, default");
+        panel.add(lblRotation, "12, 2, center, default");
+        
+        startLocationEnabled = new JCheckBox("");
+        panel.add(startLocationEnabled, "4, 4, center, bottom");
 
         textFieldStartRotation = new JTextField();
-        panel.add(textFieldStartRotation, "10, 4, fill, default");
+        panel.add(textFieldStartRotation, "12, 4, fill, default");
         textFieldStartRotation.setColumns(10);
-
-        lblSpeed1 = new JLabel("Speed 1 ↔ 2");
-        panel.add(lblSpeed1, "8, 5, right, default");
-
-        toMid1Speed = new JTextField();
-        toMid1Speed.setToolTipText("Speed between First location and Second location");
-        panel.add(toMid1Speed, "10, 5, fill, default");
-        toMid1Speed.setColumns(5);
+                
+                        lblSpeed1 = new JLabel("Speed 1 ↔ 2");
+                        panel.add(lblSpeed1, "2, 6, right, default");
+        
+                toMid1Speed = new JTextField();
+                toMid1Speed.setToolTipText("Speed between First location and Second location");
+                panel.add(toMid1Speed, "4, 6, fill, default");
+                toMid1Speed.setColumns(5);
+        
+        lblSafeZ = new JLabel("Safe Z?");
+        panel.add(lblSafeZ, "8, 6, right, default");
+        
+        toMid1SafeZ = new JCheckBox("");
+        toMid1SafeZ.addItemListener(new ItemListener() {
+            public void itemStateChanged(ItemEvent e) {
+                lblCaution1.setVisible(!toMid1SafeZ.isSelected());
+            }
+        });
+        panel.add(toMid1SafeZ, "10, 6, center, default");
+        
+        lblCaution1 = new JLabel("CAUTION!");
+        lblCaution1.setForeground(Color.RED);
+        panel.add(lblCaution1, "12, 6");
+        
+        mid1LocationEnabled = new JCheckBox("");
+        panel.add(mid1LocationEnabled, "4, 8, center, default");
 
         textFieldMidRotation1 = new JTextField();
-        panel.add(textFieldMidRotation1, "10, 6, fill, default");
+        panel.add(textFieldMidRotation1, "12, 8, fill, default");
         textFieldMidRotation1.setColumns(10);
-
-        lblSpeed2 = new JLabel("Speed 2 ↔ 3");
-        panel.add(lblSpeed2, "8, 7, right, default");
-
-        toMid2Speed = new JTextField();
-        toMid2Speed.setToolTipText("Speed between Second location and Third location");
-        toMid2Speed.setColumns(5);
-        panel.add(toMid2Speed, "10, 7, fill, default");
+                
+                        lblSpeed2 = new JLabel("Speed 2 ↔ 3");
+                        panel.add(lblSpeed2, "2, 10, right, default");
+        
+                toMid2Speed = new JTextField();
+                toMid2Speed.setToolTipText("Speed between Second location and Third location");
+                toMid2Speed.setColumns(5);
+                panel.add(toMid2Speed, "4, 10, fill, default");
+        
+        lblSafeZ_1 = new JLabel("Safe Z?");
+        panel.add(lblSafeZ_1, "8, 10, right, default");
+        
+        toMid2SafeZ = new JCheckBox("");
+        toMid2SafeZ.addItemListener(new ItemListener() {
+            public void itemStateChanged(ItemEvent e) {
+                lblCaution2.setVisible(!toMid2SafeZ.isSelected());
+            }
+        });
+        panel.add(toMid2SafeZ, "10, 10, center, default");
+        
+        lblCaution2 = new JLabel("CAUTION!");
+        lblCaution2.setForeground(Color.RED);
+        panel.add(lblCaution2, "12, 10");
+        
+        mid2LocationEnabled = new JCheckBox("");
+        panel.add(mid2LocationEnabled, "4, 12, center, default");
 
         textFieldMidRotation2 = new JTextField();
-        panel.add(textFieldMidRotation2, "10, 8, fill, default");
+        panel.add(textFieldMidRotation2, "12, 12, fill, default");
         textFieldMidRotation2.setColumns(10);
-
-        lblSpeedEnd = new JLabel("Speed 3 ↔ 4");
-        panel.add(lblSpeedEnd, "8, 9, right, default");
 
         lblStartLocation = new JLabel("First Location");
         panel.add(lblStartLocation, "2, 4, right, default");
 
         textFieldStartX = new JTextField();
-        panel.add(textFieldStartX, "4, 4, fill, default");
+        panel.add(textFieldStartX, "6, 4, fill, default");
         textFieldStartX.setColumns(10);
 
         textFieldStartY = new JTextField();
-        panel.add(textFieldStartY, "6, 4, fill, default");
+        panel.add(textFieldStartY, "8, 4, fill, default");
         textFieldStartY.setColumns(10);
 
         textFieldStartZ = new JTextField();
-        panel.add(textFieldStartZ, "8, 4, fill, default");
+        panel.add(textFieldStartZ, "10, 4, fill, default");
         textFieldStartZ.setColumns(10);
 
         startLocationButtonsPanel = new LocationButtonsPanel(textFieldStartX,
                 textFieldStartY, textFieldStartZ, (JTextField) null);
         startLocationButtonsPanel.setShowPositionToolNoSafeZ(true);
-        panel.add(startLocationButtonsPanel, "12, 4, fill, default");
+        panel.add(startLocationButtonsPanel, "14, 3, 1, 3, fill, default");
 
         lblMiddleLocation1 = new JLabel("Second Location");
-        panel.add(lblMiddleLocation1, "2, 6, right, default");
+        panel.add(lblMiddleLocation1, "2, 8, right, default");
 
         textFieldMidX1 = new JTextField();
-        panel.add(textFieldMidX1, "4, 6, fill, default");
+        panel.add(textFieldMidX1, "6, 8, fill, default");
         textFieldMidX1.setColumns(10);
 
         textFieldMidY1 = new JTextField();
-        panel.add(textFieldMidY1, "6, 6, fill, default");
+        panel.add(textFieldMidY1, "8, 8, fill, default");
         textFieldMidY1.setColumns(10);
 
         textFieldMidZ1 = new JTextField();
-        panel.add(textFieldMidZ1, "8, 6, fill, default");
+        panel.add(textFieldMidZ1, "10, 8, fill, default");
         textFieldMidZ1.setColumns(10);
 
         midLocation1ButtonsPanel = new LocationButtonsPanel(textFieldMidX1,
                 textFieldMidY1, textFieldMidZ1, (JTextField) null);
         midLocation1ButtonsPanel.setShowPositionToolNoSafeZ(true);
-        panel.add(midLocation1ButtonsPanel, "12, 6, fill, default");
+        panel.add(midLocation1ButtonsPanel, "14, 7, 1, 3, fill, default");
 
         lblMiddleLocation2 = new JLabel("Third Location");
-        panel.add(lblMiddleLocation2, "2, 8, right, default");
+        panel.add(lblMiddleLocation2, "2, 12, right, default");
 
         textFieldMidX2 = new JTextField();
         textFieldMidX2.setColumns(10);
-        panel.add(textFieldMidX2, "4, 8, fill, default");
+        panel.add(textFieldMidX2, "6, 12, fill, default");
 
         textFieldMidY2 = new JTextField();
         textFieldMidY2.setColumns(10);
-        panel.add(textFieldMidY2, "6, 8, fill, default");
+        panel.add(textFieldMidY2, "8, 12, fill, default");
 
         textFieldMidZ2 = new JTextField();
         textFieldMidZ2.setColumns(10);
-        panel.add(textFieldMidZ2, "8, 8, fill, default");
+        panel.add(textFieldMidZ2, "10, 12, fill, default");
 
         midLocation2ButtonsPanel = new LocationButtonsPanel(textFieldMidX2, textFieldMidY2, textFieldMidZ2, (JTextField) null);
         midLocation2ButtonsPanel.setShowPositionToolNoSafeZ(true);
-        panel.add(midLocation2ButtonsPanel, "12, 8, fill, default");
-
-        toEndSpeed = new JTextField();
-        toEndSpeed.setToolTipText("Speed between Third location and Last location");
-        toEndSpeed.setColumns(5);
-        panel.add(toEndSpeed, "10, 9, fill, default");
+        panel.add(midLocation2ButtonsPanel, "14, 11, 1, 3, fill, default");
+                
+                        lblSpeedEnd = new JLabel("Speed 3 ↔ 4");
+                        panel.add(lblSpeedEnd, "2, 15, right, default");
+        
+                toEndSpeed = new JTextField();
+                toEndSpeed.setToolTipText("Speed between Third location and Last location");
+                toEndSpeed.setColumns(5);
+                panel.add(toEndSpeed, "4, 15, fill, default");
+        
+        lblSafeZ_2 = new JLabel("Safe Z?");
+        panel.add(lblSafeZ_2, "8, 15, right, default");
+        
+        toEndSafeZ = new JCheckBox("");
+        toEndSafeZ.addItemListener(new ItemListener() {
+            public void itemStateChanged(ItemEvent e) {
+                lblCaution3.setVisible(!toEndSafeZ.isSelected());
+            }
+        });
+        panel.add(toEndSafeZ, "10, 15, center, default");
+        
+        lblCaution3 = new JLabel("CAUTION!");
+        lblCaution3.setForeground(Color.RED);
+        panel.add(lblCaution3, "12, 15");
 
         lblEndLocation = new JLabel("Last Location");
-        panel.add(lblEndLocation, "2, 10, right, default");
+        panel.add(lblEndLocation, "2, 17, right, default");
+        
+        endLocationEnabled = new JCheckBox("");
+        panel.add(endLocationEnabled, "4, 17, center, default");
 
         textFieldEndX = new JTextField();
-        panel.add(textFieldEndX, "4, 10, fill, default");
+        panel.add(textFieldEndX, "6, 17, fill, default");
         textFieldEndX.setColumns(10);
 
         textFieldEndY = new JTextField();
-        panel.add(textFieldEndY, "6, 10, fill, default");
+        panel.add(textFieldEndY, "8, 17, fill, default");
         textFieldEndY.setColumns(10);
 
         textFieldEndZ = new JTextField();
-        panel.add(textFieldEndZ, "8, 10, fill, default");
+        panel.add(textFieldEndZ, "10, 17, fill, default");
         textFieldEndZ.setColumns(10);
 
         textFieldEndRotation = new JTextField();
-        panel.add(textFieldEndRotation, "10, 10, fill, default");
+        panel.add(textFieldEndRotation, "12, 17, fill, default");
         textFieldEndRotation.setColumns(10);
 
         endLocationButtonsPanel = new LocationButtonsPanel(textFieldEndX,
                 textFieldEndY, textFieldEndZ, (JTextField) null);
         endLocationButtonsPanel.setShowPositionToolNoSafeZ(true);
-        panel.add(endLocationButtonsPanel, "12, 10, fill, default");
+        panel.add(endLocationButtonsPanel, "14, 16, 1, 3, fill, default");
     }
 
     @Override
@@ -335,6 +430,11 @@ public class ReferenceAdvancedMotionPlannerConfigurationWizard extends AbstractC
         addWrappedBinding(motionPlanner, "allowUncoordinated", allowUncoordinated, "selected");
         addWrappedBinding(motionPlanner, "interpolationRetiming", interpolationRetiming, "selected");
 
+        addWrappedBinding(motionPlanner, "startLocationEnabled", startLocationEnabled, "selected");
+        addWrappedBinding(motionPlanner, "mid1LocationEnabled", mid1LocationEnabled, "selected");
+        addWrappedBinding(motionPlanner, "mid2LocationEnabled", mid2LocationEnabled, "selected");
+        addWrappedBinding(motionPlanner, "endLocationEnabled", endLocationEnabled, "selected");
+        
         MutableLocationProxy startLocation = new MutableLocationProxy();
         bind(UpdateStrategy.READ_WRITE, motionPlanner, "startLocation", startLocation,
                 "location");
@@ -349,6 +449,7 @@ public class ReferenceAdvancedMotionPlannerConfigurationWizard extends AbstractC
 
         addWrappedBinding(motionPlanner, "toMid1Speed", toMid1Speed, "text",
                 doubleConverter);
+        addWrappedBinding(motionPlanner, "toMid1SafeZ", toMid1SafeZ, "selected");
 
         MutableLocationProxy midLocation1 = new MutableLocationProxy();
         bind(UpdateStrategy.READ_WRITE, motionPlanner, "midLocation1", midLocation1,
@@ -364,6 +465,7 @@ public class ReferenceAdvancedMotionPlannerConfigurationWizard extends AbstractC
 
         addWrappedBinding(motionPlanner, "toMid2Speed", toMid2Speed, "text",
                 doubleConverter);
+        addWrappedBinding(motionPlanner, "toMid2SafeZ", toMid2SafeZ, "selected");
 
         MutableLocationProxy midLocation2 = new MutableLocationProxy();
         bind(UpdateStrategy.READ_WRITE, motionPlanner, "midLocation2", midLocation2,
@@ -379,6 +481,7 @@ public class ReferenceAdvancedMotionPlannerConfigurationWizard extends AbstractC
 
         addWrappedBinding(motionPlanner, "toEndSpeed", toEndSpeed, "text",
                 doubleConverter);
+        addWrappedBinding(motionPlanner, "toEndSafeZ", toEndSafeZ, "selected");
 
         MutableLocationProxy endLocation = new MutableLocationProxy();
         bind(UpdateStrategy.READ_WRITE, motionPlanner, "endLocation", endLocation,

--- a/src/main/java/org/openpnp/machine/reference/driver/wizards/ReferenceAdvancedMotionPlannerDiagnosticsWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/wizards/ReferenceAdvancedMotionPlannerDiagnosticsWizard.java
@@ -51,6 +51,8 @@ import com.jgoodies.forms.layout.FormSpecs;
 import com.jgoodies.forms.layout.RowSpec;
 import javax.swing.JTextField;
 import java.awt.Color;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
 
 @SuppressWarnings("serial")
 public class ReferenceAdvancedMotionPlannerDiagnosticsWizard extends AbstractConfigurationWizard {
@@ -73,10 +75,12 @@ public class ReferenceAdvancedMotionPlannerDiagnosticsWizard extends AbstractCon
                 applyAction.actionPerformed(e);
                 HeadMountable selectedTool = MainFrame.get().getMachineControls().getSelectedTool();
                 UiUtils.submitUiMachineTask(() -> {
-                    
+                    if (motionPlanner.getInitialLocation(false) == null) {
+                        throw new Exception("Test Motion undefined. Please go to the Motion Planner tab and define/enable the Test Motion locations.");
+                    }
                     Location l = selectedTool.getLocation();
-                    boolean reverse = (l.getXyzcDistanceTo(motionPlanner.getStartLocation()) 
-                            > l.getXyzcDistanceTo(motionPlanner.getEndLocation()));
+                    boolean reverse = (l.getXyzcDistanceTo(motionPlanner.getInitialLocation(true)) 
+                            < l.getXyzcDistanceTo(motionPlanner.getInitialLocation(false)));
                     motionPlanner.testMotion(selectedTool, reverse);
                 });
             });

--- a/src/main/java/org/openpnp/model/AbstractMotionPath.java
+++ b/src/main/java/org/openpnp/model/AbstractMotionPath.java
@@ -114,7 +114,9 @@ public abstract class AbstractMotionPath implements Iterable<MotionProfile []> {
             leadAxis[i] = MotionProfile.getLeadAxisIndex(unitVector[i]);
             simplified[i] = false;
             for (int axis = 0; axis < profiles.length; axis++) {
-                simplified[i] |= !profiles[axis].isSupportingUncoordinated();
+                if (!profiles[axis].isEmpty()) {
+                    simplified[i] |= !profiles[axis].isSupportingUncoordinated();
+                }
             }
             if (i > 0) {
                 junctionCosineFromPrev[i] = MotionProfile.dotProduct(unitVector[i-1], unitVector[i]);

--- a/src/main/java/org/openpnp/util/SimpleGraph.java
+++ b/src/main/java/org/openpnp/util/SimpleGraph.java
@@ -45,7 +45,7 @@ public class SimpleGraph {
         private List<DataRow> dataRows = new ArrayList<>();
         private double relativePaddingTop;
         private double relativePaddingBottom;
-
+        private boolean symmetricIfSigned;
 
         public void addDataRow(DataRow dataRow) {
             dataRows.add(dataRow);
@@ -86,6 +86,12 @@ public class SimpleGraph {
         }
         public void setRelativePaddingBottom(double relativePaddingBottom) {
             this.relativePaddingBottom = relativePaddingBottom;
+        }
+        public boolean isSymmetricIfSigned() {
+            return symmetricIfSigned;
+        }
+        public void setSymmetricIfSigned(boolean symmetricIfSigned) {
+            this.symmetricIfSigned = symmetricIfSigned;
         }
 
         public Point2D.Double getMinimum() {
@@ -190,6 +196,7 @@ public class SimpleGraph {
     public static class DataRow {
         private String label;
         private Color color;
+        private int displayCycleMask = 1; // Displayed on mask 1
         private TreeMap<Double, Double> data = new TreeMap<>();
 
         // housekeeping
@@ -284,6 +291,14 @@ public class SimpleGraph {
         }
         public void setColor(Color color) {
             this.color = color;
+        }
+
+        public int getDisplayCycleMask() {
+            return displayCycleMask;
+        }
+
+        public void setDisplayCycleMask(int displayCycleMask) {
+            this.displayCycleMask = displayCycleMask;
         }
     }
 


### PR DESCRIPTION
# Description
This is a further update of #1061, #1065, #1066, #1071, #1072.

Changes:

* A Test Motion will now always be diagnosed as a whole, even if interlock happens across multiple drivers (diagnostics spans multiple motion plans).
  ![Multi-Driver-Planning](https://user-images.githubusercontent.com/9963310/97806724-5b0c4880-1c5d-11eb-8ff0-cebb95d17121.gif)
  
  ![Diagnostics](https://user-images.githubusercontent.com/9963310/97806912-49777080-1c5e-11eb-831a-d6beb57561bd.png)

* You can click the Motion Planner Diagnostics graph to cycle through visibility of planned, interpolated or both graphs.
* Motion Planner Diagnostics graph has better anti-aliasing and transparency rendering.
* Added Enabled and Safe Z option to the Test Motion. Displays CAUTION labels when Safe Z is disabled.
* Test Motion now slowly moves to Safe Z after test. 
* Make location confirmation optional in GcodeAsyncDriver. Alternatively use confirmation flow control (waiting for "ok") and wait for the last command confirmation for drivers without axes. Instructions linked below.
* This allows GcodeAsyncDriver to be used for feeder control boards etc. where position reporting is obviously not present. Such controllers can then also benefit from faster asynchronous communication. 
* Issues & Solutions: Suggest enabling reported location option if axes are present (and vice versa).
* Removed all spin-loops in the GcodeDriver/GcodeAsyncDriver: All waits for responses should now be thread-blocking, saving CPU resources (e.g. waiting for an actuator read regex to match). All operations now have timeouts.
* Issues & Solutions: Check reported axes against regex to detect misconfigurations or bad firmware. 
* If a simplified S-curve controller axis (e.g. one on a TinyG) is part of a coordinated Motion across different drivers, all other axes on the other drivers must also be forced into simplified S-curve planning (for correct coordination). These moves are then interpolated or moderated to match in time. 

# Justification
Just a continuous update in the testing version regime. See also [the group discussion](https://groups.google.com/d/msg/openpnp/j7fuo0e9VVM/AG2xPu4HBQAJ). 

# Instructions for Use
Updated instructions are these:

* [The GcodeAsyncDriver confirmation/flow control options](https://github.com/openpnp/openpnp/wiki/GcodeAsyncDriver#settings)
* [The minimum controller/firmware capabilities explained](https://github.com/openpnp/openpnp/wiki/Motion-Controller-Firmwares#controllers-and-firmwares-for-advanced-motion-control)

Otherwise, use the existing testing version Wiki documentation:
* [Advanced Motion Control intro](https://github.com/openpnp/openpnp/wiki/Advanced-Motion-Control)
* [Table of contents](https://github.com/openpnp/openpnp/wiki/Advanced-Motion-Control#advanced-motion-control-topics)

# Implementation Details
1. The changes have been tested on both my lab bench three-controller mix setup and on my machine.
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. No (further) changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. Successful `mvn test` before submitting the Pull Request. 

