### PR TITLE
Create footprint template if pipeline stage is used in bottom vision

### DIFF
--- a/src/main/java/org/openpnp/vision/pipeline/stages/CreateFootprintTemplateImage.java
+++ b/src/main/java/org/openpnp/vision/pipeline/stages/CreateFootprintTemplateImage.java
@@ -4,6 +4,7 @@ import java.awt.Color;
 import java.awt.image.BufferedImage;
 
 import org.openpnp.model.Footprint;
+import org.openpnp.model.Part;
 import org.openpnp.spi.Camera;
 import org.openpnp.util.OpenCvUtils;
 import org.openpnp.vision.FluentCv.ColorSpace;
@@ -80,6 +81,10 @@ public class CreateFootprintTemplateImage extends CvStage {
     public Result process(CvPipeline pipeline) throws Exception {
         Camera camera = (Camera) pipeline.getProperty("camera");
         Footprint footprint = (Footprint) pipeline.getProperty("footprint");
+        if (footprint == null && pipeline.getProperty("part") != null) {
+            Part part = (Part)pipeline.getProperty("part");
+            footprint = part.getPackage().getFootprint();
+        }
 
         if (camera == null) {
             throw new Exception("Property \"camera\" is required.");

--- a/src/main/java/org/openpnp/vision/pipeline/stages/CreateFootprintTemplateImage.java
+++ b/src/main/java/org/openpnp/vision/pipeline/stages/CreateFootprintTemplateImage.java
@@ -6,6 +6,7 @@ import java.awt.image.BufferedImage;
 import org.openpnp.model.Footprint;
 import org.openpnp.model.Part;
 import org.openpnp.spi.Camera;
+import org.openpnp.spi.Nozzle;
 import org.openpnp.util.OpenCvUtils;
 import org.openpnp.vision.FluentCv.ColorSpace;
 import org.openpnp.vision.pipeline.CvPipeline;
@@ -81,9 +82,11 @@ public class CreateFootprintTemplateImage extends CvStage {
     public Result process(CvPipeline pipeline) throws Exception {
         Camera camera = (Camera) pipeline.getProperty("camera");
         Footprint footprint = (Footprint) pipeline.getProperty("footprint");
-        if (footprint == null && pipeline.getProperty("part") != null) {
-            Part part = (Part)pipeline.getProperty("part");
-            footprint = part.getPackage().getFootprint();
+        if (footprint == null && pipeline.getProperty("nozzle") != null) {
+            Nozzle nozzle = (Nozzle)pipeline.getProperty("nozzle");
+            if (nozzle.getPart() != null) {
+                footprint = nozzle.getPart().getPackage().getFootprint();
+            }
         }
 
         if (camera == null) {


### PR DESCRIPTION
# Description
The pipeline stage CreateFootprintTemplate didn't work in bottom vision, since the required attribute "footprint" was not set.
Changed the pipeline, to get the footprint with the attribute "nozzle" that is available.

# Justification
Allow the generated footprint to be used in pipelines, e.g. using TemplateMatch.

```
<cv-pipeline>
   <stages>
      <cv-stage class="org.openpnp.vision.pipeline.stages.CreateFootprintTemplateImage" name="7" enabled="true" footprint-view="Fiducial">
         <pads-color r="255" g="255" b="255" a="255"/>
         <body-color r="0" g="0" b="0" a="255"/>
         <background-color r="0" g="0" b="0" a="255"/>
      </cv-stage>
      <cv-stage class="org.openpnp.vision.pipeline.stages.ConvertColor" name="18" enabled="true" conversion="Bgr2Gray"/>
      <cv-stage class="org.openpnp.vision.pipeline.stages.ImageCapture" name="0" enabled="true" default-light="true" settle-first="true" count="1"/>
      <cv-stage class="org.openpnp.vision.pipeline.stages.BlurGaussian" name="10" enabled="true" kernel-size="5"/>
      <cv-stage class="org.openpnp.vision.pipeline.stages.ConvertColor" name="6" enabled="true" conversion="Bgr2Gray"/>
      <cv-stage class="org.openpnp.vision.pipeline.stages.Normalize" name="1" enabled="true"/>
      <cv-stage class="org.openpnp.vision.pipeline.stages.MaskCircle" name="4" enabled="true" diameter="400"/>
      <cv-stage class="org.openpnp.vision.pipeline.stages.Threshold" name="12" enabled="true" threshold="150" auto="false" invert="false"/>
      <cv-stage class="org.openpnp.vision.pipeline.stages.BlurMedian" name="5" enabled="true" kernel-size="9"/>
      <cv-stage class="org.openpnp.vision.pipeline.stages.MinAreaRect" name="21" enabled="true" threshold-min="10" threshold-max="255"/>
      <cv-stage class="org.openpnp.vision.pipeline.stages.ImageRecall" name="9" enabled="true" image-stage-name="1"/>
      <cv-stage class="org.openpnp.vision.pipeline.stages.MatchPartTemplate" name="result" enabled="true" log="false" template-stage-name="18" model-stage-name="21" threshold="0.4000000059604645"/>
      <cv-stage class="org.openpnp.vision.pipeline.stages.SelectSingleRect" name="results" enabled="true" position="0" rotated-rects-stage-name="result"/>
      <cv-stage class="org.openpnp.vision.pipeline.stages.ImageRecall" name="14" enabled="true" image-stage-name="0"/>
      <cv-stage class="org.openpnp.vision.pipeline.stages.DrawRotatedRects" name="8" enabled="true" rotated-rects-stage-name="results" thickness="2" draw-rect-center="false" rect-center-radius="20" show-orientation="true"/>
   </stages>
</cv-pipeline>
```

# Instructions for Use
Does not change, only works now in bottom vision.
Call the pipeline stage, get a picture of the part as configured in the footprint.

# Implementation Details
1. How did you test the change? Created a pipeline (see above)
2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)? yes
3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing. No changes
4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted. done
