### PR TITLE
Mjpg camera feature

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/ReferenceMachine.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceMachine.java
@@ -34,6 +34,7 @@ import org.openpnp.machine.marek.MarekNozzle;
 import org.openpnp.machine.neoden4.Neoden4Camera;
 import org.openpnp.machine.rapidplacer.RapidFeeder;
 import org.openpnp.machine.reference.camera.ImageCamera;
+import org.openpnp.machine.reference.camera.MjpgCaptureCamera;
 import org.openpnp.machine.reference.camera.OnvifIPCamera;
 import org.openpnp.machine.reference.camera.OpenCvCamera;
 import org.openpnp.machine.reference.camera.OpenPnpCaptureCamera;
@@ -246,6 +247,7 @@ public class ReferenceMachine extends AbstractMachine {
         l.add(ImageCamera.class);
         l.add(SwitcherCamera.class);
         l.add(SimulatedUpCamera.class);
+        l.add(MjpgCaptureCamera.class);
         return l;
     }
 

--- a/src/main/java/org/openpnp/machine/reference/camera/MjpgCaptureCamera.java
+++ b/src/main/java/org/openpnp/machine/reference/camera/MjpgCaptureCamera.java
@@ -1,0 +1,316 @@
+/*
+ * Copyright (C) 2020 Greg Hjelstrom greg.hjelstrom@gmail.com
+ * 
+ * This file is part of OpenPnP.
+ * 
+ * OpenPnP is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * OpenPnP is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License along with OpenPnP. If not, see
+ * <http://www.gnu.org/licenses/>.
+ * 
+ * For more information about OpenPnP visit http://openpnp.org
+ */
+
+// http://www.walking-productions.com/notslop/2010/04/20/motion-jpeg-in-flash-and-java/
+// https://github.com/BITPlan/com.bitplan.mjpegstreamer/tree/master/src/main/java/com/bitplan/mjpegstreamer
+
+package org.openpnp.machine.reference.camera;
+
+import java.awt.image.BufferedImage;
+import java.beans.PropertyChangeSupport;
+import java.net.URL;
+import java.net.URLConnection;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.StringWriter;
+
+import javax.imageio.ImageIO;
+import org.openpnp.CameraListener;
+import org.openpnp.gui.support.Wizard;
+import org.openpnp.machine.reference.ReferenceCamera;
+import org.openpnp.machine.reference.camera.wizards.MjpgCaptureCameraWizard;
+import org.openpnp.model.LengthUnit;
+import org.openpnp.model.Location;
+import org.openpnp.spi.PropertySheetHolder;
+import org.simpleframework.xml.Attribute;
+import org.simpleframework.xml.core.Commit;
+
+
+
+public class MjpgCaptureCamera extends ReferenceCamera implements Runnable {
+    private PropertyChangeSupport pcs = new PropertyChangeSupport(this);
+
+    @Attribute(required = false)
+    private int fps = 24;
+
+    @Attribute(required = false)
+    private String mjpgURL = "http://192.168.1.66:5802";
+
+    @Attribute(required = false)
+    private int width = 960;
+
+    @Attribute(required = false)
+    private int height = 720;
+
+    private InputStream mjpgStream; //BufferedInputStream mjpgStream;
+    private StringWriter lineBuilder;
+    
+    private Thread thread;
+    private boolean dirty = false;
+
+    //private static final String BOUNDARY_PREFIX = "--";
+    //private static final String CONTENT_TYPE_STRING = "Content-Type: ";
+    private static final String CONTENT_LENGTH_STRING = "Content-Length: ";
+    
+
+    public MjpgCaptureCamera() {
+        setUnitsPerPixel(new Location(LengthUnit.Millimeters, 0.04233, 0.04233, 0, 0));
+        try {
+            setURL(mjpgURL);
+        }
+        catch (Exception e) {
+            
+        }
+    }
+
+    public boolean isDirty() {
+        return dirty;
+    }
+
+    public void setDirty(boolean dirty) {
+        this.dirty = dirty;
+    }
+    
+    public String getMjpgURL() {
+        return mjpgURL;
+    }
+
+    public synchronized void setMjpgURL(String url) {
+        this.mjpgURL = url;
+        setDirty(true);
+        initialize();
+    }
+    
+    @SuppressWarnings("unused")
+    @Commit
+	protected void commit() throws Exception {
+        setURL(mjpgURL);
+    }
+
+    @Override
+    public synchronized void startContinuousCapture(CameraListener listener) {
+        start();
+        super.startContinuousCapture(listener);
+    }
+
+    @Override
+    public synchronized void stopContinuousCapture(CameraListener listener) {
+        super.stopContinuousCapture(listener);
+        if (listeners.size() == 0) {
+            stop();
+        }
+    }
+
+    private synchronized void stop() {
+        if (thread != null && thread.isAlive()) {
+            thread.interrupt();
+            try {
+                thread.join(3000);
+            }
+            catch (Exception e) {
+                e.printStackTrace();
+            }
+            thread = null;
+        }
+    }
+
+    private synchronized void start() {
+        
+        try {
+            URL url = new URL(mjpgURL);
+            URLConnection urlcon = url.openConnection();
+            urlcon.setConnectTimeout(3000);
+            urlcon.setReadTimeout(1000);
+            
+            mjpgStream = urlcon.getInputStream(); //new BufferedInputStream(url.openStream());
+            lineBuilder = new StringWriter(256);
+
+            if (thread == null) {
+                thread = new Thread(this);
+                thread.setDaemon(true);
+                thread.start();
+            }
+        } catch (Exception e) {
+            System.err.println("Unknown error communicating with MJPG stream at " + mjpgURL + ": " + e.toString());
+            e.printStackTrace();
+        }
+    }
+
+    public String getURL() {
+        return mjpgURL;
+    }
+
+    public void setURL(String url) throws Exception {
+        String oldValue = this.mjpgURL;
+        this.mjpgURL = url;
+        pcs.firePropertyChange("mjpgURL", oldValue, url);
+        initialize();
+    }
+
+    private synchronized void initialize() {
+        stop();
+        if (listeners.size() > 0) {
+            start();
+        }
+    }
+
+
+    @Override
+    public BufferedImage internalCapture() {
+
+        int image_size = 0;
+        String inputLine;
+        lineBuilder.flush();
+        lineBuilder.getBuffer().setLength(0);
+
+        // Read header until we know how big the next image will be
+        while (image_size == 0) 
+        {
+        	int next_byte = 0;
+            try {
+                next_byte = mjpgStream.read();
+            }
+            catch (IOException e)
+            {
+                System.err.println("IOException reading from MJPG stream: " + e.toString());
+                e.printStackTrace();
+                return null;
+            }
+
+            if (next_byte == -1)
+            {
+                System.err.println("Could not read header from MJPG stream: " + mjpgURL);
+                return null;
+            }
+            else
+            {
+                lineBuilder.write(next_byte);
+                if (next_byte == '\n')
+                {
+                    inputLine = lineBuilder.toString();
+                    if (inputLine.startsWith(CONTENT_LENGTH_STRING))
+                    {
+                        // pull the number of bytes out of the content length string
+                    	String content_len_string = inputLine.substring(CONTENT_LENGTH_STRING.length());
+                    	content_len_string = content_len_string.replaceAll("(\\r|\\n)", "");
+                    	image_size = Integer.parseInt(content_len_string);
+                    }       
+                    lineBuilder.getBuffer().setLength(0);
+                }
+            }
+        }
+
+        // We got what we needed from the header, now just read the steam until we see a 255 which is the beginning of the JPG image
+        try {
+            while (mjpgStream.read() != 255) {
+            }
+        } catch (IOException e)
+        {
+            System.err.println("Incomplete header in MJPG stream: " + mjpgURL + "\r\n" + e.toString());
+            e.printStackTrace();
+            return null;
+        }
+
+        // Read the jpg image and create a BufferedImage
+        byte[] jpg_buffer = new byte[image_size+1];
+        jpg_buffer[0] = (byte) 255;
+        int write_cursor = 1;
+        boolean got_image = false;
+        boolean done = false;
+        
+        try {
+            while(!done)
+            {
+                int bytes_read = mjpgStream.read(jpg_buffer,write_cursor,image_size-write_cursor);
+                if (bytes_read > 0)
+                {
+                    write_cursor += bytes_read;
+                    got_image = (write_cursor>=image_size);
+                    done = got_image;
+                }
+                else
+                {
+                    // got -1 (EOF)
+                    done = true;
+                }
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+
+        if (got_image)
+        {
+	        ByteArrayInputStream jpg_stream = new ByteArrayInputStream(jpg_buffer);
+	        BufferedImage frame = null;
+	        try {
+	            frame = ImageIO.read(jpg_stream);
+	        }
+	        catch (IOException e)
+	        {
+	            System.err.println("Invalid JPG frame in MJPG steram: " + mjpgURL + "\r\n" + e.toString());
+	            e.printStackTrace();
+	        }
+	
+	        return frame;
+        }
+        else
+        {
+            System.err.println("Incomplete JPG frame in MJPG steram: " + mjpgURL);
+        	return null;
+        }
+    }
+
+    public void run() {
+        
+        while(!Thread.interrupted())
+        {
+            try {
+                BufferedImage image = internalCapture();
+                if (image != null) {
+                    broadcastCapture(image);
+                }
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+            try {
+                Thread.sleep(10);
+            }
+            catch (InterruptedException e)
+            {
+                break;
+            }
+        } 
+    }
+
+    @Override
+    public Wizard getConfigurationWizard() {
+        return new MjpgCaptureCameraWizard(this);
+    }
+
+    @Override
+    public String getPropertySheetHolderTitle() {
+        return getClass().getSimpleName() + " " + getName();
+    }
+
+    @Override
+    public PropertySheetHolder[] getChildPropertySheetHolders() {
+        return null;
+    }
+}

--- a/src/main/java/org/openpnp/machine/reference/camera/MjpgCaptureCamera.java
+++ b/src/main/java/org/openpnp/machine/reference/camera/MjpgCaptureCamera.java
@@ -17,8 +17,6 @@
  * For more information about OpenPnP visit http://openpnp.org
  */
 
-// http://www.walking-productions.com/notslop/2010/04/20/motion-jpeg-in-flash-and-java/
-// https://github.com/BITPlan/com.bitplan.mjpegstreamer/tree/master/src/main/java/com/bitplan/mjpegstreamer
 
 package org.openpnp.machine.reference.camera;
 

--- a/src/main/java/org/openpnp/machine/reference/camera/wizards/MjpgCaptureCameraWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/camera/wizards/MjpgCaptureCameraWizard.java
@@ -1,0 +1,95 @@
+package org.openpnp.machine.reference.camera.wizards;
+
+
+import java.awt.Color;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JTextField;
+import javax.swing.border.EtchedBorder;
+import javax.swing.border.TitledBorder;
+
+import org.openpnp.gui.components.ComponentDecorators;
+import org.openpnp.gui.support.AbstractConfigurationWizard;
+import org.openpnp.machine.reference.camera.MjpgCaptureCamera;
+
+import com.jgoodies.forms.layout.ColumnSpec;
+import com.jgoodies.forms.layout.FormLayout;
+import com.jgoodies.forms.layout.FormSpecs;
+import com.jgoodies.forms.layout.RowSpec;
+
+@SuppressWarnings("serial")
+public class MjpgCaptureCameraWizard extends AbstractConfigurationWizard {
+    
+	private final MjpgCaptureCamera camera;
+    private JPanel panelGeneral;
+
+    public MjpgCaptureCameraWizard(MjpgCaptureCamera camera) {
+        this.camera = camera;
+
+        panelGeneral = new JPanel();
+        contentPanel.add(panelGeneral);
+        panelGeneral.setBorder(new TitledBorder(new EtchedBorder(EtchedBorder.LOWERED, null, null),
+                "General", TitledBorder.LEADING, TitledBorder.TOP, null, new Color(0, 0, 0)));
+        panelGeneral.setLayout(new FormLayout(new ColumnSpec[] {
+                FormSpecs.RELATED_GAP_COLSPEC,
+                FormSpecs.DEFAULT_COLSPEC,
+                FormSpecs.RELATED_GAP_COLSPEC,
+                FormSpecs.DEFAULT_COLSPEC,
+                FormSpecs.RELATED_GAP_COLSPEC,
+                FormSpecs.DEFAULT_COLSPEC,},
+            new RowSpec[] {
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,}));
+
+        lblIP = new JLabel("Camera IP Address and Port Number");
+        panelGeneral.add(lblIP, "2, 2, right, default");
+
+        ipTextField = new JTextField();
+        panelGeneral.add(ipTextField, "4, 2");
+        ipTextField.setColumns(16);
+
+        lbluseFor_ip = new JLabel("(IP:port)");
+        panelGeneral.add(lbluseFor_ip, "6, 2");
+
+    }
+
+    @Override
+    public void createBindings() {
+        
+    	// Should always be last so that it doesn't trigger multiple camera reloads.
+        addWrappedBinding(camera, "mjpgURL", ipTextField, "text");
+
+        ComponentDecorators.decorateWithAutoSelect(ipTextField);
+    }
+    
+    @Override
+    protected void loadFromModel() {
+        super.loadFromModel();
+    }
+
+    @Override
+    protected void saveToModel() {
+        super.saveToModel();
+        if (camera.isDirty()) {
+            camera.setMjpgURL(camera.getMjpgURL());
+        }
+    }
+
+    private JLabel lblIP;
+    private JTextField ipTextField;
+    private JLabel lbluseFor_ip;
+
+
+}

--- a/src/main/java/org/openpnp/machine/reference/camera/wizards/MjpgCaptureCameraWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/camera/wizards/MjpgCaptureCameraWizard.java
@@ -2,6 +2,7 @@ package org.openpnp.machine.reference.camera.wizards;
 
 
 import java.awt.Color;
+
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JTextField;
@@ -19,8 +20,8 @@ import com.jgoodies.forms.layout.RowSpec;
 
 @SuppressWarnings("serial")
 public class MjpgCaptureCameraWizard extends AbstractConfigurationWizard {
-    
-	private final MjpgCaptureCamera camera;
+
+    private final MjpgCaptureCamera camera;
     private JPanel panelGeneral;
 
     public MjpgCaptureCameraWizard(MjpgCaptureCamera camera) {
@@ -30,28 +31,17 @@ public class MjpgCaptureCameraWizard extends AbstractConfigurationWizard {
         contentPanel.add(panelGeneral);
         panelGeneral.setBorder(new TitledBorder(new EtchedBorder(EtchedBorder.LOWERED, null, null),
                 "General", TitledBorder.LEADING, TitledBorder.TOP, null, new Color(0, 0, 0)));
-        panelGeneral.setLayout(new FormLayout(new ColumnSpec[] {
-                FormSpecs.RELATED_GAP_COLSPEC,
-                FormSpecs.DEFAULT_COLSPEC,
-                FormSpecs.RELATED_GAP_COLSPEC,
-                FormSpecs.DEFAULT_COLSPEC,
-                FormSpecs.RELATED_GAP_COLSPEC,
-                FormSpecs.DEFAULT_COLSPEC,},
-            new RowSpec[] {
-                FormSpecs.RELATED_GAP_ROWSPEC,
-                FormSpecs.DEFAULT_ROWSPEC,
-                FormSpecs.RELATED_GAP_ROWSPEC,
-                FormSpecs.DEFAULT_ROWSPEC,
-                FormSpecs.RELATED_GAP_ROWSPEC,
-                FormSpecs.DEFAULT_ROWSPEC,
-                FormSpecs.RELATED_GAP_ROWSPEC,
-                FormSpecs.DEFAULT_ROWSPEC,
-                FormSpecs.RELATED_GAP_ROWSPEC,
-                FormSpecs.DEFAULT_ROWSPEC,
-                FormSpecs.RELATED_GAP_ROWSPEC,
-                FormSpecs.DEFAULT_ROWSPEC,
-                FormSpecs.RELATED_GAP_ROWSPEC,
-                FormSpecs.DEFAULT_ROWSPEC,}));
+        panelGeneral.setLayout(new FormLayout(
+                new ColumnSpec[] {FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,
+                        FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,
+                        FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,},
+                new RowSpec[] {FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,}));
 
         lblIP = new JLabel("Camera IP Address and Port Number");
         panelGeneral.add(lblIP, "2, 2, right, default");
@@ -67,13 +57,13 @@ public class MjpgCaptureCameraWizard extends AbstractConfigurationWizard {
 
     @Override
     public void createBindings() {
-        
-    	// Should always be last so that it doesn't trigger multiple camera reloads.
+
+        // Should always be last so that it doesn't trigger multiple camera reloads.
         addWrappedBinding(camera, "mjpgURL", ipTextField, "text");
 
         ComponentDecorators.decorateWithAutoSelect(ipTextField);
     }
-    
+
     @Override
     protected void loadFromModel() {
         super.loadFromModel();


### PR DESCRIPTION
# Description
This pull request adds MjpgCaptureCamera and MjpgCaptureCameraWizard to OpenPNP.  This class allows you to use IP cameras which output Mjpg streams.

# Justification
My pick and place machine is using an Mjpg camera for its up camera and this feature should be generally useful for anyone who wants to use one of these cameras.  

# Instructions for Use
In the machine configuration GUI you can add an MjpgCaptureCamera anywhere that you are able to use any other type of camera (e.g. OpenPnpCaptureCamera, OpenCvCamera, etc)
![UsingMJPGCaptureCamera](https://user-images.githubusercontent.com/15841740/99267966-6fae1c00-27d9-11eb-99c5-4206816e57b2.png)


There is currently only one setting which is the IP address and port number to pull the MJPG stream from:
![MjpgCaptureCameraSettings](https://user-images.githubusercontent.com/15841740/99268485-12669a80-27da-11eb-89b8-39df2feb9c01.png)

![mjpg_camera2](https://user-images.githubusercontent.com/15841740/99269006-b3555580-27da-11eb-82f2-9fc6aaaf792f.jpg)


# Implementation Details
1. I have tested the code on my pick and place machine which uses a this type of camera.  I tested editing pipelines on this camera type as well as simply viewing the stream in the OpenPnP gui
2. I used the code formatter and tried to follow the style as closely as possible.
3. No changes to the `org.openpnp.spi` or `org.openpnp.model` packages
4. `mvn test` succeeded without errors.