### PR TITLE
Feature/fix pipeline editor bug

### DIFF
--- a/src/main/java/org/openpnp/gui/wizards/CameraConfigurationWizard.java
+++ b/src/main/java/org/openpnp/gui/wizards/CameraConfigurationWizard.java
@@ -126,9 +126,9 @@ public class CameraConfigurationWizard extends AbstractConfigurationWizard {
         panel.add(previewFps, "4, 6, fill, default");
         previewFps.setColumns(10);
 
-        lblSuspendDuringTaks = new JLabel("Suspend during taks?");
-        lblSuspendDuringTaks.setToolTipText("<html>Continuous camera preview is suspended during machine tasks, only frames<br/>\r\ncaptured using computer vision are shown. For high Preview FPS this improves <br/>\r\nperformance </html>");
-        panel.add(lblSuspendDuringTaks, "6, 6, right, default");
+        lblSuspendDuringTasks = new JLabel("Suspend during tasks?");
+        lblSuspendDuringTasks.setToolTipText("<html>Continuous camera preview is suspended during machine tasks, only frames<br/>\r\ncaptured using computer vision are shown. For high Preview FPS this improves <br/>\r\nperformance </html>");
+        panel.add(lblSuspendDuringTasks, "6, 6, right, default");
 
         suspendPreviewInTasks = new JCheckBox("");
         panel.add(suspendPreviewInTasks, "8, 6");
@@ -163,7 +163,7 @@ public class CameraConfigurationWizard extends AbstractConfigurationWizard {
                         FormSpecs.RELATED_GAP_ROWSPEC,
                         FormSpecs.DEFAULT_ROWSPEC,}));
 
-        lblLightingActuator = new JLabel("Ligh Actuator");
+        lblLightingActuator = new JLabel("Light Actuator");
         panelLight.add(lblLightingActuator, "2, 2, right, default");
 
         lightActuator = new JComboBox();
@@ -394,7 +394,7 @@ public class CameraConfigurationWizard extends AbstractConfigurationWizard {
     private JTextField nameTf;
     private JLabel lblPreviewFps;
     private JTextField previewFps;
-    private JLabel lblSuspendDuringTaks;
+    private JLabel lblSuspendDuringTasks;
     private JCheckBox suspendPreviewInTasks;
     private JLabel lblUserActionLight;
     private JCheckBox userActionLightOn;

--- a/src/main/java/org/openpnp/vision/pipeline/stages/ComposeResult.java
+++ b/src/main/java/org/openpnp/vision/pipeline/stages/ComposeResult.java
@@ -20,6 +20,7 @@
 package org.openpnp.vision.pipeline.stages;
 
 import org.opencv.core.Mat;
+import org.openpnp.vision.FluentCv.ColorSpace;
 import org.openpnp.vision.pipeline.CvPipeline;
 import org.openpnp.vision.pipeline.CvStage;
 import org.openpnp.vision.pipeline.Property;
@@ -62,6 +63,7 @@ public class ComposeResult extends CvStage {
 
         Object model = null;
         Mat image = null;
+        ColorSpace colorSpace = null;
 
         if (modelStageName == null || modelStageName.trim()
                                                     .equals("")) {
@@ -75,13 +77,15 @@ public class ComposeResult extends CvStage {
         if (imageStageName == null || imageStageName.trim()
                                                     .equals("")) {
             image = pipeline.getWorkingImage();
+            colorSpace = pipeline.getWorkingColorSpace();
         }
         else {
             image = pipeline.getExpectedResult(imageStageName).image;
+            colorSpace = pipeline.getExpectedResult(imageStageName).colorSpace;
         }
         if (model == null) {
-            return new Result(image);
+            return new Result(image, colorSpace);
         }
-        return new Result(image, model);
+        return new Result(image, colorSpace, model);
     }
 }

--- a/src/main/java/org/openpnp/vision/pipeline/stages/ImageRead.java
+++ b/src/main/java/org/openpnp/vision/pipeline/stages/ImageRead.java
@@ -2,6 +2,7 @@ package org.openpnp.vision.pipeline.stages;
 
 import java.io.File;
 
+import org.opencv.core.Mat;
 import org.opencv.imgcodecs.Imgcodecs;
 import org.openpnp.vision.FluentCv.ColorSpace;
 import org.openpnp.vision.pipeline.CvPipeline;
@@ -44,6 +45,10 @@ public class ImageRead extends CvStage {
         if (!file.exists()) {
             return null;
         }
-        return new Result(Imgcodecs.imread(file.getAbsolutePath()), colorSpace);
+        Mat image = Imgcodecs.imread(file.getAbsolutePath());
+        if (image.channels() == 1) {
+            colorSpace = ColorSpace.Gray;
+        }
+        return new Result(image, colorSpace);
     }
 }

--- a/src/main/java/org/openpnp/vision/pipeline/stages/MaskHsv.java
+++ b/src/main/java/org/openpnp/vision/pipeline/stages/MaskHsv.java
@@ -11,6 +11,7 @@ import org.opencv.core.MatOfInt;
 import org.opencv.core.Scalar;
 import org.opencv.imgproc.Imgproc;
 import org.openpnp.vision.FluentCv;
+import org.openpnp.vision.FluentCv.ColorSpace;
 import org.openpnp.vision.pipeline.CvPipeline;
 import org.openpnp.vision.pipeline.CvStage;
 import org.openpnp.vision.pipeline.Property;
@@ -439,7 +440,7 @@ public class MaskHsv extends CvStage {
         Logger.trace( "Fraction actually masked = " + fractionActuallyMasked );
         if (binaryMask) {
             masked.release();
-            return new Result(mask);
+            return new Result(mask, ColorSpace.Gray);
         } else {
             mat.copyTo(masked, mask);
             mask.release();

--- a/src/main/java/org/openpnp/vision/pipeline/stages/ReadPartTemplateImage.java
+++ b/src/main/java/org/openpnp/vision/pipeline/stages/ReadPartTemplateImage.java
@@ -32,6 +32,7 @@ import org.openpnp.model.Configuration;
 import org.openpnp.model.Part;
 import org.openpnp.spi.Camera;
 import org.openpnp.spi.Feeder;
+import org.openpnp.vision.FluentCv.ColorSpace;
 import org.openpnp.vision.pipeline.CvPipeline;
 import org.openpnp.vision.pipeline.CvStage;
 import org.openpnp.vision.pipeline.Property;
@@ -61,6 +62,10 @@ public class ReadPartTemplateImage extends CvStage {
     @Property(description = "Enable logging.")
     private boolean log = false;
 
+    @Attribute(required=false)
+    @Property(description="The color space of the image.  Use to select the color space that the original image had when it was written.  Note that this does not change any of the numerical values that represent the image but rather their interpretation when the image is displayed in the pipeline editor.")
+    private ColorSpace colorSpace = ColorSpace.Bgr;
+    
     public String getTemplateFile() {
         return templateFile;
     }
@@ -91,6 +96,14 @@ public class ReadPartTemplateImage extends CvStage {
 
     public void setPrefix(String prefix) {
         this.prefix = prefix;
+    }
+
+    public ColorSpace getColorSpace() {
+        return colorSpace;
+    }
+
+    public void setColorSpace(ColorSpace colorSpace) {
+        this.colorSpace = colorSpace;
     }
 
     @Override
@@ -204,7 +217,7 @@ public class ReadPartTemplateImage extends CvStage {
                             Logger.info("Using package body as a template.");
                         }
                         // that's all we can do for now
-                        return new Result(templateImage, rrect);
+                        return new Result(templateImage, ColorSpace.Bgr, rrect);
                     }
                     else {
                         return null;
@@ -225,12 +238,16 @@ public class ReadPartTemplateImage extends CvStage {
         // Read template image from disk
         Mat templateImage = Imgcodecs.imread(file.getAbsolutePath());
 
+        if (templateImage.channels() == 1) {
+            colorSpace = ColorSpace.Gray;
+        }
         width = templateImage.size().width;
         height = templateImage.size().height;
         if (width == 0.0 && height == 0.0) {
             return null;
         }
-        return new Result(templateImage, new RotatedRect(new Point(width / 2, height / 2),
-                new Size(width, height), (double) 0));
+        return new Result(templateImage, colorSpace,
+                new RotatedRect(new Point(width / 2, height / 2),
+                        new Size(width, height), (double) 0));
     }
 }

--- a/src/main/java/org/openpnp/vision/pipeline/ui/ResultsPanel.java
+++ b/src/main/java/org/openpnp/vision/pipeline/ui/ResultsPanel.java
@@ -37,6 +37,8 @@ import org.openpnp.vision.FluentCv.ColorSpace;
 import org.openpnp.vision.pipeline.CvStage;
 import org.openpnp.vision.pipeline.CvStage.Result;
 import org.openpnp.vision.pipeline.CvStage.Result.Circle;
+import org.pmw.tinylog.Logger;
+
 import javax.swing.JSeparator;
 
 public class ResultsPanel extends JPanel {
@@ -220,36 +222,52 @@ public class ResultsPanel extends JPanel {
                     if (displayTrueColors) {
                         ColorSpace colorSpace = result.getColorSpace();
                         if (colorSpace != null) {
-                            switch (colorSpace) {
-                                case Gray :
-                                case Bgr :
-                                    //format is already ok for display
-                                    break;
-                                case Rgb :
-                                    //need to swap channels 0 and 2 to get to Bgr format
-                                    Mat rChannel = new Mat();
-                                    Mat bChannel = new Mat();
-                                    Core.extractChannel(image, rChannel, 0);
-                                    Core.extractChannel(image, bChannel, 2);
-                                    Core.insertChannel(bChannel, image, 0);
-                                    Core.insertChannel(rChannel, image, 2);
-                                    rChannel.release();
-                                    bChannel.release();
-                                    break;
-                                case Hls :
-                                    Imgproc.cvtColor(image, image, ColorCode.Hls2Bgr.getCode());
-                                    break;
-                                case HlsFull :
-                                    Imgproc.cvtColor(image, image, ColorCode.Hls2BgrFull.getCode());
-                                    break;
-                                case Hsv :
-                                    Imgproc.cvtColor(image, image, ColorCode.Hsv2Bgr.getCode());
-                                    break;
-                                case HsvFull :
-                                    Imgproc.cvtColor(image, image, ColorCode.Hsv2BgrFull.getCode());
-                                    break;
-                                default:
-                                    break;
+                            if ((image.channels() == 3) || (colorSpace == ColorSpace.Gray)) {
+                                switch (colorSpace) {
+                                    case Gray :
+                                    case Bgr :
+                                        //format is already ok for display
+                                        break;
+                                    case Rgb :
+                                        //need to swap channels 0 and 2 to get to Bgr format
+                                        Mat rChannel = new Mat();
+                                        Mat bChannel = new Mat();
+                                        Core.extractChannel(image, rChannel, 0);
+                                        Core.extractChannel(image, bChannel, 2);
+                                        Core.insertChannel(bChannel, image, 0);
+                                        Core.insertChannel(rChannel, image, 2);
+                                        rChannel.release();
+                                        bChannel.release();
+                                        break;
+                                    case Hls :
+                                        Imgproc.cvtColor(image, image, ColorCode.Hls2Bgr.getCode());
+                                        break;
+                                    case HlsFull :
+                                        Imgproc.cvtColor(image, image, ColorCode.Hls2BgrFull.getCode());
+                                        break;
+                                    case Hsv :
+                                        Imgproc.cvtColor(image, image, ColorCode.Hsv2Bgr.getCode());
+                                        break;
+                                    case HsvFull :
+                                        Imgproc.cvtColor(image, image, ColorCode.Hsv2BgrFull.getCode());
+                                        break;
+                                    default:
+                                        break;
+                                }
+                            }
+                            else {
+                                Logger.error("Expecting image to be in the " + colorSpace +
+                                        " color space but it has only one channel. " + 
+                                        "Please send this log file to the developers!" );
+                                Logger.error("The offending pipeline is:");
+                                String pipelineStr;
+                                try {
+                                    pipelineStr = "\n" + editor.getPipeline().toXmlString();
+                                }
+                                catch (Exception ex) {
+                                    pipelineStr = "Unavailable due to " + ex.toString();
+                                }
+                                Logger.error(pipelineStr);
                             }
                         }
                     }


### PR DESCRIPTION
# Description

1. This fixes a bug introduced by PR #1112 that causes the pipeline editor to not display images when a MaskHsv stage has the binaryMask selection checked.  This also fixes all of the line endings in MaskHsv.java (changes from CRLF to LF).
2. Similar problems related to images with only one channel are fixed in ComposeResult, ImageRead, and ReadPartTemplateImage stages.
3. Added additional error checking and debug to the ResultsPanel to help debug any additional problems of a similar nature.

# Justification
Corrects a bug.

# Instructions for Use
No special instructions needed.

# Implementation Details
**1. How did you test the change?** Replicated problem using the same pipeline that was reported to have problems and then verified this change corrected the issue.
**2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)?**  Yes.
**3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing.**  No changes were made to these packages.
**4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted.**  All Maven tests were run and passed.
