### PR TITLE
Implement "Snap" option for OrientRotatedRets

### DIFF
--- a/src/main/java/org/openpnp/vision/pipeline/stages/OrientRotatedRects.java
+++ b/src/main/java/org/openpnp/vision/pipeline/stages/OrientRotatedRects.java
@@ -16,7 +16,8 @@ import org.simpleframework.xml.Attribute;
 public class OrientRotatedRects extends CvStage {
     public enum Orientation {
         Landscape,
-        Portrait
+        Portrait,
+        SnapToAngle,
     }
     
     @Attribute(required = false)
@@ -28,6 +29,10 @@ public class OrientRotatedRects extends CvStage {
     
     @Attribute(required = false)
     private boolean negateAngle = false;
+    
+    @Attribute(required = false)
+    @Property(description="Expected angle during perfect pick operation")
+    private int snapAngle = 0;
     
     public String getRotatedRectsStageName() {
         return rotatedRectsStageName;
@@ -52,7 +57,15 @@ public class OrientRotatedRects extends CvStage {
     public void setNegateAngle(boolean negateAngle) {
         this.negateAngle = negateAngle;
     }
-
+    
+    public void setSnapAngle(int snapAngle) {
+    	this.snapAngle = snapAngle;
+    }
+    
+    public int getSnapAngle() {
+    	return this.snapAngle;
+    }
+    
     @Override
     public Result process(CvPipeline pipeline) throws Exception {
         if (rotatedRectsStageName == null || rotatedRectsStageName.trim().equals("")) {
@@ -93,6 +106,18 @@ public class OrientRotatedRects extends CvStage {
             r2.size.height = r2.size.width;
             r2.size.width = tmp;
             r2.angle -= 90;
+        }
+        if(orientation == Orientation.SnapToAngle){
+        	double angle = (r2.angle + 360) % 90.0;
+        	if(angle > 45) {
+        		angle -= 90;
+        	}
+        	else {
+                double tmp = r2.size.height;
+                r2.size.height = r2.size.width;
+                r2.size.width = tmp;
+        	}
+        	r2.angle = angle + snapAngle;
         }
         if (negateAngle) {
             r2.angle = -r2.angle;


### PR DESCRIPTION
Hello,

# Description
Some of code that works with pipelines expect unambiguous orientation of oriented rectangle at the end of pipeline.
That are e.g. LoosePartFeeder and FullRotate option. Stage MinAreaRect in fact returns random 1 of 4 angles of
found rectangle. Sometimes it is required for pipeline to output 1 certain angle from those 4. When option SnapToAngle
will be selected, pipeline will return certain angle. This will work more like Align option for bottom vision. 

# Justification
Where it is needed:
1. LoosePartFeeder - when I place small component that requires Down-looking camera alignmet before pick, and
this component has defined orientation. I can place it with known orientation (e.g. about 0 degrees). Then use Snap
option with SnapAngle set to 0 degree. Pipeline then will output angle in range of -45 +45 degrees, and pick will be 
successful. 
2. When using Full rotate option for part (in my machine it is useful for bigger parts, since I have poor C accuracy).
I can force pipeline to output angle in certain range. This prevent random rotation when aligning with Full option. 
With this method I managed to achieve way better orientation accuracy for problematic part (big with fine pith). 

When I started to play with LoosePartFeeder I cannot get it to work without this option. It occured to be very
practical, so I created this Pull-request.

# Instructions for Use
Just select SnapToAngle option in OrientRotatedRets, and put angle to which output angle will be snapped. 
Supported angles are 0, 90, 180, 270. 

# Implementation Details
1. How did you test the change? Be descriptive. Untested code will not be accepted.
Rotated rect has already angle, but in fact it is random one from 4 possible angles of rectangle. 
I bring that angle to normalized range -45 to 45 degrees. Then i rotate it to desired range, where
0, 90, 180, 270 are centers of that range.

2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)?
Yes

3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing.
No

4. Tests passed

Regards,
Mateusz