### PR TITLE
Changed table row visuals to alternate colors

### DIFF
--- a/src/main/java/org/openpnp/gui/FeedersPanel.java
+++ b/src/main/java/org/openpnp/gui/FeedersPanel.java
@@ -164,8 +164,7 @@ public class FeedersPanel extends JPanel implements WizardContainer {
 		searchTextField.setColumns(15);
 
 		table = new AutoSelectTextTable(tableModel);
-        table.setDefaultRenderer(Boolean.class, new CustomBooleanRenderer());
-		table.setDefaultRenderer(Object.class, new DefaultTableCellRenderer() {
+		table.setDefaultRenderer(Boolean.class, new CustomBooleanRenderer() {
 			// cells are grayed if the feeder is not used by any enabled placement.
 			@Override
 			public Component getTableCellRendererComponent(JTable table, Object value, boolean isSelected,
@@ -192,7 +191,7 @@ public class FeedersPanel extends JPanel implements WizardContainer {
 								continue;
 							}
 
-							if (placement.getPart() != null && placement.getPart().getId() == partId) {
+							if (placement.getPart() != null && placement.getPart().getId().equals(partId)) {
 								bFound = true;
 								break;
 							}
@@ -203,6 +202,8 @@ public class FeedersPanel extends JPanel implements WizardContainer {
 					}
 					if (!bFound) {
                         c.setEnabled(false);
+                    } else {
+					    c.setEnabled(true);
                     }
 				}
 				return c;

--- a/src/main/java/org/openpnp/gui/FeedersPanel.java
+++ b/src/main/java/org/openpnp/gui/FeedersPanel.java
@@ -20,7 +20,6 @@
 package org.openpnp.gui;
 
 import java.awt.BorderLayout;
-import java.awt.Color;
 import java.awt.Component;
 import java.awt.Rectangle;
 import java.awt.event.ActionEvent;
@@ -59,6 +58,7 @@ import javax.swing.table.TableRowSorter;
 import org.openpnp.events.FeederSelectedEvent;
 import org.openpnp.gui.components.AutoSelectTextTable;
 import org.openpnp.gui.components.ClassSelectionDialog;
+import org.openpnp.gui.support.CustomBooleanRenderer;
 import org.openpnp.gui.support.AbstractConfigurationWizard;
 import org.openpnp.gui.support.ActionGroup;
 import org.openpnp.gui.support.Helpers;
@@ -164,7 +164,7 @@ public class FeedersPanel extends JPanel implements WizardContainer {
 		searchTextField.setColumns(15);
 
 		table = new AutoSelectTextTable(tableModel);
-
+        table.setDefaultRenderer(Boolean.class, new CustomBooleanRenderer());
 		table.setDefaultRenderer(Object.class, new DefaultTableCellRenderer() {
 			// cells are grayed if the feeder is not used by any enabled placement.
 			@Override

--- a/src/main/java/org/openpnp/gui/JobPanel.java
+++ b/src/main/java/org/openpnp/gui/JobPanel.java
@@ -20,7 +20,6 @@
 package org.openpnp.gui;
 
 import java.awt.BorderLayout;
-import java.awt.Color;
 import java.awt.Component;
 import java.awt.FileDialog;
 import java.awt.Frame;
@@ -71,6 +70,7 @@ import org.openpnp.events.BoardLocationSelectedEvent;
 import org.openpnp.events.JobLoadedEvent;
 import org.openpnp.events.PlacementSelectedEvent;
 import org.openpnp.gui.components.AutoSelectTextTable;
+import org.openpnp.gui.support.CustomBooleanRenderer;
 import org.openpnp.gui.importer.BoardImporter;
 import org.openpnp.gui.panelization.DlgAutoPanelize;
 import org.openpnp.gui.panelization.DlgPanelXOut;
@@ -196,7 +196,7 @@ public class JobPanel extends JPanel {
         table.setAutoCreateRowSorter(true);
         table.setSelectionMode(ListSelectionModel.MULTIPLE_INTERVAL_SELECTION);
         table.setDefaultEditor(Side.class, new DefaultCellEditor(sidesComboBox));
-
+        table.setDefaultRenderer(Boolean.class, new CustomBooleanRenderer());
         table.getModel().addTableModelListener(new TableModelListener() {
             @Override
             public void tableChanged(TableModelEvent e) {

--- a/src/main/java/org/openpnp/gui/JobPlacementsPanel.java
+++ b/src/main/java/org/openpnp/gui/JobPlacementsPanel.java
@@ -16,22 +16,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.regex.PatternSyntaxException;
 
-import javax.swing.AbstractAction;
-import javax.swing.Action;
-import javax.swing.DefaultCellEditor;
-import javax.swing.JButton;
-import javax.swing.JComboBox;
-import javax.swing.JLabel;
-import javax.swing.JMenu;
-import javax.swing.JOptionPane;
-import javax.swing.JPanel;
-import javax.swing.JPopupMenu;
-import javax.swing.JScrollPane;
-import javax.swing.JTable;
-import javax.swing.JTextField;
-import javax.swing.JToolBar;
-import javax.swing.ListSelectionModel;
-import javax.swing.RowFilter;
+import javax.swing.*;
 import javax.swing.border.LineBorder;
 import javax.swing.border.TitledBorder;
 import javax.swing.event.DocumentEvent;
@@ -43,6 +28,7 @@ import javax.swing.table.TableRowSorter;
 
 import org.openpnp.events.PlacementSelectedEvent;
 import org.openpnp.gui.components.AutoSelectTextTable;
+import org.openpnp.gui.support.CustomBooleanRenderer;
 import org.openpnp.gui.support.ActionGroup;
 import org.openpnp.gui.support.Helpers;
 import org.openpnp.gui.support.Icons;
@@ -137,6 +123,7 @@ public class JobPlacementsPanel extends JPanel {
         table.setDefaultRenderer(Part.class, new IdentifiableTableCellRenderer<Part>());
         table.setDefaultRenderer(PlacementsTableModel.Status.class, new StatusRenderer());
         table.setDefaultRenderer(Placement.Type.class, new TypeRenderer());
+        table.setDefaultRenderer(Boolean.class, new CustomBooleanRenderer());
         tableModel.setJobPlacementsPanel(this);
         table.getSelectionModel().addListSelectionListener(new ListSelectionListener() {
             @Override
@@ -761,22 +748,32 @@ public class JobPlacementsPanel extends JPanel {
     };
 
     static class TypeRenderer extends DefaultTableCellRenderer {
+        @Override
         public void setValue(Object value) {
             if (value == null) {
                 return;
             }
             Type type = (Type) value;
             setText(type.name());
-            if (type == Type.Fiducial) {
-                setBorder(new LineBorder(getBackground()));
-                setForeground(Color.black);
-                setBackground(typeColorFiducial);
+        }
+
+        @Override
+        public Component getTableCellRendererComponent(JTable table, Object value,
+                                                       boolean isSelected, boolean hasFocus, int row, int column) {
+            Component c = super.getTableCellRendererComponent(table, value, isSelected, hasFocus, row, column);
+            Color alternateRowColor = UIManager.getColor("Table.alternateRowColor");
+            if (value == Type.Fiducial) {
+                c.setForeground(Color.black);
+                c.setBackground(typeColorFiducial);
+            } else if (isSelected) {
+                c.setForeground(table.getSelectionForeground());
+                c.setBackground(table.getSelectionBackground());
+            } else {
+                c.setForeground(table.getForeground());
+                c.setBackground(row%2==0 ? table.getBackground() : alternateRowColor);
             }
-            else if (type == Type.Placement) {
-                setBorder(new LineBorder(getBackground()));
-                setForeground(Color.black);
-                setBackground(typeColorPlacement);
-            }
+
+            return c;
         }
     }
 

--- a/src/main/java/org/openpnp/gui/components/ThemeSettingsPanel.java
+++ b/src/main/java/org/openpnp/gui/components/ThemeSettingsPanel.java
@@ -283,8 +283,11 @@ public class ThemeSettingsPanel extends JPanel {
         }
         // change look and feel
         if (themeInfo.lafClassName != null) {
+            FlatAnimatedLafChange.showSnapshot();
             if (!themeInfo.lafClassName.equals(UIManager.getLookAndFeel().getClass().getName())) {
-                FlatAnimatedLafChange.showSnapshot();
+                if (themeInfo.lafClassName.equals("com.sun.java.swing.plaf.gtk.GTKLookAndFeel")) {
+                    UIManager.put("Slider.paintValue", Boolean.FALSE);
+                }
                 try {
                     UIManager.setLookAndFeel(themeInfo.lafClassName);
                 } catch (Exception ignore) {

--- a/src/main/java/org/openpnp/gui/components/ThemeSettingsPanel.java
+++ b/src/main/java/org/openpnp/gui/components/ThemeSettingsPanel.java
@@ -4,6 +4,7 @@ import com.formdev.flatlaf.*;
 import com.formdev.flatlaf.extras.FlatAnimatedLafChange;
 import com.formdev.flatlaf.util.StringUtils;
 import org.openpnp.Translations;
+import org.openpnp.gui.support.FlexibleColor;
 import org.openpnp.model.Configuration;
 
 import javax.swing.*;
@@ -310,11 +311,11 @@ public class ThemeSettingsPanel extends JPanel {
                 UIManager.put("defaultFont", newFont);
             }
         }
-        Color defaultRowColor = UIManager.getColor("Table.background");
+        FlexibleColor defaultRowColor = new FlexibleColor(UIManager.getColor("Table.background").getRGB());
         if (FlatLaf.isLafDark()) {
-            UIManager.put("Table.alternateRowColor", defaultRowColor.brighter());
+            UIManager.put("Table.alternateRowColor", defaultRowColor.brighter(30));
         } else {
-            UIManager.put("Table.alternateRowColor", defaultRowColor.darker());
+            UIManager.put("Table.alternateRowColor", defaultRowColor.darker(30));
         }
         FlatLaf.updateUI();
         removeAll();

--- a/src/main/java/org/openpnp/gui/components/ThemeSettingsPanel.java
+++ b/src/main/java/org/openpnp/gui/components/ThemeSettingsPanel.java
@@ -203,15 +203,18 @@ public class ThemeSettingsPanel extends JPanel {
 
         themes.clear();
 
-        themes.add(new ThemeInfo("System Themes", null, false, null, null));
+        themes.add(new ThemeInfo(Translations.getString("Theme.Section.System"), null, false, null, null));
         UIManager.LookAndFeelInfo[] lookAndFeels = UIManager.getInstalledLookAndFeels();
         for (UIManager.LookAndFeelInfo lookAndFeel : lookAndFeels) {
             String name = lookAndFeel.getName();
+            if (lookAndFeel.getClassName().equals(UIManager.getSystemLookAndFeelClassName())){
+                name += " - " + Translations.getString("Theme.Default");
+            }
             String className = lookAndFeel.getClassName();
             themes.add(new ThemeInfo(name, null, false, null, className));
         }
 
-        themes.add(new ThemeInfo("Extra Themes", null, false, null, null));
+        themes.add(new ThemeInfo(Translations.getString("Theme.Section.Extra"), null, false, null, null));
         themes.add(new ThemeInfo("Light", null, false, null, FlatLightLaf.class.getName()));
         themes.add(new ThemeInfo("Dark", null, true, null, FlatDarkLaf.class.getName()));
         themes.add(new ThemeInfo("IntelliJ Light", null, false, null, FlatIntelliJLaf.class.getName()));
@@ -224,7 +227,7 @@ public class ThemeSettingsPanel extends JPanel {
         File[] themeFiles = themesDirectory.listFiles((dir, name) -> name.endsWith(".theme.json") || name.endsWith(".properties"));
         if (themeFiles != null) {
             if (themeFiles.length > 0) {
-                themes.add(new ThemeInfo("User Themes", null, false, null, null));
+                themes.add(new ThemeInfo(Translations.getString("Theme.Section.User"), null, false, null, null));
                 for (File f : themeFiles) {
                     String fName = f.getName();
                     String name = fName.endsWith(".properties")

--- a/src/main/java/org/openpnp/gui/components/ThemeSettingsPanel.java
+++ b/src/main/java/org/openpnp/gui/components/ThemeSettingsPanel.java
@@ -2,14 +2,17 @@ package org.openpnp.gui.components;
 
 import com.formdev.flatlaf.*;
 import com.formdev.flatlaf.extras.FlatAnimatedLafChange;
+import com.formdev.flatlaf.util.StringUtils;
 import org.openpnp.Translations;
+import org.openpnp.model.Configuration;
 
 import javax.swing.*;
 import java.awt.*;
 import java.awt.event.MouseEvent;
+import java.io.File;
 import java.io.FileInputStream;
-import java.util.*;
 import java.util.List;
+import java.util.*;
 
 public class ThemeSettingsPanel extends JPanel {
     public enum FontSize {
@@ -202,7 +205,7 @@ public class ThemeSettingsPanel extends JPanel {
 
         themes.add(new ThemeInfo("System Themes", null, false, null, null));
         UIManager.LookAndFeelInfo[] lookAndFeels = UIManager.getInstalledLookAndFeels();
-        for( UIManager.LookAndFeelInfo lookAndFeel : lookAndFeels ) {
+        for (UIManager.LookAndFeelInfo lookAndFeel : lookAndFeels) {
             String name = lookAndFeel.getName();
             String className = lookAndFeel.getClassName();
             themes.add(new ThemeInfo(name, null, false, null, className));
@@ -213,6 +216,24 @@ public class ThemeSettingsPanel extends JPanel {
         themes.add(new ThemeInfo("Dark", null, true, null, FlatDarkLaf.class.getName()));
         themes.add(new ThemeInfo("IntelliJ Light", null, false, null, FlatIntelliJLaf.class.getName()));
         themes.add(new ThemeInfo("Darcula", null, true, null, FlatDarculaLaf.class.getName()));
+
+        File themesDirectory = new File(Configuration.get().getConfigurationDirectory(), "themes");
+        if (!themesDirectory.exists() || !themesDirectory.isDirectory()) {
+            themesDirectory.mkdirs();
+        }
+        File[] themeFiles = themesDirectory.listFiles((dir, name) -> name.endsWith(".theme.json") || name.endsWith(".properties"));
+        if (themeFiles != null) {
+            if (themeFiles.length > 0) {
+                themes.add(new ThemeInfo("User Themes", null, false, null, null));
+                for (File f : themeFiles) {
+                    String fName = f.getName();
+                    String name = fName.endsWith(".properties")
+                            ? StringUtils.removeTrailing(fName, ".properties")
+                            : StringUtils.removeTrailing(fName, ".theme.json");
+                    themes.add(new ThemeInfo(name, null, false, f, null));
+                }
+            }
+        }
 
         themesList.setModel(new AbstractListModel<ThemeInfo>() {
             @Override

--- a/src/main/java/org/openpnp/gui/components/ThemeSettingsPanel.java
+++ b/src/main/java/org/openpnp/gui/components/ThemeSettingsPanel.java
@@ -205,10 +205,6 @@ public class ThemeSettingsPanel extends JPanel {
         for( UIManager.LookAndFeelInfo lookAndFeel : lookAndFeels ) {
             String name = lookAndFeel.getName();
             String className = lookAndFeel.getClassName();
-            if (className.equals("com.sun.java.swing.plaf.windows.WindowsClassicLookAndFeel") ||
-                    className.equals("com.sun.java.swing.plaf.motif.MotifLookAndFeel")) {
-                continue;
-            }
             themes.add(new ThemeInfo(name, null, false, null, className));
         }
 

--- a/src/main/java/org/openpnp/gui/components/ThemeSettingsPanel.java
+++ b/src/main/java/org/openpnp/gui/components/ThemeSettingsPanel.java
@@ -290,6 +290,12 @@ public class ThemeSettingsPanel extends JPanel {
                 UIManager.put("defaultFont", newFont);
             }
         }
+        Color defaultRowColor = UIManager.getColor("Table.background");
+        if (FlatLaf.isLafDark()) {
+            UIManager.put("Table.alternateRowColor", defaultRowColor.brighter());
+        } else {
+            UIManager.put("Table.alternateRowColor", defaultRowColor.darker());
+        }
         FlatLaf.updateUI();
         removeAll();
         initComponents();

--- a/src/main/java/org/openpnp/gui/support/CustomBooleanRenderer.java
+++ b/src/main/java/org/openpnp/gui/support/CustomBooleanRenderer.java
@@ -1,0 +1,41 @@
+package org.openpnp.gui.support;
+
+import javax.swing.*;
+import javax.swing.border.Border;
+import javax.swing.border.EmptyBorder;
+import javax.swing.plaf.UIResource;
+import javax.swing.table.TableCellRenderer;
+import java.awt.*;
+
+public class CustomBooleanRenderer extends JCheckBox implements TableCellRenderer, UIResource
+{
+    private static final Border noFocusBorder = new EmptyBorder(1, 1, 1, 1);
+
+    public CustomBooleanRenderer() {
+        super();
+        setHorizontalAlignment(JLabel.CENTER);
+        setBorderPainted(true);
+    }
+
+    public Component getTableCellRendererComponent(JTable table, Object value,
+                                                   boolean isSelected, boolean hasFocus, int row, int column) {
+        Color alternateRowColor = UIManager.getColor("Table.alternateRowColor");
+        if (isSelected) {
+            setForeground(table.getSelectionForeground());
+            super.setBackground(table.getSelectionBackground());
+        }
+        else {
+            setForeground(table.getForeground());
+            setBackground(row%2==0 ? table.getBackground() : alternateRowColor);
+        }
+        setSelected((value != null && ((Boolean)value).booleanValue()));
+
+        if (hasFocus) {
+            setBorder(UIManager.getBorder("Table.focusCellHighlightBorder"));
+        } else {
+            setBorder(noFocusBorder);
+        }
+
+        return this;
+    }
+}

--- a/src/main/java/org/openpnp/gui/support/FlexibleColor.java
+++ b/src/main/java/org/openpnp/gui/support/FlexibleColor.java
@@ -1,0 +1,53 @@
+package org.openpnp.gui.support;
+
+import java.awt.*;
+import java.awt.color.ColorSpace;
+
+@SuppressWarnings("unused")
+public class FlexibleColor extends Color {
+    public FlexibleColor(int r, int g, int b) {
+        super(r, g, b);
+    }
+
+    public FlexibleColor(int r, int g, int b, int a) {
+        super(r, g, b, a);
+    }
+
+    public FlexibleColor(int rgb) {
+        super(rgb);
+    }
+
+    public FlexibleColor(int rgba, boolean hasalpha) {
+        super(rgba, hasalpha);
+    }
+
+    public FlexibleColor(float r, float g, float b) {
+        super(r, g, b);
+    }
+
+    public FlexibleColor(float r, float g, float b, float a) {
+        super(r, g, b, a);
+    }
+
+    public FlexibleColor(ColorSpace cspace, float[] components, float alpha) {
+        super(cspace, components, alpha);
+    }
+
+    public Color brighter(int add) {
+        int r = getRed();
+        int g = getGreen();
+        int b = getBlue();
+        int alpha = getAlpha();
+        return new Color(Math.min(r + add, 255),
+                Math.min(g + add, 255),
+                Math.min(b + add, 255),
+                alpha);
+    }
+
+    public Color darker(int subtract) {
+        return new Color(Math.max(getRed()  - subtract, 0),
+                Math.max(getGreen() - subtract, 0),
+                Math.max(getBlue()  - subtract, 0),
+                getAlpha());
+    }
+}

--- a/src/main/java/org/openpnp/machine/reference/driver/wizards/GcodeDriverSettings.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/wizards/GcodeDriverSettings.java
@@ -14,15 +14,8 @@ import java.io.FilenameFilter;
 import java.io.StringReader;
 import java.io.StringWriter;
 
-import javax.swing.AbstractAction;
-import javax.swing.Action;
-import javax.swing.JCheckBox;
-import javax.swing.JComboBox;
-import javax.swing.JLabel;
-import javax.swing.JOptionPane;
-import javax.swing.JPanel;
-import javax.swing.JTextField;
-import javax.swing.SwingUtilities;
+import javax.swing.*;
+import javax.swing.border.LineBorder;
 import javax.swing.border.TitledBorder;
 
 import org.openpnp.gui.MainFrame;
@@ -47,12 +40,10 @@ import com.jgoodies.forms.layout.ColumnSpec;
 import com.jgoodies.forms.layout.FormLayout;
 import com.jgoodies.forms.layout.FormSpecs;
 import com.jgoodies.forms.layout.RowSpec;
-import javax.swing.JTextArea;
-import javax.swing.JButton;
+
 import java.awt.SystemColor;
 import java.awt.event.ActionListener;
 import java.awt.Font;
-import javax.swing.SwingConstants;
 
 public class GcodeDriverSettings extends AbstractConfigurationWizard {
     private final GcodeDriver driver;
@@ -193,8 +184,8 @@ public class GcodeDriverSettings extends AbstractConfigurationWizard {
         settingsPanel.add(btnDetectFirmware, "2, 16");
         
         firmwareConfiguration = new JTextArea();
-        firmwareConfiguration.setForeground(SystemColor.textInactiveText);
-        firmwareConfiguration.setBackground(SystemColor.control);
+        firmwareConfiguration.setBackground(UIManager.getColor("controlLtHighlight"));
+        firmwareConfiguration.setBorder(BorderFactory.createLineBorder(UIManager.getColor( "Component.borderColor" )));
         firmwareConfiguration.setWrapStyleWord(true);
         firmwareConfiguration.setLineWrap(true);
         firmwareConfiguration.setEditable(false);

--- a/src/main/resources/org/openpnp/translations.properties
+++ b/src/main/resources/org/openpnp/translations.properties
@@ -110,3 +110,7 @@ Theme.Title=Appearance Settings
 Theme.FontSize.Default=Default
 Theme.Section.Theme=Theme
 Theme.Section.FontSize=Font Size
+Theme.Section.System=System Themes
+Theme.Section.Extra=Extra Themes
+Theme.Section.User=User Themes
+Theme.Default=DEFAULT


### PR DESCRIPTION
# Description
As the title says...
\+ Added more theme choices
\+ Added the option for the user to install more themes

# Justification
This was requested by @vonnieda 
More choices are always better.

# Instructions for Use
The user can install 3rd party IntelliJ themes by copying the `*.theme.json` file into the `.openpnp2/themes` directory. This directory is automatically created after the first run.

# Implementation Details
1. How did you test the change?
I checked the visual appearance manually for all themes. I did not touch any non visual code. This should not cause any problems
2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)?
Yes