### PR TITLE
Added maxFeedCount feature to ReferenceStripFeeder

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/feeder/ReferenceStripFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/ReferenceStripFeeder.java
@@ -108,6 +108,9 @@ public class ReferenceStripFeeder extends ReferenceFeeder {
     @Attribute
     private int feedCount = 0;
 
+	@Attribute(required = false)
+	private int maxFeedCount = 0;
+
     private Length holeDiameter = new Length(1.5, LengthUnit.Millimeters);
 
     private Length holePitch = new Length(4, LengthUnit.Millimeters);
@@ -219,6 +222,10 @@ public class ReferenceStripFeeder extends ReferenceFeeder {
 
     public void feed(Nozzle nozzle) throws Exception {
         setFeedCount(getFeedCount() + 1);
+
+        if ((maxFeedCount > 0) && (feedCount > maxFeedCount)) {
+			throw new Exception("Tried to feed part: " + part.getId() + "  Feeder " + name + " empty.");
+		}
 
         updateVisionOffsets(nozzle);
     }
@@ -397,6 +404,14 @@ public class ReferenceStripFeeder extends ReferenceFeeder {
         this.feedCount = feedCount;
         firePropertyChange("feedCount", oldValue, feedCount);
     }
+
+	public int getMaxFeedCount() {
+		return maxFeedCount;
+	}
+
+	public void setMaxFeedCount(int count) {
+		maxFeedCount = count;
+	}
 
     public Length getReferenceHoleToPartLinear() {
         return referenceHoleToPartLinear;

--- a/src/main/java/org/openpnp/machine/reference/feeder/wizards/ReferenceStripFeederConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/wizards/ReferenceStripFeederConfigurationWizard.java
@@ -116,6 +116,8 @@ public class ReferenceStripFeederConfigurationWizard extends AbstractConfigurati
     private JLabel lblFeedCount;
     private JTextField textFieldFeedCount;
     private JButton btnResetFeedCount;
+    private JLabel lblMaxFeedCount;
+    private JTextField textFieldMaxFeedCount;
     private JLabel lblTapeType;
     private JComboBox comboBoxTapeType;
     private JLabel lblRotationInTape;
@@ -220,6 +222,7 @@ public class ReferenceStripFeederConfigurationWizard extends AbstractConfigurati
                 new RowSpec[] {FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
                         FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
                         FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
                         FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,}));
 
         btnAutoSetup = new JButton(autoSetup);
@@ -260,6 +263,13 @@ public class ReferenceStripFeederConfigurationWizard extends AbstractConfigurati
             }
         });
         panelTapeSettings.add(btnResetFeedCount, "12, 6");
+
+        lblMaxFeedCount = new JLabel("Max Feed Count");
+        panelTapeSettings.add(lblMaxFeedCount,"8, 8, right, default");
+        textFieldMaxFeedCount = new JTextField();
+        panelTapeSettings.add(textFieldMaxFeedCount,"10,8");
+        textFieldMaxFeedCount.setColumns(10);
+        textFieldMaxFeedCount.setToolTipText("Max number of parts to feed from this strip.  If set to zero, this setting is ignored.");
 
         JPanel panelVision = new JPanel();
         panelVision.setBorder(new TitledBorder(null, "Vision", TitledBorder.LEADING, TitledBorder.TOP,
@@ -380,6 +390,7 @@ public class ReferenceStripFeederConfigurationWizard extends AbstractConfigurati
         addWrappedBinding(feeder, "tapeWidth", textFieldTapeWidth, "text", lengthConverter);
         addWrappedBinding(feeder, "partPitch", textFieldPartPitch, "text", lengthConverter);
         addWrappedBinding(feeder, "feedCount", textFieldFeedCount, "text", intConverter);
+        addWrappedBinding(feeder, "maxFeedCount", textFieldMaxFeedCount, "text", intConverter);
 
         MutableLocationProxy feedStartLocation = new MutableLocationProxy();
         bind(UpdateStrategy.READ_WRITE, feeder, "referenceHoleLocation", feedStartLocation,
@@ -405,6 +416,7 @@ public class ReferenceStripFeederConfigurationWizard extends AbstractConfigurati
         ComponentDecorators.decorateWithAutoSelect(pickRetryCount);
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldPartPitch);
         ComponentDecorators.decorateWithAutoSelect(textFieldFeedCount);
+        ComponentDecorators.decorateWithAutoSelect(textFieldMaxFeedCount);
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldFeedStartX);
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldFeedStartY);
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldFeedStartZ);


### PR DESCRIPTION
# Description
This change adds a 'maxFeedCount' field to ReferenceStripFeeder.  When the feeder's feedCount exceeds 'maxFeedCount' then it will throw an exception indicating that it is out of parts.  The message shown to the user will display the part and feeder name.  If the user leaves 'maxFeedCount' at the default value of zero, this feature will be ignored so we don't force everyone to immediately set maxFeedCount on all of their feeders.

# Justification
This is a much-needed feature for projects using strip feeders that cannot fit all of a given part into one strip.  For example I have a project which uses 64 leds and there is no way to safely use OpenPNP to populate those parts on my machine because it continues to feed past the end of the strip.

# Instructions for Use
If the user wants to use the new maxFeedCount option on ReferenceStripFeeder, they simply set the desired value in the wizard for the feeder.
![image](https://user-images.githubusercontent.com/15841740/103471308-939ad200-4d33-11eb-8928-df482d744ae6.png)
When a feeder runs out of parts a message like this will be displayed:
![image](https://user-images.githubusercontent.com/15841740/103471331-0310c180-4d34-11eb-96b6-e729dc47e565.png)

# Implementation Details
1. I tested the change by running several test jobs using more parts than my 'maxFeedCount' setting.
2. The coding style is followed.
3. No changes to `org.openpnp.spi` or `org.openpnp.model` packages but there is a new optional attribute named 'maxFeedCount' on ReferenceStripFeeder.
4. mvn test runs without errors
