### PR TITLE
ReferenceBottomVision - Part size check option for detecting bad part pick

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/vision/ReferenceBottomVision.java
+++ b/src/main/java/org/openpnp/machine/reference/vision/ReferenceBottomVision.java
@@ -295,8 +295,8 @@ public class ReferenceBottomVision implements PartAlignment {
 
         double widthTolerance = pxWidth * 0.01 * (double) partSettings.getCheckSizeTolerancePercent();
         double heightTolerance = pxHeight * 0.01 * (double) partSettings.getCheckSizeTolerancePercent();
-        double pxMaxWidth = pxWidth + heightTolerance;
-        double pxMinWidth = pxWidth - heightTolerance;
+        double pxMaxWidth = pxWidth + widthTolerance;
+        double pxMinWidth = pxWidth - widthTolerance;
         double pxMaxHeight = pxHeight + heightTolerance;
         double pxMinHeight = pxHeight - heightTolerance;
 

--- a/src/main/java/org/openpnp/machine/reference/vision/ReferenceBottomVision.java
+++ b/src/main/java/org/openpnp/machine/reference/vision/ReferenceBottomVision.java
@@ -253,15 +253,37 @@ public class ReferenceBottomVision implements PartAlignment {
     
     
     private boolean partSizeCheck(Part part, PartSettings partSettings, RotatedRect partRect, Camera camera) {
+    	//Check if this test needs to be done
 		if(!partSettings.getCheckPartSize()) {
 			return true;
 		}
-    	Footprint footprint = part.getPackage().getFootprint();                	
-    	Length width = new Length(footprint.getBodyWidth(), LengthUnit.Millimeters);
-    	Length height = new Length((double) footprint.getBodyHeight(), LengthUnit.Millimeters);
+		
+		//Get the part footprint body dimensions to compare to
+    	Footprint footprint = part.getPackage().getFootprint();
+    	double bodyWidth = footprint.getBodyWidth();
+    	double bodyHeight = footprint.getBodyHeight();
+    	
+    	//Make sure width is the longest dimension
+    	if (bodyHeight > bodyWidth) {
+    		double height = bodyHeight;
+    		double width = bodyHeight;
+    		bodyWidth = height;
+    		bodyHeight = width;
+    		}
+    	
+    	Length width = new Length(bodyWidth, LengthUnit.Millimeters);
+    	Length height = new Length(bodyHeight, LengthUnit.Millimeters);
     	double pxWidth = VisionUtils.toPixels(width, camera);	
     	double pxHeight = VisionUtils.toPixels(height, camera);
-    	Size meausuredSize = partRect.size;
+    	
+    	//Make sure width is the longest dimension
+    	Size measuredSize = partRect.size;
+    	if (measuredSize.height > measuredSize.width) {
+    		double mHeight = measuredSize.height;
+    		double mWidth = measuredSize.width;    		
+    		measuredSize.height = mWidth;
+    		measuredSize.width = mHeight;
+    	}
     	
     	double size_tolerance_multiplier = 1.0 + (partSettings.getCheckSizeTolerancePercent() * 0.01);
     	double pxMaxWidth = pxWidth * size_tolerance_multiplier;
@@ -269,25 +291,25 @@ public class ReferenceBottomVision implements PartAlignment {
     	double pxMaxHeight = pxHeight * size_tolerance_multiplier;
     	double pxMinHeight = pxHeight / size_tolerance_multiplier;
     	
-    	if (meausuredSize.width > pxMaxWidth) {
+    	if (measuredSize.width > pxMaxWidth) {
     		Logger.debug("Package pixel width {} : limit {} : measured {}", 
-    				pxWidth, pxMaxWidth, meausuredSize.width);                		
-    	} else if (meausuredSize.width < pxMinWidth) {
+    				pxWidth, pxMaxWidth, measuredSize.width);                		
+    	} else if (measuredSize.width < pxMinWidth) {
     		Logger.debug("Package pixel width {} : limit {} : measured {}", 
-    				pxWidth, pxMinWidth, meausuredSize.width);        
+    				pxWidth, pxMinWidth, measuredSize.width);        
     		return false;
-    	} else if (meausuredSize.height > pxMaxHeight) {
+    	} else if (measuredSize.height > pxMaxHeight) {
     		Logger.debug("Package pixel height {} : limit {} : measured {}", 
-    				pxHeight, pxMaxHeight, meausuredSize.height);                		
+    				pxHeight, pxMaxHeight, measuredSize.height);                		
     		return false;
-    	} else if (meausuredSize.height < pxMinHeight) {
+    	} else if (measuredSize.height < pxMinHeight) {
     		Logger.debug("Package pixel height {} : limit {} : measured {}", 
-    				pxHeight, pxMinHeight, meausuredSize.height);                		
+    				pxHeight, pxMinHeight, measuredSize.height);                		
     		return false;
     	}
     	
     	Logger.debug("Package pixel size ok. Width {}, Height {}", 
-				meausuredSize.width, meausuredSize.height); 
+				measuredSize.width, measuredSize.height); 
     	return true;
     }
     

--- a/src/main/java/org/openpnp/machine/reference/vision/wizards/ReferenceBottomVisionConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/vision/wizards/ReferenceBottomVisionConfigurationWizard.java
@@ -202,7 +202,7 @@ public class ReferenceBottomVisionConfigurationWizard extends AbstractConfigurat
         addWrappedBinding(bottomVision, "maxVisionPasses", textFieldMaxVisionPasses, "text", intConverter);
         addWrappedBinding(bottomVision, "maxLinearOffset", textFieldMaxLinearOffset, "text", lengthConverter);
         addWrappedBinding(bottomVision, "maxAngularOffset", textFieldMaxAngularOffset, "text", doubleConverter);
-        
+
         ComponentDecorators.decorateWithAutoSelect(textFieldMaxVisionPasses);
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldMaxLinearOffset);
         ComponentDecorators.decorateWithAutoSelect(textFieldMaxAngularOffset);

--- a/src/main/java/org/openpnp/machine/reference/vision/wizards/ReferenceBottomVisionPartConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/vision/wizards/ReferenceBottomVisionPartConfigurationWizard.java
@@ -9,13 +9,16 @@ import javax.swing.JDialog;
 import javax.swing.JLabel;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
+import javax.swing.JTextField;
 import javax.swing.border.TitledBorder;
 
 import org.openpnp.gui.MainFrame;
 import org.openpnp.gui.support.AbstractConfigurationWizard;
+import org.openpnp.gui.support.DoubleConverter;
 import org.openpnp.gui.support.MessageBoxes;
 import org.openpnp.machine.reference.vision.ReferenceBottomVision;
 import org.openpnp.machine.reference.vision.ReferenceBottomVision.PartSettings;
+import org.openpnp.model.Configuration;
 import org.openpnp.model.LengthUnit;
 import org.openpnp.model.Location;
 import org.openpnp.model.Part;
@@ -42,6 +45,8 @@ public class ReferenceBottomVisionPartConfigurationWizard extends AbstractConfig
     private JCheckBox chckbxCenterAfterTest;
     private JComboBox comboBoxPreRotate;
     private JComboBox comboBoxMaxRotation;
+    private JCheckBox checkPartSizeCheckbox;
+    private JTextField textPartSizeTolerance;
     
     public ReferenceBottomVisionPartConfigurationWizard(ReferenceBottomVision bottomVision,
             Part part) {
@@ -59,8 +64,12 @@ public class ReferenceBottomVisionPartConfigurationWizard extends AbstractConfig
                 FormSpecs.RELATED_GAP_COLSPEC,
                 FormSpecs.DEFAULT_COLSPEC,
                 FormSpecs.RELATED_GAP_COLSPEC,
+                FormSpecs.DEFAULT_COLSPEC,
+                FormSpecs.RELATED_GAP_COLSPEC,
                 FormSpecs.DEFAULT_COLSPEC,},
             new RowSpec[] {
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
                 FormSpecs.RELATED_GAP_ROWSPEC,
                 FormSpecs.DEFAULT_ROWSPEC,
                 FormSpecs.RELATED_GAP_ROWSPEC,
@@ -133,6 +142,16 @@ public class ReferenceBottomVisionPartConfigurationWizard extends AbstractConfig
         comboBoxMaxRotation = new JComboBox(ReferenceBottomVision.MaxRotation.values());
         comboBoxMaxRotation.setToolTipText("Adjust for all parts, where only some minor offset is expected. Full for parts, where bottom vision detects pin 1");
         panel.add(comboBoxMaxRotation, "4, 10, fill, default");
+
+        checkPartSizeCheckbox = new JCheckBox("Check size");
+        panel.add(checkPartSizeCheckbox, "6, 12");
+        
+        JLabel lblPartSizeTolerance = new JLabel("Size tolerance (%)");
+        panel.add(lblPartSizeTolerance, "2, 12");
+
+        textPartSizeTolerance = new JTextField();
+        panel.add(textPartSizeTolerance, "4, 12, fill, default");
+        
     }
 
     private void testAlignment() throws Exception {
@@ -219,7 +238,13 @@ public class ReferenceBottomVisionPartConfigurationWizard extends AbstractConfig
 
     @Override
     public void createBindings() {
-        addWrappedBinding(partSettings, "enabled", enabledCheckbox, "selected");
+        DoubleConverter doubleConverter = new DoubleConverter(Configuration.get()
+                .getLengthDisplayFormat());
+        
+    	addWrappedBinding(partSettings, "enabled", enabledCheckbox, "selected");
+        addWrappedBinding(partSettings, "checkPartSize", checkPartSizeCheckbox, "selected");
+        addWrappedBinding(partSettings, "checkSizeTolerancePercent", textPartSizeTolerance, "text", doubleConverter);
+        
         addWrappedBinding(partSettings, "preRotateUsage", comboBoxPreRotate, "selectedItem");
         addWrappedBinding(partSettings, "maxRotation", comboBoxMaxRotation, "selectedItem");
     }

--- a/src/main/java/org/openpnp/machine/reference/vision/wizards/ReferenceBottomVisionPartConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/vision/wizards/ReferenceBottomVisionPartConfigurationWizard.java
@@ -22,6 +22,7 @@ import org.openpnp.model.Configuration;
 import org.openpnp.model.LengthUnit;
 import org.openpnp.model.Location;
 import org.openpnp.model.Part;
+import org.openpnp.spi.Axis;
 import org.openpnp.spi.Nozzle;
 import org.openpnp.spi.PartAlignment;
 import org.openpnp.util.UiUtils;
@@ -45,7 +46,7 @@ public class ReferenceBottomVisionPartConfigurationWizard extends AbstractConfig
     private JCheckBox chckbxCenterAfterTest;
     private JComboBox comboBoxPreRotate;
     private JComboBox comboBoxMaxRotation;
-    private JCheckBox checkPartSizeCheckbox;
+    private JComboBox comboBoxcheckPartSizeMethod;
     private JTextField textPartSizeTolerance;
     
     public ReferenceBottomVisionPartConfigurationWizard(ReferenceBottomVision bottomVision,
@@ -142,9 +143,9 @@ public class ReferenceBottomVisionPartConfigurationWizard extends AbstractConfig
         comboBoxMaxRotation = new JComboBox(ReferenceBottomVision.MaxRotation.values());
         comboBoxMaxRotation.setToolTipText("Adjust for all parts, where only some minor offset is expected. Full for parts, where bottom vision detects pin 1");
         panel.add(comboBoxMaxRotation, "4, 10, fill, default");
-
-        checkPartSizeCheckbox = new JCheckBox("Check size");
-        panel.add(checkPartSizeCheckbox, "6, 12");
+        
+        comboBoxcheckPartSizeMethod = new JComboBox(PartSettings.PartSizeCheckMethod.values());
+        panel.add(comboBoxcheckPartSizeMethod, "6, 12, fill, default");        
         
         JLabel lblPartSizeTolerance = new JLabel("Size tolerance (%)");
         panel.add(lblPartSizeTolerance, "2, 12");
@@ -242,7 +243,7 @@ public class ReferenceBottomVisionPartConfigurationWizard extends AbstractConfig
                 .getLengthDisplayFormat());
         
     	addWrappedBinding(partSettings, "enabled", enabledCheckbox, "selected");
-        addWrappedBinding(partSettings, "checkPartSize", checkPartSizeCheckbox, "selected");
+        addWrappedBinding(partSettings, "checkPartSizeMethod", comboBoxcheckPartSizeMethod, "selectedItem");
         addWrappedBinding(partSettings, "checkSizeTolerancePercent", textPartSizeTolerance, "text", doubleConverter);
         
         addWrappedBinding(partSettings, "preRotateUsage", comboBoxPreRotate, "selectedItem");

--- a/src/main/java/org/openpnp/machine/reference/vision/wizards/ReferenceBottomVisionPartConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/vision/wizards/ReferenceBottomVisionPartConfigurationWizard.java
@@ -15,6 +15,7 @@ import javax.swing.border.TitledBorder;
 import org.openpnp.gui.MainFrame;
 import org.openpnp.gui.support.AbstractConfigurationWizard;
 import org.openpnp.gui.support.DoubleConverter;
+import org.openpnp.gui.support.IntegerConverter;
 import org.openpnp.gui.support.MessageBoxes;
 import org.openpnp.machine.reference.vision.ReferenceBottomVision;
 import org.openpnp.machine.reference.vision.ReferenceBottomVision.PartSettings;
@@ -48,39 +49,24 @@ public class ReferenceBottomVisionPartConfigurationWizard extends AbstractConfig
     private JComboBox comboBoxMaxRotation;
     private JComboBox comboBoxcheckPartSizeMethod;
     private JTextField textPartSizeTolerance;
-    
-    public ReferenceBottomVisionPartConfigurationWizard(ReferenceBottomVision bottomVision,
-            Part part) {
+
+    public ReferenceBottomVisionPartConfigurationWizard(ReferenceBottomVision bottomVision, Part part) {
         this.bottomVision = bottomVision;
         this.part = part;
         this.partSettings = bottomVision.getPartSettings(part);
 
         JPanel panel = new JPanel();
-        panel.setBorder(new TitledBorder(null, "General", TitledBorder.LEADING, TitledBorder.TOP,
-                null, null));
+        panel.setBorder(new TitledBorder(null, "General", TitledBorder.LEADING, TitledBorder.TOP, null, null));
         contentPanel.add(panel);
-        panel.setLayout(new FormLayout(new ColumnSpec[] {
-                FormSpecs.RELATED_GAP_COLSPEC,
-                ColumnSpec.decode("right:default"),
-                FormSpecs.RELATED_GAP_COLSPEC,
-                FormSpecs.DEFAULT_COLSPEC,
-                FormSpecs.RELATED_GAP_COLSPEC,
-                FormSpecs.DEFAULT_COLSPEC,
-                FormSpecs.RELATED_GAP_COLSPEC,
-                FormSpecs.DEFAULT_COLSPEC,},
-            new RowSpec[] {
-                FormSpecs.RELATED_GAP_ROWSPEC,
-                FormSpecs.DEFAULT_ROWSPEC,
-                FormSpecs.RELATED_GAP_ROWSPEC,
-                FormSpecs.DEFAULT_ROWSPEC,
-                FormSpecs.RELATED_GAP_ROWSPEC,
-                FormSpecs.DEFAULT_ROWSPEC,
-                FormSpecs.RELATED_GAP_ROWSPEC,
-                FormSpecs.DEFAULT_ROWSPEC,
-                FormSpecs.RELATED_GAP_ROWSPEC,
-                FormSpecs.DEFAULT_ROWSPEC,
-                FormSpecs.RELATED_GAP_ROWSPEC,
-                FormSpecs.DEFAULT_ROWSPEC,}));
+        panel.setLayout(new FormLayout(
+                new ColumnSpec[] { FormSpecs.RELATED_GAP_COLSPEC, ColumnSpec.decode("right:default"),
+                        FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC, FormSpecs.RELATED_GAP_COLSPEC,
+                        FormSpecs.DEFAULT_COLSPEC, FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC, },
+                new RowSpec[] { FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC, FormSpecs.RELATED_GAP_ROWSPEC,
+                        FormSpecs.DEFAULT_ROWSPEC, FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC, FormSpecs.RELATED_GAP_ROWSPEC,
+                        FormSpecs.DEFAULT_ROWSPEC, FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC, }));
 
         JLabel lblEnabled = new JLabel("Enabled?");
         panel.add(lblEnabled, "2, 2");
@@ -94,10 +80,10 @@ public class ReferenceBottomVisionPartConfigurationWizard extends AbstractConfig
                 testAlignment();
             });
         });
-        
+
         JLabel lblPrerotate = new JLabel("Pre-rotate");
         panel.add(lblPrerotate, "2, 4, right, default");
-        
+
         comboBoxPreRotate = new JComboBox(ReferenceBottomVision.PreRotateUsage.values());
         panel.add(comboBoxPreRotate, "4, 4");
 
@@ -125,56 +111,55 @@ public class ReferenceBottomVisionPartConfigurationWizard extends AbstractConfig
         JButton btnLoadDefault = new JButton("Reset to Default");
         btnLoadDefault.addActionListener((e) -> {
             int result = JOptionPane.showConfirmDialog(getTopLevelAncestor(),
-                    "This will replace the current part pipeline with the default pipeline. Are you sure?",
-                    null, JOptionPane.YES_NO_OPTION, JOptionPane.WARNING_MESSAGE);
+                    "This will replace the current part pipeline with the default pipeline. Are you sure?", null,
+                    JOptionPane.YES_NO_OPTION, JOptionPane.WARNING_MESSAGE);
             if (result == JOptionPane.YES_OPTION) {
                 UiUtils.messageBoxOnException(() -> {
-                    partSettings.setPipeline(bottomVision.getPipeline()
-                                                         .clone());
+                    partSettings.setPipeline(bottomVision.getPipeline().clone());
                     editPipeline();
                 });
             }
         });
         panel.add(btnLoadDefault, "6, 8");
-        
+
         JLabel lblMaxRotation = new JLabel("Rotation");
         panel.add(lblMaxRotation, "2, 10, right, top");
-        
+
         comboBoxMaxRotation = new JComboBox(ReferenceBottomVision.MaxRotation.values());
-        comboBoxMaxRotation.setToolTipText("Adjust for all parts, where only some minor offset is expected. Full for parts, where bottom vision detects pin 1");
+        comboBoxMaxRotation.setToolTipText(
+                "Adjust for all parts, where only some minor offset is expected. Full for parts, where bottom vision detects pin 1");
         panel.add(comboBoxMaxRotation, "4, 10, fill, default");
-        
+
+        JLabel lblPartCheckType = new JLabel("Part size check");
+        panel.add(lblPartCheckType, "2, 12");
+
         comboBoxcheckPartSizeMethod = new JComboBox(PartSettings.PartSizeCheckMethod.values());
-        panel.add(comboBoxcheckPartSizeMethod, "6, 12, fill, default");        
-        
+        panel.add(comboBoxcheckPartSizeMethod, "4, 12, fill, default");
+
         JLabel lblPartSizeTolerance = new JLabel("Size tolerance (%)");
-        panel.add(lblPartSizeTolerance, "2, 12");
+        panel.add(lblPartSizeTolerance, "2, 14");
 
         textPartSizeTolerance = new JTextField();
-        panel.add(textPartSizeTolerance, "4, 12, fill, default");
-        
+        panel.add(textPartSizeTolerance, "4, 14, fill, default");
+
     }
 
     private void testAlignment() throws Exception {
         if (!bottomVision.isEnabled()) {
-            MessageBoxes.errorBox(getTopLevelAncestor(), "Error",
-                    "Bottom vision is not enabled in Machine Setup.");
+            MessageBoxes.errorBox(getTopLevelAncestor(), "Error", "Bottom vision is not enabled in Machine Setup.");
             return;
         }
 
         if (!enabledCheckbox.isSelected()) {
-            MessageBoxes.errorBox(getTopLevelAncestor(), "Error",
-                    "Bottom vision is not enabled for this part.");
+            MessageBoxes.errorBox(getTopLevelAncestor(), "Error", "Bottom vision is not enabled for this part.");
             return;
         }
 
-        Nozzle nozzle = MainFrame.get()
-                                 .getMachineControls()
-                                 .getSelectedNozzle();
+        Nozzle nozzle = MainFrame.get().getMachineControls().getSelectedNozzle();
 
         // perform the alignment
-        PartAlignment.PartAlignmentOffset alignmentOffset = VisionUtils.findPartAlignmentOffsets(
-                bottomVision, part, null, new Location(LengthUnit.Millimeters), nozzle);
+        PartAlignment.PartAlignmentOffset alignmentOffset = VisionUtils.findPartAlignmentOffsets(bottomVision, part,
+                null, new Location(LengthUnit.Millimeters), nozzle);
         Location offsets = alignmentOffset.getLocation();
 
         if (!chckbxCenterAfterTest.isSelected()) {
@@ -182,19 +167,17 @@ public class ReferenceBottomVisionPartConfigurationWizard extends AbstractConfig
         }
 
         // position the part over camera center
-        Location cameraLocation = bottomVision.getCameraLocationAtPartHeight(part, 
-                VisionUtils.getBottomVisionCamera(), nozzle, 0.);
+        Location cameraLocation = bottomVision.getCameraLocationAtPartHeight(part, VisionUtils.getBottomVisionCamera(),
+                nozzle, 0.);
 
         if (alignmentOffset.getPreRotated()) {
             // See https://github.com/openpnp/openpnp/pull/590 for explanations of the magic
             // value below.
-            if (Math.abs(alignmentOffset.getLocation()
-                                        .convertToUnits(LengthUnit.Millimeters)
-                                        .getLinearDistanceTo(0., 0.)) > 19.999) {
+            if (Math.abs(alignmentOffset.getLocation().convertToUnits(LengthUnit.Millimeters).getLinearDistanceTo(0.,
+                    0.)) > 19.999) {
                 throw new Exception("Offset too big");
             }
-            nozzle.moveTo(cameraLocation
-                                .subtractWithRotation(alignmentOffset.getLocation()));
+            nozzle.moveTo(cameraLocation.subtractWithRotation(alignmentOffset.getLocation()));
             return;
         }
 
@@ -208,8 +191,7 @@ public class ReferenceBottomVisionPartConfigurationWizard extends AbstractConfig
         // Set the angle to the difference mentioned above, aligning the part to the
         // same angle as
         // the placement.
-        location = location.derive(null, null, null,
-                cameraLocation.getRotation() - offsets.getRotation());
+        location = location.derive(null, null, null, cameraLocation.getRotation() - offsets.getRotation());
 
         // Add the placement final location to move our local coordinate into global
         // space
@@ -225,12 +207,12 @@ public class ReferenceBottomVisionPartConfigurationWizard extends AbstractConfig
     private void editPipeline() throws Exception {
         CvPipeline pipeline = partSettings.getPipeline();
         pipeline.setProperty("camera", VisionUtils.getBottomVisionCamera());
-		pipeline.setProperty("nozzle", MainFrame.get().getMachineControls().getSelectedNozzle());
+        pipeline.setProperty("nozzle", MainFrame.get().getMachineControls().getSelectedNozzle());
 
         CvPipelineEditor editor = new CvPipelineEditor(pipeline);
         JDialog dialog = new CvPipelineEditorDialog(MainFrame.get(), "Bottom Vision Pipeline", editor);
         dialog.setVisible(true);
-}
+    }
 
     @Override
     public String getWizardName() {
@@ -239,13 +221,12 @@ public class ReferenceBottomVisionPartConfigurationWizard extends AbstractConfig
 
     @Override
     public void createBindings() {
-        DoubleConverter doubleConverter = new DoubleConverter(Configuration.get()
-                .getLengthDisplayFormat());
-        
-    	addWrappedBinding(partSettings, "enabled", enabledCheckbox, "selected");
+        IntegerConverter intConverter = new IntegerConverter();
+
+        addWrappedBinding(partSettings, "enabled", enabledCheckbox, "selected");
         addWrappedBinding(partSettings, "checkPartSizeMethod", comboBoxcheckPartSizeMethod, "selectedItem");
-        addWrappedBinding(partSettings, "checkSizeTolerancePercent", textPartSizeTolerance, "text", doubleConverter);
-        
+        addWrappedBinding(partSettings, "checkSizeTolerancePercent", textPartSizeTolerance, "text", intConverter);
+
         addWrappedBinding(partSettings, "preRotateUsage", comboBoxPreRotate, "selectedItem");
         addWrappedBinding(partSettings, "maxRotation", comboBoxMaxRotation, "selectedItem");
     }


### PR DESCRIPTION
# Description
Option to check package size during bottom camera part alignment.  Compares measured vs expected dimension with a part configurable tolerance.

# Justification
Enables optical detection of badly picked parts which are not sitting flat on the nozzle.

# Instructions for Use
1. Set the expected body dimension in the package (for the part) under the vision tab
2. Enable "Check size" checkbox under the Part ReferenceBottomVision tab
3. Adjust size tolerance under the Part ReferenceBottomVision tab.  Default 20%.

Only works when the bottom vision pipeline returns a single rectangle for the whole pacakge.  Is not expected to operate if individual pads are measured.


# Implementation Details
1. Tested on 0603 with a pick offset for high failure rate.  With a run of 20 parts found every instance of bad pick and rejected no instances of good picks.
One instance of a part flat on the nozzle but rotated at 45 deg.  This passed the size check.


2. Needs review on following:
	Where this funciton is implemented.  It is implemented in findOffsetxxRotate which is the only place where the part outline rect is avaialable. This method does not return measured part size.

	Comparison of lengths is in pixel units.  Would prefer human units for readadabilitu and debugging.

	Does not attempt to take account for part height.  Only uses camera calibrated pixel units.

	Compares longest side vs longest measurement to avoid problems with dimensions being swapped in the package.

	No check against users entering bad values into the tolerance field.

3. No changes to`org.openpnp.spi` or `org.openpnp.model`.  Makes changes to PartSetting in machine.xml with the check size option and tolerance.

4. `mvn test` passed
