### PR TITLE
Feature / Advanced Motion Control - Update 7

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/driver/AbstractMotionPlanner.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/AbstractMotionPlanner.java
@@ -32,7 +32,6 @@ import javax.swing.Icon;
 
 import org.openpnp.gui.support.PropertySheetWizardAdapter;
 import org.openpnp.gui.support.Wizard;
-import org.openpnp.machine.reference.ActuatorInterlockMonitor;
 import org.openpnp.machine.reference.ReferenceHeadMountable;
 import org.openpnp.machine.reference.ReferenceMachine;
 import org.openpnp.machine.reference.axis.ReferenceControllerAxis;

--- a/src/main/java/org/openpnp/machine/reference/driver/GcodeDriverSolutions.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/GcodeDriverSolutions.java
@@ -465,7 +465,11 @@ class GcodeDriverSolutions implements Solutions.Subject {
                                 commandBuilt = "$H ; Home all axes";
                             }
                             else if (tinyG) {
-                                commandBuilt = "G28.2 ; Home all axes";
+                                commandBuilt = "G28.2 ";
+                                for (String variable : gcodeDriver.getAxisVariables(machine)) {
+                                    commandBuilt += variable+"0 "; // In TinyG you need to indicate the axis and only 0 is possible. 
+                                }
+                                commandBuilt += "; Home all axes";
                             }
                             else {
                                 commandBuilt = "G28 ; Home all axes";

--- a/src/main/java/org/openpnp/model/Solutions.java
+++ b/src/main/java/org/openpnp/model/Solutions.java
@@ -65,7 +65,7 @@ public class Solutions extends AbstractTableModel {
         Warning(new Color(255, 220, 157)),
         Error(new Color(255, 157, 157)),
         None(new Color(255, 255, 255)), 
-        Fundamental(new Color(255, 157, 157));
+        Fundamental(new Color(200, 220, 255));
 
         private Color color;
 


### PR DESCRIPTION
# Description
This is Update 7 of the [`advanced-motion-control`](https://github.com/openpnp/openpnp/issues?q=label%3Aadvanced-motion-control) series.

This is intended to be the last PR in the `testing` branch.

## Features

- Bug-fix: Rotation coordinates (angles) must not be length unit converted to/from driver units in the GcodeDriver. 
- The homing command for TinyG must name the axes to be homed (Gcode suggested by Issues & Solutions).
- Cosmetic color change in Issues & Solutions. "Fundamental" issues are now blue rather than scary red. They are _important_ and _fundamental_ but they should not be _alarming_ in any way. 

# Justification
See also:
https://groups.google.com/g/openpnp/c/ObzQGzK5HW0/m/NgM3ahU0AwAJ

# Instructions for Use
- [General Advanced Motion Control documentation keeps getting linked here](https://makr.zone/openpnp-advanced-motion-control/553/)

# Implementation Details
1. Testing with the mixed three controller test rig. The driver unit conversion bug-fix cannot reliably be tested, I hope [Florian](https://groups.google.com/g/openpnp/c/ObzQGzK5HW0/m/NgM3ahU0AwAJ) will do that ASAP. 
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. Successful `mvn test` before submitting the Pull Request. 
