### PR TITLE
fix null pointer exception in feeder tab

### DIFF
--- a/src/main/java/org/openpnp/gui/FeedersPanel.java
+++ b/src/main/java/org/openpnp/gui/FeedersPanel.java
@@ -192,7 +192,7 @@ public class FeedersPanel extends JPanel implements WizardContainer {
 								continue;
 							}
 
-							if (placement.getPart().getId() == partId) {
+							if (placement.getPart() != null && placement.getPart().getId() == partId) {
 								bFound = true;
 								break;
 							}


### PR DESCRIPTION
# Description
Fixed a nullpointer exception that occurred opening the feeder tab if a job is loaded, with some parts are not yet assigned.

# Justification
restore expected behavior

# Instructions for Use
no change

# Implementation Details
1. How did you test the change? Loaded job that made the problems before, works now.
2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)? yes
3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing.
4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted.
