### PR TITLE
Improved loop syntax, fixed code to update the part info whenever the part combo is changed

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/feeder/wizards/ReferenceStripFeederConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/wizards/ReferenceStripFeederConfigurationWizard.java
@@ -175,7 +175,7 @@ public class ReferenceStripFeederConfigurationWizard extends AbstractConfigurati
 
         comboBoxPart.addActionListener(new ActionListener() {
             public void actionPerformed(ActionEvent e) {
-                updatePartInfo();            
+                updatePartInfo(e);            
             }
         });
         
@@ -413,16 +413,15 @@ public class ReferenceStripFeederConfigurationWizard extends AbstractConfigurati
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldFeedEndZ);
     }
 
-    private void updatePartInfo()
+    private void updatePartInfo(ActionEvent e)
     {
         int count = 0;
-        List<Board> boards = Configuration.get().getBoards();
-        for (int i=0; i<boards.size(); i++)    {
-            Board board = boards.get(i);
-            List<Placement> placements = board.getPlacements();
-            for (int p=0; p<placements.size(); p++)
+    	Part feeder_part =(Part)comboBoxPart.getSelectedItem(); 
+    
+        for (Board board: Configuration.get().getBoards())    {
+            for (Placement p : board.getPlacements())
             {
-                if (placements.get(p).getPart() == feeder.getPart())
+                if (p.getPart() == feeder_part)
                 {
                     count++;
                 }


### PR DESCRIPTION
# Description
Updates my recent changes to ReferenceStripFeederWizard to use nicer loop syntax and fix a bug where the part count did not update correctly when the part combo box is changed.

# Justification
Syntax change was suggested by mark and this code fixes an inconsistency in the UI.

# Instructions for Use
ReferenceStripFeederWizard displays the number of parts used by the currently loaded job next to the part combo box.

# Implementation Details
1. Tested by interacting with some reference strip feeders and a test board.  Changing the part in each feeder correctly updates the count.
2. This code follows the coding style.
3. There are no model changes.
4. mvn test passes with no errors
