### PR TITLE
MjpgCaptureCamera was missing image transform support.  Added the missing code

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/camera/MjpgCaptureCamera.java
+++ b/src/main/java/org/openpnp/machine/reference/camera/MjpgCaptureCamera.java
@@ -288,6 +288,7 @@ public class MjpgCaptureCamera extends ReferenceCamera implements Runnable {
             try {
                 BufferedImage image = internalCapture();
                 if (image != null) {
+                    image = transformImage(image);
                     broadcastCapture(image);
                 }
             }


### PR DESCRIPTION
# Description
MjpgCaptureCamera was missing a line of code to implement image transforms.  I discovered this while testing my mjpg up camera which is rotated 90 degrees on my table.

# Justification
This code change is required for the image transform options in the camera setup to work correctly.

# Instructions for Use
To reproduce the bug simply try to use any of the image transform options on mjpg camera.

# Implementation Details
1. I have an up camera on my pnp which is rotated 90 degrees.  After fixing the bug I tested the various options on the transform tab.
2. This code follows the coding style
3. No changes were made to the model
4. mvn test runs with no errors.
