### PR TITLE
Feature/ Actuator Profiles, Camera Lights -- Round 3

### DIFF
--- a/src/main/java/org/openpnp/gui/MachineControlsPanel.java
+++ b/src/main/java/org/openpnp/gui/MachineControlsPanel.java
@@ -416,7 +416,10 @@ public class MachineControlsPanel extends JPanel {
 
         @Override
         public void machineTargetedUserAction(Machine machine, HeadMountable hm) {
-            if (hm != null) {
+            if (hm != null 
+                    && hm.getHead() != null) { // Do this only if this is a true HeadMountable 
+                                               // i.e. not for bottom cameras or Machine actuators.
+
                 if (getSelectedTool() != hm || MovableUtils.isInSafeZZone(hm)) {
                     lastUserActionLocation = hm.getLocation().convertToUnits(LengthUnit.Millimeters);
                 }


### PR DESCRIPTION
# Description

Bug-Fix for #1095 and #1106 : Auto Tool Select must **not** act on HeadMountables that are not actually mounted on a head, such as a bottom camera or machine actuators. Those cannot be moved and are therefore not eligible for the Machine Controls Panel.

# Justification
See testing report:
https://groups.google.com/g/openpnp/c/nOnmi3PyUbw/m/zprS8tthCwAJ

![grafik](https://user-images.githubusercontent.com/9963310/104932347-d00f3480-59a7-11eb-9fdc-31d9178918fd.png)

# Instructions for Use
Please refer to #1095 and #1106.

# Implementation Details
1. Tested in the Simulation Machine.
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. No further changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. Successful `mvn test` before submitting the Pull Request.
