### PR TITLE
Add support for units per pixel calibration at different heights

### DIFF
--- a/src/main/java/org/openpnp/gui/components/CameraPanel.java
+++ b/src/main/java/org/openpnp/gui/components/CameraPanel.java
@@ -58,6 +58,7 @@ public class CameraPanel extends JPanel {
 
     private static final String PREF_SELECTED_CAMERA_VIEW = "JobPanel.dividerPosition";
     private Preferences prefs = Preferences.userNodeForPackage(CameraPanel.class);
+    private Object savedSelection; //used to save and restore selected camera view(s)
 
     public CameraPanel() {
 		SwingUtilities.invokeLater(() -> {
@@ -183,6 +184,24 @@ public class CameraPanel extends JPanel {
         return cameraViews.get(camera);
     }
 
+    /**
+     * Saves the currently selected views being displayed so that they may later be restored by
+     * calling restoreSelectedViews() 
+     */
+    public void saveCurrentlySelectedViews() {
+        savedSelection = camerasCombo.getSelectedItem();
+    }
+    
+    /**
+     * Restores the views being displayed to what they were when saveCurrentlySelectedViews() was
+     * last called 
+     */
+    public void restoreSelectedViews() {
+        if (savedSelection != null) {
+            camerasCombo.setSelectedItem(savedSelection);
+        }
+    }
+    
     private AbstractAction cameraSelectedAction = new AbstractAction("") {
         @Override
         public void actionPerformed(ActionEvent ev) {

--- a/src/main/java/org/openpnp/gui/components/CameraView.java
+++ b/src/main/java/org/openpnp/gui/components/CameraView.java
@@ -417,13 +417,14 @@ public class CameraView extends JComponent implements CameraListener {
     
     /**
      * Checks to see if the reticle for this camera can be changed to different heights.  This is
-     * true if the camera's Units Per Pixel has been calibrated at two different distances from the
-     * camera.
+     * true if the camera's Units Per Pixel is different at two different heights.
      * 
-     * @return the result of the check
+     * @return true if the reticle height can be changed
      */
     public boolean isReticleHeightChangable() {
-        return camera.getUnitsPerPixel().subtract(camera.getUnitsPerPixelSecondary()).getZ() != 0;
+        Location upp1 = camera.getUnitsPerPixel(new Length(0.0, LengthUnit.Millimeters));
+        Location upp2 = camera.getUnitsPerPixel(new Length(10.0, LengthUnit.Millimeters));
+        return !upp1.equals(upp2);
     }
 
     /**

--- a/src/main/java/org/openpnp/gui/components/CameraViewPopupMenu.java
+++ b/src/main/java/org/openpnp/gui/components/CameraViewPopupMenu.java
@@ -33,12 +33,18 @@ import javax.swing.JOptionPane;
 import javax.swing.JPopupMenu;
 import javax.swing.JRadioButtonMenuItem;
 
+import org.openpnp.gui.MainFrame;
 import org.openpnp.gui.components.CameraView.RenderingQuality;
 import org.openpnp.gui.components.reticle.CrosshairReticle;
 import org.openpnp.gui.components.reticle.FiducialReticle;
 import org.openpnp.gui.components.reticle.Reticle;
 import org.openpnp.gui.components.reticle.RulerReticle;
+import org.openpnp.gui.processes.EstimateObjectZCoordinateProcess;
 import org.openpnp.model.LengthUnit;
+import org.openpnp.model.Location;
+import org.openpnp.spi.Nozzle;
+import org.openpnp.util.MovableUtils;
+import org.openpnp.util.UiUtils;
 
 // TODO: For the time being, since setting a property on the reticle doesn't re-save it we are
 // making a redundant call to setReticle on every property update. Fix that somehow.
@@ -52,6 +58,30 @@ public class CameraViewPopupMenu extends JPopupMenu {
 
     public CameraViewPopupMenu(CameraView cameraView) {
         this.cameraView = cameraView;
+        
+        // For cameras that have been calibrated at two different heights, add menu options to reset
+        // the reticle height and for estimating an object's height
+        if (cameraView.isReticleHeightChangable()) {
+            JMenuItem mntmResetReticleHeight = new JMenuItem("Reset Reticle Height to Default");
+            mntmResetReticleHeight.addActionListener(new ActionListener() {
+                @Override
+                public void actionPerformed(ActionEvent e) {
+                    cameraView.resetViewingPlaneZ();
+                }
+            });
+            add(mntmResetReticleHeight);
+            
+            JMenuItem mntmEstimateZCoordinate = new JMenuItem("Estimate Z Coordinate of Object");
+            mntmEstimateZCoordinate.addActionListener(estimateZCoordinateAction);
+            add(mntmEstimateZCoordinate);
+        }
+
+        // For non-movable cameras, add a menu option to move the selected nozzle to the camera
+        if (cameraView.getCamera().getHead() == null) {
+            JMenuItem mntmMoveSelectedNozzleToCamera = new JMenuItem("Move Selected Nozzle to Camera");
+            mntmMoveSelectedNozzleToCamera.addActionListener(moveSelectedNozzleToCameraAction);
+            add(mntmMoveSelectedNozzleToCamera);
+        }
 
         zoomIncMenu = createZoomIncMenu();
 
@@ -580,4 +610,37 @@ public class CameraViewPopupMenu extends JPopupMenu {
             cameraView.setDefaultReticle(reticle);
         }
     };
+    
+    /**
+     * Listen for menu selection to estimate an object's height
+     */
+    private ActionListener estimateZCoordinateAction = new ActionListener() {
+        @Override
+        public void actionPerformed(ActionEvent e) {
+            UiUtils.messageBoxOnException(() -> {
+                new EstimateObjectZCoordinateProcess(MainFrame.get(), cameraView);
+            });
+        }
+    };
+    
+    /**
+     * Listener for menu selection to move the selected nozzle to the camera (only works for
+     * non-movable cameras)
+     */
+    private ActionListener moveSelectedNozzleToCameraAction = new ActionListener() {
+        @Override
+        public void actionPerformed(ActionEvent e) {
+            UiUtils.submitUiMachineTask(() -> {
+                // Get the selected nozzle
+                Nozzle nozzle = MainFrame.get().getMachineControls().getSelectedNozzle();
+                // Add the offsets to the Camera's nozzle calibrated position.
+                Location location = cameraView.getCamera().getLocation(nozzle);
+                // Don't change rotation. 
+                location = nozzle.getLocation().derive(location, true, true, true, false);
+                // Move the nozzle to the camera
+                MovableUtils.moveToLocationAtSafeZ(nozzle, location);
+            });
+        }
+    };
+
 }

--- a/src/main/java/org/openpnp/gui/processes/EstimateObjectZCoordinateProcess.java
+++ b/src/main/java/org/openpnp/gui/processes/EstimateObjectZCoordinateProcess.java
@@ -1,0 +1,224 @@
+/*
+ * Copyright (C) 2021 Jason von Nieda <jason@vonnieda.org>, Tony Luken <tonyluken@att.net>
+ * 
+ * This file is part of OpenPnP.
+ * 
+ * OpenPnP is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * OpenPnP is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License along with OpenPnP. If not, see
+ * <http://www.gnu.org/licenses/>.
+ * 
+ * For more information about OpenPnP visit http://openpnp.org
+ */
+
+package org.openpnp.gui.processes;
+
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.awt.event.MouseListener;
+import javax.swing.SwingUtilities;
+
+import org.openpnp.gui.MainFrame;
+import org.openpnp.gui.components.CameraView;
+import org.openpnp.model.LengthUnit;
+import org.openpnp.model.Location;
+import org.openpnp.spi.Camera;
+
+/**
+ * Guides the user with step by step instructions on using a camera to estimate an object's
+ * Z coordinate.
+ * 
+ */
+public class EstimateObjectZCoordinateProcess {
+    private final MainFrame mainFrame;
+    private final CameraView cameraView;
+    private final Camera camera;
+    private final boolean fixedCamera;
+    
+    private java.awt.Point pixelPoint1;
+    private java.awt.Point pixelPoint2;
+    private Location observationLocation1;
+    private Location observationLocation2;
+    private String estimatedZStr = "unavailable";
+
+    private int step = -1;
+    private String[] moveableCameraInstructions = new String[] {
+            "<html><body>Jog the camera so that an easily identifiable feature of the object " +
+                    "(such as a sharp corner) is in the camera's field-of-view (FOV). It is " +
+                    "better for the feature to be towards the edge of the FOV rather than " +
+                    "centered. When ready, click the mouse on the feature to capture its " +
+                    "apparent position." +
+                    "</body></html>",
+            "<html><body>Now jog the camera in X and/or Y so that the same feature is visible in " +
+                    "another part of the camera's FOV. The farther away from the original " +
+                    "position, the better.  When ready, click the mouse on the feature to " +
+                    "capture its new apparent position and estimate its Z coordinate." +
+                    "</body></html>",
+            "<html><body>The estimated Z coordinate of the feature is <b>%s</b>. Click Cancel if " +
+                    "finished or Again to perform another measurment." +
+                    "</body></html>",};
+    private String[] fixedCameraInstructions = new String[] {
+            "<html><body>Jog the nozzle so that an easily identifiable feature of the object " +
+                    "(such as a sharp corner) is in the camera's field-of-view (FOV). It is " +
+                    "better for the feature to be towards the edge of the FOV rather than " +
+                    "centered. When ready, click the mouse on the feature to capture its " +
+                    "apparent position." +
+                    "</body></html>",
+            "<html><body>Now jog the nozzle in X and/or Y so that the same feature is visible in " +
+                    "another part of the camera's FOV. The farther away from the original " +
+                    "position, the better.  When ready, click the mouse on the feature to " +
+                    "capture its new apparent position and estimate its Z coordinate." +
+                    "</body></html>",
+            "<html><body>The estimated Z coordinate of the feature is <b>%s</b>. Click Cancel if " +
+                    "finished or Again to perform another measurment." +
+                    "</body></html>",};
+
+    public EstimateObjectZCoordinateProcess(MainFrame mainFrame, CameraView cameraView)
+            throws Exception {
+        this.mainFrame = mainFrame;
+        this.cameraView = cameraView;
+        camera = cameraView.getCamera();
+        fixedCamera = camera.getHead() == null;
+        
+        cameraView.addMouseListener(mouseListener);
+        
+        mainFrame.getCameraViews().saveCurrentlySelectedViews();
+        mainFrame.getCameraViews().setSelectedCamera(camera);
+        
+        advance();
+    }
+
+    /**
+     * Advances through the steps and displays the appropriate instructions for each step
+     */
+    private void advance() {
+        boolean stepResult = true;
+        if (step == 0) {
+            stepResult = step1();
+        }
+        else if (step == 1) {
+            stepResult = step2();
+        }
+
+        if (!stepResult) {
+            return;
+        }
+        step++;
+        if (step > 2) {
+            cancel();
+        }
+        else {
+            mainFrame.showInstructions("Instructions to Estimate an Object's Z Coordinate",
+                    String.format(fixedCamera ? fixedCameraInstructions[step]
+                            : moveableCameraInstructions[step], estimatedZStr),
+                    true, step == 2, "Again", cancelActionListener, proceedActionListener);
+        }
+    }
+
+    
+    /**
+     * Action to take when transitioning from step 0 to step 1
+     * 
+     * @return true if the action was successful and the state machine should move to the next step
+     */
+    private boolean step1() {
+        return true;
+    }
+
+    /**
+     * Action to take when transitioning from step 1 to step 2
+     * 
+     * @return true if the action was successful and the state machine should move to the next step
+     */
+    private boolean step2() {
+        Location deltaLocation = observationLocation2.subtract(observationLocation1);
+        LengthUnit units = deltaLocation.getUnits();
+        int deltaPixelsX = pixelPoint2.x - pixelPoint1.x;
+        int deltaPixelsY = pixelPoint2.y - pixelPoint1.y;
+        Location observedUnitsPerPixel = new Location(units,
+                Math.abs(deltaLocation.getX()/deltaPixelsX),
+                Math.abs(deltaLocation.getY()/deltaPixelsY),
+                0.0,
+                0.0);
+        try {
+            estimatedZStr = camera.estimateZCoordinateOfObject(observedUnitsPerPixel).toString();
+        }
+        catch (Exception ex) {
+             estimatedZStr = "unavailable (due to " + ex.getMessage() + ")";
+        }
+        return true;
+    }
+
+    /**
+     * Clean-up when the process is cancelled
+     */
+    private void cancel() {
+        cameraView.removeMouseListener(mouseListener);
+
+        mainFrame.hideInstructions();
+        
+        mainFrame.getCameraViews().restoreSelectedViews();
+
+    }
+
+    /**
+     * Process Proceed button clicks
+     */
+    private final ActionListener proceedActionListener = new ActionListener() {
+        @Override
+        public void actionPerformed(ActionEvent e) {
+            if (step >= 2) {
+                step = -1;
+            }
+            advance();
+        }
+    };
+
+    /**
+     * Process Cancel button clicks
+     */
+    private final ActionListener cancelActionListener = new ActionListener() {
+        @Override
+        public void actionPerformed(ActionEvent e) {
+            cancel();
+        }
+    };
+    
+    /**
+     * Process mouse clicks
+     */
+    private MouseListener mouseListener = new MouseAdapter() {
+        @Override
+        public void mouseClicked(MouseEvent e) {
+            if (e.isPopupTrigger() || e.isShiftDown() || SwingUtilities.isRightMouseButton(e) ||
+                    e.getClickCount() == 2) {
+                // skip everything that's not a simple mouse click
+                return;
+            }
+            if (step == 0) {
+                // capture the first point
+                pixelPoint1 = cameraView.getCameraViewCenterPixelsFromXy(e.getX(), e.getY());
+                observationLocation1 = fixedCamera ? MainFrame.get().getMachineControls().
+                        getSelectedNozzle().getLocation() : camera.getLocation();
+            }
+            else if (step == 1) {
+                // capture the second point
+                pixelPoint2 = cameraView.getCameraViewCenterPixelsFromXy(e.getX(), e.getY());
+                observationLocation2 = fixedCamera ? MainFrame.get().getMachineControls().
+                        getSelectedNozzle().getLocation() : camera.getLocation();
+            }
+            advance();
+        }
+
+    };
+
+
+}

--- a/src/main/java/org/openpnp/gui/processes/EstimateObjectZCoordinateProcess.java
+++ b/src/main/java/org/openpnp/gui/processes/EstimateObjectZCoordinateProcess.java
@@ -31,6 +31,7 @@ import org.openpnp.gui.components.CameraView;
 import org.openpnp.model.LengthUnit;
 import org.openpnp.model.Location;
 import org.openpnp.spi.Camera;
+import org.openpnp.spi.base.AbstractCamera;
 
 /**
  * Guides the user with step by step instructions on using a camera to estimate an object's
@@ -149,7 +150,8 @@ public class EstimateObjectZCoordinateProcess {
                 0.0,
                 0.0);
         try {
-            estimatedZStr = camera.estimateZCoordinateOfObject(observedUnitsPerPixel).toString();
+            estimatedZStr = ((AbstractCamera) camera).
+                    estimateZCoordinateOfObject(observedUnitsPerPixel).toString();
         }
         catch (Exception ex) {
              estimatedZStr = "unavailable (due to " + ex.getMessage() + ")";

--- a/src/main/java/org/openpnp/gui/wizards/CameraConfigurationWizard.java
+++ b/src/main/java/org/openpnp/gui/wizards/CameraConfigurationWizard.java
@@ -26,9 +26,11 @@ import java.util.Locale;
 
 import javax.swing.AbstractAction;
 import javax.swing.Action;
+import javax.swing.ButtonGroup;
 import javax.swing.JButton;
 import javax.swing.JComboBox;
 import javax.swing.JLabel;
+import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.JTextField;
 import javax.swing.border.EtchedBorder;
@@ -38,25 +40,99 @@ import org.jdesktop.beansbinding.AutoBinding.UpdateStrategy;
 import org.openpnp.gui.MainFrame;
 import org.openpnp.gui.components.CameraView;
 import org.openpnp.gui.components.ComponentDecorators;
+import org.openpnp.gui.components.LocationButtonsPanel;
 import org.openpnp.gui.support.AbstractConfigurationWizard;
 import org.openpnp.gui.support.LengthConverter;
 import org.openpnp.gui.support.MutableLocationProxy;
+import org.openpnp.model.Configuration;
+import org.openpnp.model.LengthUnit;
+import org.openpnp.model.Location;
 import org.openpnp.spi.Camera;
+import org.openpnp.spi.Nozzle;
+import org.openpnp.util.MovableUtils;
+import org.openpnp.util.UiUtils;
+import org.pmw.tinylog.Logger;
 
 import com.jgoodies.forms.layout.ColumnSpec;
 import com.jgoodies.forms.layout.FormLayout;
 import com.jgoodies.forms.layout.FormSpecs;
 import com.jgoodies.forms.layout.RowSpec;
+import javax.swing.JRadioButton;
 
 @SuppressWarnings("serial")
 public class CameraConfigurationWizard extends AbstractConfigurationWizard {
     private final Camera camera;
-    
+
     private static String uppFormat = "%.8f";
+    private static String zFormat = "%.4f";
+
+    private static String downLookingCalibrationInstructions = "<html>\r\n\r\n" +
+            "Note: Calibrating Units Per Pixel at two different heights is not manditory but "
+            + "does enable additional features. If Dual Height calibration is not desired, "
+            + "calibrate the Primary Units Per Pixel at <b>exactly</b> the desired working "
+            + "height using the instructions below and then copy those settings to the Secondary "
+            + "Units Per Pixel fields.\r\n<ol>\r\n" +
+            "<li>Select a rectangular object with a known width and length that will fit within "
+            + "the camera's field-of-view. Graphing paper is a good, easy choice for this. Enter "
+            + "the object's width and length into the Width and Length fields above.\r\n" +
+            "<li>Place the object on the table and align it square with the camera's reticle.\r\n" + 
+            "<li>Select the Primary (or Secondary) Units Per Pixel to calibrate using the Cal "
+            + "Select radio buttons.  Note that the Primary Units Per Pixel should be calibrated "
+            + "near the same Z height as the top surface of the circuit board(s) to be populated "
+            + "and the Secondary at least as high as the top of the tallest part that may ever be "
+            + "placed.\r\n" + 
+            "<li>Jog the nozzle over the object and then down so that it is just touching the "
+            + "object.  Press Capture Z.  If calibrating the Primary Units Per Pixel, a dialog "
+            + "will pop-up asking if the measurement location height should be used as the "
+            + "default working height for the camera.  Answer Yes or No.  (If No, be sure to "
+            + "manually populate the Default Working Height field after Units Per Pixel "
+            + "calibration is complete.)\r\n" + 
+            "<li>Jog the camera to where it is centered over the object.\r\n" + 
+            "<li>Press Measure and use the camera selection rectangle to measure the object.  "
+            + "If the object is not in perfect focus, use the middle of the blurry edges for the "
+            + "measurement.  Press Confirm when finished.\r\n" + 
+            "<li>The calculated units per pixel values will be inserted into the X and Y "
+            + "fields.\r\n" + 
+            "<li>Place a spacer (about as thick as the tallest part that may ever be expected to "
+            + "be placed) under the object (or for machines that can physically move the top "
+            + "camera in Z, jog the camera up or down by about that much) and repeat steps 3 "
+            + "though 7 for the Secondary Units Per Pixel. Note that if the object now appears "
+            + "too big to fit within the camera's field-of-view, a smaller object can be used for "
+            + "this as long as the Width and Length fields are updated to match its size.\r\n" + 
+            "</ol>\r\n</html>";
+    
+    private static String upLookingCalibrationInstructions = "<html>\r\n\r\n" + 
+            "Note: Calibrating Units Per Pixel at two different heights is not manditory but it "
+            + "does enable additional features. If Dual Height calibration is not desired, "
+            + "calibrate the Primary Units Per Pixel per the instructions below and then copy "
+            + "those settings to the Secondary Units Per Pixel fields.\r\n<ol>\r\n" +
+            "<li>Select an object with a known width, length, and thickness that will fit within "
+            + "the camera's field-of-view. Enter the object's width, length, and thickness into "
+            + "the Width, Length, and Thickness fields above.\r\n" + 
+            "<li>Place the object square on the table and using a nozzle, pick up the object.\r\n" + 
+            "<li>Select the Primary (or Secondary) Units Per Pixel to calibrate using the Cal "
+            + "Select radio buttons. Note that the Primary Units Per Pixel is calibrated at the "
+            + "up looking camera's location while the Secondary should be calibrated at a higher "
+            + "location.\r\n" + 
+            "<li>WARNING - if the nozzle is not already over the up looking camera's position, "
+            + "the next step will automatically move the nozzle to that position.\r\n" + 
+            "<li>Press Measure and use the camera selection rectangle to measure the object.  If "
+            + "necessary, use the jog panel to rotate the nozzle so that the object is square with "
+            + "the selection rectangle.  If the object is not in perfect focus, use the middle of "
+            + "the blurry edges for the measurement.  Press Confirm when finished.\r\n" + 
+            "<li>The calculated units per pixel values will be inserted into the X and Y "
+            + "fields.\r\n" + 
+            "<li>Jog the nozzle up by about the thickness of the tallest part that may be "
+            + "expected to be placed and repeat steps 3 though 6 for the Secondary Units Per "
+            + "Pixel.\r\n" + 
+            "</ol>\r\n</html>";
+
+    protected Location measurementLocation;
+
 
     public CameraConfigurationWizard(Camera camera) {
         this.camera = camera;
-        
+
         panel = new JPanel();
         panel.setBorder(new TitledBorder(null, "Properties", TitledBorder.LEADING, TitledBorder.TOP, null, null));
         contentPanel.add(panel);
@@ -65,115 +141,346 @@ public class CameraConfigurationWizard extends AbstractConfigurationWizard {
                 FormSpecs.DEFAULT_COLSPEC,
                 FormSpecs.RELATED_GAP_COLSPEC,
                 FormSpecs.DEFAULT_COLSPEC,},
-            new RowSpec[] {
-                FormSpecs.RELATED_GAP_ROWSPEC,
-                FormSpecs.DEFAULT_ROWSPEC,
-                FormSpecs.RELATED_GAP_ROWSPEC,
-                FormSpecs.DEFAULT_ROWSPEC,}));
-        
+                new RowSpec[] {
+                        FormSpecs.RELATED_GAP_ROWSPEC,
+                        FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC,
+                        FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC,}));
+
         lblName = new JLabel("Name");
         panel.add(lblName, "2, 2, right, default");
-        
+
         nameTf = new JTextField();
         panel.add(nameTf, "4, 2");
         nameTf.setColumns(20);
-        
+
         lblLooking = new JLabel("Looking");
         panel.add(lblLooking, "2, 4, right, default");
-        
-        lookingCb = new JComboBox(Camera.Looking.values());
+
+        lookingCb = new JComboBox<Object>(Camera.Looking.values());
+        lookingCb.addActionListener(lookingAction);
         panel.add(lookingCb, "4, 4");
+
+        panelDefaultWorkingPlane = new JPanel();
+        panelDefaultWorkingPlane.setBorder(new TitledBorder(
+                new EtchedBorder(EtchedBorder.LOWERED, new Color(255, 255, 255),
+                        new Color(160, 160, 160)),
+                "Default Working Height", TitledBorder.LEADING, TitledBorder.TOP, null,
+                new Color(0, 0, 0)));
+        contentPanel.add(panelDefaultWorkingPlane);
+        panelDefaultWorkingPlane.setLayout(new FormLayout(new ColumnSpec[] {
+                FormSpecs.RELATED_GAP_COLSPEC,
+                FormSpecs.DEFAULT_COLSPEC,
+                FormSpecs.RELATED_GAP_COLSPEC,
+                ColumnSpec.decode("max(57dlu;default)"),
+                FormSpecs.RELATED_GAP_COLSPEC,
+                FormSpecs.DEFAULT_COLSPEC,
+                FormSpecs.RELATED_GAP_COLSPEC,},
+                new RowSpec[] {
+                        FormSpecs.RELATED_GAP_ROWSPEC,
+                        FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC,
+                        FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC,}));
+
+        lblNewLabel_4 = new JLabel("Z");
+        panelDefaultWorkingPlane.add(lblNewLabel_4, "4, 2, center, default");
+
+        lblNewLabel_2 = new JLabel("Default Working Height");
+        panelDefaultWorkingPlane.add(lblNewLabel_2, "2, 4, right, default");
+
+        textFieldDefaultZ = new JTextField();
+        textFieldDefaultZ.setToolTipText("<html>" +
+                "This is the Z level at which objects in the camera view are assumed<br>" +
+                "to be if their true height is unknown.  Generally this should be set<br>" +
+                "to the Z height of the working surface of the circuit board(s) that<br>" +
+                "are to be populated.</html>");
+        panelDefaultWorkingPlane.add(textFieldDefaultZ, "4, 4, fill, default");
+        textFieldDefaultZ.setColumns(8);
+        
+        locationButtonsDefaultWorkingPlane = new LocationButtonsPanel(null,
+                null, textFieldDefaultZ, null);
+        panelDefaultWorkingPlane.add(locationButtonsDefaultWorkingPlane, "6, 4");
+
+
 
         panelUpp = new JPanel();
         contentPanel.add(panelUpp);
         panelUpp.setBorder(new TitledBorder(new EtchedBorder(EtchedBorder.LOWERED, null, null),
                 "Units Per Pixel", TitledBorder.LEADING, TitledBorder.TOP, null,
                 new Color(0, 0, 0)));
-        panelUpp.setLayout(new FormLayout(
-                new ColumnSpec[] {FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,
-                        FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,
-                        FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,
-                        FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,
-                        FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,
-                        FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,},
-                new RowSpec[] {FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
-                        FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
-                        FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,}));
-
-        lblWidth = new JLabel("Width");
-        panelUpp.add(lblWidth, "2, 2");
-
-        lblHeight = new JLabel("Length");
-        panelUpp.add(lblHeight, "4, 2");
+        panelUpp.setLayout(new FormLayout(new ColumnSpec[] {
+                FormSpecs.RELATED_GAP_COLSPEC,
+                FormSpecs.DEFAULT_COLSPEC,
+                FormSpecs.RELATED_GAP_COLSPEC,
+                FormSpecs.DEFAULT_COLSPEC,
+                FormSpecs.RELATED_GAP_COLSPEC,
+                FormSpecs.DEFAULT_COLSPEC,
+                FormSpecs.RELATED_GAP_COLSPEC,
+                FormSpecs.DEFAULT_COLSPEC,
+                FormSpecs.RELATED_GAP_COLSPEC,
+                FormSpecs.DEFAULT_COLSPEC,
+                FormSpecs.RELATED_GAP_COLSPEC,
+                ColumnSpec.decode("max(99dlu;default)"),
+                FormSpecs.RELATED_GAP_COLSPEC,},
+                new RowSpec[] {
+                        FormSpecs.RELATED_GAP_ROWSPEC,
+                        FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC,
+                        FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC,
+                        FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.UNRELATED_GAP_ROWSPEC,
+                        FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC,}));
 
         lblX = new JLabel("X");
-        panelUpp.add(lblX, "6, 2");
+        panelUpp.add(lblX, "4, 2, center, default");
 
         lblY = new JLabel("Y");
-        panelUpp.add(lblY, "8, 2");
+        panelUpp.add(lblY, "6, 2, center, default");
+
+        lblObjectZ = new JLabel("Height Above Camera");
+        panelUpp.add(lblObjectZ, "8, 2, center, default");
+
+        lblNewLabel_3 = new JLabel("Cal Select");
+        panelUpp.add(lblNewLabel_3, "10, 2, center, default");
+
+        lblNewLabel = new JLabel("Primary");
+        panelUpp.add(lblNewLabel, "2, 4, left, default");
+
+        textFieldPrimaryUppX = new JTextField();
+        textFieldPrimaryUppX.setColumns(8);
+        panelUpp.add(textFieldPrimaryUppX, "4, 4, fill, default");
+
+        textFieldPrimaryUppY = new JTextField();
+        textFieldPrimaryUppY.setColumns(8);
+        panelUpp.add(textFieldPrimaryUppY, "6, 4, fill, default");
+
+        textFieldPrimaryUppHeightAboveCamera = new JTextField();
+        textFieldPrimaryUppHeightAboveCamera.setToolTipText("<html>" +
+            "This is the height above the camera at which the Primary Units Per Pixel<br>" +
+            "is calibrated.</html>");
+        panelUpp.add(textFieldPrimaryUppHeightAboveCamera, "8, 4, fill, default");
+        textFieldPrimaryUppHeightAboveCamera.setColumns(8);
+
+        ButtonGroup bg = new ButtonGroup();
+
+        rdbtnPrimaryUpp = new JRadioButton("");
+        panelUpp.add(rdbtnPrimaryUpp, "10, 4, center, default");
+        bg.add(rdbtnPrimaryUpp);
+
+        lblNewLabel_1 = new JLabel("Secondary");
+        panelUpp.add(lblNewLabel_1, "2, 6, left, default");
+
+        textFieldSecondaryUppX = new JTextField();
+        panelUpp.add(textFieldSecondaryUppX, "4, 6, fill, default");
+        textFieldSecondaryUppX.setColumns(8);
+
+        textFieldSecondaryUppY = new JTextField();
+        panelUpp.add(textFieldSecondaryUppY, "6, 6, fill, default");
+        textFieldSecondaryUppY.setColumns(8);
+
+        textFieldSecondaryUppHeightAboveCamera = new JTextField();
+        textFieldSecondaryUppHeightAboveCamera.setToolTipText("<html>" +
+            "This is the height above the camera at which the Secondary Units Per Pixel<br>" +
+            "is calibrated. If dual-height calibration is not to be used, set this to the<br>" +
+            "same height as the Primary Units Per Pixel.</html>");
+        panelUpp.add(textFieldSecondaryUppHeightAboveCamera, "8, 6, fill, default");
+        textFieldSecondaryUppHeightAboveCamera.setColumns(8);
+
+        rdbtnSecondaryUpp = new JRadioButton("");
+        panelUpp.add(rdbtnSecondaryUpp, "10, 6, center, default");
+        bg.add(rdbtnSecondaryUpp);
+
+        panelCal = new JPanel();
+        panelCal.setName("Units Per Pixel Calibration Tool");
+        panelCal.setBorder(new TitledBorder(null, "Calibration Tool", TitledBorder.LEADING,
+                TitledBorder.TOP, null, null));
+        panelUpp.add(panelCal, "2, 8, 11, 1, fill, fill");
+        panelCal.setLayout(new FormLayout(new ColumnSpec[] {
+                FormSpecs.RELATED_GAP_COLSPEC,
+                FormSpecs.DEFAULT_COLSPEC,
+                FormSpecs.RELATED_GAP_COLSPEC,
+                FormSpecs.DEFAULT_COLSPEC,
+                FormSpecs.RELATED_GAP_COLSPEC,
+                FormSpecs.DEFAULT_COLSPEC,
+                FormSpecs.RELATED_GAP_COLSPEC,
+                FormSpecs.DEFAULT_COLSPEC,
+                FormSpecs.RELATED_GAP_COLSPEC,
+                FormSpecs.DEFAULT_COLSPEC,
+                FormSpecs.RELATED_GAP_COLSPEC,
+                FormSpecs.DEFAULT_COLSPEC,
+                FormSpecs.RELATED_GAP_COLSPEC,
+                ColumnSpec.decode("default:grow"),
+                FormSpecs.RELATED_GAP_COLSPEC,},
+                new RowSpec[] {
+                        FormSpecs.RELATED_GAP_ROWSPEC,
+                        FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC,
+                        FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC,
+                        FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC,}));
+        cancelMeasureAction.setEnabled(false);
+
+        lblWidth = new JLabel("Width (X)");
+        panelCal.add(lblWidth, "2, 2, center, default");
+
+        lblHeight = new JLabel("Length (Y)");
+        panelCal.add(lblHeight, "4, 2, center, default");
+
+        lblThickness = new JLabel("Thickness (Z)");
+        panelCal.add(lblThickness, "6, 2, center, default");
 
         textFieldWidth = new JTextField();
+        panelCal.add(textFieldWidth, "2, 4");
         textFieldWidth.setText("1");
-        panelUpp.add(textFieldWidth, "2, 4");
         textFieldWidth.setColumns(8);
 
         textFieldHeight = new JTextField();
+        panelCal.add(textFieldHeight, "4, 4");
         textFieldHeight.setText("1");
-        panelUpp.add(textFieldHeight, "4, 4");
         textFieldHeight.setColumns(8);
 
-        textFieldUppX = new JTextField();
-        textFieldUppX.setColumns(8);
-        panelUpp.add(textFieldUppX, "6, 4, fill, default");
-
-        textFieldUppY = new JTextField();
-        textFieldUppY.setColumns(8);
-        panelUpp.add(textFieldUppY, "8, 4, fill, default");
+        textFieldThickness = new JTextField();
+        panelCal.add(textFieldThickness, "6, 4, fill, default");
+        textFieldThickness.setText("1");
+        textFieldThickness.setColumns(8);
 
         btnMeasure = new JButton("Measure");
+        panelCal.add(btnMeasure, "8, 4");
         btnMeasure.setAction(measureAction);
-        panelUpp.add(btnMeasure, "10, 4");
+
+        btnCaptureZ = new JButton("Capture Z");
+        panelCal.add(btnCaptureZ, "10, 4");
+        btnCaptureZ.setAction(captureZAction);
 
         btnCancelMeasure = new JButton("Cancel");
+        panelCal.add(btnCancelMeasure, "12, 4");
         btnCancelMeasure.setAction(cancelMeasureAction);
-        panelUpp.add(btnCancelMeasure, "12, 4");
 
-        lblUppInstructions = new JLabel(
-                "<html>\n<ol>\n<li>Place an object with a known width and length on the table. Graphing paper is a good, easy choice for this.\n<li>Enter the width and length of the object into the Width and Length fields.\n<li>Jog the camera to where it is centered over the object and in focus.\n<li>Press Measure and use the camera selection rectangle to measure the object. Press Confirm when finished.\n<li>The calculated units per pixel values will be inserted into the X and Y fields.\n</ol>\n</html>");
-        panelUpp.add(lblUppInstructions, "2, 6, 10, 1, default, fill");
+        lblUppInstructions = new JLabel(upLookingCalibrationInstructions);
+        panelCal.add(lblUppInstructions, "2, 6, 13, 1");
     }
 
     @Override
     public void createBindings() {
-        LengthConverter lengthConverter = new LengthConverter(uppFormat);
-        
+        LengthConverter uppLengthConverter = new LengthConverter(uppFormat);
+        LengthConverter zLengthConverter = new LengthConverter(zFormat);
+
         addWrappedBinding(camera, "name", nameTf, "text");
         addWrappedBinding(camera, "looking", lookingCb, "selectedItem");
-        
-        MutableLocationProxy unitsPerPixel = new MutableLocationProxy();
-        bind(UpdateStrategy.READ_WRITE, camera, "unitsPerPixel", unitsPerPixel, "location");
-        addWrappedBinding(unitsPerPixel, "lengthX", textFieldUppX, "text", lengthConverter);
-        addWrappedBinding(unitsPerPixel, "lengthY", textFieldUppY, "text", lengthConverter);
+        addWrappedBinding(camera, "defaultZ", textFieldDefaultZ, "text", zLengthConverter);
 
-        ComponentDecorators.decorateWithAutoSelect(textFieldUppX);
-        ComponentDecorators.decorateWithAutoSelect(textFieldUppY);
-        ComponentDecorators.decorateWithLengthConversion(textFieldUppX, uppFormat);
-        ComponentDecorators.decorateWithLengthConversion(textFieldUppY, uppFormat);
+        MutableLocationProxy defaultUnitsPerPixel = new MutableLocationProxy();
+        bind(UpdateStrategy.READ_WRITE, camera, "unitsPerPixel", defaultUnitsPerPixel, "location");
+        addWrappedBinding(defaultUnitsPerPixel, "lengthX", textFieldPrimaryUppX, "text", uppLengthConverter);
+        addWrappedBinding(defaultUnitsPerPixel, "lengthY", textFieldPrimaryUppY, "text", uppLengthConverter);
+        addWrappedBinding(defaultUnitsPerPixel, "lengthZ", textFieldPrimaryUppHeightAboveCamera, "text", zLengthConverter);
+
+        MutableLocationProxy secondaryUnitsPerPixel = new MutableLocationProxy();
+        bind(UpdateStrategy.READ_WRITE, camera, "unitsPerPixelSecondary", secondaryUnitsPerPixel, "location");
+        addWrappedBinding(secondaryUnitsPerPixel, "lengthX", textFieldSecondaryUppX, "text", uppLengthConverter);
+        addWrappedBinding(secondaryUnitsPerPixel, "lengthY", textFieldSecondaryUppY, "text", uppLengthConverter);
+        addWrappedBinding(secondaryUnitsPerPixel, "lengthZ", textFieldSecondaryUppHeightAboveCamera, "text", zLengthConverter);
+
+        ComponentDecorators.decorateWithAutoSelect(textFieldPrimaryUppX);
+        ComponentDecorators.decorateWithAutoSelect(textFieldPrimaryUppY);
+        ComponentDecorators.decorateWithAutoSelect(textFieldPrimaryUppHeightAboveCamera);
+        ComponentDecorators.decorateWithLengthConversion(textFieldPrimaryUppX, uppFormat);
+        ComponentDecorators.decorateWithLengthConversion(textFieldPrimaryUppY, uppFormat);
+        ComponentDecorators.decorateWithLengthConversion(textFieldPrimaryUppHeightAboveCamera, zFormat);
+
+        ComponentDecorators.decorateWithAutoSelect(textFieldSecondaryUppX);
+        ComponentDecorators.decorateWithAutoSelect(textFieldSecondaryUppY);
+        ComponentDecorators.decorateWithAutoSelect(textFieldSecondaryUppHeightAboveCamera);
+        ComponentDecorators.decorateWithLengthConversion(textFieldSecondaryUppX, uppFormat);
+        ComponentDecorators.decorateWithLengthConversion(textFieldSecondaryUppY, uppFormat);
+        ComponentDecorators.decorateWithLengthConversion(textFieldSecondaryUppHeightAboveCamera, zFormat);
 
         ComponentDecorators.decorateWithAutoSelect(nameTf);
+        ComponentDecorators.decorateWithAutoSelect(textFieldDefaultZ);
         ComponentDecorators.decorateWithAutoSelect(textFieldWidth);
         ComponentDecorators.decorateWithAutoSelect(textFieldHeight);
-        
+        ComponentDecorators.decorateWithAutoSelect(textFieldThickness);
+        ComponentDecorators.decorateWithLengthConversion(textFieldDefaultZ, zFormat);
+        ComponentDecorators.decorateWithLengthConversion(textFieldWidth, zFormat);
+        ComponentDecorators.decorateWithLengthConversion(textFieldHeight, zFormat);
+        ComponentDecorators.decorateWithLengthConversion(textFieldThickness, zFormat);
+
     }
+
+    private Action lookingAction = new AbstractAction("Looking") {
+        @Override
+        public void actionPerformed(ActionEvent arg0) {
+            if ((Camera.Looking) lookingCb.getSelectedItem() == Camera.Looking.Up) {
+                panelDefaultWorkingPlane.setVisible(false);
+                lblUppInstructions.setText(upLookingCalibrationInstructions);
+                lblThickness.setVisible(true);
+                textFieldThickness.setVisible(true);
+                btnCaptureZ.setVisible(false);
+                btnMeasure.setEnabled(true);
+            }
+            else {
+                panelDefaultWorkingPlane.setVisible(true);
+                lblUppInstructions.setText(downLookingCalibrationInstructions);
+                lblThickness.setVisible(false);
+                textFieldThickness.setVisible(false);
+                btnCaptureZ.setVisible(true);
+                btnMeasure.setEnabled(false);
+            }
+        }
+    };
 
     private Action measureAction = new AbstractAction("Measure") {
         @Override
         public void actionPerformed(ActionEvent arg0) {
-            btnMeasure.setAction(confirmMeasureAction);
-            cancelMeasureAction.setEnabled(true);
-            CameraView cameraView = MainFrame.get().getCameraViews().setSelectedCamera(camera);
-            cameraView.setSelectionEnabled(true);
-            cameraView.setSelection(0, 0, 100, 100);
+            if (rdbtnPrimaryUpp.isSelected() || rdbtnSecondaryUpp.isSelected()) {
+                if ((Camera.Looking) lookingCb.getSelectedItem() == Camera.Looking.Up) {
+                    LengthUnit units = Configuration.get().getSystemUnits();
+                    Location cameraLocation = camera.getLocation().convertToUnits(units);
+                    Nozzle nozzle = MainFrame.get().getMachineControls().getSelectedNozzle();
+                    Location nozzleLocation = nozzle.getLocation().convertToUnits(units);
+                    double thickness = Double.parseDouble(textFieldThickness.getText());
+                    Location desiredNozzleLocation;
+                    if (rdbtnPrimaryUpp.isSelected()) {
+                        desiredNozzleLocation = cameraLocation.add(
+                                new Location(units, 0, 0, thickness, 0));
+                    }
+                    else {
+                        desiredNozzleLocation = cameraLocation.derive(null, null,
+                                nozzleLocation.getZ(), nozzleLocation.getRotation());
+                    }
+                    if (!nozzleLocation.getLengthX().equals(desiredNozzleLocation.getLengthX()) || 
+                            !nozzleLocation.getLengthY().equals(desiredNozzleLocation.getLengthY()) ||
+                            !nozzleLocation.getLengthZ().equals(desiredNozzleLocation.getLengthZ()) ||
+                            nozzleLocation.getRotation() != desiredNozzleLocation.getRotation()) {
+                        UiUtils.submitUiMachineTask(() -> {
+                            MovableUtils.moveToLocationAtSafeZ(nozzle, desiredNozzleLocation);
+                        });
+                    }
+                    measurementLocation = desiredNozzleLocation.subtract(
+                            new Location(units, 0, 0, thickness, 0)).convertToUnits(units);
+                    Logger.trace("measurementLocation = " + measurementLocation);
+                    if (rdbtnPrimaryUpp.isSelected()) {
+                        textFieldDefaultZ.setText(String.format(Locale.US, zFormat,
+                                measurementLocation.getZ()));
+                    }
+                }
+                btnMeasure.setAction(confirmMeasureAction);
+                cancelMeasureAction.setEnabled(true);
+                MainFrame.get().getCameraViews().saveCurrentlySelectedViews();
+                CameraView cameraView = MainFrame.get().getCameraViews().setSelectedCamera(camera);
+                cameraView.setSelectionEnabled(true);
+                cameraView.setSelection(0, 0, 100, 100);
+            }
+            else {
+                JOptionPane.showMessageDialog(null,
+                        "Select either the Primary or the Secondary Units Per Pixel to calibrate.",
+                        "Info", JOptionPane.INFORMATION_MESSAGE, null);
+            }
         }
     };
 
@@ -182,13 +489,96 @@ public class CameraConfigurationWizard extends AbstractConfigurationWizard {
         public void actionPerformed(ActionEvent arg0) {
             btnMeasure.setAction(measureAction);
             cancelMeasureAction.setEnabled(false);
+            if ((Camera.Looking) lookingCb.getSelectedItem() == Camera.Looking.Up) {
+                btnMeasure.setEnabled(true);
+            }
+            else {
+                btnMeasure.setEnabled(false);
+                btnCaptureZ.setEnabled(true);
+            }
             CameraView cameraView = MainFrame.get().getCameraViews().getCameraView(camera);
             cameraView.setSelectionEnabled(false);
+            MainFrame.get().getCameraViews().restoreSelectedViews();
             Rectangle selection = cameraView.getSelection();
             double width = Double.parseDouble(textFieldWidth.getText());
             double height = Double.parseDouble(textFieldHeight.getText());
-            textFieldUppX.setText(String.format(Locale.US, uppFormat, (width / Math.abs(selection.width))));
-            textFieldUppY.setText(String.format(Locale.US, uppFormat, (height / Math.abs(selection.height))));
+            if (rdbtnPrimaryUpp.isSelected()) {
+                textFieldPrimaryUppX.setText(String.format(Locale.US, uppFormat,
+                        (width / Math.abs(selection.width))));
+                textFieldPrimaryUppY.setText(String.format(Locale.US, uppFormat,
+                        (height / Math.abs(selection.height))));
+            }
+            else {
+                textFieldSecondaryUppX.setText(String.format(Locale.US, uppFormat,
+                        (width / Math.abs(selection.width))));
+                textFieldSecondaryUppY.setText(String.format(Locale.US, uppFormat,
+                        (height / Math.abs(selection.height))));
+            }
+
+            //Get the camera's actual location (ignoring virtual axis)
+            Location cameraLocation = camera.getActualLocation();
+
+            double heightAboveCamera = measurementLocation.subtract(cameraLocation).getZ();
+            if (rdbtnPrimaryUpp.isSelected()) {
+                textFieldPrimaryUppHeightAboveCamera.setText(String.format(Locale.US, zFormat,
+                        heightAboveCamera));
+            }
+            else {
+                textFieldSecondaryUppHeightAboveCamera.setText(String.format(Locale.US, zFormat,
+                        heightAboveCamera));
+            }
+        }
+    };
+
+    private Action captureZAction = new AbstractAction("Capture Z") {
+        @Override
+        public void actionPerformed(ActionEvent arg0) {
+            if (rdbtnPrimaryUpp.isSelected() || rdbtnSecondaryUpp.isSelected()) {
+                LengthUnit units = Configuration.get().getSystemUnits();
+                Nozzle nozzle = MainFrame.get().getMachineControls().getSelectedNozzle();
+                measurementLocation = nozzle.getLocation().convertToUnits(units);
+                Logger.trace("measurementLocation = " + measurementLocation);
+                if ((Camera.Looking) lookingCb.getSelectedItem() != Camera.Looking.Up) {
+                    Location safeLocation = measurementLocation.derive(null, null, nozzle.
+                            getSafeZ().convertToUnits(units).getValue(), null);
+                    UiUtils.submitUiMachineTask(() -> {
+                        MovableUtils.moveToLocationAtSafeZ(nozzle, safeLocation);
+                    });
+                    if (rdbtnPrimaryUpp.isSelected()) {
+                        int selection = JOptionPane.showConfirmDialog(null,
+                                "If calibrating the Primary Units Per Pixels at a height different than the height\r\n" +
+                                "of the circuit board surface, the Default Working Height field must be manually set\r\n" +
+                                "to the height of the circuit board surface!  Failure to do so will result in inaccurate\r\n" +
+                                "scaling of objects in the camera's view and camera jogging will not perform as expected.\r\n" +
+                                "\r\n" +
+                                "Set the Default Working Height field to the height of the current calibration\r\n" +
+                                "location (" + measurementLocation.getLengthZ() + ")?",
+                                "Warning!",
+                                JOptionPane.YES_NO_OPTION,
+                                JOptionPane.QUESTION_MESSAGE,
+                                null
+                                );
+                        if (selection == JOptionPane.YES_OPTION) {
+                            textFieldDefaultZ.setText(String.format(Locale.US, zFormat, 
+                                    measurementLocation.getZ()));
+                        }
+                    }
+                }
+                else {
+                    //For an up looking camera, the default z is always the same height as the
+                    //camera
+                    textFieldDefaultZ.setText(String.format(Locale.US, zFormat,
+                            measurementLocation.getZ()));
+                }
+                btnMeasure.setEnabled(true);
+                btnCaptureZ.setEnabled(false);
+                btnCancelMeasure.setEnabled(true);
+            }
+            else {
+                JOptionPane.showMessageDialog(null,
+                        "Select either the Primary or the Secondary Units Per Pixel to calibrate.",
+                        "Info", JOptionPane.INFORMATION_MESSAGE, null);
+            }
         }
     };
 
@@ -196,9 +586,19 @@ public class CameraConfigurationWizard extends AbstractConfigurationWizard {
         @Override
         public void actionPerformed(ActionEvent arg0) {
             btnMeasure.setAction(measureAction);
+            btnCancelMeasure.setEnabled(false);
             cancelMeasureAction.setEnabled(false);
+            if ((Camera.Looking) lookingCb.getSelectedItem() == Camera.Looking.Up) {
+                btnMeasure.setEnabled(true);
+                btnCaptureZ.setEnabled(false);
+            }
+            else {
+                btnMeasure.setEnabled(false);
+                btnCaptureZ.setEnabled(true);
+            }
             CameraView cameraView = MainFrame.get().getCameraViews().getCameraView(camera);
             cameraView.setSelectionEnabled(false);
+            MainFrame.get().getCameraViews().restoreSelectedViews();
         }
     };
 
@@ -208,8 +608,8 @@ public class CameraConfigurationWizard extends AbstractConfigurationWizard {
     private JLabel lblUppInstructions;
     private JTextField textFieldWidth;
     private JTextField textFieldHeight;
-    private JTextField textFieldUppX;
-    private JTextField textFieldUppY;
+    private JTextField textFieldPrimaryUppX;
+    private JTextField textFieldPrimaryUppY;
     private JLabel lblWidth;
     private JLabel lblHeight;
     private JLabel lblX;
@@ -217,6 +617,25 @@ public class CameraConfigurationWizard extends AbstractConfigurationWizard {
     private JPanel panel;
     private JLabel lblName;
     private JLabel lblLooking;
-    private JComboBox lookingCb;
+    private JComboBox<?> lookingCb;
     private JTextField nameTf;
+    private JRadioButton rdbtnPrimaryUpp;
+    private JRadioButton rdbtnSecondaryUpp;
+    private JTextField textFieldSecondaryUppX;
+    private JTextField textFieldSecondaryUppY;
+    private JLabel lblNewLabel;
+    private JLabel lblNewLabel_1;
+    private JTextField textFieldPrimaryUppHeightAboveCamera;
+    private JTextField textFieldSecondaryUppHeightAboveCamera;
+    private JLabel lblObjectZ;
+    private JLabel lblNewLabel_3;
+    private JButton btnCaptureZ;
+    private JPanel panelCal;
+    private JTextField textFieldThickness;
+    private JLabel lblThickness;
+    private JPanel panelDefaultWorkingPlane;
+    private JLabel lblNewLabel_2;
+    private JTextField textFieldDefaultZ;
+    private JLabel lblNewLabel_4;
+    private LocationButtonsPanel locationButtonsDefaultWorkingPlane;
 }

--- a/src/main/java/org/openpnp/gui/wizards/CameraConfigurationWizard.java
+++ b/src/main/java/org/openpnp/gui/wizards/CameraConfigurationWizard.java
@@ -49,6 +49,7 @@ import org.openpnp.model.LengthUnit;
 import org.openpnp.model.Location;
 import org.openpnp.spi.Camera;
 import org.openpnp.spi.Nozzle;
+import org.openpnp.spi.base.AbstractCamera;
 import org.openpnp.util.MovableUtils;
 import org.openpnp.util.UiUtils;
 import org.pmw.tinylog.Logger;
@@ -515,10 +516,12 @@ public class CameraConfigurationWizard extends AbstractConfigurationWizard {
                         (height / Math.abs(selection.height))));
             }
 
-            //Get the camera's actual location (ignoring virtual axis)
-            Location cameraLocation = camera.getActualLocation();
-
-            double heightAboveCamera = measurementLocation.subtract(cameraLocation).getZ();
+            double heightAboveCamera = ((AbstractCamera) camera).
+                    getHeightAboveCamera(measurementLocation).getValue();
+//            //Get the camera's actual location (ignoring virtual axis)
+//            Location cameraLocation = camera.getActualLocation();
+//
+//            double heightAboveCamera = measurementLocation.subtract(cameraLocation).getZ();
             if (rdbtnPrimaryUpp.isSelected()) {
                 textFieldPrimaryUppHeightAboveCamera.setText(String.format(Locale.US, zFormat,
                         heightAboveCamera));

--- a/src/main/java/org/openpnp/spi/Camera.java
+++ b/src/main/java/org/openpnp/spi/Camera.java
@@ -49,24 +49,6 @@ public interface Camera extends HeadMountable, WizardConfigurable,
     public Location getLocation(HeadMountable tool);
 
     /**
-     * Get the actual location of the camera.  This is the same as that obtained by getLocation()
-     * except coordinates for virtual axis are replaced by their home coordinates.
-     * 
-     * @return
-     */
-    public Location getActualLocation();
-    
-    /**
-     * Get the actual location of the camera including the calibrated offset for the given tool.
-     * This is the same as that obtained by getLocation(HeadMountable tool) except coordinates for
-     * virtual axis are replaced by their home coordinates.
-     * 
-     * @param tool
-     * @return
-     */
-    public Location getActualLocation(HeadMountable tool);
-    
-    /**
      * Get the direction the Camera is looking.
      * 
      * @return

--- a/src/main/java/org/openpnp/spi/Camera.java
+++ b/src/main/java/org/openpnp/spi/Camera.java
@@ -91,24 +91,6 @@ public interface Camera extends HeadMountable, WizardConfigurable,
     public Location getUnitsPerPixel(Location location);
 
     /**
-     * Gets the secondary units per pixel
-     * 
-     * @return a location whose x and y coordinates are the measured pixels per unit for those axis
-     *         respectively and the z coordinate is the height above the camera at which the
-     *         measurements were made.
-     */
-    public Location getUnitsPerPixelSecondary();
-    
-    /**
-     * Sets the secondary units per pixel
-     * 
-     * @param unitsPerPixelSecondary - a location whose x and y coordinates are the measured pixels
-     * per unit for those axis respectively and the z coordinate is the height above the camera at
-     * which the measurements were made.
-     */
-    public void setUnitsPerPixelSecondary(Location unitsPerPixelSecondary);
-
-    /**
      * Gets the Z  height of the default working plane for this camera.  This is the height
      * at which objects are assumed to be if no other information is available.
      * 
@@ -124,18 +106,6 @@ public interface Camera extends HeadMountable, WizardConfigurable,
      */
     public void setDefaultZ(Length defaultZ);
     
-    /**
-     * Estimates the Z height of an object based upon the observed units per pixel for the
-     * object. This is typically found by capturing images of a feature of the object from two
-     * different camera positions. The observed units per pixel is then computed by dividing the
-     * actual change in camera position (in machine units) by the apparent change in position of the
-     * feature (in pixels) between the two images.
-     *
-     * @param observedUnitsPerPixel - the observed units per pixel for the object
-     * @return - the estimated Z height of the object
-     */
-    public Length estimateZCoordinateOfObject(Location observedUnitsPerPixel) throws Exception;
-
     /**
      * Immediately captures an image from the camera and returns it in it's native format. Fires
      * the Camera.BeforeCapture and Camera.AfterCapture scripting events before and after.

--- a/src/main/java/org/openpnp/spi/Locatable.java
+++ b/src/main/java/org/openpnp/spi/Locatable.java
@@ -39,7 +39,11 @@ public interface Locatable {
          * Suppress dynamic (i.e. runtime calibrated) compensations, such as
          * NozzleTip runout compensation.
          */
-        SuppressDynamicCompensation
+        SuppressDynamicCompensation,
+        /**
+         * Replaces virtual coordinates with the head offset.
+         */
+        ReplaceVirtual
     }
 
     /**

--- a/src/main/java/org/openpnp/spi/base/AbstractCamera.java
+++ b/src/main/java/org/openpnp/spi/base/AbstractCamera.java
@@ -303,7 +303,7 @@ public abstract class AbstractCamera extends AbstractHeadMountable implements Ca
      * @param zCoordinate
      * @return the height above the camera in the same units as zCoordinate
      */
-    protected Length getHeightAboveCamera(Length zCoordinate) {
+    public Length getHeightAboveCamera(Length zCoordinate) {
         Location cameraLocation = getLocation();
         try {
             //Replace virtual axis coordinates, if any, with the head offset
@@ -321,7 +321,7 @@ public abstract class AbstractCamera extends AbstractHeadMountable implements Ca
      * @param location - the location whose height is being determined
      * @return the height above the camera in the same units as location
      */
-    protected Length getHeightAboveCamera(Location location) {
+    public Length getHeightAboveCamera(Location location) {
         return getHeightAboveCamera(location.getLengthZ());
     }
     
@@ -384,12 +384,24 @@ public abstract class AbstractCamera extends AbstractHeadMountable implements Ca
         this.unitsPerPixel = unitsPerPixel;
     }
 
-    @Override
+    /**
+     * Gets the secondary units per pixel
+     * 
+     * @return a location whose x and y coordinates are the measured pixels per unit for those axis
+     *         respectively and the z coordinate is the height above the camera at which the
+     *         measurements were made.
+     */
     public Location getUnitsPerPixelSecondary() {
         return unitsPerPixelSecondary;
     }
 
-    @Override
+    /**
+     * Sets the secondary units per pixel
+     * 
+     * @param unitsPerPixelSecondary - a location whose x and y coordinates are the measured pixels
+     * per unit for those axis respectively and the z coordinate is the height above the camera at
+     * which the measurements were made.
+     */
     public void setUnitsPerPixelSecondary(Location unitsPerPixelSecondary) {
         this.unitsPerPixelSecondary = unitsPerPixelSecondary;
     }
@@ -404,7 +416,16 @@ public abstract class AbstractCamera extends AbstractHeadMountable implements Ca
         this.defaultZ = defaultZ;
     }
 
-    @Override
+    /**
+     * Estimates the Z height of an object based upon the observed units per pixel for the
+     * object. This is typically found by capturing images of a feature of the object from two
+     * different camera positions. The observed units per pixel is then computed by dividing the
+     * actual change in camera position (in machine units) by the apparent change in position of the
+     * feature (in pixels) between the two images.
+     *
+     * @param observedUnitsPerPixel - the observed units per pixel for the object
+     * @return - the estimated Z height of the object
+     */
     public Length estimateZCoordinateOfObject(Location observedUnitsPerPixel) throws Exception {
         LengthUnit units = observedUnitsPerPixel.getUnits();
         double uppX = Math.abs(observedUnitsPerPixel.getX());

--- a/src/main/java/org/openpnp/spi/base/AbstractHeadMountable.java
+++ b/src/main/java/org/openpnp/spi/base/AbstractHeadMountable.java
@@ -6,6 +6,7 @@ import org.openpnp.ConfigurationListener;
 import org.openpnp.machine.reference.ReferenceHeadMountable;
 import org.openpnp.machine.reference.ReferenceMachine;
 import org.openpnp.machine.reference.axis.ReferenceControllerAxis;
+import org.openpnp.machine.reference.axis.ReferenceVirtualAxis;
 import org.openpnp.model.AbstractModelObject;
 import org.openpnp.model.AxesLocation;
 import org.openpnp.model.Configuration;
@@ -387,6 +388,11 @@ public abstract class AbstractHeadMountable extends AbstractModelObject implemen
                     desiredRawLocation = desiredRawLocation
                             .put(new AxesLocation(rawAxis, currentRawLocation.getCoordinate(rawAxis)));
                 }
+            }
+            else if ((axis instanceof ReferenceVirtualAxis) && (Arrays.asList(options).contains(LocationOption.ReplaceVirtual))) {
+                // Replace the virtual axis coordinate with zero
+                desiredRawLocation = desiredRawLocation
+                        .put(new AxesLocation(axis, new Length(0.0, LengthUnit.Millimeters)));
             }
         }    
         // Now transform it forward, NOT applying any options, i.e. when a moveTo() is later made, it will effectively reverse 

--- a/src/test/java/VisionUtilsTest.java
+++ b/src/test/java/VisionUtilsTest.java
@@ -204,17 +204,6 @@ public class VisionUtilsTest {
         public void home() throws Exception {
         }
 
-        @Override
-        public Location getActualLocation() {
-            return new Location(LengthUnit.Millimeters, 1, 1, 0, 0);
-        }
-
-        @Override
-        public Location getActualLocation(HeadMountable tool) {
-            return new Location(LengthUnit.Millimeters, 1, 1, 0, 0);
-        }
-
-        @Override
         public Location getUnitsPerPixel(Length z) {
             return new Location(LengthUnit.Millimeters, 1, 1, 0, 0).derive(null, null, z.getValue(), null);
         }

--- a/src/test/java/VisionUtilsTest.java
+++ b/src/test/java/VisionUtilsTest.java
@@ -214,26 +214,12 @@ public class VisionUtilsTest {
         }
 
         @Override
-        public Location getUnitsPerPixelSecondary() {
-            return new Location(LengthUnit.Millimeters, 1, 1, 0, 0);
-        }
-
-        @Override
-        public void setUnitsPerPixelSecondary(Location unitsPerPixelSecondary) {
-        }
-
-        @Override
         public Length getDefaultZ() {
             return new Length(0.0, LengthUnit.Millimeters);
         }
 
         @Override
         public void setDefaultZ(Length defaultZ) {
-        }
-
-        @Override
-        public Length estimateZCoordinateOfObject(Location observedUnitsPerPixel) throws Exception {
-            return new Length(0.0, LengthUnit.Millimeters);
         }
     }
 }

--- a/src/test/java/VisionUtilsTest.java
+++ b/src/test/java/VisionUtilsTest.java
@@ -203,5 +203,48 @@ public class VisionUtilsTest {
         @Override
         public void home() throws Exception {
         }
+
+        @Override
+        public Location getActualLocation() {
+            return new Location(LengthUnit.Millimeters, 1, 1, 0, 0);
+        }
+
+        @Override
+        public Location getActualLocation(HeadMountable tool) {
+            return new Location(LengthUnit.Millimeters, 1, 1, 0, 0);
+        }
+
+        @Override
+        public Location getUnitsPerPixel(Length z) {
+            return new Location(LengthUnit.Millimeters, 1, 1, 0, 0).derive(null, null, z.getValue(), null);
+        }
+
+        @Override
+        public Location getUnitsPerPixel(Location location) {
+            return new Location(LengthUnit.Millimeters, 1, 1, 0, 0);
+        }
+
+        @Override
+        public Location getUnitsPerPixelSecondary() {
+            return new Location(LengthUnit.Millimeters, 1, 1, 0, 0);
+        }
+
+        @Override
+        public void setUnitsPerPixelSecondary(Location unitsPerPixelSecondary) {
+        }
+
+        @Override
+        public Length getDefaultZ() {
+            return new Length(0.0, LengthUnit.Millimeters);
+        }
+
+        @Override
+        public void setDefaultZ(Length defaultZ) {
+        }
+
+        @Override
+        public Length estimateZCoordinateOfObject(Location observedUnitsPerPixel) throws Exception {
+            return new Length(0.0, LengthUnit.Millimeters);
+        }
     }
 }


### PR DESCRIPTION
# Description

1. Cameras can now be calibrated at two different heights which permits more accurate measurements and camera jogging when the height of an object is known to be at something other than the height at which the camera was calibrated.  When upgrading from earlier versions of OpenPnP, the existing calibration remains in effect until calibration is re-run at two different heights.
2. The camera views are enhanced to allow the operator to adjust the height of the reticle so that it is scaled appropriately for any desired height.  This height is also used to scale camera drag and shift-click jogging so that it is correct for that height.
3. The camera views are enhanced to allow the operator to estimate object heights based on two different perspectives of the object.  This feature is mainly proof-of-concept but is included in case someone finds it useful.
4. Bottom camera drag and shift-click jogging are changed to be more consistent with top camera jogging.  Bottom camera jogging now moves the machine such that the point at the end of the drag (or the point shift-clicked) is moved to the center of the camera view (exactly the same end result as with top camera jogging).  A separate pop-up menu option is added to bottom camera views to allow the operator to quickly move the selected nozzle to the bottom camera much as the original bottom camera jogging worked. 

# Justification
Item 1 above is mostly a stepping stone for future upgrades.  It adds properties and methods to cameras which will allow future upgrades to obtain better estimates of object sizes and distances from the vision system.  For instance, since the height of the top of a strip feeder is known, the vision processing associated with a strip feeder can now be upgraded (but not included with this PR) to accurately scale the images of the strip at that height to get more precise hole locations and hence more accurate pick locations.

Items 2 and 3 above are enhancements that allow the operator to take advantage of the new calibration data when performing manual operations with the camera.

Item 4 above makes bottom camera jogging more intuitive for the user.

# Instructions for Use
1.  The Issues and Solutions system detects if a camera has not been calibrated at two different heights and shows a recommendation to calibrate the camera a two different heights.  The General Configuration tab of the Camera wizard provides instructions on how to perform the new calibrations. Unique instructions are provided to the operator for bottom and top cameras and should be self explanatory.  For top cameras only, a new field called Default Working Height needs to be populated with the height at which objects will be assumed to be if no explicit height information for the object is known .  This should be set to the height where the legacy Units Per Pixel was calibrated which was typically the height of the top surface of the circuit board.  For bottom cameras, the default working height is simply the Z height of the camera so no additional field is needed there.  Only once calibration is completed at two different heights, will Items 2 and 3 become available to the operator.
2. Ctrl-scroll wheel (1 unit per tick) and ctrl-alt-scroll wheel (0.1 unit per tick) change the height at which the reticle is correctly scaled.  If the reticle height is changed from its default, the lower right corner of the camera's view will display the reticle's height along with its default height. A pop-up menu selection "Reset Reticle Height to Default" is also available to quickly reset the reticle height to its default.   Camera drag and shift-click jogging is performed using the same scaling as the reticle.  Example for use: Suppose a board's top surface is at Z=-35mm and a 10mm tall part is sitting on the board.  With the top camera over the part, the reticle height can be changed to -35+10 = -25mm and the reticle will be correctly scaled for the top surface of the part.   Drag and/or Shift-Click jogging can then be used to accurately jog around on the top surface of the part.
3. A pop-up menu option "Estimate Z Coordinate of Object" allows the operator to use the camera to estimate the height of a feature.  When the menu option is selected, instructions will appear guiding the operator on how to make the measurement.  They should be self explanatory (basically click on the feature, jog to a different location, and click on the feature again).
4.  Bottom camera jogging now works similar to the top camera jogging.  Grab the drag handle with the mouse and the location where the mouse is released will move to the center of the camera view.  Shift-click on a location and it will move to the center of the camera view.  These are best observed with a part on the nozzle over the bottom camera.

# Implementation Details
1. **How did you test the change?** Started with a legacy machine.xml file and verified camera vision still worked as it had previously.  Checked the machine Issues and Solutions tab and verified both cameras had a recommendation to calibrate at two different heights.  Performed the calibrations and verified the the issues cleared.  Places a ruler over/under the camera at different heights to verify that the reticle scaling was correct at those heights and also that jogging was accurate at those heights.  Selected the "Estimate Z Coordinate of Object" menu selection and followed to the instructions that appeared - verified that the estimated height was close (within a millimeter) to the height measured by touching the nozzle to the object.  Tested the bottom camera jogging changes by picking a part with the nozzle and moving it over the bottom camera.  Tried jogging to various pins of the part and they moved to the center of the camera view as expected.
2. **Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)?**  Yes.
3. **If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing.**  Changes were made to the Camera interface to add new interfaces to allow calibration at two different heights and allow that calibration information to be used.  No existing interfaces were changed.  The new methods were implemented in AbstractCamera and only one existing method (getUnitsPerPixel()) was modified so that any legacy code that calls getUnitsPerPixel() works correctly both before and after calibration is performed at two different heights.
4. **Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted.**  The Maven tests were run and all passed.
