### PR TITLE
Fix / Camera Transforms while Calibrating.

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/ReferenceCamera.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceCamera.java
@@ -413,12 +413,14 @@ public abstract class ReferenceCamera extends AbstractBroadcastingCamera impleme
             }
 
             // We do skip the convert to and from Mat if no transforms are needed.
-            if (isCropped() 
-                || isDeinterlaced() 
+            // But we must enter while calibrating. 
+            if (isDeinterlaced()
+                || isCropped() 
+                || isCalibrating()
+                || isUndistorted()
+                || isScaled()
                 || isRotated()
                 || isOffset()
-                || isScaled()
-                || isUndistorted()
                 || isFlipped()) {
 
                 Mat mat = OpenCvUtils.toMat(image);
@@ -611,7 +613,7 @@ public abstract class ReferenceCamera extends AbstractBroadcastingCamera impleme
     }
 
     private Mat calibrate(Mat mat) {
-        if (!calibrating) {
+        if (!isCalibrating()) {
             return mat;
         }
 
@@ -652,6 +654,10 @@ public abstract class ReferenceCamera extends AbstractBroadcastingCamera impleme
         return appliedMat;
     }
 
+    public boolean isCalibrating() {
+        return calibrating;
+    }
+
     protected void clearCalibrationCache() {
         // Clear the calibration cache
         if (undistortionMap1 != null) {
@@ -673,7 +679,7 @@ public abstract class ReferenceCamera extends AbstractBroadcastingCamera impleme
     }
 
     public void cancelCalibration() {
-        if (calibrating) {
+        if (isCalibrating()) {
             lensCalibration.close();
         }
         calibrating = false;


### PR DESCRIPTION
# Description
A bug was introduced when I optimized camera transforms to skip image conversion to OpenCv Mat and back when no transforms apply. Unfortunately this also skipped ongoing camera calibration, that was interwoven in the transform steps. 

The bug is now fixed.

I also reordered the predicates to match the order of the transforms to better see if all of them are covered. 

Thanks, @tonyluken, for correctly diagnosing this.

# Justification
Image calibration no longer works unless you happen to have at least one transformation active. 

See also:
https://groups.google.com/g/openpnp/c/nsY9XU_8hFw/m/XOjhtNq4AAAJ

# Instructions for Use
No change.

# Implementation Details
1. Performed a calibration on a camera with no transforms. Verified by debugger that optimization still works before/after calibration. 
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. Successful `mvn test` before submitting the Pull Request. 
