### PR TITLE
Fix / Bring back Camera.AfterSettle (lost in merge conflict)

### DIFF
--- a/src/main/java/org/openpnp/spi/base/AbstractCamera.java
+++ b/src/main/java/org/openpnp/spi/base/AbstractCamera.java
@@ -675,24 +675,37 @@ public abstract class AbstractCamera extends AbstractHeadMountable implements Ca
             Logger.warn(e);
         }
 
-        // Make sure the camera (or its subject) stands still.
-        waitForCompletion(CompletionType.WaitForStillstand);
+        try {
+            // Make sure the camera (or its subject) stands still.
+            waitForCompletion(CompletionType.WaitForStillstand);
 
-        if (settleMethod == null) {
-            // Method undetermined, probably created a new camera (no @Commit handler)
-            settleMethod = SettleMethod.FixedTime;
+            if (settleMethod == null) {
+                // Method undetermined, probably created a new camera (no @Commit handler)
+                settleMethod = SettleMethod.FixedTime;
+            }
+            if (settleMethod == SettleMethod.FixedTime) {
+                try {
+                    Thread.sleep(getSettleTimeMs());
+                }
+                catch (Exception e) {
+
+                }
+                return capture();
+            }
+            else {
+                return autoSettleAndCapture();
+            }
         }
-        if (settleMethod == SettleMethod.FixedTime) {
+        finally {
+
             try {
-                Thread.sleep(getSettleTimeMs());
+                Map<String, Object> globals = new HashMap<>();
+                globals.put("camera", this);
+                Configuration.get().getScripting().on("Camera.AfterSettle", globals);
             }
             catch (Exception e) {
-
+                Logger.warn(e);
             }
-            return capture();
-        }
-        else {
-            return autoSettleAndCapture();
         }
     }
 


### PR DESCRIPTION
# Description
This brings back #999 after it got lost in a faulty conflict resolution somewhere in #1086.

NOTE: due to indentation, best [look at the changes ignoring whitespace](https://github.com/openpnp/openpnp/pull/1089/files?diff=unified&w=1).

# Justification
See the [user group discussion](https://groups.google.com/g/openpnp/c/j4ucK1JuyH0/m/hvmpc2hmBQAJ).

# Instructions for Use
See #999.

# Implementation Details
1. Assuming original PR tests are conclusive.
2. Original did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. Successful run of `mvn test` before submitting the Pull Request. 
