### PR TITLE
Feature/Set Width, Height on SimulatedUpCamera, ImageCamera

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/camera/ImageCamera.java
+++ b/src/main/java/org/openpnp/machine/reference/camera/ImageCamera.java
@@ -91,6 +91,22 @@ public class ImageCamera extends ReferenceCamera {
         setUnitsPerPixel(new Location(LengthUnit.Millimeters, 0.04233, 0.04233, 0, 0));
     }
 
+    public int getWidth() {
+        return width;
+    }
+
+    public void setWidth(int width) {
+        this.width = width;
+    }
+
+    public int getHeight() {
+        return height;
+    }
+
+    public void setHeight(int height) {
+        this.height = height;
+    }
+
     public String getSourceUri() {
         return sourceUri;
     }

--- a/src/main/java/org/openpnp/machine/reference/camera/SimulatedUpCamera.java
+++ b/src/main/java/org/openpnp/machine/reference/camera/SimulatedUpCamera.java
@@ -26,14 +26,17 @@ import org.openpnp.spi.Head;
 import org.openpnp.spi.Nozzle;
 import org.openpnp.spi.PropertySheetHolder;
 import org.openpnp.util.Utils2D;
+import org.simpleframework.xml.Attribute;
 import org.simpleframework.xml.Element;
 import org.simpleframework.xml.Root;
 
 
 @Root
 public class SimulatedUpCamera extends ReferenceCamera {
+    @Attribute(required=false)
     protected int width = 640;
 
+    @Attribute(required=false)
     protected int height = 480;
 
     @Element(required=false)
@@ -145,6 +148,22 @@ public class SimulatedUpCamera extends ReferenceCamera {
         // Draw
         g.setColor(color);
         g.fill(shape);
+    }
+
+    public int getWidth() {
+        return width;
+    }
+
+    public void setWidth(int width) {
+        this.width = width;
+    }
+
+    public int getHeight() {
+        return height;
+    }
+
+    public void setHeight(int height) {
+        this.height = height;
     }
 
     public Location getErrorOffsets() {

--- a/src/main/java/org/openpnp/machine/reference/camera/wizards/ImageCameraConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/camera/wizards/ImageCameraConfigurationWizard.java
@@ -66,29 +66,59 @@ public class ImageCameraConfigurationWizard extends AbstractConfigurationWizard 
                 FormSpecs.RELATED_GAP_COLSPEC,
                 FormSpecs.DEFAULT_COLSPEC,
                 FormSpecs.RELATED_GAP_COLSPEC,
-                ColumnSpec.decode("default:grow"),
+                FormSpecs.DEFAULT_COLSPEC,
+                FormSpecs.RELATED_GAP_COLSPEC,
+                ColumnSpec.decode("max(50dlu;default):grow"),
                 FormSpecs.RELATED_GAP_COLSPEC,
                 FormSpecs.DEFAULT_COLSPEC,},
             new RowSpec[] {
                 FormSpecs.RELATED_GAP_ROWSPEC,
                 FormSpecs.DEFAULT_ROWSPEC,
                 FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
                 FormSpecs.DEFAULT_ROWSPEC,}));
+        
+        lblWidth = new JLabel("Width");
+        panelGeneral.add(lblWidth, "2, 2, right, default");
+        
+        width = new JTextField();
+        panelGeneral.add(width, "4, 2, fill, default");
+        width.setColumns(10);
+        
+        lblHeight = new JLabel("Height");
+        panelGeneral.add(lblHeight, "2, 4, right, default");
+        
+        height = new JTextField();
+        panelGeneral.add(height, "4, 4, fill, default");
+        height.setColumns(10);
 
         lblSourceUrl = new JLabel("Source URL");
-        panelGeneral.add(lblSourceUrl, "2, 2, right, default");
+        panelGeneral.add(lblSourceUrl, "2, 8, right, default");
 
         textFieldSourceUrl = new JTextField();
-        panelGeneral.add(textFieldSourceUrl, "4, 2, fill, default");
-        textFieldSourceUrl.setColumns(10);
+        panelGeneral.add(textFieldSourceUrl, "4, 8, 3, 1, fill, default");
+        textFieldSourceUrl.setColumns(40);
 
         btnBrowse = new JButton(browseAction);
-        panelGeneral.add(btnBrowse, "6, 2");
+        panelGeneral.add(btnBrowse, "8, 8");
     }
 
     @Override
     public void createBindings() {
+        IntegerConverter intConverter = new IntegerConverter();
+
+        addWrappedBinding(camera, "width", width, "text", intConverter);
+        addWrappedBinding(camera, "height", height, "text", intConverter);
+
         addWrappedBinding(camera, "sourceUri", textFieldSourceUrl, "text");
+
+        ComponentDecorators.decorateWithAutoSelect(width);
+        ComponentDecorators.decorateWithAutoSelect(height);
         ComponentDecorators.decorateWithAutoSelect(textFieldSourceUrl);
     }
 
@@ -120,6 +150,10 @@ public class ImageCameraConfigurationWizard extends AbstractConfigurationWizard 
             textFieldSourceUrl.setText(file.toURI().toString());
         }
     };
+    private JLabel lblWidth;
+    private JLabel lblHeight;
+    private JTextField width;
+    private JTextField height;
 
     @Override
     protected void saveToModel() {

--- a/src/main/java/org/openpnp/machine/reference/camera/wizards/SimulatedUpCameraConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/camera/wizards/SimulatedUpCameraConfigurationWizard.java
@@ -32,6 +32,7 @@ import org.jdesktop.beansbinding.AutoBinding.UpdateStrategy;
 import org.openpnp.gui.components.ComponentDecorators;
 import org.openpnp.gui.support.AbstractConfigurationWizard;
 import org.openpnp.gui.support.DoubleConverter;
+import org.openpnp.gui.support.IntegerConverter;
 import org.openpnp.gui.support.LengthConverter;
 import org.openpnp.gui.support.MutableLocationProxy;
 import org.openpnp.machine.reference.camera.SimulatedUpCamera;
@@ -57,6 +58,10 @@ public class SimulatedUpCameraConfigurationWizard extends AbstractConfigurationW
     private JLabel lblY;
     private JLabel lblZ;
     private JLabel lblRotation;
+    private JLabel lblCameraWidth;
+    private JTextField width;
+    private JLabel lblHeight;
+    private JTextField height;
 
     public SimulatedUpCameraConfigurationWizard(SimulatedUpCamera camera) {
         this.camera = camera;
@@ -80,37 +85,57 @@ public class SimulatedUpCameraConfigurationWizard extends AbstractConfigurationW
                 FormSpecs.RELATED_GAP_ROWSPEC,
                 FormSpecs.DEFAULT_ROWSPEC,
                 FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
                 FormSpecs.DEFAULT_ROWSPEC,}));
         
+        lblCameraWidth = new JLabel("Width");
+        panelGeneral.add(lblCameraWidth, "2, 2, right, default");
+        
+        width = new JTextField();
+        panelGeneral.add(width, "4, 2, fill, default");
+        width.setColumns(10);
+        
+        lblHeight = new JLabel("Height");
+        panelGeneral.add(lblHeight, "2, 4, right, default");
+        
+        height = new JTextField();
+        panelGeneral.add(height, "4, 4, fill, default");
+        height.setColumns(10);
+        
         lblX = new JLabel("X");
-        panelGeneral.add(lblX, "4, 2, center, default");
+        panelGeneral.add(lblX, "4, 8, center, default");
         
         lblY = new JLabel("Y");
-        panelGeneral.add(lblY, "6, 2, center, default");
+        panelGeneral.add(lblY, "6, 8, center, default");
         
         lblZ = new JLabel("Z");
-        panelGeneral.add(lblZ, "8, 2, center, default");
+        panelGeneral.add(lblZ, "8, 8, center, default");
         
         lblRotation = new JLabel("Rotation");
-        panelGeneral.add(lblRotation, "10, 2, center, default");
+        panelGeneral.add(lblRotation, "10, 8, center, default");
         
         lblErrorOffsets = new JLabel("Error Offsets");
-        panelGeneral.add(lblErrorOffsets, "2, 4, right, default");
+        panelGeneral.add(lblErrorOffsets, "2, 10, right, default");
         
         errorOffsetsX = new JTextField();
-        panelGeneral.add(errorOffsetsX, "4, 4, fill, default");
+        panelGeneral.add(errorOffsetsX, "4, 10, fill, default");
         errorOffsetsX.setColumns(10);
         
         errorOffsetsY = new JTextField();
-        panelGeneral.add(errorOffsetsY, "6, 4, fill, default");
+        panelGeneral.add(errorOffsetsY, "6, 10, fill, default");
         errorOffsetsY.setColumns(10);
         
         errorOffsetsZ = new JTextField();
-        panelGeneral.add(errorOffsetsZ, "8, 4, fill, default");
+        panelGeneral.add(errorOffsetsZ, "8, 10, fill, default");
         errorOffsetsZ.setColumns(10);
         
         errorOffsetsRotation = new JTextField();
-        panelGeneral.add(errorOffsetsRotation, "10, 4, fill, default");
+        panelGeneral.add(errorOffsetsRotation, "10, 10, fill, default");
         errorOffsetsRotation.setColumns(10);
     }
 
@@ -118,7 +143,11 @@ public class SimulatedUpCameraConfigurationWizard extends AbstractConfigurationW
     public void createBindings() {
         DoubleConverter doubleConverter =
                 new DoubleConverter(Configuration.get().getLengthDisplayFormat());
+        IntegerConverter intConverter = new IntegerConverter();
         LengthConverter lengthConverter = new LengthConverter();
+
+        addWrappedBinding(camera, "width", width, "text", intConverter);
+        addWrappedBinding(camera, "height", height, "text", intConverter);
 
         MutableLocationProxy errorOffsets = new MutableLocationProxy();
         bind(UpdateStrategy.READ_WRITE, camera, "errorOffsets", errorOffsets,
@@ -129,6 +158,8 @@ public class SimulatedUpCameraConfigurationWizard extends AbstractConfigurationW
         addWrappedBinding(errorOffsets, "rotation", errorOffsetsRotation, "text",
                 doubleConverter);
         
+        ComponentDecorators.decorateWithAutoSelect(width);
+        ComponentDecorators.decorateWithAutoSelect(height);
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(errorOffsetsX);
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(errorOffsetsY);
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(errorOffsetsZ);


### PR DESCRIPTION
# Description
Break-out from ongoing other work: Set the pixel Width and Height on `SimulatedUpCamera` and `ImageCamera` through the GUI.

# Justification
The resolution of the bottom camera (`SimulatedUpCamera`) was reduced in recent PRs to speed up the lengthy `SampleJobTest`. However, the camera was now too small for large ICs. Rather than permanently increasing the resolution, it is now user settable. Large ICs can now again be rendered:

![TQFP32](https://user-images.githubusercontent.com/9963310/109421490-d0074900-79d7-11eb-9ec1-281d81b1f96e.png)


# Instructions for Use
New Width and Height fields appear on the Device tab of the `SimulatedUpCamera` and `ImageCamera`:

![ImageCamera](https://user-images.githubusercontent.com/9963310/109421224-b87b9080-79d6-11eb-87f2-b17da98ab21b.png)

![SimulatedUpCamera](https://user-images.githubusercontent.com/9963310/109421228-be717180-79d6-11eb-9713-368d9bc3e722.png)

# Implementation Details
1. Tested with large IC, alignment etc.
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. Successful `mvn test` before submitting the Pull Request. 
