### PR TITLE
ReferenceDragFeeder works with 0402 parts with vision enabled and dis…

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/feeder/ReferenceDragFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/ReferenceDragFeeder.java
@@ -76,6 +76,8 @@ public class ReferenceDragFeeder extends ReferenceFeeder {
     @Element
     protected Location feedEndLocation = new Location(LengthUnit.Millimeters);
     @Element(required = false)
+    private Length partPitch = new Length(4, LengthUnit.Millimeters);
+    @Element(required = false)
     protected double feedSpeed = 1.0;
     @Attribute(required = false)
     protected String actuatorName;
@@ -99,7 +101,7 @@ public class ReferenceDragFeeder extends ReferenceFeeder {
      * correct feed locations.
      */
     protected Location visionOffset;
-    protected Location partPitch;
+    protected Location partPick;
 
     @Override
     public Location getPickLocation() throws Exception {
@@ -107,8 +109,8 @@ public class ReferenceDragFeeder extends ReferenceFeeder {
             pickLocation = location;
         }
 
-        if (this.isPart0402() && partPitch != null) {
-			pickLocation = pickLocation.add(partPitch);
+        if (partPitch.convertToUnits(LengthUnit.Millimeters).getValue() == 2 && partPick != null) {
+			pickLocation = pickLocation.add(partPick);
 		}
 
         if (vision.isEnabled() && visionOffset != null) {
@@ -213,8 +215,13 @@ public class ReferenceDragFeeder extends ReferenceFeeder {
 
 	        // retract the pin
 	        actuator.actuate(false);
+            
+            // evaluate for backwards compatibility
+            if(this.isPart0402() == true){
+                partPitch = new Length(2, LengthUnit.Millimeters);
+            }
 
-	        if (this.isPart0402() == true) {
+	        if (partPitch.convertToUnits(LengthUnit.Millimeters).getValue() == 2) {
 				// can change it to "feededCount = parts_count_userSettings;"
 				feededCount = 2;
 	        }
@@ -229,11 +236,11 @@ public class ReferenceDragFeeder extends ReferenceFeeder {
         if (feededCount > 0) {
             feededCount--;
             if (feededCount > 0) {
-                partPitch = new Location(LengthUnit.Millimeters, partsPitchX * feededCount,
+                partPick = new Location(LengthUnit.Millimeters, partsPitchX * feededCount,
                         partsPitchY * feededCount, 0, 0);
             } 
             else {
-                partPitch = null;
+                partPick = null;
             }
         }
 
@@ -343,7 +350,7 @@ public class ReferenceDragFeeder extends ReferenceFeeder {
 			Logger.debug("resetVisionOffsets " + visionOffset);
 		}
 
-		partPitch = null;
+		partPick = null;
 	}
 
 	public boolean isPart0402() {
@@ -365,6 +372,14 @@ public class ReferenceDragFeeder extends ReferenceFeeder {
 
     public void setFeedEndLocation(Location feedEndLocation) {
         this.feedEndLocation = feedEndLocation;
+    }
+
+    public Length getPartPitch() {
+        return partPitch;
+    }
+
+    public void setPartPitch(Length partPitch) {
+        this.partPitch = partPitch;
     }
 
     public Double getFeedSpeed() {

--- a/src/main/java/org/openpnp/machine/reference/feeder/ReferenceDragFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/ReferenceDragFeeder.java
@@ -107,13 +107,12 @@ public class ReferenceDragFeeder extends ReferenceFeeder {
             pickLocation = location;
         }
 
+        if (this.isPart0402() && partPitch != null) {
+			pickLocation = pickLocation.add(partPitch);
+		}
+
         if (vision.isEnabled() && visionOffset != null) {
-			if (this.isPart0402() && partPitch != null) {
-				return pickLocation.subtract(visionOffset).add(partPitch);
-			}
-			else {
-				return pickLocation.subtract(visionOffset);
-			}
+			pickLocation = pickLocation.subtract(visionOffset);
         }
 
         return pickLocation;
@@ -227,19 +226,19 @@ public class ReferenceDragFeeder extends ReferenceFeeder {
 
         head.moveToSafeZ();
 
+        if (feededCount > 0) {
+            feededCount--;
+            if (feededCount > 0) {
+                partPitch = new Location(LengthUnit.Millimeters, partsPitchX * feededCount,
+                        partsPitchY * feededCount, 0, 0);
+            } 
+            else {
+                partPitch = null;
+            }
+        }
+
         if (vision.isEnabled()) {
             visionOffset = getVisionOffsets(head, location);
-
-			if (feededCount > 0) {
-				feededCount--;
-				if (feededCount > 0) {
-					partPitch = new Location(LengthUnit.Millimeters, partsPitchX * feededCount,
-							partsPitchY * feededCount, 0, 0);
-				} 
-				else {
-					partPitch = null;
-				}
-			}
 
             Logger.debug("final visionOffsets " + visionOffset);
 

--- a/src/main/java/org/openpnp/machine/reference/feeder/wizards/ReferenceDragFeederConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/wizards/ReferenceDragFeederConfigurationWizard.java
@@ -79,6 +79,9 @@ public class ReferenceDragFeederConfigurationWizard
     private JTextField textFieldFeedEndY;
     private JTextField textFieldFeedEndZ;
     private JTextField textFieldFeedRate;
+    private JLabel lblPartPitch;
+    private JTextField textFieldPartPitch;
+    private JLabel lblFeedRate;
     private JLabel lblActuatorId;
     private JLabel lblPeelOffActuatorId;
     private JLabel lbl0402PartDetected;
@@ -110,6 +113,8 @@ public class ReferenceDragFeederConfigurationWizard
     private JPanel panel;
     private JButton btnCancelChangeTemplateImage;
     private JButton btnResetVisionOffsets;
+    private JLabel lblBackoffDistance;
+    private JTextField backoffDistTf;
 
     public ReferenceDragFeederConfigurationWizard(ReferenceDragFeeder feeder) {
         super(feeder);
@@ -129,27 +134,35 @@ public class ReferenceDragFeederConfigurationWizard
                         FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,
                         FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,},
                 new RowSpec[] {FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
                         FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,}));
 
-        JLabel lblFeedRate = new JLabel("Feed Speed %");
-        panelGeneral.add(lblFeedRate, "2, 2");
+        lblPartPitch = new JLabel("Part Pitch");
+        panelGeneral.add(lblPartPitch, "2, 2, right, default");
+
+        textFieldPartPitch = new JTextField();
+        panelGeneral.add(textFieldPartPitch, "4, 2");
+        textFieldPartPitch.setColumns(5);
+
+        lblFeedRate = new JLabel("Feed Speed %");
+        panelGeneral.add(lblFeedRate, "2, 4");
 
         textFieldFeedRate = new JTextField();
-        panelGeneral.add(textFieldFeedRate, "4, 2");
+        panelGeneral.add(textFieldFeedRate, "4, 4");
         textFieldFeedRate.setColumns(5);
 
         lblActuatorId = new JLabel("Actuator Name");
-        panelGeneral.add(lblActuatorId, "2, 4, right, default");
+        panelGeneral.add(lblActuatorId, "2, 6, right, default");
 
         textFieldActuatorId = new JTextField();
-        panelGeneral.add(textFieldActuatorId, "4, 4");
+        panelGeneral.add(textFieldActuatorId, "4, 6");
         textFieldActuatorId.setColumns(5);
 
         lblPeelOffActuatorId = new JLabel("Peel Off Actuator Name");
-        panelGeneral.add(lblPeelOffActuatorId, "6, 4, right, default");
+        panelGeneral.add(lblPeelOffActuatorId, "6, 6, right, default");
 
         textFieldPeelOffActuatorId = new JTextField();
-        panelGeneral.add(textFieldPeelOffActuatorId, "8, 4");
+        panelGeneral.add(textFieldPeelOffActuatorId, "8, 6");
         textFieldPeelOffActuatorId.setColumns(5);
 
         if (feeder.isPart0402()) {
@@ -364,6 +377,7 @@ public class ReferenceDragFeederConfigurationWizard
         BufferedImageIconConverter imageConverter = new BufferedImageIconConverter();
         PercentConverter percentConverter = new PercentConverter();
 
+        addWrappedBinding(feeder, "partPitch", textFieldPartPitch, "text", lengthConverter);
         addWrappedBinding(feeder, "feedSpeed", textFieldFeedRate, "text", percentConverter);
         addWrappedBinding(feeder, "actuatorName", textFieldActuatorId, "text");
         addWrappedBinding(feeder, "peelOffActuatorName", textFieldPeelOffActuatorId, "text");
@@ -397,6 +411,7 @@ public class ReferenceDragFeederConfigurationWizard
         
         addWrappedBinding(feeder, "backoffDistance", backoffDistTf, "text", lengthConverter);
 
+        ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldPartPitch);
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldFeedRate);
         ComponentDecorators.decorateWithAutoSelect(textFieldActuatorId);
         ComponentDecorators.decorateWithAutoSelect(textFieldPeelOffActuatorId);
@@ -560,6 +575,4 @@ public class ReferenceDragFeederConfigurationWizard
             });
         }
     };
-    private JLabel lblBackoffDistance;
-    private JTextField backoffDistTf;
 }


### PR DESCRIPTION
…abled

# Description
Currently when using 0402 parts with ReferenceDragFeeder feeder vision must be enabled to pick two parts per advance of the tape (required for 2mm component pitch tapes common on 0402 components).  This feature is now fully independant of feeder vision features so can be used with or without feeder vision enabled.

# Justification
This enables higher accuracy machines to disable feeder vision and pick 0402 components.  If required feeder vision can still be used in conjunction with this feature.

# Instructions for Use
As before but now 0402 components can be picked without feeder vision enabled

# Implementation Details
1. Tested with physical drag feeder, both with feeder vision enabled and disabled, verifying correct pick location for multiple picks.
2. Yes
3. N/A
4. Tests pass
