### PR TITLE
Implemented part count display on the ReferenceStripFeederConfigurationWizard

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/feeder/wizards/ReferenceStripFeederConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/wizards/ReferenceStripFeederConfigurationWizard.java
@@ -64,11 +64,13 @@ import org.openpnp.gui.support.PartsComboBoxModel;
 import org.openpnp.machine.reference.camera.BufferedImageCamera;
 import org.openpnp.machine.reference.feeder.ReferenceStripFeeder;
 import org.openpnp.machine.reference.feeder.ReferenceStripFeeder.TapeType;
+import org.openpnp.model.Board;
 import org.openpnp.model.Configuration;
 import org.openpnp.model.Length;
 import org.openpnp.model.LengthUnit;
 import org.openpnp.model.Location;
 import org.openpnp.model.Part;
+import org.openpnp.model.Placement;
 import org.openpnp.spi.Camera;
 import org.openpnp.util.HslColor;
 import org.openpnp.util.OpenCvUtils;
@@ -96,7 +98,8 @@ public class ReferenceStripFeederConfigurationWizard extends AbstractConfigurati
     private JPanel panelPart;
 
     private JComboBox comboBoxPart;
-
+    private JLabel lblPartInfo;
+    
     private JTextField textFieldFeedStartX;
     private JTextField textFieldFeedStartY;
     private JTextField textFieldFeedStartZ;
@@ -143,7 +146,9 @@ public class ReferenceStripFeederConfigurationWizard extends AbstractConfigurati
                 FormSpecs.RELATED_GAP_COLSPEC,
                 FormSpecs.DEFAULT_COLSPEC,
                 FormSpecs.RELATED_GAP_COLSPEC,
-                FormSpecs.DEFAULT_COLSPEC,},
+                FormSpecs.DEFAULT_COLSPEC,
+                FormSpecs.RELATED_GAP_COLSPEC,
+                FormSpecs.DEFAULT_COLSPEC },
             new RowSpec[] {
                 FormSpecs.RELATED_GAP_ROWSPEC,
                 FormSpecs.DEFAULT_ROWSPEC,
@@ -168,6 +173,15 @@ public class ReferenceStripFeederConfigurationWizard extends AbstractConfigurati
         comboBoxPart.setRenderer(new IdentifiableListCellRenderer<Part>());
         panelPart.add(comboBoxPart, "4, 2, left, default");
 
+        comboBoxPart.addActionListener(new ActionListener() {
+            public void actionPerformed(ActionEvent e) {
+                updatePartInfo();            
+            }
+        });
+        
+        lblPartInfo = new JLabel("");
+        panelPart.add(lblPartInfo,"6, 2, left, default");
+        
         lblRotationInTape = new JLabel("Rotation In Tape");
         panelPart.add(lblRotationInTape, "2, 4, left, default");
 
@@ -399,6 +413,32 @@ public class ReferenceStripFeederConfigurationWizard extends AbstractConfigurati
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldFeedEndZ);
     }
 
+    private void updatePartInfo()
+    {
+        int count = 0;
+        List<Board> boards = Configuration.get().getBoards();
+        for (int i=0; i<boards.size(); i++)    {
+            Board board = boards.get(i);
+            List<Placement> placements = board.getPlacements();
+            for (int p=0; p<placements.size(); p++)
+            {
+                if (placements.get(p).getPart() == feeder.getPart())
+                {
+                    count++;
+                }
+            }
+        }
+        if (count > 0)
+        {
+            String lbl = Integer.toString(count) + " used by current job";
+            lblPartInfo.setText(lbl);
+        }
+        else
+        {
+            lblPartInfo.setText("");
+        }
+    }
+    
     private Action autoSetup = new AbstractAction("Auto Setup") {
         @Override
         public void actionPerformed(ActionEvent e) {


### PR DESCRIPTION
# Description
This feature tells the user how many of a the currently selected part are used by the currently loaded job.  It is useful because with strip feeders you need to pull back the tape to uncover enough parts for the job to complete and it can be tedious to go back and forth between panes to add this information up.

# Justification
It saves me a lot of time for people using strip feeders.

# Instructions for Use
See the attached image, next to the part selection combo box, OpenPNP will tell you how many parts are used.

# Implementation Details
1. How did you test the change?  - I added a new label to the wizard and a function to update the label based on the part selected.
2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)?  Yes
3. No changes to the model were needed.
4. mvn test completes with no errors.
