### PR TITLE
Closes #1005: Replace actuator text field with combobox

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/feeder/wizards/ReferenceSlotAutoFeederConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/wizards/ReferenceSlotAutoFeederConfigurationWizard.java
@@ -36,21 +36,12 @@ import javax.swing.border.EtchedBorder;
 import javax.swing.border.TitledBorder;
 
 import org.jdesktop.beansbinding.AbstractBindingListener;
-import org.jdesktop.beansbinding.AutoBinding;
 import org.jdesktop.beansbinding.AutoBinding.UpdateStrategy;
 import org.jdesktop.beansbinding.Binding;
-import org.jdesktop.beansbinding.BindingListener;
 import org.openpnp.gui.components.ComponentDecorators;
 import org.openpnp.gui.components.LocationButtonsPanel;
-import org.openpnp.gui.support.AbstractConfigurationWizard;
-import org.openpnp.gui.support.DoubleConverter;
-import org.openpnp.gui.support.IdentifiableListCellRenderer;
-import org.openpnp.gui.support.IntegerConverter;
+import org.openpnp.gui.support.*;
 import org.openpnp.gui.support.JBindings.Wrapper;
-import org.openpnp.gui.support.LengthConverter;
-import org.openpnp.gui.support.MessageBoxes;
-import org.openpnp.gui.support.MutableLocationProxy;
-import org.openpnp.gui.support.PartsComboBoxModel;
 import org.openpnp.machine.reference.feeder.ReferenceAutoFeeder.ActuatorType;
 import org.openpnp.machine.reference.feeder.ReferenceSlotAutoFeeder;
 import org.openpnp.machine.reference.feeder.ReferenceSlotAutoFeeder.Bank;
@@ -62,17 +53,23 @@ import com.jgoodies.forms.layout.ColumnSpec;
 import com.jgoodies.forms.layout.FormLayout;
 import com.jgoodies.forms.layout.FormSpecs;
 import com.jgoodies.forms.layout.RowSpec;
+import org.openpnp.spi.Actuator;
+import org.openpnp.util.UiUtils;
+import org.pmw.tinylog.Logger;
+
 import java.awt.FlowLayout;
 
 public class ReferenceSlotAutoFeederConfigurationWizard
         extends AbstractConfigurationWizard {
     private final ReferenceSlotAutoFeeder feeder;
-    private JTextField actuatorName;
+    private JComboBox comboBoxFeedActuator;
     private JTextField actuatorValue;
-    private JTextField postPickActuatorName;
+    private JComboBox comboBoxPostPickActuator;
     private JTextField postPickActuatorValue;
     private JComboBox actuatorType;
     private JComboBox postPickActuatorType;
+    private JButton btnTestFeedActuator;
+    private JButton btnTestPostPickActuator;
     private JTextField feederNameTf;
     private JTextField bankNameTf;
     private JCheckBox ckBoxMoveBeforeFeed;
@@ -236,6 +233,8 @@ public class ReferenceSlotAutoFeederConfigurationWizard
                 FormSpecs.RELATED_GAP_COLSPEC,
                 FormSpecs.DEFAULT_COLSPEC,
                 FormSpecs.RELATED_GAP_COLSPEC,
+                ColumnSpec.decode("default:grow"),
+                FormSpecs.RELATED_GAP_COLSPEC,
                 FormSpecs.DEFAULT_COLSPEC,
                 FormSpecs.RELATED_GAP_COLSPEC,
                 FormSpecs.DEFAULT_COLSPEC,
@@ -253,8 +252,8 @@ public class ReferenceSlotAutoFeederConfigurationWizard
                 FormSpecs.RELATED_GAP_ROWSPEC,
                 FormSpecs.DEFAULT_ROWSPEC,}));
 
-        JLabel lblActuatorName = new JLabel("Actuator Name");
-        panelActuator.add(lblActuatorName, "4, 2, left, default");
+        JLabel lblActuator = new JLabel("Actuator");
+        panelActuator.add(lblActuator, "4, 2, left, default");
 
         JLabel lblActuatorType = new JLabel("Actuator Type");
         panelActuator.add(lblActuatorType, "6, 2, left, default");
@@ -265,9 +264,9 @@ public class ReferenceSlotAutoFeederConfigurationWizard
         JLabel lblFeed = new JLabel("Feed");
         panelActuator.add(lblFeed, "2, 4, right, default");
 
-        actuatorName = new JTextField();
-        panelActuator.add(actuatorName, "4, 4");
-        actuatorName.setColumns(10);
+        comboBoxFeedActuator = new JComboBox();
+        comboBoxFeedActuator.setModel(new ActuatorsComboBoxModel(Configuration.get().getMachine()));
+        panelActuator.add(comboBoxFeedActuator, "4, 4, fill, default");
         
         actuatorType = new JComboBox(ActuatorType.values());
         panelActuator.add(actuatorType, "6, 4, fill, default");
@@ -279,12 +278,15 @@ public class ReferenceSlotAutoFeederConfigurationWizard
         JLabel lblForBoolean = new JLabel("For Boolean: 1 = True, 0 = False");
         panelActuator.add(lblForBoolean, "10, 4");
 
+        btnTestFeedActuator = new JButton(testFeedActuatorAction);
+        panelActuator.add(btnTestFeedActuator, "12, 4");
+
         JLabel lblPostPick = new JLabel("Post Pick");
         panelActuator.add(lblPostPick, "2, 6, right, default");
 
-        postPickActuatorName = new JTextField();
-        postPickActuatorName.setColumns(10);
-        panelActuator.add(postPickActuatorName, "4, 6");
+        comboBoxPostPickActuator = new JComboBox();
+        comboBoxPostPickActuator.setModel(new ActuatorsComboBoxModel(Configuration.get().getMachine()));
+        panelActuator.add(comboBoxPostPickActuator, "4, 6, fill, default");
         
         postPickActuatorType = new JComboBox(ActuatorType.values());
         panelActuator.add(postPickActuatorType, "6, 6, fill, default");
@@ -295,6 +297,9 @@ public class ReferenceSlotAutoFeederConfigurationWizard
         
         JLabel lblForBoolean_1 = new JLabel("For Boolean: 1 = True, 0 = False");
         panelActuator.add(lblForBoolean_1, "10, 6");
+
+        btnTestPostPickActuator = new JButton(testPostPickActuatorAction);
+        panelActuator.add(btnTestPostPickActuator, "12, 6");
         
         JLabel lblMoveBeforeFeed = new JLabel("Move before feed");
         panelActuator.add(lblMoveBeforeFeed, "2, 8, right, default");
@@ -384,11 +389,11 @@ public class ReferenceSlotAutoFeederConfigurationWizard
         DoubleConverter doubleConverter =
                 new DoubleConverter(Configuration.get().getLengthDisplayFormat());
 
-        addWrappedBinding(feeder, "actuatorName", actuatorName, "text");
+        addWrappedBinding(feeder, "actuatorName", comboBoxFeedActuator, "selectedItem");
         addWrappedBinding(feeder, "actuatorType", actuatorType, "selectedItem");
         addWrappedBinding(feeder, "actuatorValue", actuatorValue, "text", doubleConverter);
-        
-        addWrappedBinding(feeder, "postPickActuatorName", postPickActuatorName, "text");
+
+        addWrappedBinding(feeder, "postPickActuatorName", comboBoxPostPickActuator, "selectedItem");
         addWrappedBinding(feeder, "postPickActuatorType", postPickActuatorType, "selectedItem");
         addWrappedBinding(feeder, "postPickActuatorValue", postPickActuatorValue, "text", doubleConverter);
         
@@ -451,9 +456,7 @@ public class ReferenceSlotAutoFeederConfigurationWizard
         bind(UpdateStrategy.READ_WRITE, offsets, "lengthZ", zOffsetTf, "text", lengthConverter);
         bind(UpdateStrategy.READ_WRITE, offsets, "rotation", rotOffsetTf, "text", doubleConverter);
 
-        ComponentDecorators.decorateWithAutoSelect(actuatorName);
         ComponentDecorators.decorateWithAutoSelect(actuatorValue);
-        ComponentDecorators.decorateWithAutoSelect(postPickActuatorName);
         ComponentDecorators.decorateWithAutoSelect(postPickActuatorValue);
         ComponentDecorators.decorateWithAutoSelect(feederNameTf);
         ComponentDecorators.decorateWithAutoSelect(bankNameTf);
@@ -517,6 +520,52 @@ public class ReferenceSlotAutoFeederConfigurationWizard
             }
             ReferenceSlotAutoFeeder.getBanks().remove(bank);
             bankCb.removeItem(bank);
+        }
+    };
+
+    private Action testFeedActuatorAction = new AbstractAction("Test feed") {
+        @Override
+        public void actionPerformed(ActionEvent arg0) {
+            UiUtils.messageBoxOnException(() -> {
+                if (feeder.getActuatorName() == null || feeder.getActuatorName().equals("")) {
+                    Logger.warn("No actuatorName specified for feeder {}.", feeder.getName());
+                    return;
+                }
+                Actuator actuator = Configuration.get().getMachine().getActuatorByName(feeder.getActuatorName());
+
+                if (actuator == null) {
+                    throw new Exception("Feed failed. Unable to find an actuator named " + feeder.getActuatorName());
+                }
+                if (feeder.getActuatorType() == ActuatorType.Boolean) {
+                    actuator.actuate(feeder.getActuatorValue() != 0);
+                } else {
+                    actuator.actuate(feeder.getActuatorValue());
+                }
+            });
+        }
+    };
+
+    private Action testPostPickActuatorAction = new AbstractAction("Test post pick") {
+        @Override
+        public void actionPerformed(ActionEvent arg0) {
+            UiUtils.messageBoxOnException(() -> {
+                if (feeder.getPostPickActuatorName() == null || feeder.getPostPickActuatorName().equals("")) {
+                    Logger.warn("No postPickActuatorName specified for feeder {}.", feeder.getName());
+                    return;
+                }
+                Actuator actuator = Configuration.get().getMachine()
+                        .getActuatorByName(feeder.getPostPickActuatorName());
+
+                if (actuator == null) {
+                    throw new Exception(
+                            "Feed failed. Unable to find an actuator named " + feeder.getPostPickActuatorName());
+                }
+                if (feeder.getPostPickActuatorType() == ActuatorType.Boolean) {
+                    actuator.actuate(feeder.getPostPickActuatorValue() != 0);
+                } else {
+                    actuator.actuate(feeder.getPostPickActuatorValue());
+                }
+            });
         }
     };
 


### PR DESCRIPTION
# Description
The ReferenceAutoFeederCongiruationWizard used dropdowns for actuators and even had a "test" button for the ReferenceAutoFeeder. I noticed the ReferenceSlotAutoFeeder had text fields for the actuators and no test buttons. I replicated the functionality from the auto feeder wizard into the slot auto feeder wizard.

I am a little worried about the amount of duplication between those two classes, but it liked like there was a lot of existing duplication so I did not try and refactor it.

# Justification
This makes it much easier to configure your actuators when using the ReferenceSlotAutoFeeder. You're far less likely to get it wrong when you can just select from a list instead of trying to copy it into a field exactly.

# Instructions for Use
Steps:
1. In the "Machine Setup" tab, select the "Actuators" label and click the green plus symbol to add a new Actuator.
2. Select the "ReferenceActuator" and click "Accept". Feel free to give your actuator a good name in the panel that shows below. Make sure to hit "Apply" if you make any changes.
3. Go to the "Feeders" tab, click the green plus symbol again, and select "ReferenceSlotAutoFeeder" in the list before clicking "Accept". 
4. In the panel below, you will see a section called "Actuators". Click the drop down to the right of the "Feed" label and select the actuator you just made.
5. Feel free to use the test button to test your actuator and hit "Apply" when you are done.

# Implementation Details
1. How did you test the change? Be descriptive. Untested code will not be accepted.
I tested the changes manually. Basically, I started the app up, made sure it didn't crash anything immediately (which it did, but I fixed that) and then tested a few scenarios like changing the feeder name in the drop down and seeing if that was propagated to the feeder correctly.

2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)?
I believe so. I'm running IntelliJ and I didn't find a formatter spec for that, so I just did the best I could to match it.

3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing.
No changes were made to those packages.

4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted.
I ran tests inside IntelliJ and it worked. I tried getting it to work using `mvn test` but there were failures with reading my machine.xml file. The mvn test failures occurred on the develop branch as well so I do not suspect that these errors are related to my changes nor that my changes introduced any issues.