### PR TITLE
Remove GUI dependencies from Scripting

### DIFF
--- a/src/main/java/org/openpnp/gui/MainFrame.java
+++ b/src/main/java/org/openpnp/gui/MainFrame.java
@@ -92,6 +92,7 @@ import org.openpnp.gui.support.OSXAdapter;
 import org.openpnp.gui.support.RotationCellValue;
 import org.openpnp.model.Configuration;
 import org.openpnp.model.LengthUnit;
+import org.openpnp.scripting.ScriptFileWatcher;
 import org.pmw.tinylog.Logger;
 
 import com.jgoodies.forms.layout.ColumnSpec;
@@ -219,6 +220,8 @@ public class MainFrame extends JFrame {
 
     private ActionListener instructionsCancelActionListener;
     private ActionListener instructionsProceedActionListener;
+
+    private ScriptFileWatcher scriptFileWatcher;
 
     public MainFrame(Configuration configuration) {
         mainFrame = this;
@@ -654,7 +657,8 @@ public class MainFrame extends JFrame {
         while (!configurationLoaded) {
 	        try {
 	            configuration.load();
-	            configuration.getScripting().setMenu(mnScripts);
+	            scriptFileWatcher = new ScriptFileWatcher(configuration.getScripting());
+	            scriptFileWatcher.setMenu(mnScripts);
 	            
 	            if (Configuration.get().getMachine().getProperty("Welcome2_0_Dialog_Shown") == null) {
 	                Welcome2_0Dialog dialog = new Welcome2_0Dialog(this);

--- a/src/main/java/org/openpnp/machine/reference/ScriptActuator.java
+++ b/src/main/java/org/openpnp/machine/reference/ScriptActuator.java
@@ -4,7 +4,7 @@ import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.openpnp.Scripting;
+import org.openpnp.scripting.Scripting;
 import org.openpnp.gui.support.Wizard;
 import org.openpnp.machine.reference.wizards.ScriptActuatorConfigurationWizard;
 import org.openpnp.model.Configuration;

--- a/src/main/java/org/openpnp/model/Configuration.java
+++ b/src/main/java/org/openpnp/model/Configuration.java
@@ -309,8 +309,9 @@ public class Configuration extends AbstractModelObject {
         for (ConfigurationListener listener : listeners) {
             listener.configurationComplete(this);
         }
-        
-        scripting = new Scripting();
+
+        File scriptingDirectory = new File(Configuration.get().getConfigurationDirectory(), "scripts");
+        scripting = new Scripting(scriptingDirectory);
     }
 
     public synchronized void save() throws Exception {

--- a/src/main/java/org/openpnp/model/Configuration.java
+++ b/src/main/java/org/openpnp/model/Configuration.java
@@ -23,7 +23,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
@@ -35,7 +34,7 @@ import java.util.prefs.Preferences;
 
 import org.apache.commons.io.FileUtils;
 import org.openpnp.ConfigurationListener;
-import org.openpnp.Scripting;
+import org.openpnp.scripting.Scripting;
 import org.openpnp.spi.Machine;
 import org.openpnp.util.NanosecondTime;
 import org.openpnp.util.ResourceUtils;

--- a/src/main/java/org/openpnp/scripting/ScriptFileWatcher.java
+++ b/src/main/java/org/openpnp/scripting/ScriptFileWatcher.java
@@ -1,0 +1,227 @@
+package org.openpnp.scripting;
+
+import org.apache.commons.io.FileUtils;
+import org.openpnp.Translations;
+import org.openpnp.util.UiUtils;
+
+import javax.swing.*;
+import java.awt.*;
+import java.awt.event.ActionEvent;
+import java.awt.event.KeyEvent;
+import java.io.File;
+import java.nio.file.FileSystems;
+import java.nio.file.StandardWatchEventKinds;
+import java.nio.file.WatchKey;
+import java.nio.file.WatchService;
+import java.util.*;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class ScriptFileWatcher {
+    private final Scripting scripting;
+
+    JMenu menu;
+    WatchService fileWatcher;
+
+    public ScriptFileWatcher(Scripting scripting) {
+        this.scripting = scripting;
+
+        copyExampleScripts();
+    }
+
+    private void copyExampleScripts() {
+        // TODO: It would be better if we just copied all the files from the Examples
+        // directory in the jar, but this is relatively difficult to do.
+        // There is some information on how to do it in:
+        // http://stackoverflow.com/questions/1386809/copy-directory-from-a-jar-file
+        File examplesDir = new File(scripting.getScriptsDirectory(), "Examples");
+        examplesDir.mkdirs();
+        String[] exampleScripts =
+                new String[] {
+                        "JavaScript/Call_Java.js",
+                        "JavaScript/Hello_World.js",
+                        "JavaScript/Move_Machine.js",
+                        "JavaScript/Pipeline.js",
+                        "JavaScript/Print_Scripting_Info.js",
+                        "JavaScript/QrCodeXout.js",
+                        "JavaScript/Reset_Strip_Feeders.js",
+                        "JavaScript/Utility.js",
+                        "Python/call_java.py",
+                        "Python/move_machine.py",
+                        "Python/print_hallo_openpnp.py",
+                        "Python/print_methods_vars.py",
+                        "Python/print_nozzle_info.py",
+                        "Python/print_scripting_info.py",
+                        "Python/use_module.py",
+                        "Python/utility.py"
+                };
+        for (String name : exampleScripts) {
+            try {
+                File file = new File(examplesDir, name);
+                if (file.exists()) {
+                    continue;
+                }
+                FileUtils.copyURLToFile(ClassLoader.getSystemResource("scripts/Examples/" + name),
+                        file);
+            }
+            catch (Exception e) {
+                e.printStackTrace();
+            }
+        }
+    }
+
+    public void setMenu(JMenu menu) {
+        setupFileWatcher();
+
+        this.menu = menu;
+        // Add a separator and the Refresh Scripts and Open Scripts Directory items
+        menu.addSeparator();
+        menu.add(new AbstractAction(Translations.getString("Scripting.Action.Refresh")) {
+            {
+                putValue(MNEMONIC_KEY, KeyEvent.VK_R);
+            }
+
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                synchronizeMenu(menu, scripting.getScriptsDirectory());
+            }
+        });
+        menu.add(new AbstractAction(Translations.getString("Scripting.Action.OpenScriptsDirectory")) {
+            {
+                putValue(MNEMONIC_KEY, KeyEvent.VK_O);
+            }
+
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                UiUtils.messageBoxOnException(() -> {
+                    if (Desktop.isDesktopSupported()) {
+                        Desktop.getDesktop().open(scripting.getScriptsDirectory());
+                    }
+                });
+            }
+        });
+
+        // Synchronize the menu
+        synchronizeMenu(menu, scripting.getScriptsDirectory());
+    }
+
+    private void setupFileWatcher() {
+        // Add a file watcher so that we can be notified if any scripts change
+        try {
+            fileWatcher = FileSystems.getDefault().newWatchService();
+            watchDirectory(scripting.getScriptsDirectory());
+            Thread thread = new Thread(() -> {
+                for (;;) {
+                    try {
+                        // wait for an event
+                        WatchKey key = fileWatcher.take();
+                        key.pollEvents();
+                        key.reset();
+                        // rescan
+                        synchronizeMenu(menu, scripting.getScriptsDirectory());
+                    }
+                    catch (Exception e) {
+                        e.printStackTrace();
+                    }
+                }
+            });
+            thread.setDaemon(true);
+            thread.start();
+        }
+        catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    private void watchDirectory(File directory) {
+        try {
+            directory.toPath().register(fileWatcher, StandardWatchEventKinds.ENTRY_CREATE,
+                    StandardWatchEventKinds.ENTRY_DELETE, StandardWatchEventKinds.ENTRY_MODIFY);
+        }
+        catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    private synchronized void synchronizeMenu(JMenu menu, File directory) {
+        if (menu == null) {
+            return;
+        }
+        // Remove any menu items that don't have a matching entry in the directory
+        Set<String> filenames = new HashSet<>(Arrays.asList(directory.list()));
+        for (JMenuItem item : getScriptMenuItems(menu)) {
+            if (!filenames.contains(item.getText())) {
+                menu.remove(item);
+            }
+        }
+
+        // Add any scripts not already in the menu
+        Set<String> itemNames = getScriptMenuItems(menu).stream().map(JMenuItem::getText)
+                .collect(Collectors.toSet());
+        for (File script : FileUtils.listFiles(directory, scripting.getExtensions(), false)) {
+            if (!script.isFile()) {
+                continue;
+            }
+            if (itemNames.contains(script.getName())) {
+                continue;
+            }
+            JMenuItem item = new JMenuItem(script.getName());
+            item.addActionListener((e) -> {
+                UiUtils.messageBoxOnException(() -> scripting.execute(script));
+            });
+            addSorted(menu, item);
+        }
+
+        // And add any directories not already in the menu
+        itemNames = getScriptMenuItems(menu).stream().map(JMenuItem::getText)
+                .collect(Collectors.toSet());
+        for (File d : directory.listFiles(File::isDirectory)) {
+            if (d.equals(scripting.getEventsDirectory())) {
+                continue;
+            }
+            if (new File(d, ".ignore").exists()) {
+                continue;
+            }
+            if (!itemNames.contains(d.getName())) {
+                JMenu m = new JMenu(d.getName());
+                addSorted(menu, m);
+                watchDirectory(d);
+            }
+        }
+
+        // Synchronize all of the sub-menus with their directories
+        for (JMenuItem item : getScriptMenuItems(menu)) {
+            if (item instanceof JMenu) {
+                synchronizeMenu((JMenu) item, new File(directory, item.getText()));
+            }
+        }
+    }
+
+    private void addSorted(JMenu menu, JMenuItem item) {
+        if (menu.getItemCount() == 0) {
+            menu.add(item);
+            return;
+        }
+        for (int i = 0; i < menu.getItemCount(); i++) {
+            JMenuItem existingItem = menu.getItem(i);
+            if (existingItem == null || item.getText().toLowerCase()
+                    .compareTo(existingItem.getText().toLowerCase()) <= 0) {
+                menu.insert(item, i);
+                return;
+            }
+        }
+        menu.add(item);
+    }
+
+    private java.util.List<JMenuItem> getScriptMenuItems(JMenu menu) {
+        List<JMenuItem> items = new ArrayList<>();
+        for (int i = 0; i < menu.getItemCount(); i++) {
+            // Once we hit the separator we stop
+            if (menu.getItem(i) == null) {
+                break;
+            }
+            items.add(menu.getItem(i));
+        }
+        return items;
+    }
+}

--- a/src/main/java/org/openpnp/scripting/Scripting.java
+++ b/src/main/java/org/openpnp/scripting/Scripting.java
@@ -1,35 +1,20 @@
 package org.openpnp.scripting;
 
-import java.awt.Desktop;
-import java.awt.event.ActionEvent;
-import java.awt.event.KeyEvent;
 import java.io.File;
 import java.io.FileReader;
-import java.nio.file.FileSystems;
-import java.nio.file.StandardWatchEventKinds;
-import java.nio.file.WatchKey;
-import java.nio.file.WatchService;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import javax.script.ScriptEngine;
 import javax.script.ScriptEngineFactory;
 import javax.script.ScriptEngineManager;
-import javax.swing.AbstractAction;
-import javax.swing.JMenu;
-import javax.swing.JMenuItem;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
-import org.openpnp.Translations;
 import org.openpnp.gui.MainFrame;
 import org.openpnp.model.Configuration;
-import org.openpnp.util.UiUtils;
 import org.pmw.tinylog.Logger;
 
 import com.google.common.io.Files;
@@ -37,12 +22,10 @@ import com.google.common.io.Files;
 import bsh.engine.BshScriptEngineFactory;
 
 public class Scripting {
-    JMenu menu;
-    final ScriptEngineManager manager = new ScriptEngineManager();
-    final String[] extensions;
-    File scriptsDirectory;
-    File eventsDirectory;
-    WatchService watcher;
+    private final ScriptEngineManager manager = new ScriptEngineManager();
+    private final String[] extensions;
+    private final File scriptsDirectory;
+    private final File eventsDirectory;
 
     public Scripting(File scriptsDirectory) {
         this.scriptsDirectory = scriptsDirectory;
@@ -56,7 +39,7 @@ public class Scripting {
                 extensions.add(ext.toLowerCase());
             }
         }
-        
+
         // Hack to fix BSH on Windows. See https://github.com/openpnp/openpnp/issues/462
         manager.registerEngineExtension("bsh", new BshScriptEngineFactory());
         manager.registerEngineExtension("java", new BshScriptEngineFactory());
@@ -65,210 +48,27 @@ public class Scripting {
 
         this.extensions = extensions.toArray(new String[] {});
 
-        // Create the scripts directory if it doesn't exist and copy the example scripts
-        // over.
-        if (!getScriptsDirectory().exists()) {
-            getScriptsDirectory().mkdirs();
-        }
-        
-        // TODO: It would be better if we just copied all the files from the Examples
-        // directory in the jar, but this is relatively difficult to do.
-        // There is some information on how to do it in:
-        // http://stackoverflow.com/questions/1386809/copy-directory-from-a-jar-file
-        File examplesDir = new File(getScriptsDirectory(), "Examples");
-        examplesDir.mkdirs();
-        String[] exampleScripts =
-                new String[] {
-                        "JavaScript/Call_Java.js", 
-                        "JavaScript/Hello_World.js", 
-                        "JavaScript/Move_Machine.js", 
-                        "JavaScript/Pipeline.js",
-                        "JavaScript/Print_Scripting_Info.js",
-                        "JavaScript/QrCodeXout.js",
-                        "JavaScript/Reset_Strip_Feeders.js", 
-                        "JavaScript/Utility.js", 
-                        "Python/call_java.py", 
-                        "Python/move_machine.py", 
-                        "Python/print_hallo_openpnp.py",
-                        "Python/print_methods_vars.py", 
-                        "Python/print_nozzle_info.py", 
-                        "Python/print_scripting_info.py",
-                        "Python/use_module.py", 
-                        "Python/utility.py"
-                        };
-        for (String name : exampleScripts) {
-            try {
-                File file = new File(examplesDir, name);
-                if (file.exists()) {
-                    continue;
-                }
-                FileUtils.copyURLToFile(ClassLoader.getSystemResource("scripts/Examples/" + name),
-                        file);
-            }
-            catch (Exception e) {
-                e.printStackTrace();
-            }
+        // Create the scripts directory if it doesn't exist.
+        if (!scriptsDirectory.exists()) {
+            scriptsDirectory.mkdirs();
         }
 
         this.eventsDirectory = new File(scriptsDirectory, "Events");
         if (!eventsDirectory.exists()) {
             eventsDirectory.mkdirs();
         }
-
-        // Add a file watcher so that we can be notified if any scripts change
-        try {
-            watcher = FileSystems.getDefault().newWatchService();
-            watchDirectory(getScriptsDirectory());
-            Thread thread = new Thread(() -> {
-                for (;;) {
-                    try {
-                        // wait for an event
-                        WatchKey key = watcher.take();
-                        key.pollEvents();
-                        key.reset();
-                        // rescan
-                        synchronizeMenu(menu, getScriptsDirectory());
-                    }
-                    catch (Exception e) {
-                        e.printStackTrace();
-                    }
-                }
-            });
-            thread.setDaemon(true);
-            thread.start();
-        }
-        catch (Exception e) {
-            e.printStackTrace();
-        }
     }
 
-    public void setMenu(JMenu menu) {
-        this.menu = menu;
-        // Add a separator and the Refresh Scripts and Open Scripts Directory items
-        menu.addSeparator();
-        menu.add(new AbstractAction(Translations.getString("Scripting.Action.Refresh")) {
-            {
-                putValue(MNEMONIC_KEY, KeyEvent.VK_R);
-            }
-
-            @Override
-            public void actionPerformed(ActionEvent e) {
-                synchronizeMenu(menu, getScriptsDirectory());
-            }
-        });
-        menu.add(new AbstractAction(Translations.getString("Scripting.Action.OpenScriptsDirectory")) {
-            {
-                putValue(MNEMONIC_KEY, KeyEvent.VK_O);
-            }
-
-            @Override
-            public void actionPerformed(ActionEvent e) {
-                UiUtils.messageBoxOnException(() -> {
-                    if (Desktop.isDesktopSupported()) {
-                        Desktop.getDesktop().open(getScriptsDirectory());
-                    }
-                });
-            }
-        });
-
-        // Synchronize the menu
-        synchronizeMenu(menu, getScriptsDirectory());
+    public String[] getExtensions() {
+        return extensions;
     }
 
     public File getScriptsDirectory() {
         return scriptsDirectory;
     }
 
-    private void watchDirectory(File directory) {
-        try {
-            directory.toPath().register(watcher, StandardWatchEventKinds.ENTRY_CREATE,
-                    StandardWatchEventKinds.ENTRY_DELETE, StandardWatchEventKinds.ENTRY_MODIFY);
-        }
-        catch (Exception e) {
-            e.printStackTrace();
-        }
-    }
-
-    private synchronized void synchronizeMenu(JMenu menu, File directory) {
-        if (menu == null) {
-            return;
-        }
-        // Remove any menu items that don't have a matching entry in the directory
-        Set<String> filenames = new HashSet<>(Arrays.asList(directory.list()));
-        for (JMenuItem item : getScriptMenuItems(menu)) {
-            if (!filenames.contains(item.getText())) {
-                menu.remove(item);
-            }
-        }
-
-        // Add any scripts not already in the menu
-        Set<String> itemNames = getScriptMenuItems(menu).stream().map(JMenuItem::getText)
-                .collect(Collectors.toSet());
-        for (File script : FileUtils.listFiles(directory, extensions, false)) {
-            if (!script.isFile()) {
-                continue;
-            }
-            if (itemNames.contains(script.getName())) {
-                continue;
-            }
-            JMenuItem item = new JMenuItem(script.getName());
-            item.addActionListener((e) -> {
-                UiUtils.messageBoxOnException(() -> execute(script));
-            });
-            addSorted(menu, item);
-        }
-
-        // And add any directories not already in the menu
-        itemNames = getScriptMenuItems(menu).stream().map(JMenuItem::getText)
-                .collect(Collectors.toSet());
-        for (File d : directory.listFiles(File::isDirectory)) {
-            if (d.equals(eventsDirectory)) {
-                continue;
-            }
-            if (new File(d, ".ignore").exists()) {
-                continue;
-            }
-            if (!itemNames.contains(d.getName())) {
-                JMenu m = new JMenu(d.getName());
-                addSorted(menu, m);
-                watchDirectory(d);
-            }
-        }
-
-        // Synchronize all of the sub-menus with their directories
-        for (JMenuItem item : getScriptMenuItems(menu)) {
-            if (item instanceof JMenu) {
-                synchronizeMenu((JMenu) item, new File(directory, item.getText()));
-            }
-        }
-    }
-
-    private void addSorted(JMenu menu, JMenuItem item) {
-        if (menu.getItemCount() == 0) {
-            menu.add(item);
-            return;
-        }
-        for (int i = 0; i < menu.getItemCount(); i++) {
-            JMenuItem existingItem = menu.getItem(i);
-            if (existingItem == null || item.getText().toLowerCase()
-                    .compareTo(existingItem.getText().toLowerCase()) <= 0) {
-                menu.insert(item, i);
-                return;
-            }
-        }
-        menu.add(item);
-    }
-
-    private List<JMenuItem> getScriptMenuItems(JMenu menu) {
-        List<JMenuItem> items = new ArrayList<>();
-        for (int i = 0; i < menu.getItemCount(); i++) {
-            // Once we hit the separator we stop
-            if (menu.getItem(i) == null) {
-                break;
-            }
-            items.add(menu.getItem(i));
-        }
-        return items;
+    public File getEventsDirectory() {
+        return eventsDirectory;
     }
 
     public void execute(String script) throws Exception {

--- a/src/main/java/org/openpnp/scripting/Scripting.java
+++ b/src/main/java/org/openpnp/scripting/Scripting.java
@@ -1,7 +1,6 @@
 package org.openpnp.scripting;
 
 import java.awt.Desktop;
-import java.awt.Toolkit;
 import java.awt.event.ActionEvent;
 import java.awt.event.KeyEvent;
 import java.io.File;
@@ -24,7 +23,6 @@ import javax.script.ScriptEngineManager;
 import javax.swing.AbstractAction;
 import javax.swing.JMenu;
 import javax.swing.JMenuItem;
-import javax.swing.KeyStroke;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
@@ -46,7 +44,9 @@ public class Scripting {
     File eventsDirectory;
     WatchService watcher;
 
-    public Scripting() {
+    public Scripting(File scriptsDirectory) {
+        this.scriptsDirectory = scriptsDirectory;
+
         // Collect all the script filename extensions we know how to handle from the list of
         // available scripting engines.
         List<ScriptEngineFactory> factories = manager.getEngineFactories();
@@ -64,9 +64,6 @@ public class Scripting {
         extensions.add("java");
 
         this.extensions = extensions.toArray(new String[] {});
-
-        this.scriptsDirectory =
-                new File(Configuration.get().getConfigurationDirectory(), "scripts");
 
         // Create the scripts directory if it doesn't exist and copy the example scripts
         // over.

--- a/src/main/java/org/openpnp/scripting/Scripting.java
+++ b/src/main/java/org/openpnp/scripting/Scripting.java
@@ -1,4 +1,4 @@
-package org.openpnp;
+package org.openpnp.scripting;
 
 import java.awt.Desktop;
 import java.awt.Toolkit;
@@ -28,6 +28,7 @@ import javax.swing.KeyStroke;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
+import org.openpnp.Translations;
 import org.openpnp.gui.MainFrame;
 import org.openpnp.model.Configuration;
 import org.openpnp.util.UiUtils;


### PR DESCRIPTION
# Description
The Scripting class is used to execute scripts (through a menu item) or execute events (triggered in various places in the code). The Scripting class was also handling copying example scripts over from project resources as well as starting a file watcher which updated a menu in the GUI.

This diff:
- Moves the Scripting class to an org.openpnp.scripting package.
- Refactors the scriptsDirectory to be a parameter passed into the Configuration class.
- Adds a ScriptFileWatcher class in the scripting package that handles copying the example scripts over and handles synchronizing the menu in the GUI application.

# Justification
This is mostly to clean up the code for testability. We don't have tests relying on scripting (e.g. verifying that events are sent off properly) just yet, but the scripting engine was created (indirectly through Configuration.initialize) in a lot of tests which meant the file watcher was also kicked off for each of those tests.

# Instructions for Use
This should be a change that only affects developers. End users should notice no change whatsoever.

# Implementation Details
I tested this change by running the application and updating some scripts in the scripts directory as well as running them through the menu. No changes to the spi but the configuration class did get a small change just to inject the scriptsDirectory into the scripting class. Unit tests pass.