### PR TITLE
Fix for issue 755 "ReferenceStripFeeder Breaks When Part Pitch > Hole to Hole Distance"

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/feeder/ReferenceStripFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/ReferenceStripFeeder.java
@@ -167,8 +167,18 @@ public class ReferenceStripFeeder extends ReferenceFeeder {
         // It's the P1 value according to EIA-481-C, October 2003, pg. 9, 11, 13
         // Accuracy variations as specified in the document are not taken into account!
         double partPitchAdjusted = lineLocations[0].getLinearDistanceTo(lineLocations[1]);
-        partPitchAdjusted =
-                partPitchAdjusted / (Math.round(partPitchAdjusted / partPitch.getValue()));
+        double holeCount = (Math.round(partPitchAdjusted / partPitch.getValue()));
+
+        // if the two points are at least 1 hole apart, we can compute the adjusted pitch. 
+        // otherwise use the un-adjusted holePitch (and avoid a divide by zero).  The second 
+        // case means the feeder is set up incorrectly but has been tested to behave in a 
+        // reasonable way, even if the two points are coincident
+        if (holeCount > 0) {
+        	partPitchAdjusted = partPitchAdjusted / (Math.round(partPitchAdjusted / partPitch.getValue()));
+        } else {
+        	partPitchAdjusted = holePitch.getValue();
+        }
+        	
         Location l = Utils2D.getPointAlongLine(lineLocations[0], lineLocations[1],
                 new Length((feedCount - 1) * partPitchAdjusted, partPitch.getUnits()));
         // Create the offsets that are required to go from a reference hole


### PR DESCRIPTION
# Description
Fixes issue #755 which was caused by a divide by zero when the user incorrectly configures a strip feeder.

# Justification
Fixes a bug

# Instructions for Use
No change in usage of ReferenceStripFeeder

# Implementation Details
1. I configured a strip feeder with holes very close together (less than one partPitch distance) and the new code uses the user-supplied part pitch rather than using a computed "adjustedPartPitch".  This spaces the pick locations along a vector in the direction between the two supplied points.  I also configured a feeder with two holes exactly on top of each other and in this case, all pick locations will be computed as the same as pick location zero.  In all cases "reasonable" behavior for an incorrectly configured feeder.

2. The code follows the standard
3. No model changes
4. mvn test passes with no issues
