### PR TITLE
Fixed issues in PartSizeCheck feature in ReferenceBottomVision

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/vision/ReferenceBottomVision.java
+++ b/src/main/java/org/openpnp/machine/reference/vision/ReferenceBottomVision.java
@@ -126,7 +126,7 @@ public class ReferenceBottomVision implements PartAlignment {
             Location offsets = new Location(nozzleLocation.getUnits());
             // Try getting a good fix on the part in multiple passes.
             for(int pass = 0;;) {
-            	RotatedRect rect = processPipelineAndGetResult(pipeline, camera, part, nozzle);
+                RotatedRect rect = processPipelineAndGetResult(pipeline, camera, part, nozzle);
                 camera=(Camera)pipeline.getProperty("camera");
 
                 Logger.debug("Bottom vision part {} result rect {}", part.getId(), rect);
@@ -167,10 +167,10 @@ public class ReferenceBottomVision implements PartAlignment {
                         .convertToUnits(maxLinearOffset.getUnits());
                 Location cornerWithAngularOffset = corner.rotateXy(angleOffset);
                 if (!partSizeCheck(part, partSettings, rect, camera) ) {
-                   throw new Exception(String.format(
-                      "ReferenceBottomVision (%s): Incorrect part size.",
-                      part.getId() 
-                      )); 
+                    throw new Exception(String.format(
+                            "ReferenceBottomVision (%s): Incorrect part size.",
+                            part.getId() 
+                            )); 
                 }
                 else if (center.getLinearDistanceTo(offsets) > getMaxLinearOffset().getValue()) {
                     Logger.debug("Offsets too large {} : center offset {} > {}", 
@@ -185,10 +185,10 @@ public class ReferenceBottomVision implements PartAlignment {
                             offsets, Math.abs(angleOffset), getMaxAngularOffset());
                 }
                 else {
-                   	 // We have a good enough fix - go on with that. 
-                     break;                		
+                    // We have a good enough fix - go on with that. 
+                    break;                		
                 }
-                
+
                 // Not a good enough fix - try again with corrected position.
                 nozzle.moveTo(nozzleLocation);
             }


### PR DESCRIPTION
# Description
Fixed issues in partSizeCheck code found while testing this feature.


# Justification
I tried the new version of size checking using the parts definition height and width added a few weeks ago.
I tried the partSizeCheck on a 1206 resistor and encountered a few problems.

(1) The partSizeCheck in findOffsetsPreRotate never returns an error even if I intentionally define wrong part size.
I found that a false result from the size check code only causes the "for(int pass = 0;;) " loop to reiterate until
maxVisionPasses is reached. The part is placed even if size check fails. I did not see any code to display an error message.
Also if the center offset or corner offset or angle offset is still to large after maxVisionPasses then partSizeCheck is never even called. 
I added the Exception Message display code from findOffsetsPostRotate below the loop and changed the scope of "rect"

(2) Contrary to never displaying size error in PreRotate code, The partSizeCheck in PostRotate always displayed
the part Size Error message. I found this error in partSizeCheck code which sets the wrong size for width.
`
double width = checkHeight; <<<<<< SHOULD BE checkWidth >>>>>>>>>>>
`

(3) After fixing (1) and (2),  I flipped the resistor on its side and the size check did not fail and placed the part.
I found that the MaxWidth check is missing the "return false"
```
if (measuredSize.width > pxMaxWidth) {
    Logger.debug("Package pixel width {} : limit {} : measured {}", pxWidth, pxMaxWidth, measuredSize.width);
    <<<<<<<<<< missing "return false" >>>>>>>>>>>>>>>
} else if (measuredSize.width < pxMinWidth) {
    Logger.debug("Package pixel width {} : limit {} : measured {}", pxWidth, pxMinWidth, measuredSize.width);
    return false;
```
# Instructions for Use
As before

# Implementation Details
1. How did you test the change? Be descriptive. Untested code will not be accepted.
On my machine with 1206 resistors changing part size to invoke fails
2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)?
Yes (I hope so!)
3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing.
 No
4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted.
 I ran the test
