### PR TITLE
Improved "MaxFeedCount" for Reference Strip Feeder

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/feeder/ReferenceStripFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/ReferenceStripFeeder.java
@@ -223,11 +223,20 @@ public class ReferenceStripFeeder extends ReferenceFeeder {
     public void feed(Nozzle nozzle) throws Exception {
         setFeedCount(getFeedCount() + 1);
 
+        // normally the feeder will automatically disable when it runs out but
+        // if the user re-enables and tries to feed, throw an exception that we are out of parts.
         if ((maxFeedCount > 0) && (feedCount > maxFeedCount)) {
 			throw new Exception("Tried to feed part: " + part.getId() + "  Feeder " + name + " empty.");
 		}
 
         updateVisionOffsets(nozzle);
+        
+        // automatically disable when we reach the last part, openpnp will try
+        // to pick another feeder that provides the same part for the next feed.
+        if ((maxFeedCount > 0) && (feedCount >= maxFeedCount))
+        {
+        	enabled = false;
+        }
     }
 
     private void updateVisionOffsets(Nozzle nozzle) throws Exception {

--- a/src/main/java/org/openpnp/machine/reference/feeder/ReferenceStripFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/ReferenceStripFeeder.java
@@ -223,20 +223,12 @@ public class ReferenceStripFeeder extends ReferenceFeeder {
     public void feed(Nozzle nozzle) throws Exception {
         setFeedCount(getFeedCount() + 1);
 
-        // normally the feeder will automatically disable when it runs out but
-        // if the user re-enables and tries to feed, throw an exception that we are out of parts.
+        // Throw an exception when the feeder runs out of parts
         if ((maxFeedCount > 0) && (feedCount > maxFeedCount)) {
 			throw new Exception("Tried to feed part: " + part.getId() + "  Feeder " + name + " empty.");
 		}
 
         updateVisionOffsets(nozzle);
-        
-        // automatically disable when we reach the last part, openpnp will try
-        // to pick another feeder that provides the same part for the next feed.
-        if ((maxFeedCount > 0) && (feedCount >= maxFeedCount))
-        {
-        	enabled = false;
-        }
     }
 
     private void updateVisionOffsets(Nozzle nozzle) throws Exception {

--- a/src/main/java/org/openpnp/machine/reference/feeder/wizards/ReferenceStripFeederConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/wizards/ReferenceStripFeederConfigurationWizard.java
@@ -117,6 +117,7 @@ public class ReferenceStripFeederConfigurationWizard extends AbstractConfigurati
     private JTextField textFieldFeedCount;
     private JButton btnResetFeedCount;
     private JLabel lblMaxFeedCount;
+    private JButton btnMaxFeedCount;
     private JTextField textFieldMaxFeedCount;
     private JLabel lblTapeType;
     private JComboBox comboBoxTapeType;
@@ -270,7 +271,20 @@ public class ReferenceStripFeederConfigurationWizard extends AbstractConfigurati
         panelTapeSettings.add(textFieldMaxFeedCount,"10,8");
         textFieldMaxFeedCount.setColumns(10);
         textFieldMaxFeedCount.setToolTipText("Max number of parts to feed from this strip.  If set to zero, this setting is ignored.");
-
+        btnMaxFeedCount = new JButton(new AbstractAction("Auto Set MaxFeedCount") {
+        	@Override
+        	public void actionPerformed(ActionEvent e) {
+        		Location h0 = feeder.getReferenceHoleLocation();
+        		Location h1 = feeder.getLastHoleLocation();
+        		Length strip_len = h0.getLinearLengthTo(h1);
+        		double part_count = strip_len.divide(feeder.getPartPitch());
+        		int ipart_count = 1+(int)Math.round(part_count);
+        		textFieldMaxFeedCount.setText(Integer.toString(ipart_count));
+        	}
+        });
+        btnMaxFeedCount.setToolTipText("Calculate the Max Feed Count using the feeder's hole locations and part pitch");
+        panelTapeSettings.add(btnMaxFeedCount,"12,8");
+        
         JPanel panelVision = new JPanel();
         panelVision.setBorder(new TitledBorder(null, "Vision", TitledBorder.LEADING, TitledBorder.TOP,
                 null, null));


### PR DESCRIPTION
# Description
This adds a few more details to the 'maxFeedCount' feature of ReferenceStripFeeder
- When a feeder feeds its last part, it will automatically disable itself.  This causes OpenPNP to automatically switch to another feeder for that part (if there is one)
- There is a new button for automatically setting the MaxFeedCount based on the configured reference hole locations

# Justification
This further improves the behavior of ReferenceStripFeeder when you need more parts than will fit in one strip.

# Instructions for Use
If you press the 'Auto Set MaxFeedCount' button, the MaxFeedCount field will be set based on the distance between the reference hole locations you have selected and the pitch of the part.  If you configure multiple strip feeders for a given part and one of them runs out of parts, OpenPNP will automatically start using the next strip that it can find in the list.
![image](https://user-images.githubusercontent.com/15841740/103728057-c2ae7f00-4f91-11eb-89f9-dc510e69df70.png)

# Implementation Details
1. Tested the change by running jobs which used more parts than fit in one strip.  Also tested the 'Auto Set MaxFeedCount' button on some strip feeders to see if it computed the correct number of parts.
2. This follows the coding style
3. No changes to the model
4. mvn test runs without errors
