### PR TITLE
Add read for http actuator

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/HttpActuator.java
+++ b/src/main/java/org/openpnp/machine/reference/HttpActuator.java
@@ -54,6 +54,9 @@ public class HttpActuator extends ReferenceActuator {
     // configuration changes. 
     protected String lastActuationUrl = null;
 
+    @Element(required = false)
+    protected String readUrl = "";
+
     public HttpActuator() {}
 
     @Override
@@ -115,6 +118,42 @@ public class HttpActuator extends ReferenceActuator {
     }
 
     @Override
+    public String read() throws Exception {
+        if (isCoordinatedBeforeRead()) {
+            coordinateWithMachine(false);
+        }
+        
+        
+        
+        // getDriver().actuate(this, on);
+        URL obj = null;
+        obj = new URL(this.readUrl);
+        
+        HttpURLConnection con = (HttpURLConnection) obj.openConnection();
+        
+        con.setRequestMethod("GET");
+        con.setRequestProperty("User-Agent", "Mozilla/5.0");
+
+        int responseCode = con.getResponseCode();
+
+        BufferedReader in = new BufferedReader(new InputStreamReader(con.getInputStream()));
+        String inputLine;
+        StringBuffer response = new StringBuffer();
+
+        while ((inputLine = in.readLine()) != null) {
+            response.append(inputLine);
+        }
+        in.close();
+        
+        
+        if (isCoordinatedAfterActuate()) {
+            coordinateWithMachine(true);
+        }
+        getMachine().fireMachineHeadActivity(head);
+        return response.toString();
+    }
+
+    @Override
     public Wizard getConfigurationWizard() {
         return new HttpActuatorConfigurationWizard(getMachine(), this);
     }
@@ -143,5 +182,14 @@ public class HttpActuator extends ReferenceActuator {
 
     public void setParamUrl(String paramUrl) {
         this.paramUrl = paramUrl;
+    }
+
+    public String getReadUrl() {
+        return this.readUrl;
+    }
+
+    public void setReadUrl(String url) {
+        this.readUrl = url;
+        firePropertyChange("readUrl", null, this.readUrl);
     }
 }

--- a/src/main/java/org/openpnp/machine/reference/HttpActuator.java
+++ b/src/main/java/org/openpnp/machine/reference/HttpActuator.java
@@ -26,9 +26,17 @@ import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.ProtocolException;
 import java.net.URL;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.openpnp.gui.support.Wizard;
+import org.openpnp.machine.reference.camera.SimulatedUpCamera;
+import org.openpnp.machine.reference.driver.GcodeDriver.Line;
 import org.openpnp.machine.reference.wizards.HttpActuatorConfigurationWizard;
+import org.openpnp.model.Solutions;
+import org.openpnp.model.Solutions.Severity;
+import org.openpnp.spi.Camera.Looking;
 import org.openpnp.util.TextUtils;
 import org.pmw.tinylog.Logger;
 import org.simpleframework.xml.Element;
@@ -43,6 +51,9 @@ public class HttpActuator extends ReferenceActuator {
 
     @Element(required = false)
     protected String paramUrl = "";
+
+    @Element(required = false)
+    protected String regex = "";
 
     // The actuation state should not be persisted.
     @Deprecated
@@ -124,13 +135,12 @@ public class HttpActuator extends ReferenceActuator {
         }
         
         
-        
         // getDriver().actuate(this, on);
         URL obj = null;
         obj = new URL(this.readUrl);
-        
+
         HttpURLConnection con = (HttpURLConnection) obj.openConnection();
-        
+
         con.setRequestMethod("GET");
         con.setRequestProperty("User-Agent", "Mozilla/5.0");
 
@@ -140,16 +150,26 @@ public class HttpActuator extends ReferenceActuator {
         String inputLine;
         StringBuffer response = new StringBuffer();
 
+        Pattern pattern = Pattern.compile(regex);
+
         while ((inputLine = in.readLine()) != null) {
-            response.append(inputLine);
+            Matcher matcher = pattern.matcher(inputLine);
+            if (matcher.matches()) {
+                String s = matcher.group("Value");
+                response.append(s);
+            }
+            if (regex.length() == 0) {
+                response.append(inputLine);
+            }
+
         }
         in.close();
-        
-        
+
         if (isCoordinatedAfterActuate()) {
             coordinateWithMachine(true);
         }
         getMachine().fireMachineHeadActivity(head);
+
         return response.toString();
     }
 
@@ -191,5 +211,35 @@ public class HttpActuator extends ReferenceActuator {
     public void setReadUrl(String url) {
         this.readUrl = url;
         firePropertyChange("readUrl", null, this.readUrl);
+    }
+
+    public String getRegex() {
+        return this.regex;
+    }
+
+    public void setRegex(String regex) {
+        this.regex = regex;
+        firePropertyChange("regex", null, this.regex);
+    }
+
+    @Override
+    public void findIssues(List<Solutions.Issue> issues) {
+        super.findIssues(issues);
+        if (this.readUrl.length() > 0 && this.regex.length() == 0) {
+
+            issues.add(new Solutions.Issue(this,
+                    "A HTTPActuator with Read URL likely needs a regular Expression to parse the value.",
+                    "Set an example expression", Severity.Warning,
+                    "https://github.com/openpnp/openpnp/wiki/HttpActuatorRead") {
+
+                @Override
+                public void setState(Solutions.State state) throws Exception {
+                    if (confirmStateChange(state)) {
+                        setRegex("read:(?<Value>-?\\d+)");
+                        super.setState(state);
+                    }
+                }
+            });
+        }
     }
 }

--- a/src/main/java/org/openpnp/machine/reference/wizards/HttpActuatorConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/wizards/HttpActuatorConfigurationWizard.java
@@ -20,9 +20,6 @@
 
 package org.openpnp.machine.reference.wizards;
 
-import java.awt.event.ItemEvent;
-import java.awt.event.ItemListener;
-
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JTextField;
@@ -30,7 +27,6 @@ import javax.swing.border.TitledBorder;
 
 import org.openpnp.gui.components.ComponentDecorators;
 import org.openpnp.machine.reference.HttpActuator;
-import org.openpnp.spi.Actuator.ActuatorValueType;
 import org.openpnp.spi.base.AbstractMachine;
 
 import com.jgoodies.forms.layout.ColumnSpec;
@@ -73,6 +69,8 @@ public class HttpActuatorConfigurationWizard extends AbstractActuatorConfigurati
                 FormSpecs.RELATED_GAP_ROWSPEC,
                 FormSpecs.DEFAULT_ROWSPEC,
                 FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
                 FormSpecs.DEFAULT_ROWSPEC,}));
 
         lblName = new JLabel("Name");
@@ -104,20 +102,31 @@ public class HttpActuatorConfigurationWizard extends AbstractActuatorConfigurati
         panelProperties.add(paramUrl, "4, 8, fill, default");
         paramUrl.setColumns(40);
 
+        lblReadUrl = new JLabel("Read URL");
+        panelProperties.add(lblReadUrl, "2, 8, right, default");
+
+        readUrlTf = new JTextField();
+        panelProperties.add(readUrlTf, "4, 8, fill, default");
+        readUrlTf.setColumns(40);
+
+
         super.createUi(machine);
     }
 
     @Override
     public void createBindings() {
+        super.createBindings();
         addWrappedBinding(actuator, "name", nameTf, "text");
         addWrappedBinding(actuator, "onUrl", onUrlTf, "text");
         addWrappedBinding(actuator, "offUrl", offUrlTf, "text");
         addWrappedBinding(actuator, "paramUrl", paramUrl, "text");
+        addWrappedBinding(actuator, "readUrl", readUrlTf, "text");
 
         ComponentDecorators.decorateWithAutoSelect(nameTf);
         ComponentDecorators.decorateWithAutoSelect(onUrlTf);
         ComponentDecorators.decorateWithAutoSelect(offUrlTf);
         ComponentDecorators.decorateWithAutoSelect(paramUrl);
+        ComponentDecorators.decorateWithAutoSelect(readUrlTf);
 
         super.createBindings();
     }
@@ -131,5 +140,7 @@ public class HttpActuatorConfigurationWizard extends AbstractActuatorConfigurati
         offUrlTf.setVisible(isBoolean);
         lblParametricUrl.setVisible(!isBoolean);
         paramUrl.setVisible(!isBoolean);
+        lblReadUrl.setVisible(!isBoolean);
+        readUrlTf.setVisible(!isBoolean);
     }
 }

--- a/src/main/java/org/openpnp/machine/reference/wizards/HttpActuatorConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/wizards/HttpActuatorConfigurationWizard.java
@@ -27,6 +27,7 @@ import javax.swing.border.TitledBorder;
 
 import org.openpnp.gui.components.ComponentDecorators;
 import org.openpnp.machine.reference.HttpActuator;
+import org.openpnp.spi.Actuator.ActuatorValueType;
 import org.openpnp.spi.base.AbstractMachine;
 
 import com.jgoodies.forms.layout.ColumnSpec;
@@ -45,6 +46,8 @@ public class HttpActuatorConfigurationWizard extends AbstractActuatorConfigurati
     private JTextField offUrlTf;
     private JLabel lblParametricUrl;
     private JTextField paramUrl;
+    private JTextField readUrlTf;
+    private JLabel lblReadUrl;
 
     public HttpActuatorConfigurationWizard(AbstractMachine machine, HttpActuator httpActuator) {
         super(machine, httpActuator);
@@ -103,10 +106,10 @@ public class HttpActuatorConfigurationWizard extends AbstractActuatorConfigurati
         paramUrl.setColumns(40);
 
         lblReadUrl = new JLabel("Read URL");
-        panelProperties.add(lblReadUrl, "2, 8, right, default");
+        panelProperties.add(lblReadUrl, "2, 10, right, default");
 
         readUrlTf = new JTextField();
-        panelProperties.add(readUrlTf, "4, 8, fill, default");
+        panelProperties.add(readUrlTf, "4, 10, fill, default");
         readUrlTf.setColumns(40);
 
 

--- a/src/main/java/org/openpnp/machine/reference/wizards/HttpActuatorConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/wizards/HttpActuatorConfigurationWizard.java
@@ -20,6 +20,8 @@
 
 package org.openpnp.machine.reference.wizards;
 
+import java.util.List;
+
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JTextField;
@@ -27,7 +29,11 @@ import javax.swing.border.TitledBorder;
 
 import org.openpnp.gui.components.ComponentDecorators;
 import org.openpnp.machine.reference.HttpActuator;
+import org.openpnp.machine.reference.camera.SimulatedUpCamera;
+import org.openpnp.model.Solutions;
+import org.openpnp.model.Solutions.Severity;
 import org.openpnp.spi.Actuator.ActuatorValueType;
+import org.openpnp.spi.Camera.Looking;
 import org.openpnp.spi.base.AbstractMachine;
 
 import com.jgoodies.forms.layout.ColumnSpec;
@@ -48,6 +54,8 @@ public class HttpActuatorConfigurationWizard extends AbstractActuatorConfigurati
     private JTextField paramUrl;
     private JTextField readUrlTf;
     private JLabel lblReadUrl;
+    private JTextField regexTf;
+    private JLabel lblRegex;
 
     public HttpActuatorConfigurationWizard(AbstractMachine machine, HttpActuator httpActuator) {
         super(machine, httpActuator);
@@ -65,6 +73,8 @@ public class HttpActuatorConfigurationWizard extends AbstractActuatorConfigurati
                 FormSpecs.RELATED_GAP_COLSPEC,
                 FormSpecs.DEFAULT_COLSPEC,},
             new RowSpec[] {
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
                 FormSpecs.RELATED_GAP_ROWSPEC,
                 FormSpecs.DEFAULT_ROWSPEC,
                 FormSpecs.RELATED_GAP_ROWSPEC,
@@ -111,6 +121,14 @@ public class HttpActuatorConfigurationWizard extends AbstractActuatorConfigurati
         readUrlTf = new JTextField();
         panelProperties.add(readUrlTf, "4, 10, fill, default");
         readUrlTf.setColumns(40);
+        
+        lblRegex = new JLabel("Regular Expression");
+        panelProperties.add(lblRegex, "2, 12, right, default");
+
+        regexTf = new JTextField();
+        panelProperties.add(regexTf, "4, 12, fill, default");
+        regexTf.setColumns(40);
+        
 
 
         super.createUi(machine);
@@ -124,12 +142,14 @@ public class HttpActuatorConfigurationWizard extends AbstractActuatorConfigurati
         addWrappedBinding(actuator, "offUrl", offUrlTf, "text");
         addWrappedBinding(actuator, "paramUrl", paramUrl, "text");
         addWrappedBinding(actuator, "readUrl", readUrlTf, "text");
+        addWrappedBinding(actuator, "regex", regexTf, "text");
 
         ComponentDecorators.decorateWithAutoSelect(nameTf);
         ComponentDecorators.decorateWithAutoSelect(onUrlTf);
         ComponentDecorators.decorateWithAutoSelect(offUrlTf);
         ComponentDecorators.decorateWithAutoSelect(paramUrl);
         ComponentDecorators.decorateWithAutoSelect(readUrlTf);
+        ComponentDecorators.decorateWithAutoSelect(regexTf);
 
         super.createBindings();
     }
@@ -145,5 +165,9 @@ public class HttpActuatorConfigurationWizard extends AbstractActuatorConfigurati
         paramUrl.setVisible(!isBoolean);
         lblReadUrl.setVisible(!isBoolean);
         readUrlTf.setVisible(!isBoolean);
+        lblRegex.setVisible(!isBoolean);
+        regexTf.setVisible(!isBoolean);
     }
+    
+   
 }

--- a/src/test/java/HttpActuatorTest.java
+++ b/src/test/java/HttpActuatorTest.java
@@ -1,7 +1,8 @@
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.IOException;
-
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
 
 import javax.swing.Action;
 import javax.swing.Icon;
@@ -11,6 +12,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.openpnp.CameraListener;
 import org.openpnp.gui.support.Wizard;
+import org.openpnp.machine.reference.HttpActuator;
 import org.openpnp.model.Configuration;
 import org.openpnp.model.Length;
 import org.openpnp.model.LengthUnit;
@@ -25,9 +27,12 @@ import org.openpnp.spi.base.AbstractHeadMountable;
 import org.openpnp.util.VisionUtils;
 
 import com.google.common.io.Files;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
 
 
-public class VisionUtilsTest {
+public class HttpActuatorTest {
 	
 	@Before
 	public void before() throws Exception {
@@ -45,225 +50,58 @@ public class VisionUtilsTest {
 	 
     @Test
     public void testOffsets() {
-        Camera camera = new TestCamera();
-        Location location = camera.getLocation();
-        Assert.assertEquals(location, new Location(LengthUnit.Millimeters, 0, 0, 0, 0));
-        Assert.assertEquals(camera.getWidth(), 640);
-        Assert.assertEquals(camera.getHeight(), 480);
-        Location pixelOffsets = VisionUtils.getPixelCenterOffsets(camera, 100, 100);
-        Assert.assertEquals(pixelOffsets, new Location(LengthUnit.Millimeters, -220, 140, 0, 0));
-        Location pixelLocation = VisionUtils.getPixelLocation(camera, 100, 100);
-        Assert.assertEquals(pixelLocation, new Location(LengthUnit.Millimeters, -220, 140, 0, 0));
+        TestHttpServer server=new TestHttpServer ();
+        HttpActuator actuator=new HttpActuator();
+        
+        
+        actuator.setRegex("read:(?<Value>-?\\d+)");
+        actuator.setReadUrl("http://127.0.0.1:3042/msr");
+        
+        String stringResult="";
+        try {
+            Configuration.get().getMachine().setEnabled(true);
+            stringResult= Configuration.get().getMachine().execute(() -> {
+                 return  actuator.read();
+            }, false, 0);
+      
+        }
+        catch (Exception e) {
+            // TODO Auto-generated catch block
+            e.printStackTrace();
+        }
+        
+        Double result=Double.parseDouble(stringResult);
+        
+        Assert.assertEquals(result, Double.valueOf( 42.0));
+       
     }
-
-    static class TestCamera extends AbstractHeadMountable implements Camera {
-        protected Head head;
-
-        @Override
-        public String getId() {
-            return null;
+    static class TestHttpServer   {
+        TestHttpServer() {
+            HttpServer server;
+            try {
+                server = HttpServer.create(new InetSocketAddress(3042), 0);
+                server.createContext("/msr", new MyHandler());
+                server.setExecutor(null); // creates a default executor
+                server.start();  
+            }
+            catch (IOException e) {
+                // TODO Auto-generated catch block
+                e.printStackTrace();
+            }
+          
         }
-
-        @Override
-        public Head getHead() {
-            return head;
-        }
-
-        @Override
-        public void setHead(Head head) {
-            this.head = head;
-        }
-
-        @Override
-        public Location getLocation() {
-            return new Location(LengthUnit.Millimeters, 0, 0, 0, 0);
-        }
-
-        @Override
-        public Location getLocation(HeadMountable tool) {
-            if (tool != null) {
-                return getLocation().subtract(tool.getCameraToolCalibratedOffset(this));
+        static class MyHandler implements HttpHandler {
+            @Override
+            public void handle(HttpExchange t) throws IOException {
+                String response = "read:42";
+                t.sendResponseHeaders(200, response.length());
+                OutputStream os = t.getResponseBody();
+                os.write(response.getBytes());
+                os.close();
             }
 
-            return getLocation();
-        }
-
-       @Override
-        public Location getCameraToolCalibratedOffset(Camera camera) {
-            return new Location(camera.getUnitsPerPixel().getUnits());
-        }
-
-        @Override
-        public Wizard getConfigurationWizard() {
-            return null;
-        }
-
-        @Override
-        public String getPropertySheetHolderTitle() {
-            return null;
-        }
-
-        @Override
-        public PropertySheetHolder[] getChildPropertySheetHolders() {
-            return null;
-        }
-
-        @Override
-        public PropertySheet[] getPropertySheets() {
-            return null;
-        }
-
-        @Override
-        public Action[] getPropertySheetHolderActions() {
-            return null;
-        }
-
-        @Override
-        public String getName() {
-            return null;
-        }
-
-        @Override
-        public void setName(String name) {
-
-        }
-
-        @Override
-        public Looking getLooking() {
-            return null;
-        }
-
-        @Override
-        public void setLooking(Looking looking) {
-
-        }
-
-        @Override
-        public Location getUnitsPerPixel() {
-            return new Location(LengthUnit.Millimeters, 1, 1, 0, 0);
-        }
-
-        @Override
-        public void setUnitsPerPixel(Location unitsPerPixel) {
-
-        }
-
-        @Override
-        public BufferedImage capture() {
-            return null;
-        }
-
-        @Override
-        public BufferedImage captureTransformed() {
-            return null;
-        }
-
-        @Override
-        public BufferedImage captureRaw() {
-            return null;
-        }
-
-        @Override
-        public void startContinuousCapture(CameraListener listener) {
-
-        }
-
-        @Override
-        public void stopContinuousCapture(CameraListener listener) {
-
-        }
-
-        @Override
-        public void setVisionProvider(VisionProvider visionProvider) {
-
-        }
-
-        @Override
-        public VisionProvider getVisionProvider() {
-            return null;
-        }
-
-        @Override
-        public int getWidth() {
-            return 640;
-        }
-
-        @Override
-        public int getHeight() {
-            return 480;
-        }
-
-        @Override
-        public Icon getPropertySheetHolderIcon() {
-            return null;
-        }
-
-        @Override
-        public void close() throws IOException {
-        }
-
-        @Override
-        public BufferedImage settleAndCapture() throws Exception {
-            return null;
-        }
-
-        @Override
-        public BufferedImage lightSettleAndCapture() {
-            return null;
-        }
-
-        @Override
-        public void actuateLightBeforeCapture(Object light) throws Exception {
-        }
-
-        @Override
-        public void actuateLightAfterCapture() throws Exception {
-        }
-
-        @Override
-        public Length getSafeZ() {
-            return null;
-        }
-
-        @Override
-        public Location getHeadOffsets() {
-            return null;
-        }
-
-        @Override
-        public void setHeadOffsets(Location headOffsets) {
-        }
-
-        @Override
-        public void home() throws Exception {
-        }
-
-        @Override
-        public Actuator getLightActuator() {
-            return null;
-        }
-
-        @Override
-        public void ensureCameraVisible() {
-        }
-
-        @Override
-        public boolean hasNewFrame() {
-            return true;
-        }
-
-        public Location getUnitsPerPixel(Length z) {
-            return new Location(LengthUnit.Millimeters, 1, 1, 0, 0).derive(null, null, z.getValue(), null);
-        }
-
-        @Override
-        public Length getDefaultZ() {
-            return new Length(0.0, LengthUnit.Millimeters);
-        }
-
-        @Override
-        public boolean isShownInMultiCameraView() {
-            return false;
+           
         }
     }
+
 }

--- a/src/test/java/HttpActuatorTest.java
+++ b/src/test/java/HttpActuatorTest.java
@@ -1,0 +1,269 @@
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.io.IOException;
+
+
+import javax.swing.Action;
+import javax.swing.Icon;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.openpnp.CameraListener;
+import org.openpnp.gui.support.Wizard;
+import org.openpnp.model.Configuration;
+import org.openpnp.model.Length;
+import org.openpnp.model.LengthUnit;
+import org.openpnp.model.Location;
+import org.openpnp.spi.Actuator;
+import org.openpnp.spi.Camera;
+import org.openpnp.spi.Head;
+import org.openpnp.spi.HeadMountable;
+import org.openpnp.spi.PropertySheetHolder;
+import org.openpnp.spi.VisionProvider;
+import org.openpnp.spi.base.AbstractHeadMountable;
+import org.openpnp.util.VisionUtils;
+
+import com.google.common.io.Files;
+
+
+public class VisionUtilsTest {
+	
+	@Before
+	public void before() throws Exception {
+		/**
+		 * Create a new config directory and load the default configuration.
+		 */
+		File workingDirectory = Files.createTempDir();
+		workingDirectory = new File(workingDirectory, ".openpnp");
+		System.out.println("Configuration directory: " + workingDirectory);
+		Configuration.initialize(workingDirectory);
+		Configuration.get().load();
+
+	}
+	 
+	 
+    @Test
+    public void testOffsets() {
+        Camera camera = new TestCamera();
+        Location location = camera.getLocation();
+        Assert.assertEquals(location, new Location(LengthUnit.Millimeters, 0, 0, 0, 0));
+        Assert.assertEquals(camera.getWidth(), 640);
+        Assert.assertEquals(camera.getHeight(), 480);
+        Location pixelOffsets = VisionUtils.getPixelCenterOffsets(camera, 100, 100);
+        Assert.assertEquals(pixelOffsets, new Location(LengthUnit.Millimeters, -220, 140, 0, 0));
+        Location pixelLocation = VisionUtils.getPixelLocation(camera, 100, 100);
+        Assert.assertEquals(pixelLocation, new Location(LengthUnit.Millimeters, -220, 140, 0, 0));
+    }
+
+    static class TestCamera extends AbstractHeadMountable implements Camera {
+        protected Head head;
+
+        @Override
+        public String getId() {
+            return null;
+        }
+
+        @Override
+        public Head getHead() {
+            return head;
+        }
+
+        @Override
+        public void setHead(Head head) {
+            this.head = head;
+        }
+
+        @Override
+        public Location getLocation() {
+            return new Location(LengthUnit.Millimeters, 0, 0, 0, 0);
+        }
+
+        @Override
+        public Location getLocation(HeadMountable tool) {
+            if (tool != null) {
+                return getLocation().subtract(tool.getCameraToolCalibratedOffset(this));
+            }
+
+            return getLocation();
+        }
+
+       @Override
+        public Location getCameraToolCalibratedOffset(Camera camera) {
+            return new Location(camera.getUnitsPerPixel().getUnits());
+        }
+
+        @Override
+        public Wizard getConfigurationWizard() {
+            return null;
+        }
+
+        @Override
+        public String getPropertySheetHolderTitle() {
+            return null;
+        }
+
+        @Override
+        public PropertySheetHolder[] getChildPropertySheetHolders() {
+            return null;
+        }
+
+        @Override
+        public PropertySheet[] getPropertySheets() {
+            return null;
+        }
+
+        @Override
+        public Action[] getPropertySheetHolderActions() {
+            return null;
+        }
+
+        @Override
+        public String getName() {
+            return null;
+        }
+
+        @Override
+        public void setName(String name) {
+
+        }
+
+        @Override
+        public Looking getLooking() {
+            return null;
+        }
+
+        @Override
+        public void setLooking(Looking looking) {
+
+        }
+
+        @Override
+        public Location getUnitsPerPixel() {
+            return new Location(LengthUnit.Millimeters, 1, 1, 0, 0);
+        }
+
+        @Override
+        public void setUnitsPerPixel(Location unitsPerPixel) {
+
+        }
+
+        @Override
+        public BufferedImage capture() {
+            return null;
+        }
+
+        @Override
+        public BufferedImage captureTransformed() {
+            return null;
+        }
+
+        @Override
+        public BufferedImage captureRaw() {
+            return null;
+        }
+
+        @Override
+        public void startContinuousCapture(CameraListener listener) {
+
+        }
+
+        @Override
+        public void stopContinuousCapture(CameraListener listener) {
+
+        }
+
+        @Override
+        public void setVisionProvider(VisionProvider visionProvider) {
+
+        }
+
+        @Override
+        public VisionProvider getVisionProvider() {
+            return null;
+        }
+
+        @Override
+        public int getWidth() {
+            return 640;
+        }
+
+        @Override
+        public int getHeight() {
+            return 480;
+        }
+
+        @Override
+        public Icon getPropertySheetHolderIcon() {
+            return null;
+        }
+
+        @Override
+        public void close() throws IOException {
+        }
+
+        @Override
+        public BufferedImage settleAndCapture() throws Exception {
+            return null;
+        }
+
+        @Override
+        public BufferedImage lightSettleAndCapture() {
+            return null;
+        }
+
+        @Override
+        public void actuateLightBeforeCapture(Object light) throws Exception {
+        }
+
+        @Override
+        public void actuateLightAfterCapture() throws Exception {
+        }
+
+        @Override
+        public Length getSafeZ() {
+            return null;
+        }
+
+        @Override
+        public Location getHeadOffsets() {
+            return null;
+        }
+
+        @Override
+        public void setHeadOffsets(Location headOffsets) {
+        }
+
+        @Override
+        public void home() throws Exception {
+        }
+
+        @Override
+        public Actuator getLightActuator() {
+            return null;
+        }
+
+        @Override
+        public void ensureCameraVisible() {
+        }
+
+        @Override
+        public boolean hasNewFrame() {
+            return true;
+        }
+
+        public Location getUnitsPerPixel(Length z) {
+            return new Location(LengthUnit.Millimeters, 1, 1, 0, 0).derive(null, null, z.getValue(), null);
+        }
+
+        @Override
+        public Length getDefaultZ() {
+            return new Length(0.0, LengthUnit.Millimeters);
+        }
+
+        @Override
+        public boolean isShownInMultiCameraView() {
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
# Description
This change adds a read URL to read values from an http actuator.

# Justification
I have a small c++ Program on my Rpi which implements a simple http server to actuate GPIO and
read Preassure (and possibly Distance ) sensor via http. The request looks like this:
http://192.168.0.42:8001/msr the response looks like this:
pump:11583

The idea is that the Pattern Matching is used to read then the preasure value.
Sadly the Null Driver has no pattern matching - it is thus not easy to test or should this be part of the HTTP actuator?

# Instructions for Use
The regex to match the result is given in parallel to the URL to read. It's only available for non boolean
actuators.

# Implementation Details
1. How did you test the change? I can read the value with the read button, which should be the first MVP.
2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)? I hope so.
3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing. 

I hope this didn't affect anything.

4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted.

done, I even added a unit test particually for this item.