### PR TITLE
CreateFootprintTemplateImage: Allow to create minimal images

### DIFF
--- a/src/main/java/org/openpnp/vision/pipeline/stages/CreateFootprintTemplateImage.java
+++ b/src/main/java/org/openpnp/vision/pipeline/stages/CreateFootprintTemplateImage.java
@@ -46,6 +46,11 @@ public class CreateFootprintTemplateImage extends CvStage {
     @Property(description = "Color of the background.")
     private Color backgroundColor = Color.black; 
 
+    @Attribute(required=false)
+    @Property(description = "If enabled dimensions are only controled by the part size.")
+    private boolean minimalImageSize = false;
+
+    
     public FootprintView getFootprintView() {
         return footprintView;
     }
@@ -96,11 +101,19 @@ public class CreateFootprintTemplateImage extends CvStage {
             throw new Exception("Property \"footprint\" is required.");
         }
 
+        double marginFactor = 1.5f;
+        int minimumMarginSize = 3;
+        
+        if (minimalImageSize) {
+            marginFactor = 1;
+            minimumMarginSize = 0;
+        }
+        
         BufferedImage template = OpenCvUtils.createFootprintTemplate(camera, footprint, 0.0,
                 footprintView == FootprintView.TopView, 
                 padsColor, 
                 (footprintView == FootprintView.Fiducial ? null : bodyColor), 
-                backgroundColor, 1.5, 3);
+                backgroundColor, marginFactor, minimumMarginSize);
 
         return new Result(OpenCvUtils.toMat(template), ColorSpace.Bgr);
     }

--- a/src/main/java/org/openpnp/vision/pipeline/stages/CreateFootprintTemplateImage.java
+++ b/src/main/java/org/openpnp/vision/pipeline/stages/CreateFootprintTemplateImage.java
@@ -51,6 +51,14 @@ public class CreateFootprintTemplateImage extends CvStage {
     private boolean minimalImageSize = false;
 
     
+    public boolean isMinimalImageSize() {
+        return minimalImageSize;
+    }
+
+    public void setMinimalImageSize(boolean minimalImageSize) {
+        this.minimalImageSize = minimalImageSize;
+    }
+
     public FootprintView getFootprintView() {
         return footprintView;
     }


### PR DESCRIPTION
# Description
Added a boolean value to disabling the default border around the part.

# Justification
The border can make problems in some cases for template matching.  (template is to large => exception)

# Instructions for Use
Just enable the checkbox in the stage settings, and the border disappears.
Warning: only works with symmetrical parts. Parts where the body is not in the center, one side will have border, the other will be cut off.

# Implementation Details
1. How did you test the change? Be descriptive. Untested code will not be accepted. on my machine with different parts
2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)? yes
3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing. no
4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted.
