### PR TITLE
AdvancedLoosePartFeeder: Support for the async gcode driver

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/feeder/AdvancedLoosePartFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/AdvancedLoosePartFeeder.java
@@ -54,10 +54,7 @@ public class AdvancedLoosePartFeeder extends ReferenceFeeder {
 
     @Override
     public Location getPickLocation() throws Exception {
-        if (pickLocation == null) {
-            throw new Exception("Feeder " + getName() + ": No parts found.");
-        }
-        return pickLocation;
+        return pickLocation == null ? location : pickLocation;
     }
 
     @Override
@@ -68,6 +65,10 @@ public class AdvancedLoosePartFeeder extends ReferenceFeeder {
         // if there is a part, get a precise location
         for (int i = 0; i < 3 && pickLocation != null; i++) {
             pickLocation = locateFeederPart(nozzle, pickLocation);
+        }
+        // throw if feed results in no parts
+        if (pickLocation == null) {
+            throw new Exception("Feeder " + getName() + ": No parts found.");
         }
     }
 

--- a/src/main/java/org/openpnp/machine/reference/feeder/AdvancedLoosePartFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/AdvancedLoosePartFeeder.java
@@ -54,7 +54,10 @@ public class AdvancedLoosePartFeeder extends ReferenceFeeder {
 
     @Override
     public Location getPickLocation() throws Exception {
-        return pickLocation == null ? location : pickLocation;
+        if (pickLocation == null) {
+            throw new Exception("Feeder " + getName() + ": No parts found.");
+        }
+        return pickLocation;
     }
 
     @Override

--- a/src/main/java/org/openpnp/machine/reference/feeder/AdvancedLoosePartFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/AdvancedLoosePartFeeder.java
@@ -35,7 +35,6 @@ import org.openpnp.model.Location;
 import org.openpnp.spi.Camera;
 import org.openpnp.spi.MotionPlanner.CompletionType;
 import org.openpnp.spi.Nozzle;
-import org.openpnp.spi.NozzleTip;
 import org.openpnp.spi.PropertySheetHolder;
 import org.openpnp.util.MovableUtils;
 import org.openpnp.util.OpenCvUtils;
@@ -60,11 +59,6 @@ public class AdvancedLoosePartFeeder extends ReferenceFeeder {
 
     @Override
     public void feed(Nozzle nozzle) throws Exception {
-        // just to be sure it's the right nozzle for the job
-        if ( !getPart().getPackage().getCompatibleNozzleTips().contains(nozzle.getNozzleTip())) {
-            nozzle.loadNozzleTip(getPart().getPackage().getCompatibleNozzleTips().toArray(new NozzleTip[0])[0]);
-        }
-
         // no part found => no pick location
         pickLocation = location.derive(null, null, Double.NaN, 0.0);
 

--- a/src/main/java/org/openpnp/machine/reference/feeder/AdvancedLoosePartFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/AdvancedLoosePartFeeder.java
@@ -117,6 +117,14 @@ public class AdvancedLoosePartFeeder extends ReferenceFeeder {
         }
     }
 
+    /**
+     * Checks if the testLocation is inside the camera view starting on the feeder location.
+     * Avoids to run outside the initial area if a bad pipeline repeated detects the parts
+     * on one edge of the field of view, even after moving the camera to the location.
+     * @param camera the used camera
+     * @param testLocation the location to test
+     * @return the testLocation, or null if outside the initial field of view
+     */
     private Location checkIfInInitialView(Camera camera, Location testLocation) {
         // just make sure, the vision did not "run away" => outside of the initial camera range
         // should never happen, but with badly dialed in pipelines ...

--- a/src/main/resources/org/openpnp/machine/reference/feeder/AdvancedLoosePartFeeder-DefaultPipeline.xml
+++ b/src/main/resources/org/openpnp/machine/reference/feeder/AdvancedLoosePartFeeder-DefaultPipeline.xml
@@ -1,7 +1,7 @@
 <cv-pipeline>
    <stages>
       <cv-stage class="org.openpnp.vision.pipeline.stages.ImageRead" name="00" enabled="false" file="_openpnp/vision/openpnp-pipeline-tests"/>
-      <cv-stage class="org.openpnp.vision.pipeline.stages.ImageCapture" name="0" enabled="true" settle-first="false"/>
+      <cv-stage class="org.openpnp.vision.pipeline.stages.ImageCapture" name="0" enabled="true" settle-first="true"/>
       <cv-stage class="org.openpnp.vision.pipeline.stages.BlurGaussian" name="1" enabled="true" kernel-size="19"/>
       <cv-stage class="org.openpnp.vision.pipeline.stages.ConvertColor" name="19" enabled="true" conversion="Bgr2HsvFull"/>
       <cv-stage class="org.openpnp.vision.pipeline.stages.Normalize" name="2" enabled="true"/>
@@ -11,7 +11,7 @@
       <cv-stage class="org.openpnp.vision.pipeline.stages.FindContours" name="6" enabled="true" retrieval-mode="List" approximation-method="None"/>
       <cv-stage class="org.openpnp.vision.pipeline.stages.FilterContours" name="7" enabled="true" contours-stage-name="6" min-area="1000.0" max-area="100000.0"/>
       <cv-stage class="org.openpnp.vision.pipeline.stages.MinAreaRectContours" name="8" enabled="true" contours-stage-name="7"/>
-      <cv-stage class="org.openpnp.vision.pipeline.stages.ReadPartTemplateImage" name="14" enabled="true" template-file="_openpnp/vision/templates" extension=".png"/>
+      <cv-stage class="org.openpnp.vision.pipeline.stages.ReadPartTemplateImage" name="14" enabled="true" template-file="" extension=".png" prefix="top-" log="false"/>
       <cv-stage class="org.openpnp.vision.pipeline.stages.ConvertColor" name="10" enabled="true" conversion="Bgr2Gray"/>
       <cv-stage class="org.openpnp.vision.pipeline.stages.Normalize" name="16" enabled="true"/>
       <cv-stage class="org.openpnp.vision.pipeline.stages.ComposeResult" name="13" enabled="true" image-stage-name="16" model-stage-name="14"/>

--- a/src/main/resources/org/openpnp/machine/reference/feeder/AdvancedLoosePartFeeder-DefaultTrainingPipeline.xml
+++ b/src/main/resources/org/openpnp/machine/reference/feeder/AdvancedLoosePartFeeder-DefaultTrainingPipeline.xml
@@ -17,6 +17,6 @@
          <color r="0" g="0" b="0" a="255"/>
       </cv-stage>
       <cv-stage class="org.openpnp.vision.pipeline.stages.CreateModelTemplateImage" name="14" enabled="true" model-stage-name="10" degrees="0.0"/>
-      <cv-stage class="org.openpnp.vision.pipeline.stages.WritePartTemplateImage" name="13" enabled="true" template-file="_openpnp/vision/templates/new" extension=".png"/>
+      <cv-stage class="org.openpnp.vision.pipeline.stages.WritePartTemplateImage" name="13" enabled="true" template-file="" extension=".png" prefix="top-" as-package="false"/>
    </stages>
 </cv-pipeline>


### PR DESCRIPTION
# Description
Fixed synchronization so that it works with the async gcode driver:

- In the default pipelines made sure the "settle-first" is enabled
- Added explicit synchronization in the code to make sure the next call to the vision pipeline is called after movement finished

Added a safety feature, to make sure the vision pipeline can not "run away" during the location. Ensures the pick location stays inside the camera field of view if the camera is above the feeder location.

# Justification
fixed bug and added safety feature.

# Instructions for Use
no changes

# Implementation Details
1. How did you test the change? Pipelines not tested, but tested with own pipelines, works normal again
2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)? yes
3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing. no
4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted.
