### PR TITLE
Fork for each test a new VM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -363,6 +363,7 @@
 				<artifactId>maven-surefire-plugin</artifactId>
 				<version>2.19</version>
 				<configuration>
+  					<reuseForks>false</reuseForks>
 					<argLine>-Xmx512m</argLine>
 				</configuration>
 			</plugin>


### PR DESCRIPTION

# Description
This change changes the configuration of the plugin to execute the unit tests to recreate
a vm on each test
# Justification
This is a good idea as static variables are used which may be not initailized accidentally.

# Instructions for Use
Nothing
# Implementation Details
Got this information from 
https://maven.apache.org/surefire/maven-surefire-plugin/examples/fork-options-and-parallel-execution.html