### PR TITLE
Feature/Duet Firmware Detect, Issues and Solutions, Bugfix

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/camera/OpenPnpCaptureCamera.java
+++ b/src/main/java/org/openpnp/machine/reference/camera/OpenPnpCaptureCamera.java
@@ -210,6 +210,8 @@ public class OpenPnpCaptureCamera extends ReferenceCamera implements Runnable {
         if (stream == null || format == null) {
             throw new Exception("Camera stream not properly initialized."); 
         }
+        // Stop the broadcasting thread.
+        stop();
         // Start warmup capture timer for 1 second.
         boolean warmup = true;
         long t0 = System.currentTimeMillis();
@@ -236,6 +238,8 @@ public class OpenPnpCaptureCamera extends ReferenceCamera implements Runnable {
                 }
             }
         }
+        // Start the broadcasting thread.
+        start();
         // Compute the fps.
         return capturedFrames*1000./(t1-t0);
     }

--- a/src/main/java/org/openpnp/machine/reference/driver/wizards/GcodeDriverSettings.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/wizards/GcodeDriverSettings.java
@@ -92,11 +92,7 @@ public class GcodeDriverSettings extends AbstractConfigurationWizard {
                 FormSpecs.RELATED_GAP_ROWSPEC,
                 FormSpecs.DEFAULT_ROWSPEC,
                 FormSpecs.RELATED_GAP_ROWSPEC,
-                FormSpecs.DEFAULT_ROWSPEC,
-                FormSpecs.RELATED_GAP_ROWSPEC,
-                FormSpecs.DEFAULT_ROWSPEC,
-                FormSpecs.RELATED_GAP_ROWSPEC,
-                FormSpecs.DEFAULT_ROWSPEC,}));
+                RowSpec.decode("max(50dlu;default)"),}));
         
         JLabel lblMotionControlType = new JLabel("Motion Control Type");
         lblMotionControlType.setToolTipText("<html>\r\n<p>Determines how the OpenPnP MotionPlanner will plan the motion and how it will talk <br/>\r\nto the controller:</p>\r\n<ul>\r\n\r\n<li><strong>ToolpathFeedRate:</strong><br/>\r\nApply the nominal driver feed-rate limit multiplied by the speed factor to the tool-path.<br/>\r\nThe driver feed-rate must be specified. No acceleration control is applied.</li>\r\n\r\n<li><strong>EuclideanAxisLimits:</strong><br/>\r\nApply axis feed-rate, acceleration and jerk limits multiplied by the proper speed factors. <br/>\r\nThe Euclidean Metric is calculated to allow the machine to run faster in a diagonal.<br/>\r\nOpenPnP only sets the speed factor maximum, ramping up and down the speed is <br/>\r\nentirely left to the controller. </li>  \r\n\r\n<li><strong>ConstantAcceleration:</strong><br/>\r\nApply motion planning assuming a controller with constant acceleration motion control. </li>\r\n\r\n<li><strong>ModeratedConstantAcceleration:</strong><br/>\r\nApply motion planning assuming a controller with constant acceleration motion control but<br/>\r\nmoderate the acceleration and velocity to resemble those of 3rd order control, resulting<br/>\r\nin a move that takes the same amount of time and has similar average acceleration. <br/>\r\nThis will already reduce vibrations a bit.</li>\r\n\r\n<li><strong>SimpleSCurve:</strong><br/>\r\nApply motion planning assuming a controller with simplified S-Curve motion control. <br/>\r\nSimplified S-Curves have no constant acceleration phase, only jerk phases (e.g. TinyG, Marlin).</li>\r\n\r\n<li><strong>Simulated3rdOrderControl:</strong><br/>\r\nApply motion planning assuming a controller with constant acceleration motion control but<br/>\r\nsimulating 3rd order control with time step interpolation. </li> \r\n\r\n<li><strong>Full3rdOrderControl:</strong><br/>\r\nApply motion planning assuming a controller with full 3rd order motion control.</li> \r\n\r\n</html>");
@@ -184,7 +180,7 @@ public class GcodeDriverSettings extends AbstractConfigurationWizard {
         btnDetectFirmware.addActionListener(new ActionListener() {
             public void actionPerformed(ActionEvent e) {
                 setCursor(Cursor.getPredefinedCursor(Cursor.WAIT_CURSOR));
-                detectedFirmware.setText("Detecting...");
+                firmwareConfiguration.setText("Detecting...");
                 SwingUtilities.invokeLater(() -> {
                     UiUtils.messageBoxOnException(() -> driver.detectFirmware(false));
                     setCursor(Cursor.getPredefinedCursor(Cursor.DEFAULT_CURSOR));
@@ -196,26 +192,17 @@ public class GcodeDriverSettings extends AbstractConfigurationWizard {
         settingsPanel.add(label_1, "10, 14");
         settingsPanel.add(btnDetectFirmware, "2, 16");
         
-        detectedFirmware = new JTextArea();
-        detectedFirmware.setForeground(SystemColor.textInactiveText);
-        detectedFirmware.setBackground(SystemColor.control);
-        detectedFirmware.setWrapStyleWord(true);
-        detectedFirmware.setLineWrap(true);
-        detectedFirmware.setEditable(false);
-        detectedFirmware.setFont(new Font("Dialog", Font.PLAIN, 11));
-        settingsPanel.add(detectedFirmware, "4, 16, 7, 5, fill, fill");
+        firmwareConfiguration = new JTextArea();
+        firmwareConfiguration.setForeground(SystemColor.textInactiveText);
+        firmwareConfiguration.setBackground(SystemColor.control);
+        firmwareConfiguration.setWrapStyleWord(true);
+        firmwareConfiguration.setLineWrap(true);
+        firmwareConfiguration.setEditable(false);
+        firmwareConfiguration.setFont(new Font("Dialog", Font.PLAIN, 11));
+        settingsPanel.add(firmwareConfiguration, "4, 16, 7, 3, fill, fill");
         
         JLabel label = new JLabel(" ");
         settingsPanel.add(label, "2, 18");
-        
-        reportedAxes = new JTextArea();
-        reportedAxes.setForeground(SystemColor.textInactiveText);
-        reportedAxes.setBackground(SystemColor.control);
-        reportedAxes.setWrapStyleWord(true);
-        reportedAxes.setLineWrap(true);
-        reportedAxes.setEditable(false);
-        reportedAxes.setFont(new Font("Dialog", Font.PLAIN, 11));
-        settingsPanel.add(reportedAxes, "4, 22, 7, 1, fill, fill");
     }
 
     @Override
@@ -224,7 +211,7 @@ public class GcodeDriverSettings extends AbstractConfigurationWizard {
         DoubleConverter doubleConverter =
                 new DoubleConverter(Configuration.get().getLengthDisplayFormat());
         DoubleConverter doubleConverterFine = new DoubleConverter("%f");
-        
+
         addWrappedBinding(driver, "motionControlType", motionControlType, "selectedItem");
         addWrappedBinding(driver, "units", unitsCb, "selectedItem");
         addWrappedBinding(driver, "maxFeedRate", maxFeedRateTf, "text", intConverter);
@@ -236,9 +223,8 @@ public class GcodeDriverSettings extends AbstractConfigurationWizard {
         addWrappedBinding(driver, "supportingPreMove", supportingPreMove, "selected");
         addWrappedBinding(driver, "usingLetterVariables", letterVariables, "selected");
         addWrappedBinding(driver, "loggingGcode", loggingGcode, "selected");
-        addWrappedBinding(driver, "detectedFirmware", detectedFirmware, "text");
-        addWrappedBinding(driver, "reportedAxes", reportedAxes, "text");
-        
+        addWrappedBinding(driver, "firmwareConfiguration", firmwareConfiguration, "text");
+
         ComponentDecorators.decorateWithAutoSelect(maxFeedRateTf);
         ComponentDecorators.decorateWithAutoSelect(commandTimeoutTf);
         ComponentDecorators.decorateWithAutoSelect(connectWaitTimeTf);
@@ -385,9 +371,7 @@ public class GcodeDriverSettings extends AbstractConfigurationWizard {
 
     private JCheckBox loggingGcode;
 
-    private JTextArea detectedFirmware;
-
-    private JTextArea reportedAxes;
+    private JTextArea firmwareConfiguration;
 
     static class HeadMountableItem {
         private HeadMountable hm;


### PR DESCRIPTION
# Description
This adds support for the Duet 3D firmware in Detection and [Issues & Solutions](https://github.com/openpnp/openpnp/wiki/Issues-and-Solutions). The new firmware version 3.3beta now supports all mandatory OpenPnP Advanced Motion Control features. 

Issues & Solutions recognizes the firmware using `M115` and compares major and minor version number to make sure a 3.3 version is at least present. Otherwise, it tells the user to upgrade. 

![Issues & Solutions](https://user-images.githubusercontent.com/9963310/108625495-8654b680-744b-11eb-9370-7ef70c6192c3.png)

Firmware detection now also queries the axis configuration, if a Duet controller was detected. Based on this, Issues & Solutions makes sure, rotational axes are configured as linear for feed-rate calculations. Otherwise, it tells the user to use proper configuration using the `M584` `S0` [command option](https://duet3d.dozuki.com/Wiki/Gcode#Section_M584_Set_drive_mapping).

The Firmware Detection UI was slightly changed to display all detection relevant information in one text area.  

As a stow-away this PR introduces a small fix in the OpenPnpCamera Capture FPS test (see #1053). The camera preview broadcasting thread is now stopped before the measurement, then restarted to prevent a deadlock situation and to improve the measurement accuracy. 

# Justification
OpenPnP should now fully embrace Duet 3D after all issues have been resolved. Many thanks to @dc42 for implementing substantial improvements and for accepting my [pull request](https://github.com/Duet3D/RepRapFirmware/pull/471).

Duet firmware was improved in 

- USB serial speed 
- Fixes for compressed G-code parsing
- Fixes and configurable option for correct feed rate calculations according to section 2.1.2.5 of the NIST G-Code standard.
- Configurable grace period for proper look-ahead planning

# Instructions for Use
See the general [Issues & Solutions](https://github.com/openpnp/openpnp/wiki/Issues-and-Solutions) instructions.

# Implementation Details
1. Tested on a lab bench Duet 3 configuration.
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. Nochanges in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. Successful `mvn test` before submitting the Pull Request.
