### PR TITLE
Feature/Nozzle Tip Changer XYZ Calibration, Part Height, Feeder, Placement contact probing, Auto-Focus

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,25 @@
 This file lists major or notable changes to OpenPnP in chronological order. This is not
 a complete change list, only those that may directly interest or affect users.
 
+# 2021-04-05 
+
+## Nozzle Tip Changer XYZ Calibration, Auto-Focus, Part Height, Feeder, Placement sensing 
+
+This adds Nozzle tip changer XY and Z calibration using vision and probing. Used 
+to calibrate the nozzle to be able to precisely contact probe part heights, feeder 
+heights and placements. Also adds Auto-Focus based part height sensing for parts 
+with enabled bottom vision. 
+
+* Vision calibrated nozzle changer slot locations (XY) based on template images. 
+  Also detects nozzle changer slot empty/occupied status and prevents collisions.
+* Manual and automatic nozzle/nozzle tip/slot Z calibration for precision multi-
+  nozzle leveling and nozzle tip length calibration.
+* Adds Focus sensing method to cameras (FocusProvider interface). 
+  AutoFocusProvider default implementation.
+* Bottom vision uses Focus sensing to determine the part height, if unknown. 
+* ContactProbeNozzle provides on-the-fly part height probing/learning, feeder Z 
+  calibration, placement height calibration. 
+
 # 2021-03-20
 
 ## (Another) OpenCV Upgrade and Arm7 (32 Bit)

--- a/src/main/java/org/openpnp/gui/JogControlsPanel.java
+++ b/src/main/java/org/openpnp/gui/JogControlsPanel.java
@@ -26,7 +26,6 @@ import java.awt.FocusTraversalPolicy;
 import java.awt.Font;
 import java.awt.Window;
 import java.awt.event.ActionEvent;
-import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.util.HashMap;
 import java.util.Hashtable;
@@ -809,16 +808,21 @@ public class JogControlsPanel extends JPanel {
             // add property listener for recycle button
             // enable recycle only if part on current head
             PropertyChangeListener recyclePropertyListener = (e) -> {
-                    boolean canTakeBack = false;
-                    Part part = machineControlsPanel.getSelectedNozzle().getPart();
-                    if (part != null) {
-                        for (Feeder feeder : Configuration.get().getMachine().getFeeders()) {
-                            if (feeder.isEnabled() && feeder.getPart().equals(part) && feeder.canTakeBackPart()) {
-                                canTakeBack = true;
+                    Nozzle selectedNozzle = machineControlsPanel.getSelectedNozzle();
+                    if (selectedNozzle != null) {
+                        boolean canTakeBack = false;
+                        Part part = selectedNozzle.getPart();
+                        if (part != null) {
+                            for (Feeder feeder : Configuration.get().getMachine().getFeeders()) {
+                                if (feeder.isEnabled() 
+                                        && feeder.getPart() == part
+                                        && feeder.canTakeBackPart()) {
+                                    canTakeBack = true;
+                                }
                             }
                         }
+                        recycleAction.setEnabled(canTakeBack);
                     }
-                    recycleAction.setEnabled(canTakeBack);
                 };
             // add to all nozzles
             for (Head head : Configuration.get().getMachine().getHeads()) {

--- a/src/main/java/org/openpnp/gui/components/TemplateImageControl.java
+++ b/src/main/java/org/openpnp/gui/components/TemplateImageControl.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright (C) 2021 <mark@makr.zone>
+ * 
+ * This file is part of OpenPnP.
+ * 
+ * OpenPnP is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * OpenPnP is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License along with OpenPnP. If not, see
+ * <http://www.gnu.org/licenses/>.
+ * 
+ * For more information about OpenPnP visit http://openpnp.org
+ */
+
+package org.openpnp.gui.components;
+
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.Font;
+import java.awt.FontMetrics;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.RenderingHints;
+import java.awt.event.MouseEvent;
+import java.awt.event.MouseListener;
+import java.awt.event.MouseMotionListener;
+import java.awt.geom.AffineTransform;
+import java.awt.geom.Rectangle2D;
+import java.awt.image.BufferedImage;
+
+import javax.swing.JComponent;
+import javax.swing.UIManager;
+
+import org.openpnp.gui.MainFrame;
+import org.openpnp.model.Location;
+import org.openpnp.spi.Camera;
+import org.openpnp.vision.TemplateImage;
+
+@SuppressWarnings("serial")
+public class TemplateImageControl extends JComponent implements MouseMotionListener, MouseListener {  
+
+    private TemplateImage templateImage = null;
+    private int minWidth = 100;
+    private int minHeight = 100;
+    private Camera camera = null;
+    private String name = "Template";
+    private Location captureLocation = null; 
+    
+    public TemplateImageControl() {
+        addMouseMotionListener(this);
+        addMouseListener(this);
+    }
+    public TemplateImageControl(TemplateImage templateImage) {
+        this();
+        this.templateImage = templateImage;
+    }
+
+    public TemplateImage getTemplateImage() {
+        return templateImage;
+    }
+    public void setTemplateImage(TemplateImage templateImage) {
+        this.templateImage = templateImage;
+        repaint();
+    }
+
+    public int getMinWidth() {
+        return minWidth;
+    }
+    public void setMinWidth(int minWidth) {
+        this.minWidth = minWidth;
+        validate();
+    }
+    public int getMinHeight() {
+        return minHeight;
+    }
+    public void setMinHeight(int minHeight) {
+        this.minHeight = minHeight;
+        validate();
+    }
+
+    public Camera getCamera() {
+        return camera;
+    }
+    public void setCamera(Camera camera) {
+        this.camera = camera;
+    }
+
+    public String getName() {
+        return name;
+    }
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public synchronized void paintComponent(Graphics g) {
+        super.paintComponent(g);
+        Graphics2D g2d = (Graphics2D) g;
+        g2d.setRenderingHint(RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_QUALITY);
+        g2d.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+        Color gridColor = UIManager.getColor ( "PasswordField.capsLockIconColor" );
+        Font font = getFont();
+        FontMetrics dfm = g2d.getFontMetrics(font);
+        g2d.setFont(font);
+        int w = getWidth();
+        int h = getHeight();
+        if (gridColor == null) {
+            gridColor = new Color(0, 0, 0, 64);
+        } else {
+            gridColor = new Color(gridColor.getRed(), gridColor.getGreen(), gridColor.getBlue(), 64);
+        }
+        BufferedImage image = getImage();
+        if (image != null) {
+            g2d.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_BILINEAR);
+            AffineTransform t = new AffineTransform();
+            double scale = Math.min(((double)w)/image.getWidth(), ((double)h)/image.getHeight());
+            t.scale(scale, scale);
+            g2d.drawImage(image, t, null);
+        }
+        else {
+            g2d.setColor(gridColor);
+            int d = Math.min(w, h)-1;
+            g2d.drawRect(0, 0, d, d);
+            String text = "no image";
+            Rectangle2D bounds = dfm.getStringBounds(text, 0, text.length(), g2d);
+            g2d.drawString(text, (int)(Math.min(h, w)/2-bounds.getWidth()/2), (int)(h/2));
+        }
+    }
+    protected BufferedImage getImage() {
+        BufferedImage image = null;
+        if (templateImage != null) {
+            try {
+                image = templateImage.getImage();
+            }
+            catch (Exception e) {
+            }
+        }
+        return image;
+    }
+
+    @Override
+    public Dimension getPreferredSize() {
+        Dimension superDim = super.getPreferredSize();
+        BufferedImage image = getImage();
+        if (image != null) {
+            double scale = Math.max(Math.max(minWidth, superDim.getWidth())/image.getWidth(), Math.max(minHeight, superDim.getHeight())/image.getHeight());
+            int width = (int)(image.getWidth()*scale);
+            int height = (int)(image.getHeight()*scale); 
+            return new Dimension(width, height);
+        }
+        else {
+            int width = (int)Math.max(minWidth, superDim.getWidth());
+            int height = (int)Math.max(minHeight, superDim.getHeight());; 
+            return new Dimension(width, height);
+        }
+    }
+    @Override
+    public void mouseDragged(MouseEvent e) {
+    }
+    @Override
+    public void mouseMoved(MouseEvent e) {
+        if (camera != null) {
+            BufferedImage image = getImage();
+            if (image != null) {
+                CameraPanel cameraViews = MainFrame.get().getCameraViews();
+                CameraView view = cameraViews.getCameraView(camera);
+                view.showFilteredImage(image, name, 2000);
+                cameraViews.ensureCameraVisible(camera);
+            }
+        }
+    }
+    @Override
+    public void mouseClicked(MouseEvent e) {
+        
+    }
+    @Override
+    public void mousePressed(MouseEvent e) {
+    }
+    @Override
+    public void mouseReleased(MouseEvent e) {
+    }
+    @Override
+    public void mouseEntered(MouseEvent e) {
+    }
+    @Override
+    public void mouseExited(MouseEvent e) {
+    }
+
+}

--- a/src/main/java/org/openpnp/gui/support/Icons.java
+++ b/src/main/java/org/openpnp/gui/support/Icons.java
@@ -30,6 +30,7 @@ public class Icons {
     public static Icon centerCameraMoveNext = getIcon("/icons/position-camera-move-next.svg");
     public static Icon centerTool = getIcon("/icons/position-nozzle.svg");
     public static Icon centerToolNoSafeZ = getIcon("/icons/position-nozzle-no-safe-z.svg");
+    public static Icon contactProbeNozzle = getIcon("/icons/contact-probe-nozzle.svg");
     public static Icon centerPin = getIcon("/icons/position-actuator.svg");
     public static Icon centerPinNoSafeZ = getIcon("/icons/position-actuator-no-safe-z.svg");
     public static Icon centerCameraOnFeeder = getIcon("/icons/position-camera-on-feeder.svg");

--- a/src/main/java/org/openpnp/gui/tablemodel/PartsTableModel.java
+++ b/src/main/java/org/openpnp/gui/tablemodel/PartsTableModel.java
@@ -128,7 +128,22 @@ public class PartsTableModel extends AbstractTableModel implements PropertyChang
 
     @Override
     public void propertyChange(PropertyChangeEvent arg0) {
-        parts = new ArrayList<>(Configuration.get().getParts());
-        fireTableDataChanged();
+        if (arg0.getSource() instanceof Part) {
+            // Only single part data changed, but sort order might change, so still need fireTableDataChanged().
+            fireTableDataChanged();
+        }
+        else  {
+            // Parts list itself changes.
+            if (parts != null) { 
+                for (Part part : parts) {
+                    part.removePropertyChangeListener(this);
+                }
+            }
+            parts = new ArrayList<>(Configuration.get().getParts());
+            fireTableDataChanged();
+            for (Part part : parts) {
+                part.addPropertyChangeListener(this);
+            }
+        }
     }
 }

--- a/src/main/java/org/openpnp/gui/tablemodel/PlacementsTableModel.java
+++ b/src/main/java/org/openpnp/gui/tablemodel/PlacementsTableModel.java
@@ -186,7 +186,7 @@ public class PlacementsTableModel extends AbstractTableModel {
                 return Status.MissingFeeder;
             }
 
-            if (placement.getPart().getHeight().getValue() == 0) {
+            if (placement.getPart().isPartHeightUnknown()) {
                 return Status.ZeroPartHeight;
             }
         }

--- a/src/main/java/org/openpnp/gui/wizards/CameraConfigurationWizard.java
+++ b/src/main/java/org/openpnp/gui/wizards/CameraConfigurationWizard.java
@@ -19,7 +19,6 @@
 
 package org.openpnp.gui.wizards;
 
-import java.awt.Color;
 import java.awt.Rectangle;
 import java.awt.event.ActionEvent;
 import java.awt.event.ItemEvent;
@@ -51,6 +50,7 @@ import org.openpnp.gui.support.MessageBoxes;
 import org.openpnp.gui.support.MutableLocationProxy;
 import org.openpnp.gui.support.NamedConverter;
 import org.openpnp.machine.reference.AbstractBroadcastingCamera;
+import org.openpnp.machine.reference.ReferenceCamera.FocusSensingMethod;
 import org.openpnp.machine.reference.axis.ReferenceVirtualAxis;
 import org.openpnp.model.Configuration;
 import org.openpnp.model.Length;
@@ -154,16 +154,26 @@ public class CameraConfigurationWizard extends AbstractConfigurationWizard {
         panel.setBorder(new TitledBorder(null, "Properties", TitledBorder.LEADING, TitledBorder.TOP,
                 null, null));
         contentPanel.add(panel);
-        panel.setLayout(new FormLayout(
-                new ColumnSpec[] {FormSpecs.RELATED_GAP_COLSPEC,
-                        ColumnSpec.decode("max(70dlu;default)"), FormSpecs.RELATED_GAP_COLSPEC,
-                        ColumnSpec.decode("max(70dlu;default)"), FormSpecs.RELATED_GAP_COLSPEC,
-                        ColumnSpec.decode("max(70dlu;default)"), FormSpecs.RELATED_GAP_COLSPEC,
-                        FormSpecs.DEFAULT_COLSPEC,},
-                new RowSpec[] {FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
-                        FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
-                        FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
-                        FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,}));
+        panel.setLayout(new FormLayout(new ColumnSpec[] {
+                FormSpecs.RELATED_GAP_COLSPEC,
+                ColumnSpec.decode("max(70dlu;default)"),
+                FormSpecs.RELATED_GAP_COLSPEC,
+                ColumnSpec.decode("max(70dlu;default)"),
+                FormSpecs.RELATED_GAP_COLSPEC,
+                ColumnSpec.decode("max(70dlu;default)"),
+                FormSpecs.RELATED_GAP_COLSPEC,
+                FormSpecs.DEFAULT_COLSPEC,},
+            new RowSpec[] {
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,}));
 
         lblName = new JLabel("Name");
         panel.add(lblName, "2, 2, right, default");
@@ -211,6 +221,17 @@ public class CameraConfigurationWizard extends AbstractConfigurationWizard {
         
         shownInMultiCameraView = new JCheckBox("");
         panel.add(shownInMultiCameraView, "8, 8");
+        
+        lblFocusSensing = new JLabel("Focus Sensing Method");
+        panel.add(lblFocusSensing, "2, 10, right, default");
+        
+        focusSensingMethod = new JComboBox(FocusSensingMethod.values());
+        focusSensingMethod.addItemListener(new ItemListener() {
+            public void itemStateChanged(ItemEvent e) {
+                reloadWizard = true;
+            }
+        });
+        panel.add(focusSensingMethod, "4, 10, fill, default");
         panelLight = new JPanel();
         panelLight.setBorder(new TitledBorder(null, "Light", TitledBorder.LEADING, TitledBorder.TOP,
                 null, null));
@@ -514,6 +535,9 @@ public class CameraConfigurationWizard extends AbstractConfigurationWizard {
         lblCameraZ.setVisible(cameraZ);
         cameraPrimaryZ.setVisible(cameraZ);
         cameraSecondaryZ.setVisible(cameraZ);
+
+        lblFocusSensing.setVisible(camera.getHead() == null);
+        focusSensingMethod.setVisible(camera.getHead() == null);
     };
 
     @Override
@@ -532,6 +556,7 @@ public class CameraConfigurationWizard extends AbstractConfigurationWizard {
         addWrappedBinding(camera, "suspendPreviewInTasks", suspendPreviewInTasks, "selected");
         addWrappedBinding(camera, "autoVisible", autoVisible, "selected");
         addWrappedBinding(camera, "shownInMultiCameraView", shownInMultiCameraView, "selected");
+        addWrappedBinding(camera, "focusSensingMethod", focusSensingMethod, "selectedItem");
 
         addWrappedBinding(camera, "allowMachineActuators", allowMachineActuators, "selected");
         addWrappedBinding(camera, "lightActuator", lightActuator, "selectedItem", actuatorConverter);
@@ -703,6 +728,9 @@ public class CameraConfigurationWizard extends AbstractConfigurationWizard {
     @Override
     protected void saveToModel() {
         super.saveToModel();
+        if (reloadWizard) {
+            MainFrame.get().getMachineSetupTab().selectCurrentTreePath();
+        }
         UiUtils.messageBoxOnException(() -> {
             camera.reinitialize();
         });
@@ -886,4 +914,7 @@ public class CameraConfigurationWizard extends AbstractConfigurationWizard {
     private JCheckBox autoViewPlaneZ;
     private JLabel lblShowMultiview;
     private JCheckBox shownInMultiCameraView;
+    private JLabel lblFocusSensing;
+    private JComboBox focusSensingMethod;
+    private boolean reloadWizard;
 }

--- a/src/main/java/org/openpnp/machine/rapidplacer/RapidFeeder.java
+++ b/src/main/java/org/openpnp/machine/rapidplacer/RapidFeeder.java
@@ -57,6 +57,11 @@ public class RapidFeeder extends ReferenceFeeder {
     }
 
     @Override
+    public boolean isPartHeightAbovePickLocation() {
+        return false;
+    }
+
+    @Override
     public void feed(Nozzle nozzle) throws Exception {
         Actuator actuator = nozzle.getHead().getActuatorByName(actuatorName);
         if (actuator == null) {

--- a/src/main/java/org/openpnp/machine/reference/ContactProbeNozzle.java
+++ b/src/main/java/org/openpnp/machine/reference/ContactProbeNozzle.java
@@ -19,24 +19,54 @@
 
 package org.openpnp.machine.reference;
 
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 import org.openpnp.gui.support.PropertySheetWizardAdapter;
+import org.openpnp.machine.reference.ReferenceNozzleTip.VacuumMeasurementMethod;
+import org.openpnp.machine.reference.ReferenceNozzleTip.ZCalibrationTrigger;
 import org.openpnp.machine.reference.driver.GcodeAsyncDriver;
+import org.openpnp.machine.reference.driver.GcodeDriver;
+import org.openpnp.machine.reference.driver.GcodeDriverSolutions;
 import org.openpnp.machine.reference.wizards.ContactProbeNozzleWizard;
 import org.openpnp.model.Configuration;
+import org.openpnp.model.Length;
+import org.openpnp.model.LengthUnit;
+import org.openpnp.model.Location;
 import org.openpnp.model.Part;
 import org.openpnp.model.Solutions;
+import org.openpnp.model.Solutions.Issue;
 import org.openpnp.model.Solutions.Severity;
 import org.openpnp.spi.Actuator;
+import org.openpnp.spi.Camera;
 import org.openpnp.spi.ControllerAxis;
 import org.openpnp.spi.Driver;
+import org.openpnp.spi.Feeder;
+import org.openpnp.spi.Head;
+import org.openpnp.spi.Machine;
+import org.openpnp.spi.Nozzle;
+import org.openpnp.spi.NozzleTip;
 import org.openpnp.spi.base.AbstractActuator;
+import org.openpnp.spi.base.AbstractHead;
+import org.openpnp.spi.base.AbstractPnpJobProcessor;
 import org.openpnp.util.Collect;
+import org.openpnp.util.MovableUtils;
+import org.openpnp.util.UiUtils;
+import org.openpnp.util.VisionUtils;
 import org.pmw.tinylog.Logger;
+import org.simpleframework.xml.Attribute;
 import org.simpleframework.xml.Element;
+import org.simpleframework.xml.ElementMap;
+import org.simpleframework.xml.Serializer;
+import org.simpleframework.xml.convert.AnnotationStrategy;
+import org.simpleframework.xml.core.Persister;
+import org.simpleframework.xml.stream.Format;
+import org.simpleframework.xml.stream.HyphenStyle;
+import org.simpleframework.xml.stream.Style;
 
 public class ContactProbeNozzle extends ReferenceNozzle {
 
@@ -52,6 +82,60 @@ public class ContactProbeNozzle extends ReferenceNozzle {
     private String contactProbeActuatorName = "";
     private boolean isDisabled;
 
+    @Element(required = false)
+    private Length contactProbeStartOffsetZ = new Length(1, LengthUnit.Millimeters);
+
+    @Element(required = false)
+    private Length contactProbeDepthZ = new Length(2, LengthUnit.Millimeters);
+
+    @Element(required = false)
+    private Length sniffleIncrementZ = new Length(0.1, LengthUnit.Millimeters); 
+
+    @Attribute(required=false)
+    private long sniffleDwellTime = 250;
+
+    @Element(required = false)
+    private Length contactProbeAdjustZ = new Length(0, LengthUnit.Millimeters);
+
+    public enum ContactProbeMethod {
+        None,
+        VacuumSense,
+        ContactSenseActuator;
+
+        public boolean isPlacementCompatible() {
+            return this == ContactSenseActuator;
+        }
+    };
+    @Attribute(required=false)
+    private ContactProbeMethod contactProbeMethod = ContactProbeMethod.ContactSenseActuator;
+
+    public enum ContactProbeTrigger {
+        Off,
+        Once,
+        AfterHoming,
+        EachTime
+    };
+
+    @Attribute(required=false)
+    private ContactProbeTrigger feederHeightProbing = ContactProbeTrigger.EachTime;
+
+    @Attribute(required=false)
+    private ContactProbeTrigger partHeightProbing = ContactProbeTrigger.EachTime;
+
+    @Element(required=false)
+    private Length calibrationOffsetZ = null;
+
+    @Attribute(required=false)
+    private double maxZOffsetMm = 2.0;
+
+    @ElementMap(required = false)
+    private HashMap<Feeder, Length> probedFeederHeightOffsets = new HashMap<>();
+
+    @ElementMap(required = false)
+    private HashMap<Part, Length> probedPartHeightOffsets = new HashMap<>();
+
+    private ReferenceNozzleTip zCalibratedNozzleTip;
+
     @Override
     public PropertySheet[] getPropertySheets() {
         return Collect.concat(super.getPropertySheets(), new PropertySheet[] {
@@ -59,64 +143,222 @@ public class ContactProbeNozzle extends ReferenceNozzle {
     }
 
     @Override
-    public void pick(Part part) throws Exception {
+    public void home() throws Exception {
+        if (feederHeightProbing == ContactProbeTrigger.Off
+                || feederHeightProbing == ContactProbeTrigger.AfterHoming
+                || contactProbeMethod != ContactProbeMethod.ContactSenseActuator) {
+            // Reset the probed feeder heights.
+            probedFeederHeightOffsets.clear();
+        }
+        if (partHeightProbing == ContactProbeTrigger.Off
+                || partHeightProbing == ContactProbeTrigger.AfterHoming
+                || contactProbeMethod != ContactProbeMethod.ContactSenseActuator) {
+            // Reset the probed part heights.
+            probedPartHeightOffsets.clear();
+        }
+        // After homing, recalibrate.
+        zCalibratedNozzleTip = null;
         try {
-            Map<String, Object> globals = new HashMap<>();
-            globals.put("nozzle", this);
-            globals.put("part", part);
-            Configuration.get().getScripting().on("Nozzle.BeforePickProbe", globals);
-        } catch (Exception e) {
-            Logger.warn(e);
+            ensureZCalibrated();
+        }
+        catch (Exception e) {
+            ReferenceNozzleTip nt = getCalibrationNozzleTip();
+            if (nt != null && nt.iszCalibrationFailHoming()) {
+                throw e;
+            }
+            else {
+                UiUtils.messageBoxOnExceptionLater(() -> {
+                    throw e;
+                });
+            }
+        }
+        super.home();
+    }
+
+    protected boolean isFeederHeightProbingNeeded(Feeder feeder) {
+        if (isDisabled || feeder == null) {
+            return false;
+        }
+        if (contactProbeMethod != ContactProbeMethod.ContactSenseActuator
+                || feederHeightProbing == ContactProbeTrigger.Off) {
+            return false;
+        }
+        if (feederHeightProbing == ContactProbeTrigger.EachTime) {
+            return true;
+        }
+        if (feeder.isPartHeightAbovePickLocation()
+                && feeder.getPart().isPartHeightUnknown()) {
+            return true;
+        }
+        Length z = probedFeederHeightOffsets.get(feeder);
+        return (z == null);
+    }
+
+    protected boolean isPartHeightProbingNeeded(Part part) {
+        if (isDisabled || part == null) {
+            return false;
+        }
+        if (contactProbeMethod != ContactProbeMethod.ContactSenseActuator
+                || partHeightProbing == ContactProbeTrigger.Off) {
+            return false;
+        }
+        if (feederHeightProbing == ContactProbeTrigger.EachTime) {
+            return true;
+        }
+        if (part.isPartHeightUnknown()) {
+            return true;
+        }
+        Length z = probedPartHeightOffsets.get(part);
+        return (z == null);
+    }
+
+    @Override
+    public void moveToPickLocation(Feeder feeder) throws Exception {
+        Part part = feeder.getPart();
+        Location pickLocation = feeder.getPickLocation();
+        Location pickLocationPart = pickLocation;
+        boolean partHeightProbing = false;
+        if (feeder.isPartHeightAbovePickLocation()) {
+            partHeightProbing = part.isPartHeightUnknown();
+            Length partHeight = getSafePartHeight(part);
+            pickLocationPart = pickLocationPart.add(new Location(partHeight.getUnits(), 0, 0, partHeight.getValue(), 0));
         }
 
-        // First probe down from current position above the part until the probe sensor
-        // is triggered.
-		if (!isDisabled) {
-			actuateContactProbe(true);
-		}
-        // Now call the default pick() which usually just turns on the vacuum.
-        super.pick(part);
-        // Retract from probing i.e. until the probe sensor is released.
-        actuateContactProbe(false);
+        if (isFeederHeightProbingNeeded(feeder)) {
+            moveAboveProbingLocation(pickLocationPart);
 
-        try {
-            Map<String, Object> globals = new HashMap<>();
-            globals.put("nozzle", this);
-            globals.put("part", part);
-            Configuration.get().getScripting().on("Nozzle.AfterPickProbe", globals);
-        } catch (Exception e) {
-            Logger.warn(e);
+            try {
+                Map<String, Object> globals = new HashMap<>();
+                globals.put("nozzle", this);
+                globals.put("feeder", feeder);
+                globals.put("part", part);
+                Configuration.get().getScripting().on("Nozzle.BeforePickProbe", globals);
+            } catch (Exception e) {
+                Logger.warn(e);
+            }
+
+            Length depthZ;
+            if (partHeightProbing) {
+                // We're probing for the part height.
+                depthZ = nozzleTip.getMaxPartHeight();
+            }
+            else {
+                depthZ = contactProbeDepthZ;
+            }
+            // Probe down from current position above the part until the probe sensor
+            // is triggered.
+            Location probedLocation = contactProbe(true, depthZ);
+            Length offsetZ;
+            if (partHeightProbing) { 
+                // Part height is difference to pick location (as part is above it). 
+                Length partHeight = probedLocation.subtract(pickLocation).getLengthZ();
+                part.setHeight(partHeight);
+                offsetZ = new Length(0, LengthUnit.Millimeters);
+                Logger.info("Nozzle "+getName()+" probed part "+part.getId()+" height at "+partHeight);
+            }
+            else {
+                offsetZ = probedLocation.subtract(pickLocationPart).getLengthZ();
+                Logger.debug("Nozzle "+getName()+" probed feeder "+feeder.getName()+" Z at offset "+offsetZ);
+            }
+            // Store the probed location offset.
+            probedFeederHeightOffsets.put(feeder, offsetZ);
+
+            // Retract from probing e.g. until the probe sensor is released.
+            contactProbe(false, contactProbeDepthZ);
+
+            try {
+                Map<String, Object> globals = new HashMap<>();
+                globals.put("nozzle", this);
+                globals.put("feeder", feeder);
+                globals.put("part", part);
+                Configuration.get().getScripting().on("Nozzle.AfterPickProbe", globals);
+            } catch (Exception e) {
+                Logger.warn(e);
+            }
+        }
+        else {
+            Length offsetZ = probedFeederHeightOffsets.get(feeder);
+            if (offsetZ != null) {
+                // Apply the probed offset.
+                Logger.trace("Nozzle "+getName()+" applies feeder "+feeder.getName()+" height offset "+offsetZ);
+                pickLocationPart = pickLocationPart.add(new Location(offsetZ .getUnits(), 0, 0, offsetZ.getValue(), 0));
+                MovableUtils.moveToLocationAtSafeZ(this, pickLocationPart);
+            }
+            else {
+                super.moveToPickLocation(feeder);
+            }
         }
     }
 
     @Override
-    public void place() throws Exception {
-        try {
-            Map<String, Object> globals = new HashMap<>();
-            globals.put("nozzle", this);
-            globals.put("part", getPart());
-            Configuration.get().getScripting().on("Nozzle.BeforePlaceProbe", globals);
-        } catch (Exception e) {
-            Logger.warn(e);
+    public void moveToPlacementLocation(Location placementLocation, Part part) throws Exception {
+        Length partHeight = getSafePartHeight(part);
+        Location placementLocationPart = placementLocation.add(new Location(partHeight.getUnits(), 0, 0, partHeight.getValue(), 0));
+        if (isPartHeightProbingNeeded(part)) {
+            boolean partHeightProbing = part.isPartHeightUnknown();
+            // Calculate the probe starting location.
+            moveAboveProbingLocation(placementLocationPart);
+
+            try {
+                Map<String, Object> globals = new HashMap<>();
+                globals.put("nozzle", this);
+                globals.put("part", getPart());
+                Configuration.get().getScripting().on("Nozzle.BeforePlaceProbe", globals);
+            } catch (Exception e) {
+                Logger.warn(e);
+            }
+
+            Length depthZ;
+            if (partHeightProbing) {
+                // We're probing for the part height.
+                depthZ = nozzleTip.getMaxPartHeight();
+            }
+            else {
+                depthZ = contactProbeDepthZ;
+            }
+            // Probe down from current position above the part until the probe sensor
+            // is triggered.
+            Location probedLocation = contactProbe(true, depthZ);
+            Length offsetZ;
+            if (partHeightProbing) { 
+                // Part height is difference to placement location (part is above it). 
+                partHeight = probedLocation.subtract(placementLocation).getLengthZ();
+                Logger.info("Nozzle "+getName()+" probed part "+part.getId()+" height at "+partHeight);
+                if (partHeight.getValue() <= 0) {
+                    throw new Exception("Part height "+part.getId()+" probing by nozzle "+getName()+" failed (returned negative height). Check PCB Z and probing adjustment.");
+                }
+                part.setHeight(partHeight);
+                offsetZ = new Length(0, LengthUnit.Millimeters);
+            }
+            else {
+                offsetZ = probedLocation.subtract(placementLocationPart).getLengthZ();
+                Logger.debug("Nozzle "+getName()+" probed part "+part.getId()+" height at offset "+offsetZ);
+            }
+            // Store the probed location offset.
+            probedPartHeightOffsets.put(part, offsetZ);
+
+            contactProbe(false, contactProbeDepthZ);
+
+            try {
+                Map<String, Object> globals = new HashMap<>();
+                globals.put("nozzle", this);
+                globals.put("part", getPart());
+                Configuration.get().getScripting().on("Nozzle.AfterPlaceProbe", globals);
+            } catch (Exception e) {
+                Logger.warn(e);
+            }
         }
-
-        // First probe down from current position above the PCB until the probe sensor
-        // is triggered.
-		if (!isDisabled) {
-			actuateContactProbe(true);
-		}
-        // Now call the default place() which usually just turns off the vacuum.
-        super.place();
-        // Retract from probing i.e. until the probe sensor is released.
-        actuateContactProbe(false);
-
-        try {
-            Map<String, Object> globals = new HashMap<>();
-            globals.put("nozzle", this);
-            globals.put("part", getPart());
-            Configuration.get().getScripting().on("Nozzle.AfterPlaceProbe", globals);
-        } catch (Exception e) {
-            Logger.warn(e);
+        else {
+            Length offsetZ = probedPartHeightOffsets.get(part);
+            if (offsetZ != null) {
+                // Apply the probed offset.
+                Logger.trace("Nozzle "+getName()+" applies part "+part.getId()+" height offset "+offsetZ);
+                placementLocationPart = placementLocationPart.add(new Location(offsetZ .getUnits(), 0, 0, offsetZ.getValue(), 0));
+                MovableUtils.moveToLocationAtSafeZ(this, placementLocationPart);
+            }
+            else {
+                super.moveToPlacementLocation(placementLocationPart, part);
+            }
         }
     }
 
@@ -128,13 +370,9 @@ public class ContactProbeNozzle extends ReferenceNozzle {
         return actuator;
     }
 
-    protected void actuateContactProbe(boolean on) throws Exception {
-        getContactProbeActuator().actuate(on);
+    public void disableContactProbeActuator(boolean set) {
+        isDisabled = set;
     }
-    
-	public void disableContactProbeActuator(boolean set) {
-		isDisabled = set;
-	}
 
     public String getContactProbeActuatorName() {
         return contactProbeActuatorName;
@@ -148,14 +386,301 @@ public class ContactProbeNozzle extends ReferenceNozzle {
         }
     }
 
+    public Length getContactProbeStartOffsetZ() {
+        return contactProbeStartOffsetZ;
+    }
+
+    public void setContactProbeStartOffsetZ(Length contactProbeStartOffsetZ) {
+        this.contactProbeStartOffsetZ = contactProbeStartOffsetZ;
+    }
+
+    public Length getContactProbeDepthZ() {
+        return contactProbeDepthZ;
+    }
+
+    public void setContactProbeDepthZ(Length contactProbeDepthZ) {
+        this.contactProbeDepthZ = contactProbeDepthZ;
+    }
+
+    public Length getSniffleIncrementZ() {
+        return sniffleIncrementZ;
+    }
+
+    public void setSniffleIncrementZ(Length sniffleIncrementZ) {
+        this.sniffleIncrementZ = sniffleIncrementZ;
+    }
+
+    public long getSniffleDwellTime() {
+        return sniffleDwellTime;
+    }
+
+    public void setSniffleDwellTime(long sniffleDwellTime) {
+        this.sniffleDwellTime = sniffleDwellTime;
+    }
+
+    public Length getContactProbeAdjustZ() {
+        return contactProbeAdjustZ;
+    }
+
+    public void setContactProbeAdjustZ(Length contactProbeAdjustZ) {
+        this.contactProbeAdjustZ = contactProbeAdjustZ;
+    }
+
+    public ContactProbeMethod getContactProbeMethod() {
+        return contactProbeMethod;
+    }
+
+    public void setContactProbeMethod(ContactProbeMethod contactProbeMethod) {
+        this.contactProbeMethod = contactProbeMethod;
+    }
+
+    public ContactProbeTrigger getFeederHeightProbing() {
+        return feederHeightProbing;
+    }
+
+    public void setFeederHeightProbing(ContactProbeTrigger feederHeightProbing) {
+        this.feederHeightProbing = feederHeightProbing;
+    }
+
+    public ContactProbeTrigger getPartHeightProbing() {
+        return partHeightProbing;
+    }
+
+    public void setPartHeightProbing(ContactProbeTrigger partHeightProbing) {
+        this.partHeightProbing = partHeightProbing;
+    }
+
+    /**
+     * Move above the probing location at safe Z, apply the start offset as needed.
+     *  
+     * @param nominalLocation
+     * @throws Exception
+     */
+    public void moveAboveProbingLocation(Location nominalLocation) throws Exception {
+        nominalLocation = nominalLocation.add(new Location(contactProbeStartOffsetZ .getUnits(), 0, 0, contactProbeStartOffsetZ.getValue(), 0));
+        MovableUtils.moveToLocationAtSafeZ(this, nominalLocation);
+    }
+
+    /**
+     * Z-Probe this Nozzle for contact underneath the current location. When forward is true, the nozzle probes 
+     * for contact and stops when contact is made. The current machine position determines the effective contact 
+     * location. When forward is false, the nozzle retracts from probing (if needed).  
+     *   
+     * @param forward
+     *  
+     * @return The probed location.
+     * @throws Exception
+     */
+    public Location contactProbe(boolean forward, Length contactProbeDepthZ) throws Exception {
+        switch (contactProbeMethod) {
+            case VacuumSense: {
+                if (! forward) {
+                    return getLocation();
+                }
+                // Note, we simply use the "part-off" check for sniffle probing, so all the various settings and methods can be used.
+                ReferenceNozzleTip nozzleTip = getNozzleTip();
+                if (nozzleTip == null) {
+                    throw new Exception("Nozzle "+getName()+" cannot sniffle-probe without nozzle tip.");
+                }
+                if (nozzleTip.getMethodPartOff() == VacuumMeasurementMethod.None) {
+                    throw new Exception("Nozzle tip "+nozzleTip.getName()+" cannot sniffle-probe without Part-Off sensing method.");
+                }
+                if (!isVaccumActuatorEnabled()) {
+                    throw new Exception("Nozzle "+getName()+" cannot sniffle-probe without vacuum valve actuator.");
+                }
+                if (getVacuumSenseActuator() == null) {
+                    throw new Exception("Nozzle "+getName()+" cannot sniffle-probe without vacuum sensing actuator.");
+                }
+                if (getPart() != null) {
+                    throw new Exception("Nozzle "+getName()+" cannot sniffle-probe with part on nozzle. Free nozzle vacuum sensing needed.");
+                }
+                AbstractHead head = (AbstractHead) getHead();
+                Location probeIncrement = new Location(sniffleIncrementZ.getUnits(), 
+                        0, 0, sniffleIncrementZ.convertToUnits(LengthUnit.Millimeters).getValue(), 0);
+
+                // Establish initially free nozzle.
+                if (!isPartOff()) {
+                    throw new Exception("Nozzle "+getName()+" first sniffle-probe was already sensing contact. Check the settings."); 
+                }
+                // We allow two times the offset, i.e. it is a +/- range we probe.   
+                int count = (int) Math.ceil(contactProbeDepthZ.divide(sniffleIncrementZ));
+                Location probedLocation = getLocation();
+                for (int i = 0; i < count; i++) {
+                    probedLocation = probedLocation.subtract(probeIncrement);
+                    moveTo(probedLocation);
+                    Thread.sleep(sniffleDwellTime);
+                    if (! isPartOff()) {
+                        // We got contact.
+                        probedLocation = probedLocation.add(new Location(contactProbeAdjustZ .getUnits(), 0, 0, contactProbeAdjustZ.getValue(), 0));
+                        moveTo(probedLocation);
+                        return probedLocation;
+                    }
+                }
+                throw new Exception("Nozzle "+getName()+" sniffle-probing made no contact. Check the settings."); 
+            }
+
+            case ContactSenseActuator: {
+                Actuator contactProbeActuator = getContactProbeActuator();
+                contactProbeActuator.actuate(forward);
+                Location probedLocation = getLocation();
+                if (forward) {
+                    probedLocation = probedLocation.add(new Location(contactProbeAdjustZ .getUnits(), 0, 0, contactProbeAdjustZ.getValue(), 0));
+                    moveTo(probedLocation);
+                }
+                return probedLocation;
+            }
+
+            default:
+                throw new Exception("Nozzle "+getName()+" has contact probing disabled."); 
+        }
+    }
+
+    /**
+     * Performs a whole probing cycle: Moves above the nominalLocation, probes and retracts. 
+     * 
+     * @param nominalLocation
+     * @return
+     * @throws Exception
+     */
+    public Location contactProbeCycle(Location nominalLocation) throws Exception {
+        moveAboveProbingLocation(nominalLocation);
+        Location probedLocation = contactProbe(true, contactProbeDepthZ);
+        contactProbe(false, contactProbeDepthZ);
+        return probedLocation;
+    }
+
+    @Override
+    public void ensureZCalibrated() throws Exception {
+        if (contactProbeMethod == ContactProbeMethod.None) {
+            return;
+        }
+        ReferenceNozzleTip nt = getCalibrationNozzleTip();
+        if (nt == null) {
+            return;
+        }
+        if (nt.getzCalibrationTrigger() == ZCalibrationTrigger.Manual) {
+            return;
+        }
+        if (zCalibratedNozzleTip == nt 
+                || (zCalibratedNozzleTip != null && nt.getzCalibrationTrigger() == ZCalibrationTrigger.MachineHome)) {
+            // Already calibrated.
+            return;
+        }
+        calibrateZ(nt);
+    }
+
+    @Override
+    public Location toHeadLocation(Location location, Location currentLocation, LocationOption... options) {
+        // Apply the Z calibration.
+        // Check SuppressCompensation, in that case disable Z calibration
+        if (! Arrays.asList(options).contains(LocationOption.SuppressDynamicCompensation)) {
+            if (zCalibratedNozzleTip != null && calibrationOffsetZ != null) {
+                location = location.subtract(new Location(calibrationOffsetZ .getUnits(), 0, 0, calibrationOffsetZ.getValue(), 0));
+                Logger.trace("{}.transformToHeadLocation({}, ...) Z offset {}", getName(), location, calibrationOffsetZ);
+            }
+        }
+        return super.toHeadLocation(location, currentLocation, options);
+    }
+
+    @Override
+    public Location toHeadMountableLocation(Location location, Location currentLocation, LocationOption... options) {
+        location = super.toHeadMountableLocation(location, currentLocation, options);
+        // Unapply the Z calibration.
+        // Check SuppressCompensation, in that case disable Z calibration.
+        if (! Arrays.asList(options).contains(LocationOption.SuppressDynamicCompensation)) {
+            if (zCalibratedNozzleTip != null && calibrationOffsetZ != null) {
+                location = location.add(new Location(calibrationOffsetZ .getUnits(), 0, 0, calibrationOffsetZ.getValue(), 0));
+            }
+        }
+        return location;
+    }
+
+    public Length getCalibrationOffsetZ() {
+        return calibrationOffsetZ;
+    }
+
+    public void setCalibrationOffsetZ(Length calibrationOffsetZ) {
+        Object oldValue = this.calibrationOffsetZ;
+        this.calibrationOffsetZ = calibrationOffsetZ;
+        firePropertyChange("calibrationOffsetZ", oldValue, calibrationOffsetZ);
+        if (calibrationOffsetZ != oldValue) {
+            NozzleTip nt = getCalibrationNozzleTip();
+            if (nt instanceof ReferenceNozzleTip) {
+                // Pseudo setter also fires in the name of the nozzle tip.
+                ((ReferenceNozzleTip) nt).setCalibrationOffsetZ(calibrationOffsetZ);
+            }
+            Machine machine = Configuration.get().getMachine();
+            if (machine instanceof ReferenceMachine) {
+                ((ReferenceMachine)machine).fireMachineHeadActivity(getHead());
+            }
+        }
+    }
+
+    public void calibrateZ(ReferenceNozzleTip nt) throws Exception {
+        if (nt != getCalibrationNozzleTip()) {
+            throw new Exception("Nozzle "+getName()+" has not nozzle tip "+nt.getName()+" loaded.");
+        }
+        if (nt == null) {
+            throw new Exception("Nozzle " + getName() + " has no nozzle tip loaded.");
+        }
+        resetZCalibration();
+        Location nominalLocation = nt.getTouchLocation();
+        Location probedLocation = contactProbeCycle(nominalLocation);
+        Length offsetZ = nominalLocation.getLengthZ().subtract(probedLocation.getLengthZ());
+        Logger.debug("Nozzle "+getName()+" nozzle tip "+nt.getName()+" Z calibration offset "+offsetZ);
+        if (Math.abs(offsetZ.convertToUnits(LengthUnit.Millimeters).getValue()) > maxZOffsetMm) {
+            throw new Exception("Nozzle "+getName()+" nozzle tip "+nt.getName()+" Z calibration offset "+offsetZ+" unexpectedly large. Check setup.");
+        }
+        // Remember which nozzle tip for trigger control.
+        zCalibratedNozzleTip = nt;
+        // Establish the new Z calibration.
+        setCalibrationOffsetZ(offsetZ);
+    }
+
+    public void resetZCalibration() {
+        setCalibrationOffsetZ(null);
+        zCalibratedNozzleTip = null;
+    }
+
+    public static void referenceAllTouchLocationsZ() throws Exception {
+        ReferenceNozzleTip templateNozzleTip = ReferenceNozzleTip.getTemplateNozzleTip();
+        if (templateNozzleTip == null) {
+            throw new Exception("No nozzle tip is marked as Template.");
+        }
+        // Always use the default nozzle.
+        ContactProbeNozzle probeNozzle = ContactProbeNozzle.getDefaultNozzle();
+        if (probeNozzle == null) {
+            throw new Exception("No default ContactProbeNozzle found.");
+        }
+        if (probeNozzle.getNozzleTip() != templateNozzleTip) {
+            probeNozzle.loadNozzleTip(templateNozzleTip);
+        }
+        probeNozzle.calibrateZ(templateNozzleTip);
+        for (NozzleTip nt : Configuration.get().getMachine().getNozzleTips()) {
+            if (nt != templateNozzleTip 
+                    && nt instanceof ReferenceNozzleTip) {
+                Location touchLocation = ((ReferenceNozzleTip) nt).getTouchLocation();
+                if (touchLocation.getLinearDistanceTo(Location.origin) != 0
+                        && !((ReferenceNozzleTip) nt).isUnloadedNozzleTipStandin()) {
+                    Location probedLocation = probeNozzle.contactProbeCycle(touchLocation);
+
+                    Logger.info("Nozzle tip "+nt.getName()+" touch location Z set to "+probedLocation.getLengthZ()+" (previously "+touchLocation.getLengthZ()+")");
+                    ((ReferenceNozzleTip) nt).setTouchLocation(probedLocation);
+                }
+            }
+        }
+        probeNozzle.moveToSafeZ();
+    }
+
     @Override
     public void findIssues(List<Solutions.Issue> issues) {
         super.findIssues(issues);
         try {
             if (getContactProbeActuator() instanceof AbstractActuator) {
-                if (!getContactProbeActuator().isCoordinatedAfterActuate()) {
+                AbstractActuator contactProbeActuator = (AbstractActuator) getContactProbeActuator();
+                if (!contactProbeActuator.isCoordinatedAfterActuate()) {
                     issues.add(new Solutions.Issue(
-                            getContactProbeActuator(), 
+                            contactProbeActuator, 
                             "Contact probe actuator needs machine coordination after actuation.", 
                             "Enable After Actuation machine coordination.", 
                             Severity.Error,
@@ -164,7 +689,7 @@ public class ContactProbeNozzle extends ReferenceNozzle {
                         @Override
                         public void setState(Solutions.State state) throws Exception {
                             if (confirmStateChange(state)) {
-                                ((AbstractActuator) getContactProbeActuator()).setCoordinatedAfterActuate((state == Solutions.State.Solved));
+                                contactProbeActuator.setCoordinatedAfterActuate((state == Solutions.State.Solved));
                                 super.setState(state);
                             }
                         }
@@ -172,6 +697,26 @@ public class ContactProbeNozzle extends ReferenceNozzle {
                 }
                 if (getAxisZ() instanceof ControllerAxis) {
                     Driver driver = ((ControllerAxis) getAxisZ()).getDriver();
+                    Driver oldDriver = contactProbeActuator.getDriver();
+                    if (driver != null && driver != oldDriver) {
+                        issues.add(new Solutions.Issue(
+                                this, 
+                                "Z driver "+driver.getName()+" not same as actuator "+contactProbeActuator.getName()+" driver "+
+                                        (oldDriver == null ? "(unassigned)" : oldDriver.getName())+".", 
+                                "Assign driver "+driver.getName()+" to actuator "+contactProbeActuator.getName()+".", 
+                                Severity.Error,
+                                "https://github.com/openpnp/openpnp/wiki/Setup-and-Calibration%3A-Actuators#adding-actuators") {
+
+                            @Override
+                            public void setState(Solutions.State state) throws Exception {
+                                if (confirmStateChange(state)) {
+                                    contactProbeActuator.setDriver((state == Solutions.State.Solved) ?
+                                            driver : oldDriver);
+                                    super.setState(state);
+                                }
+                            }
+                        });
+                    }
                     if (driver instanceof GcodeAsyncDriver) {
                         if (!((GcodeAsyncDriver) driver).isReportedLocationConfirmation()) { 
                             issues.add(new Solutions.Issue(
@@ -200,10 +745,173 @@ public class ContactProbeNozzle extends ReferenceNozzle {
                                 "https://github.com/openpnp/openpnp/wiki/GcodeAsyncDriver#advanced-settings"));
                     }
                 }
+                if (contactProbeActuator.getDriver() instanceof GcodeDriver) {
+                    GcodeDriver gcodeDriver = (GcodeDriver) contactProbeActuator.getDriver();
+                    String suggestedCommand = null; 
+                    if (gcodeDriver.getFirmwareProperty("FIRMWARE_NAME", "").contains("Smoothieware")) {
+                        suggestedCommand = 
+                                "{True:G38.2 Z-42 F800 ; probe down max. range for contact with picked/placed part }\n" + 
+                                "{True:M400            ; wait until machine has stopped }\n";
+                    }
+                    else if (gcodeDriver.getFirmwareProperty("FIRMWARE_NAME", "").contains("TinyG")) {
+                        suggestedCommand = 
+                                "{True:G38.2 Z-42 F800 ; probe down in absolute coordinates until zmin switch is hit}\n" + 
+                                "{True:M400            ; wait for motion to stop}\n";
+                    }
+                    if (suggestedCommand != null) {
+                        GcodeDriverSolutions.suggestGcodeCommand(gcodeDriver, contactProbeActuator, issues, 
+                                GcodeDriver.CommandType.ACTUATE_BOOLEAN_COMMAND, suggestedCommand, false, false);
+                    }
+                    else {
+                        issues.add(new Solutions.PlainIssue(
+                                this, 
+                                "Missing ACTUATE_BOOLEAN_COMMAND for actuator "+contactProbeActuator.getName()+" on driver "+gcodeDriver.getName()+" (no suggestion available for detected firmware).", 
+                                "Please add the command manually.",
+                                Severity.Error,
+                                "https://github.com/openpnp/openpnp/wiki/Contact-Probing-Nozzle#setting-up-the-g-code"));
+                    }
+                }
             }
         }
         catch (Exception e) {
-            // Ignore a stale Actuator name here.
+            // Ignore a stale or missing Actuator name here.
+        }
+    }
+
+    protected boolean isPartHeightSensingAvailable(Part part, NozzleTip nozzleTip) {
+        Machine machine = Configuration.get().getMachine();
+        if (part != null && AbstractPnpJobProcessor.findPartAligner(machine, part) != null) {
+            // Uses Alignment, so it also needs a vision based method.
+            Camera camera;
+            try {
+                camera = VisionUtils.getBottomVisionCamera();
+                return (camera.getFocusProvider() != null);
+            }
+            catch (Exception e) {
+            }
+            return false;
+        }
+        else {
+            // It must support a placement height probing method.
+            return (getContactProbeMethod()
+                    .isPlacementCompatible());
+        }
+    }
+
+    @Override
+    protected boolean isNozzleTipAndPartCompatible(NozzleTip nt, Part part) {
+        if (! super.isNozzleTipAndPartCompatible(nt, part)) {
+            return false;
+        }
+        if (part.getHeight().getValue() <= 0) {
+            // Part height unknown, part height sensing needed.
+            if (! isPartHeightSensingAvailable(part, nt)) {
+                return false;
+            }
+        }
+        return true; 
+    }
+
+    public static ContactProbeNozzle getDefaultNozzle() {
+        Machine machine = Configuration.get().getMachine();
+        for (Head head : machine.getHeads()) {
+            for (Nozzle nozzle : head.getNozzles()) {
+                if (nozzle instanceof ContactProbeNozzle) {
+                    if (((ContactProbeNozzle) nozzle).getContactProbeMethod() != ContactProbeMethod.None) {
+                        return (ContactProbeNozzle) nozzle;
+                    }
+                }
+            }
+        }
+        return null;
+    }
+    public static boolean isConfigured() {
+        return getDefaultNozzle() != null;
+    }
+    public static void addConversionIssue(List<Issue> issues, final ReferenceNozzle nozzle) {
+        if (! (nozzle instanceof ContactProbeNozzle)) {
+            issues.add(new Solutions.Issue(
+                    nozzle, 
+                    "The nozzle can be replaced with a ContactProbeNozzle to support various probing features.", 
+                    "Replace with ContactProbeNozzle.", 
+                    Severity.Fundamental,
+                    "https://github.com/openpnp/openpnp/wiki/Contact-Probing-Nozzle") {
+
+                @Override
+                public void setState(Solutions.State state) throws Exception {
+                    if (confirmStateChange(state)) {
+                        if (state == Solutions.State.Solved) {
+                            ContactProbeNozzle contactProbeNozzle = convertToContactProbe(nozzle);
+                            replaceNozzle(contactProbeNozzle);
+                        }
+                        else if (getState() == Solutions.State.Solved) {
+                            // Place the old one back (from the captured ImageCamera.this).
+                            replaceNozzle(nozzle);
+                        }
+                        super.setState(state);
+                    }
+                }
+            });
+        }
+    }
+
+    private static Serializer createSerializer() {
+        Style style = new HyphenStyle();
+        Format format = new Format(style);
+        AnnotationStrategy strategy = new AnnotationStrategy();
+        Serializer serializer = new Persister(strategy, format);
+        return serializer;
+    }
+
+    /**
+     * Convert an existing ReferenceNozzle to a ContactProbeNozzle while keeping all settings.
+     * 
+     * @param nozzle
+     * @return
+     * @throws Exception
+     */
+    public static ContactProbeNozzle convertToContactProbe(ReferenceNozzle nozzle) throws Exception {
+        // Serialize the nozzle
+        Serializer serOut = createSerializer();
+        StringWriter sw = new StringWriter();
+        serOut.write(nozzle, sw);
+        String serialized = sw.toString();
+        // Patch it.
+        serialized.replace(
+                nozzle.getClass().getCanonicalName(), 
+                ContactProbeNozzle.class.getCanonicalName());
+        // De-serialize it.
+        Serializer serIn = createSerializer();
+        StringReader sr = new StringReader(serialized);
+        ContactProbeNozzle contactProbeNozzle = serIn.read(ContactProbeNozzle.class, sr);
+        contactProbeNozzle.applyConfiguration(Configuration.get());
+        contactProbeNozzle.setHead(nozzle.getHead());
+        return contactProbeNozzle;
+    }
+
+    /**
+     * Replace a nozzle with the same Id at the same place in the head nozzles list.
+     * 
+     * @param nozzle
+     * @throws Exception
+     */
+    public static void replaceNozzle(Nozzle nozzle) throws Exception {
+        // Find the old nozzle with the same Id.
+        List<Nozzle> list = nozzle.getHead().getNozzles();
+        Nozzle replaced = null;
+        int index;
+        for (index = 0; index < list.size(); index++) {
+            if (list.get(index).getId().equals(nozzle.getId())) {
+                replaced = list.get(index);
+                nozzle.getHead().removeNozzle(replaced);
+                break;
+            }
+        }
+        // Add the new one.
+        nozzle.getHead().addNozzle(nozzle);
+        // Permutate it back to the old list place (cumbersome but works).
+        for (int p = list.size()-index; p > 1; p--) {
+            nozzle.getHead().permutateNozzle(nozzle, -1);
         }
     }
 }

--- a/src/main/java/org/openpnp/machine/reference/ReferenceHead.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceHead.java
@@ -53,9 +53,18 @@ public class ReferenceHead extends AbstractHead {
 
     @Override
     public void home() throws Exception {
+        // Note, don't call super.home() yet, need to do visual homing first.
         Logger.debug("{}.home()", getName());
+        ReferenceMachine machine = getMachine();
 
-        // Note, don't call super.home() yet, need to do the physical homing first.
+        visualHome(machine, true);
+
+        super.home();
+        // Let everybody know.
+        getMachine().fireMachineHeadActivity(this);
+    }
+
+    public void visualHome(ReferenceMachine machine, boolean apply) throws Exception {
         if (getVisualHomingMethod() != VisualHomingMethod.None) {
             /*
              * The head default camera should now be (if everything has homed correctly) directly
@@ -75,27 +84,24 @@ public class ReferenceHead extends AbstractHead {
                 throw new Exception("Visual homing failed");
             }
 
-            ReferenceMachine machine = getMachine();
-            AxesLocation axesHomingLocation;
-            if (getVisualHomingMethod() == VisualHomingMethod.ResetToFiducialLocation) {
-                // Convert fiducial location to raw coordinates
-                // TODO: are you sure the toHeadLocation() is needed?
-                axesHomingLocation = hm.toRaw(hm.toHeadLocation(getHomingFiducialLocation()));
+            if (apply) {
+                AxesLocation axesHomingLocation;
+                if (getVisualHomingMethod() == VisualHomingMethod.ResetToFiducialLocation) {
+                    // Convert fiducial location to raw coordinates
+                    // TODO: are you sure the toHeadLocation() is needed?
+                    axesHomingLocation = hm.toRaw(hm.toHeadLocation(getHomingFiducialLocation()));
+                }
+                else {
+                    // Use bare X, Y homing coordinates (legacy mode).
+                    axesHomingLocation =  new AxesLocation(machine, 
+                            (axis) -> (axis.getHomeCoordinate())); 
+                }
+                // Just take the X and Y axes.
+                axesHomingLocation = axesHomingLocation.byType(Axis.Type.X, Axis.Type.Y); 
+                // Reset to the homing fiducial location as the new Working Coordinate System.
+                machine.getMotionPlanner().setGlobalOffsets(axesHomingLocation);
             }
-            else {
-                // Use bare X, Y homing coordinates (legacy mode).
-                axesHomingLocation =  new AxesLocation(machine, 
-                        (axis) -> (axis.getHomeCoordinate())); 
-            }
-            // Just take the X and Y axes.
-            axesHomingLocation = axesHomingLocation.byType(Axis.Type.X, Axis.Type.Y); 
-            // Reset to the homing fiducial location as the new Working Coordinate System.
-            machine.getMotionPlanner().setGlobalOffsets(axesHomingLocation);
         }
-        // Now that the machine is physically homed, do the logical homing.
-        super.home();
-        // Let everybody know.
-        getMachine().fireMachineHeadActivity(this);
     }
 
     @Override

--- a/src/main/java/org/openpnp/machine/reference/ReferenceNozzle.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceNozzle.java
@@ -1,7 +1,9 @@
 package org.openpnp.machine.reference;
 
 import java.awt.event.ActionEvent;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import javax.swing.AbstractAction;
@@ -26,10 +28,11 @@ import org.openpnp.model.Length;
 import org.openpnp.model.LengthUnit;
 import org.openpnp.model.Location;
 import org.openpnp.model.Part;
+import org.openpnp.model.Solutions;
 import org.openpnp.spi.Actuator;
-import org.openpnp.spi.Actuator.ActuatorValueType;
 import org.openpnp.spi.Camera;
 import org.openpnp.spi.CoordinateAxis;
+import org.openpnp.spi.Feeder;
 import org.openpnp.spi.Nozzle;
 import org.openpnp.spi.NozzleTip;
 import org.openpnp.spi.PropertySheetHolder;
@@ -37,10 +40,10 @@ import org.openpnp.spi.base.AbstractActuator;
 import org.openpnp.spi.base.AbstractNozzle;
 import org.openpnp.util.MovableUtils;
 import org.openpnp.util.SimpleGraph;
+import org.openpnp.util.UiUtils;
 import org.pmw.tinylog.Logger;
 import org.simpleframework.xml.Attribute;
 import org.simpleframework.xml.Element;
-import org.simpleframework.xml.core.Commit;
 
 public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMountable {
     @Element
@@ -127,8 +130,8 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
                     }
                     if (blowOffActuator != null) {
                         // Type both the vacuum and the blow off actuators as Double (typical use).
-                        AbstractActuator.suggestValueType(vacuumActuator, ActuatorValueType.Double);
-                        AbstractActuator.suggestValueType(blowOffActuator, ActuatorValueType.Double);
+                        AbstractActuator.suggestValueType(vacuumActuator, Actuator.ActuatorValueType.Double);
+                        AbstractActuator.suggestValueType(blowOffActuator, Actuator.ActuatorValueType.Double);
                     }
                     // Migration is done.
                     version = 200;
@@ -199,11 +202,15 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
 
     @Override
     public void setHeadOffsets(Location headOffsets) {
-        Object oldValue = this.headOffsets;
+        Location oldValue = this.headOffsets;
         this.headOffsets = headOffsets;
         firePropertyChange("headOffsets", oldValue, headOffsets);
-        // Changing a head offset invalidates the nozzle tip calibration.
-        ReferenceNozzleTipCalibration.resetAllNozzleTips();
+        oldValue = oldValue.convertToUnits(LengthUnit.Millimeters);
+        if (Math.abs(oldValue.getLengthX().subtract(headOffsets.getLengthX()).getValue()) > 0.01
+                || Math.abs(oldValue.getLengthY().subtract(headOffsets.getLengthY()).getValue()) > 0.01) {
+            // Changing a X, Y head offset invalidates the nozzle tip calibration. Just changing Z leaves it intact. 
+            ReferenceNozzleTipCalibration.resetAllNozzleTips();
+        }
     }
 
     public String getVacuumSenseActuatorName() {
@@ -255,6 +262,18 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
     }
 
     @Override
+    public void moveToPickLocation(Feeder feeder) throws Exception {
+        // The default ReferenceNozzle implementation just moves to the feeder part pickLocation at safe Z.
+        // But see Overrides such ContactProbeNozzle.
+        Location pickLocation = feeder.getPickLocation();
+        if (feeder.isPartHeightAbovePickLocation()) {
+            Length partHeight = getSafePartHeight(feeder.getPart());
+            pickLocation = pickLocation.add(new Location(partHeight.getUnits(), 0, 0, partHeight.getValue(), 0));
+        }
+        MovableUtils.moveToLocationAtSafeZ(this, pickLocation);
+    }
+
+    @Override
     public void pick(Part part) throws Exception {
         Logger.debug("{}.pick()", getName());
         if (part == null) {
@@ -301,6 +320,13 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
         catch (Exception e) {
             Logger.warn(e);
         }
+    }
+
+    @Override
+    public void moveToPlacementLocation(Location placementLocation, Part part) throws Exception {
+        // The default ReferenceNozzle implementation just moves to the placementLocation + partHeight at safe Z.
+        MovableUtils.moveToLocationAtSafeZ(this, placementLocation
+                .add(new Location(part.getHeight().getUnits(), 0, 0, part.getHeight().getValue(), 0)));
     }
 
     @Override
@@ -410,42 +436,46 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
 
     @Override
     public Location toHeadLocation(Location location, Location currentLocation, LocationOption... options) {
-        location = super.toHeadLocation(location, currentLocation);
         // Apply runout compensation.
-        ReferenceNozzleTip calibrationNozzleTip = getCalibrationNozzleTip();
-        // check if totally raw move, in that case disable nozzle calibration
-        for (LocationOption option: options) {
-            if (option == LocationOption.SuppressDynamicCompensation) {
-                calibrationNozzleTip = null;
+        // Check SuppressCompensation, in that case disable nozzle calibration
+        if (! Arrays.asList(options).contains(LocationOption.SuppressDynamicCompensation)) {
+            ReferenceNozzleTip calibrationNozzleTip = getCalibrationNozzleTip();
+            if (calibrationNozzleTip != null && calibrationNozzleTip.getCalibration().isCalibrated(this)) {
+                Location correctionOffset = calibrationNozzleTip.getCalibration().getCalibratedOffset(this, location.getRotation());
+                location = location.subtract(correctionOffset);
+                Logger.trace("{}.transformToHeadLocation({}, ...) runout compensation {}", getName(), location, correctionOffset);
             }
         }
-        if (calibrationNozzleTip != null && calibrationNozzleTip.getCalibration().isCalibrated(this)) {
-            Location correctionOffset = calibrationNozzleTip.getCalibration().getCalibratedOffset(this, location.getRotation());
-            location = location.subtract(correctionOffset);
-            Logger.trace("{}.transformToHeadLocation({}, ...) runout compensation: {}", getName(), location, correctionOffset);
-        } else {
-            Logger.trace("{}.transformToHeadLocation({}, ...)", getName(), location);
+        return super.toHeadLocation(location, currentLocation, options);
+    }
+
+    @Override
+    public Location toHeadMountableLocation(Location location, Location currentLocation, LocationOption... options) {
+        location = super.toHeadMountableLocation(location, currentLocation, options);
+        // Unapply runout compensation.
+        // Check SuppressCompensation, in that case disable nozzle calibration.
+        if (! Arrays.asList(options).contains(LocationOption.SuppressDynamicCompensation)) {
+            ReferenceNozzleTip calibrationNozzleTip = getCalibrationNozzleTip();
+            if (calibrationNozzleTip != null && calibrationNozzleTip.getCalibration().isCalibrated(this)) {
+                Location offset =
+                        calibrationNozzleTip.getCalibration().getCalibratedOffset(this, location.getRotation());
+                location = location.add(offset);
+            }
         }
         return location;
     }
 
     @Override
-    public Location toHeadMountableLocation(Location location, Location currentLocation, LocationOption... options) {
-        location = super.toHeadMountableLocation(location, currentLocation);
-        // Unapply runout compensation.
-        ReferenceNozzleTip calibrationNozzleTip = getCalibrationNozzleTip();
-        // Check SuppressCompensation, in that case disable nozzle calibration.
-        for (LocationOption option: options) {
-            if (option == LocationOption.SuppressDynamicCompensation) {
-                calibrationNozzleTip = null;
+    public Length getSafePartHeight(Part part) {
+        if (part != null) {
+            if (part.isPartHeightUnknown() && nozzleTip != null) {
+                return nozzleTip.getMaxPartHeight();
+            }
+            else {
+                return part.getHeight();
             }
         }
-        if (calibrationNozzleTip != null && calibrationNozzleTip.getCalibration().isCalibrated(this)) {
-            Location offset =
-                    calibrationNozzleTip.getCalibration().getCalibratedOffset(this, location.getRotation());
-            location = location.add(offset);
-        }
-        return location;
+        return new Length(0, LengthUnit.Millimeters);
     }
 
     @Override 
@@ -456,11 +486,9 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
         }
         if (enableDynamicSafeZ) { 
             // if a part is loaded, decrease (higher) safeZ
-            if (getPart() != null) {
-                safeZ = safeZ.add(getPart().getHeight());
-                // Note, the safeZ value will be validated in moveToSafeZ()
-                // to make sure it is not outside the Safe Z Zone.
-            }
+            safeZ = safeZ.add(getSafePartHeight());
+            // Note, the safeZ value will be validated in moveToSafeZ()
+            // to make sure it is not outside the Safe Z Zone.
         }
         return safeZ;
     }
@@ -474,8 +502,20 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
                 if (calibrationNozzleTip.getCalibration().isRecalibrateOnHomeNeeded(this)) {
                     if (calibrationNozzleTip == this.getCalibrationNozzleTip()) {
                         // The currently mounted nozzle tip.
-                        Logger.debug("{}.home() nozzle tip {} calibration neeeded", getName(), calibrationNozzleTip.getName());
-                        calibrationNozzleTip.getCalibration().calibrate(this, true, false);
+                        try {
+                            Logger.debug("{}.home() nozzle tip {} calibration neeeded", getName(), calibrationNozzleTip.getName());
+                            calibrationNozzleTip.getCalibration().calibrate(this, true, false);
+                        }
+                        catch (Exception e) {
+                            if (calibrationNozzleTip.getCalibration().isFailHoming()) {
+                                throw e; 
+                            }
+                            else {
+                                UiUtils.messageBoxOnExceptionLater(() -> {
+                                    throw e;
+                                });
+                            }
+                        }
                     }
                     else {
                         // Not currently mounted so just reset.
@@ -531,9 +571,11 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
                     Logger.warn(e);
                 }
 
+                ensureZCalibrated();
+
                 Logger.debug("{}.loadNozzleTip({}): moveTo Start Location",
                         new Object[] {getName(), nozzleTip.getName()});
-                MovableUtils.moveToLocationAtSafeZ(this, nt.getChangerStartLocation(), speed);
+                MovableUtils.moveToLocationAtSafeZ(this, nt.getChangerStartLocationCalibrated(true), speed);
 
                 if (tcPostOneActuator != null) {
                     tcPostOneActuator.actuate(true);
@@ -541,7 +583,7 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
 
                 Logger.debug("{}.loadNozzleTip({}): moveTo Mid Location",
                         new Object[] {getName(), nozzleTip.getName()});
-                moveTo(nt.getChangerMidLocation(), nt.getChangerStartToMidSpeed() * speed);
+                moveTo(nt.getChangerMidLocationCalibrated(false), nt.getChangerStartToMidSpeed() * speed);
 
                 if (tcPostTwoActuator !=null) {
                     tcPostTwoActuator.actuate(true);
@@ -549,7 +591,7 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
 
                 Logger.debug("{}.loadNozzleTip({}): moveTo Mid Location 2",
                         new Object[] {getName(), nozzleTip.getName()});
-                moveTo(nt.getChangerMidLocation2(), nt.getChangerMidToMid2Speed() * speed);
+                moveTo(nt.getChangerMidLocation2Calibrated(false), nt.getChangerMidToMid2Speed() * speed);
 
                 if (tcPostThreeActuator !=null) {
                     tcPostThreeActuator.actuate(true);
@@ -557,7 +599,7 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
 
                 Logger.debug("{}.loadNozzleTip({}): moveTo End Location",
                         new Object[] {getName(), nozzleTip.getName()});
-                moveTo(nt.getChangerEndLocation(), nt.getChangerMid2ToEndSpeed() * speed);
+                moveTo(nt.getChangerEndLocationCalibrated(false), nt.getChangerMid2ToEndSpeed() * speed);
                 moveToSafeZ(getHead().getMachine().getSpeed());
 
                 Logger.debug("{}.loadNozzleTip({}): Finished",
@@ -589,6 +631,8 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
         currentNozzleTipId = nozzleTip.getId();
         firePropertyChange("nozzleTip", null, getNozzleTip());
         ((ReferenceMachine) head.getMachine()).fireMachineHeadActivity(head);
+
+        ensureZCalibrated();
 
         if (!nt.isUnloadedNozzleTipStandin()) {
             if (!changerEnabled) {
@@ -646,29 +690,31 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
             double speed = getHead().getMachine().getSpeed();
 
             if (changerEnabled) {
+                ensureZCalibrated();
+
                 Logger.debug("{}.unloadNozzleTip(): moveTo End Location", getName());
-                MovableUtils.moveToLocationAtSafeZ(this, nt.getChangerEndLocation(), speed);
+                MovableUtils.moveToLocationAtSafeZ(this, nt.getChangerEndLocationCalibrated(true), speed);
 
                 if (tcPostThreeActuator !=null) {
                     tcPostThreeActuator.actuate(true);
                 }
 
                 Logger.debug("{}.unloadNozzleTip(): moveTo Mid Location 2", getName());
-                moveTo(nt.getChangerMidLocation2(), nt.getChangerMid2ToEndSpeed() * speed);
+                moveTo(nt.getChangerMidLocation2Calibrated(false), nt.getChangerMid2ToEndSpeed() * speed);
 
                 if (tcPostTwoActuator !=null) {
                     tcPostTwoActuator.actuate(true);
                 }
 
                 Logger.debug("{}.unloadNozzleTip(): moveTo Mid Location", getName());
-                moveTo(nt.getChangerMidLocation(), nt.getChangerMidToMid2Speed() * speed);
+                moveTo(nt.getChangerMidLocationCalibrated(false), nt.getChangerMidToMid2Speed() * speed);
 
                 if (tcPostOneActuator != null) {
                     tcPostOneActuator.actuate(true);
                 }
 
                 Logger.debug("{}.unloadNozzleTip(): moveTo Start Location", getName());
-                moveTo(nt.getChangerStartLocation(), nt.getChangerStartToMidSpeed() * speed);
+                moveTo(nt.getChangerStartLocationCalibrated(false), nt.getChangerStartToMidSpeed() * speed);
                 moveToSafeZ(getHead().getMachine().getSpeed());
 
                 Logger.debug("{}.unloadNozzleTip(): Finished", getName());
@@ -701,6 +747,9 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
         if (!changerEnabled) {
             throw new Exception("Manual NozzleTip "+nt.getName()+" unload from Nozzle "+getName()+" required!");
         }
+
+        ensureZCalibrated();
+
         // May need to calibrate the "unloaded" nozzle tip stand-in i.e. the naked nozzle tip holder. 
         ReferenceNozzleTip calibrationNozzleTip = this.getCalibrationNozzleTip();
         if (calibrationNozzleTip != null && calibrationNozzleTip.getCalibration().isRecalibrateOnNozzleTipChangeNeeded(this)) {
@@ -726,6 +775,8 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
     public void setChangerEnabled(boolean changerEnabled) {
         this.changerEnabled = changerEnabled;
     }
+
+    protected void ensureZCalibrated() throws Exception {}
 
     @Override
     public Wizard getConfigurationWizard() {
@@ -1180,6 +1231,11 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
         return true;
     }
 
+    @Override
+    public void findIssues(List<Solutions.Issue> issues) {
+        super.findIssues(issues);
+        ContactProbeNozzle.addConversionIssue(issues, this);
+    }
     @Deprecated
     public void migrateSafeZ() {
         if (safeZ == null) {

--- a/src/main/java/org/openpnp/machine/reference/ReferenceNozzleTip.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceNozzleTip.java
@@ -2,8 +2,21 @@ package org.openpnp.machine.reference;
 
 import java.awt.Color;
 import java.awt.event.ActionEvent;
-import javax.swing.*;
+import java.awt.image.BufferedImage;
+import java.io.File;
 
+import javax.imageio.ImageIO;
+import javax.swing.AbstractAction;
+import javax.swing.Action;
+import javax.swing.JOptionPane;
+import javax.swing.UIManager;
+
+import org.opencv.core.Core;
+import org.opencv.core.Core.MinMaxLocResult;
+import org.opencv.core.Mat;
+import org.opencv.core.Rect;
+import org.opencv.imgcodecs.Imgcodecs;
+import org.opencv.imgproc.Imgproc;
 import org.openpnp.ConfigurationListener;
 import org.openpnp.gui.MainFrame;
 import org.openpnp.gui.support.Icons;
@@ -17,13 +30,19 @@ import org.openpnp.model.Configuration;
 import org.openpnp.model.Length;
 import org.openpnp.model.LengthUnit;
 import org.openpnp.model.Location;
+import org.openpnp.spi.Camera;
 import org.openpnp.spi.Head;
 import org.openpnp.spi.Nozzle;
+import org.openpnp.spi.NozzleTip;
 import org.openpnp.spi.PropertySheetHolder;
 import org.openpnp.spi.base.AbstractNozzleTip;
+import org.openpnp.util.ImageUtils;
+import org.openpnp.util.LogUtils;
 import org.openpnp.util.MovableUtils;
+import org.openpnp.util.OpenCvUtils;
 import org.openpnp.util.SimpleGraph;
 import org.openpnp.util.UiUtils;
+import org.openpnp.vision.TemplateImage;
 import org.pmw.tinylog.Logger;
 import org.simpleframework.xml.Attribute;
 import org.simpleframework.xml.Element;
@@ -41,23 +60,108 @@ public class ReferenceNozzleTip extends AbstractNozzleTip {
 
     @Element(required = false)
     private double changerStartToMidSpeed = 1D;
-    
+
     @Element(required = false)
     private Location changerMidLocation = new Location(LengthUnit.Millimeters);
-    
+
     @Element(required = false)
     private double changerMidToMid2Speed = 1D;
-    
+
     @Element(required = false)
     private Location changerMidLocation2 = new Location(LengthUnit.Millimeters);
-    
+
     @Element(required = false)
     private double changerMid2ToEndSpeed = 1D;
-    
+
     @Element(required = false)
     private Location changerEndLocation = new Location(LengthUnit.Millimeters);
+
+    @Element(required = false)
+    private Location touchLocation = new Location(LengthUnit.Millimeters);
+
+    public enum VisionCalibration {
+        None, FirstLocation, SecondLocation, ThirdLocation, LastLocation, TouchLocation;
+
+        public Location getLocation(ReferenceNozzleTip nt) {
+            switch (this) {
+                case None:
+                    return null;
+                case FirstLocation:
+                    return nt.getChangerStartLocation();
+                case SecondLocation:
+                    return nt.getChangerMidLocation();
+                case ThirdLocation:
+                    return nt.getChangerMidLocation2();
+                case LastLocation:
+                    return nt.getChangerEndLocation();
+                case TouchLocation:
+                    return nt.getTouchLocation();
+            }
+            return null;
+        }
+    }
+
+    @Attribute(required = false)
+    private VisionCalibration visionCalibration = VisionCalibration.None;
     
-    
+    public enum VisionCalibrationTrigger {
+        Manual, MachineHome, NozzleTipChange
+    }
+
+    @Attribute(required = false)
+    VisionCalibrationTrigger visionCalibrationTrigger = VisionCalibrationTrigger.Manual;
+
+    @Element(required = false)
+    private Length visionTemplateDimensionX = new Length(10, LengthUnit.Millimeters);
+
+    @Element(required = false)
+    private Length visionTemplateDimensionY = new Length(10, LengthUnit.Millimeters);
+
+    @Attribute(required = false)
+    private double visionMatchMinimumScore = 0.2;
+
+    private Double visionMatchLastScore = null;
+
+    @Element(required = false)
+    private Length visionTemplateTolerance = new Length(4, LengthUnit.Millimeters);
+
+    @Attribute(required = false)
+    private int visionCalibrationMaxPasses = 3; 
+
+    @Element(required = false)
+    private Length visionCalibrationTolerance = new Length(0.7, LengthUnit.Millimeters); 
+
+    @Element(required = false)
+    private TemplateImage visionTemplateImageEmpty = null;
+
+    @Element(required = false)
+    private TemplateImage visionTemplateImageOccupied = null;
+
+    @Element(required = false)
+    private Location visionCalibrationOffset;
+
+    public enum ZCalibrationTrigger {
+        Manual, MachineHome, NozzleTipChange
+    }
+
+    @Attribute(required = false)
+    private ZCalibrationTrigger zCalibrationTrigger = ZCalibrationTrigger.Manual;
+
+    @Attribute(required = false)
+    private boolean zCalibrationFailHoming = true;
+
+    @Attribute(required = false)
+    private boolean templateNozzleTip = false;
+
+    @Attribute(required = false)
+    private boolean templateLocked = false;
+
+    @Element(required = false)
+    private Length maxPartDiameter = new Length(20, LengthUnit.Millimeters);
+
+    @Element(required = false)
+    private Length maxPartHeight = new Length(10, LengthUnit.Millimeters);
+
     @Element(required = false)
     private ReferenceNozzleTipCalibration calibration = new ReferenceNozzleTipCalibration();
 
@@ -228,6 +332,22 @@ public class ReferenceNozzleTip extends AbstractNozzleTip {
                 };
     }
 
+    public Length getMaxPartHeight() {
+        return maxPartHeight;
+    }
+
+    public void setMaxPartHeight(Length maxPartHeight) {
+        this.maxPartHeight = maxPartHeight;
+    }
+
+    public Length getMaxPartDiameter() {
+        return maxPartDiameter;
+    }
+
+    public void setMaxPartDiameter(Length maxPartDiameter) {
+        this.maxPartDiameter = maxPartDiameter;
+    }
+
     public int getPickDwellMilliseconds() {
         return pickDwellMilliseconds;
     }
@@ -344,6 +464,16 @@ public class ReferenceNozzleTip extends AbstractNozzleTip {
         firePropertyChange("changerActuatorPostStepThree", oldValue, changerActuatorPostStepThree);
     }
 
+    public VisionCalibrationTrigger getVisionCalibrationTrigger() {
+        return visionCalibrationTrigger;
+    }
+
+    public void setVisionCalibrationTrigger(VisionCalibrationTrigger visionCalibrationTrigger) {
+        Object oldValue = this.visionCalibrationTrigger;
+        this.visionCalibrationTrigger = visionCalibrationTrigger;
+        firePropertyChange("visionCalibrationTrigger", oldValue, visionCalibrationTrigger);
+    }
+
     public ReferenceNozzle getNozzleAttachedTo() {
         for (Head head : Configuration.get().getMachine().getHeads()) {
             for (Nozzle nozzle : head.getNozzles()) {
@@ -358,6 +488,180 @@ public class ReferenceNozzleTip extends AbstractNozzleTip {
             }
         }
         return null;
+    }
+
+    public Location getTouchLocation() {
+        return touchLocation;
+    }
+
+    public void setTouchLocation(Location touchLocation) {
+        Object oldValue = this.touchLocation;
+        this.touchLocation = touchLocation;
+        firePropertyChange("touchLocation", oldValue, touchLocation);
+    }
+
+    public VisionCalibration getVisionCalibration() {
+        return visionCalibration;
+    }
+
+    public void setVisionCalibration(VisionCalibration visionCalibration) {
+        Object oldValue = this.visionCalibration;
+        this.visionCalibration = visionCalibration;
+        firePropertyChange("visionCalibration", oldValue, visionCalibration);
+    }
+
+    public Length getVisionTemplateDimensionX() {
+        return visionTemplateDimensionX;
+    }
+
+    public void setVisionTemplateDimensionX(Length visionTemplateDimensionX) {
+        Object oldValue = this.visionTemplateDimensionX;
+        this.visionTemplateDimensionX = visionTemplateDimensionX;
+        firePropertyChange("visionTemplateDimensionX", oldValue, visionTemplateDimensionX);
+    }
+
+    public Length getVisionTemplateDimensionY() {
+        return visionTemplateDimensionY;
+    }
+
+    public void setVisionTemplateDimensionY(Length visionTemplateDimensionY) {
+        Object oldValue = this.visionTemplateDimensionY;
+        this.visionTemplateDimensionY = visionTemplateDimensionY;
+        firePropertyChange("visionTemplateDimensionY", oldValue, visionTemplateDimensionY);
+    }
+
+    public double getVisionMatchMinimumScore() {
+        return visionMatchMinimumScore;
+    }
+
+    public void setVisionMatchMinimumScore(double visionMatchMinimumScore) {
+        Object oldValue = this.visionMatchMinimumScore;
+        this.visionMatchMinimumScore = visionMatchMinimumScore;
+        firePropertyChange("visionMatchMinimumScore", oldValue, visionMatchMinimumScore);
+    }
+
+    public Double getVisionMatchLastScore() {
+        return visionMatchLastScore;
+    }
+
+    public void setVisionMatchLastScore(Double visionMatchLastScore) {
+        Object oldValue = this.visionMatchLastScore;
+        this.visionMatchLastScore = visionMatchLastScore;
+        firePropertyChange("visionMatchLastScore", oldValue, visionMatchLastScore);
+    }
+
+    public Length getVisionTemplateTolerance() {
+        return visionTemplateTolerance;
+    }
+
+    public void setVisionTemplateTolerance(Length visionTemplateTolerance) {
+        Object oldValue = this.visionTemplateTolerance;
+        this.visionTemplateTolerance = visionTemplateTolerance;
+        firePropertyChange("visionTemplateTolerance", oldValue, visionTemplateTolerance);
+    }
+
+    public int getVisionCalibrationMaxPasses() {
+        return visionCalibrationMaxPasses;
+    }
+
+    public void setVisionCalibrationMaxPasses(int visionCalibrationMaxPasses) {
+        Object oldValue = this.visionCalibrationMaxPasses;
+        this.visionCalibrationMaxPasses = visionCalibrationMaxPasses;
+        firePropertyChange("visionCalibrationMaxPasses", oldValue, visionCalibrationMaxPasses);
+    }
+
+    public Length getVisionCalibrationTolerance() {
+        return visionCalibrationTolerance;
+    }
+
+    public void setVisionCalibrationTolerance(Length visionCalibrationTolerance) {
+        Object oldValue = this.visionCalibrationTolerance;
+        this.visionCalibrationTolerance = visionCalibrationTolerance;
+        firePropertyChange("visionCalibrationTolerance", oldValue, visionCalibrationTolerance);
+    }
+
+    public TemplateImage getVisionTemplateImageEmpty() {
+        return visionTemplateImageEmpty;
+    }
+
+    public void setVisionTemplateImageEmpty(TemplateImage visionTemplateImageEmpty) {
+        Object oldValue = this.visionTemplateImageEmpty;
+        this.visionTemplateImageEmpty = visionTemplateImageEmpty;
+        firePropertyChange("visionTemplateImageEmpty", oldValue, visionTemplateImageEmpty);
+    }
+
+    public TemplateImage getVisionTemplateImageOccupied() {
+        return visionTemplateImageOccupied;
+    }
+
+    public void setVisionTemplateImageOccupied(TemplateImage visionTemplateImageOccupied) {
+        Object oldValue = this.visionTemplateImageOccupied;
+        this.visionTemplateImageOccupied = visionTemplateImageOccupied;
+        firePropertyChange("visionTemplateImageOccupied", oldValue, visionTemplateImageOccupied);
+    }
+
+    public ZCalibrationTrigger getzCalibrationTrigger() {
+        return zCalibrationTrigger;
+    }
+
+    public void setzCalibrationTrigger(ZCalibrationTrigger zCalibrationTrigger) {
+        Object oldValue = this.zCalibrationTrigger;
+        this.zCalibrationTrigger = zCalibrationTrigger;
+        firePropertyChange("zCalibrationTrigger", oldValue, zCalibrationTrigger);
+    }
+
+    public boolean iszCalibrationFailHoming() {
+        return zCalibrationFailHoming;
+    }
+
+    public void setzCalibrationFailHoming(boolean zCalibrationFailHoming) {
+        Object oldValue = this.zCalibrationFailHoming;
+        this.zCalibrationFailHoming = zCalibrationFailHoming;
+        firePropertyChange("zCalibrationFailHoming", oldValue, zCalibrationFailHoming);
+    }
+
+    public boolean isTemplateNozzleTip() {
+        return templateNozzleTip;
+    }
+
+    public void setTemplateNozzleTip(boolean templateNozzleTip) {
+        boolean oldValue = this.templateNozzleTip;
+        this.templateNozzleTip = templateNozzleTip;
+        firePropertyChange("templateNozzleTip", oldValue, templateNozzleTip);
+        if (templateNozzleTip && ! oldValue) {
+            // Make sure, only one nozzle tip is template. 
+            for (NozzleTip nt : Configuration.get().getMachine().getNozzleTips()) {
+                if (nt != this
+                        && nt instanceof ReferenceNozzleTip
+                        && ((ReferenceNozzleTip) nt).isTemplateNozzleTip()) {
+                    ((ReferenceNozzleTip) nt).setTemplateNozzleTip(false);
+                }
+            }
+        }
+    }
+
+    public boolean isTemplateLocked() {
+        return templateLocked;
+    }
+
+    public void setTemplateLocked(boolean templateLocked) {
+        this.templateLocked = templateLocked;
+    }
+
+    /**
+     * @return the calibration offset Z of the nozzle this nozzle tip is attached to.
+     */
+    public Length getCalibrationOffsetZ() {
+        Length offsetZ = null;
+        Nozzle nozzle = getNozzleAttachedTo();
+        if (nozzle instanceof ContactProbeNozzle) {
+            offsetZ = ((ContactProbeNozzle) nozzle).getCalibrationOffsetZ();
+        }
+        return offsetZ;
+    }
+
+    public void setCalibrationOffsetZ(Length calibrationOffsetZ) {
+        firePropertyChange("calibrationOffsetZ", null, calibrationOffsetZ);
     }
 
     public VacuumMeasurementMethod getMethodPartOn() {
@@ -662,6 +966,53 @@ public class ReferenceNozzleTip extends AbstractNozzleTip {
         return vacuumGraph;
     }
 
+    public static ReferenceNozzleTip getTemplateNozzleTip() throws Exception {
+        for (NozzleTip nt : Configuration.get().getMachine().getNozzleTips()) {
+            if (nt instanceof ReferenceNozzleTip
+                    && ((ReferenceNozzleTip)nt).isTemplateNozzleTip()) {
+                return (ReferenceNozzleTip)nt;
+            }
+        }
+        throw new Exception("No Nozzle Tip is defined as template.");
+    }
+
+    public void assignNozzleTipChangerSettings(ReferenceNozzleTip templateNozzleTip, 
+            boolean changerLocations, boolean zCalibration, boolean visionCalibration) {
+        if (getChangerStartLocation().getLinearDistanceTo(Location.origin) != 0
+                && !isTemplateLocked()) {
+            if (changerLocations) {
+                Location offsets = getChangerStartLocation()
+                        .subtract(templateNozzleTip.getChangerStartLocation());
+                setChangerMidLocation(templateNozzleTip.getChangerMidLocation().add(offsets));
+                setChangerMidLocation2(templateNozzleTip.getChangerMidLocation2().add(offsets));
+                setChangerEndLocation(templateNozzleTip.getChangerEndLocation().add(offsets));
+                setChangerActuatorPostStepOne(templateNozzleTip.getChangerActuatorPostStepOne());
+                setChangerActuatorPostStepTwo(templateNozzleTip.getChangerActuatorPostStepTwo());
+                setChangerActuatorPostStepThree(templateNozzleTip.getChangerActuatorPostStepThree());
+                setChangerStartToMidSpeed(templateNozzleTip.getChangerStartToMidSpeed());
+                setChangerMidToMid2Speed(templateNozzleTip.getChangerMidToMid2Speed());
+                setChangerMid2ToEndSpeed(templateNozzleTip.getChangerMid2ToEndSpeed());
+                setTouchLocation(templateNozzleTip.getTouchLocation().add(offsets));
+            }
+            if (zCalibration) {
+                setzCalibrationTrigger(templateNozzleTip.getzCalibrationTrigger());
+                setzCalibrationFailHoming(templateNozzleTip.iszCalibrationFailHoming());
+            }
+            if (visionCalibration) {
+                setVisionCalibration(templateNozzleTip.getVisionCalibration());
+                setVisionCalibrationTrigger(templateNozzleTip.getVisionCalibrationTrigger());
+                setVisionTemplateDimensionX(templateNozzleTip.getVisionTemplateDimensionX());
+                setVisionTemplateDimensionY(templateNozzleTip.getVisionTemplateDimensionY());
+                setVisionTemplateTolerance(templateNozzleTip.getVisionTemplateTolerance());
+                setVisionCalibrationTolerance(templateNozzleTip.getVisionCalibrationTolerance());
+                setVisionCalibrationMaxPasses(templateNozzleTip.getVisionCalibrationMaxPasses());
+                setVisionMatchMinimumScore(templateNozzleTip.getVisionMatchMinimumScore());
+                setVisionTemplateImageEmpty(templateNozzleTip.getVisionTemplateImageEmpty());
+                setVisionTemplateImageOccupied(templateNozzleTip.getVisionTemplateImageOccupied());
+            }
+        }
+    }
+
     public Action loadAction = new AbstractAction("Load") {
         {
             putValue(SMALL_ICON, Icons.nozzleTipLoad);
@@ -712,4 +1063,174 @@ public class ReferenceNozzleTip extends AbstractNozzleTip {
             }
         }
     };
+
+    public Location getChangerStartLocationCalibrated(boolean nozzleTipChange) throws Exception {
+        return applyVisionCalibration(getChangerStartLocation(), nozzleTipChange);
+    }
+
+    public Location getChangerMidLocationCalibrated(boolean nozzleTipChange) throws Exception {
+        return applyVisionCalibration(getChangerMidLocation(), nozzleTipChange);
+    }
+
+    public Location getChangerMidLocation2Calibrated(boolean nozzleTipChange) throws Exception {
+        return applyVisionCalibration(getChangerMidLocation2(), nozzleTipChange);
+    }
+
+    public Location getChangerEndLocationCalibrated(boolean nozzleTipChange) throws Exception {
+        return applyVisionCalibration(getChangerEndLocation(), nozzleTipChange);
+    }
+
+    private Location applyVisionCalibration(Location location, boolean nozzleTipChange) throws Exception {
+        ensureVisionCalibration(nozzleTipChange);
+        if (visionCalibrationOffset != null) {
+            return location.add(visionCalibrationOffset);
+        }
+        else {
+            return location;
+        }
+    }
+
+    public void resetVisionCalibration() {
+        visionCalibrationOffset = null;
+    }
+
+    public void ensureVisionCalibration(boolean nozzleTipChange) throws Exception {
+        Location location = getVisionCalibration().getLocation(this);
+        if (location != null) {
+            // When location is not null, the calibrations is enabled.
+            if (visionCalibrationOffset == null 
+                    || (getVisionCalibrationTrigger() == VisionCalibrationTrigger.NozzleTipChange && nozzleTipChange)) {
+                // Not yet calibrated.
+                if (getVisionTemplateImageEmpty() == null) {
+                    throw new Exception("Nozzle tip "+getName()+" changer slot vision calibration: Template Empty missing.");
+                }
+                if (getVisionTemplateImageOccupied() == null) {
+                    throw new Exception("Nozzle tip "+getName()+" changer slot vision calibration: Template Occupied missing.");
+                }
+                
+                Camera camera = MainFrame.get()
+                                         .getMachineControls()
+                                         .getSelectedTool()
+                                         .getHead()
+                                         .getDefaultCamera();
+
+                Location upp = camera.getUnitsPerPixel();
+                int width =
+                        ((int) Math.ceil(getVisionTemplateDimensionX().add(visionTemplateTolerance)
+                                                                      .divide(upp.getLengthX())))
+                                & ~1; // divisible by 2
+                int height =
+                        ((int) Math.ceil(getVisionTemplateDimensionY().add(visionTemplateTolerance)
+                                                                      .divide(upp.getLengthY())))
+                                & ~1; // divisible by 2
+                
+                BufferedImage templateEmpty = getVisionTemplateImageEmpty().getImage();
+                BufferedImage templateOccupied = getVisionTemplateImageOccupied().getImage();
+
+                Mat templateMatEmpty = OpenCvUtils.toMat(templateEmpty);
+                Mat templateMatOccupied = OpenCvUtils.toMat(templateOccupied);
+                try {
+                    Location originalLocation = location;
+                    boolean shouldBeOccupied = (getNozzleAttachedTo() == null);
+                    for (int pass = 0; pass < visionCalibrationMaxPasses; ++pass) {
+                        MovableUtils.moveToLocationAtSafeZ(camera, location);
+                        BufferedImage cameraImage = camera.lightSettleAndCapture();
+                        int x = (cameraImage.getWidth() - width) / 2;
+                        int y = (cameraImage.getHeight() - height) / 2;
+                        // Convert the camera image to the same type as the templates. This
+                        // is required by the matchTemplate call.
+                        cameraImage =
+                                ImageUtils.convertBufferedImage(cameraImage, templateEmpty.getType());
+                        // Crop to a center area with the given tolerance arount the template.  
+                        Mat cameraImageMat = OpenCvUtils.toMat(cameraImage);
+                        Mat cameraCropMat = new Mat(cameraImageMat, new Rect(x, y, width, height));
+                        cameraImageMat.release();
+                        if (LogUtils.isDebugEnabled()) {
+                            File file;
+                            file = Configuration.get().createResourceFile(getClass(), "camera-cropped", ".png");
+                            Imgcodecs.imwrite(file.getAbsolutePath(), cameraCropMat);
+                            file = Configuration.get().createResourceFile(getClass(), "template-empty", ".png");
+                            Imgcodecs.imwrite(file.getAbsolutePath(), templateMatEmpty);
+                            file = Configuration.get().createResourceFile(getClass(), "template-occupied", ".png");
+                            Imgcodecs.imwrite(file.getAbsolutePath(), templateMatOccupied);
+                        }
+                        Mat resultEmptyMat = new Mat();
+                        Mat resultOccupiedMat = new Mat();
+                        Imgproc.matchTemplate(cameraCropMat, templateMatEmpty, resultEmptyMat,
+                                Imgproc.TM_CCOEFF_NORMED);
+                        MinMaxLocResult emptyMatch = Core.minMaxLoc(resultEmptyMat);
+                        emptyMatch.maxLoc.x -= resultEmptyMat.cols()/2;
+                        emptyMatch.maxLoc.y -= resultEmptyMat.rows()/2;
+                        Imgproc.matchTemplate(cameraCropMat, templateMatOccupied, resultOccupiedMat,
+                                Imgproc.TM_CCOEFF_NORMED);
+                        MinMaxLocResult occupiedMatch = Core.minMaxLoc(resultOccupiedMat);
+                        occupiedMatch.maxLoc.x -= resultOccupiedMat.cols()/2.;
+                        occupiedMatch.maxLoc.y -= resultOccupiedMat.rows()/2.;
+                        if (LogUtils.isDebugEnabled()) {
+                            File file;
+                            file = Configuration.get().createResourceFile(getClass(), "match-empty", ".png");
+                            // this is a 3x32bit image, cannot save these as .png, need to convert to known image format first
+                            BufferedImage img;
+                            img = OpenCvUtils.toBufferedImage(resultEmptyMat);
+                            ImageIO.write(img, "png", file);
+                            file = Configuration.get().createResourceFile(getClass(), "match-occupied", ".png");
+                            img = OpenCvUtils.toBufferedImage(resultOccupiedMat);
+                            ImageIO.write(img, "png", file);
+                        }
+                        resultEmptyMat.release();
+                        resultOccupiedMat.release();
+                        cameraCropMat.release();
+
+                        Logger.trace(String.format(
+                                "Nozzle tip %s changer slot empty template at pixel offset %f, %f, score %f", 
+                                getName(), emptyMatch.maxLoc.x, emptyMatch.maxLoc.y, emptyMatch.maxVal));
+                        Logger.trace(String.format(
+                                "Nozzle tip %s changer slot occupied template at pixel offset %f, %f, score %f",
+                                getName(), occupiedMatch.maxLoc.x, occupiedMatch.maxLoc.y, occupiedMatch.maxVal));
+                        
+                        if (Math.max(emptyMatch.maxVal, occupiedMatch.maxVal) < visionMatchMinimumScore) {
+                            throw new Exception(String.format(
+                                    "Nozzle tip %s changer slot vision calibration failed. Score %f lower than minmum %f.",
+                                    getName(), Math.max(emptyMatch.maxVal, occupiedMatch.maxVal), visionMatchMinimumScore));
+                        }
+                        boolean foundOccupied = (emptyMatch.maxVal < occupiedMatch.maxVal);
+                        if (foundOccupied != shouldBeOccupied) {
+                            throw new Exception(String.format(
+                                    "Nozzle tip %s changer slot was expected %s, but found %s.",
+                                    getName(), shouldBeOccupied ? "occupied" : "empty",
+                                    foundOccupied ? "occupied" : "empty"));
+                        }
+                        MinMaxLocResult match = shouldBeOccupied ? occupiedMatch : emptyMatch;
+                        Location lastOffset = upp.multiply(match.maxLoc.x, match.maxLoc.y, 0, 0);
+                        location = location.add(lastOffset);
+                        setVisionMatchLastScore(match.maxVal);
+                        if (lastOffset.getLinearLengthTo(Location.origin)
+                                                   .compareTo(visionCalibrationTolerance) < 0) {
+                            // Good enough, done.
+                            break;
+                        }
+                    } 
+                    visionCalibrationOffset = location.subtract(originalLocation);
+                    Logger.trace(String.format(
+                            "Nozzle tip %s changer slot calibration offset %s, %s, distance %s",
+                            getName(), visionCalibrationOffset.getLengthX(), visionCalibrationOffset.getLengthY(), 
+                            visionCalibrationOffset.getLinearLengthTo(Location.origin)));
+                }
+                finally {
+                    templateMatEmpty.release();
+                    templateMatOccupied.release();
+                }
+            }
+        }
+        else if (visionCalibrationOffset != null) {
+            visionCalibrationOffset = null;
+        }
+    }
+
+    @Override
+    public void home() throws Exception {
+        if (getVisionCalibrationTrigger() != VisionCalibrationTrigger.Manual) {
+            resetVisionCalibration();
+        }
+    }
 }

--- a/src/main/java/org/openpnp/machine/reference/ReferenceNozzleTip.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceNozzleTip.java
@@ -645,7 +645,22 @@ public class ReferenceNozzleTip extends AbstractNozzleTip {
     }
 
     public void setTemplateLocked(boolean templateLocked) {
+        boolean oldValue = this.templateLocked;
         this.templateLocked = templateLocked;
+        firePropertyChange("templateLocked", oldValue, templateLocked);
+    }
+
+    public boolean isTemplateClone() {
+        return !(templateNozzleTip || templateLocked);
+    }
+
+    public void setTemplateClone(boolean templateClone) {
+        boolean oldValue = isTemplateClone();
+        if (templateClone && !oldValue) {
+            setTemplateLocked(false);
+            firePropertyChange("templateClone", oldValue, templateClone);
+            setTemplateNozzleTip(false);
+        }
     }
 
     /**

--- a/src/main/java/org/openpnp/machine/reference/ReferenceNozzleTipCalibration.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceNozzleTipCalibration.java
@@ -20,7 +20,6 @@ import org.openpnp.model.LengthUnit;
 import org.openpnp.model.Location;
 import org.openpnp.model.Point;
 import org.openpnp.spi.Camera;
-import org.openpnp.spi.Nozzle;
 import org.openpnp.spi.NozzleTip;
 import org.openpnp.util.MovableUtils;
 import org.openpnp.util.OpenCvUtils;
@@ -459,7 +458,7 @@ public class ReferenceNozzleTipCalibration extends AbstractModelObject {
         @Override
         public Location getCameraOffset() {
             // Return the axis offset as the camera tool specific calibration offset.
-            Logger.debug("[nozzleTipCalibration] getCameraOffset() returns: {}, {}", this.centerX, this.centerY);
+            Logger.trace("[nozzleTipCalibration] getCameraOffset() returns: {}, {}", this.centerX, this.centerY);
             return new Location(this.units, this.centerX, this.centerY, 0., 0.);
         }
     }
@@ -482,6 +481,8 @@ public class ReferenceNozzleTipCalibration extends AbstractModelObject {
 
     @Attribute(required = false)
     private boolean enabled;
+    @Attribute(required = false)
+    private boolean failHoming = true;
 
     private boolean calibrating;
 
@@ -660,13 +661,15 @@ public class ReferenceNozzleTipCalibration extends AbstractModelObject {
                 } else {
                     misdetects++;
                     if (misdetects > this.allowMisdetections) {
-                        throw new Exception("Too many vision misdetects. Check pipeline and threshold.");
+                        throw new Exception(
+                                "Nozzle tip calibration: too many vision misdetects. Check pipeline and threshold.");
                     }
                 }
             }
 
             if (nozzleTipMeasuredLocations.size() < Math.max(3, angleSubdivisions + 1 - this.allowMisdetections)) {
-                throw new Exception("Not enough results from vision. Check pipeline and threshold."); 
+                throw new Exception(
+                        "Nozzle tip calibration: not enough results from vision. Check pipeline and threshold.");
             }
 
             Configuration.get().getScripting().on("NozzleCalibration.Finished", params);
@@ -1015,6 +1018,14 @@ public class ReferenceNozzleTipCalibration extends AbstractModelObject {
 
     public void setEnabled(boolean enabled) {
         this.enabled = enabled;
+    }
+
+    public boolean isFailHoming() {
+        return failHoming;
+    }
+
+    public void setFailHoming(boolean failHoming) {
+        this.failHoming = failHoming;
     }
 
     public CvPipeline getPipeline() throws Exception {

--- a/src/main/java/org/openpnp/machine/reference/ReferenceNozzleTipCalibration.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceNozzleTipCalibration.java
@@ -458,7 +458,6 @@ public class ReferenceNozzleTipCalibration extends AbstractModelObject {
         @Override
         public Location getCameraOffset() {
             // Return the axis offset as the camera tool specific calibration offset.
-            Logger.trace("[nozzleTipCalibration] getCameraOffset() returns: {}, {}", this.centerX, this.centerY);
             return new Location(this.units, this.centerX, this.centerY, 0., 0.);
         }
     }

--- a/src/main/java/org/openpnp/machine/reference/ReferencePnpJobProcessor.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferencePnpJobProcessor.java
@@ -34,6 +34,7 @@ import org.openpnp.machine.reference.wizards.ReferencePnpJobProcessorConfigurati
 import org.openpnp.model.BoardLocation;
 import org.openpnp.model.Configuration;
 import org.openpnp.model.Job;
+import org.openpnp.model.Length;
 import org.openpnp.model.LengthUnit;
 import org.openpnp.model.Location;
 import org.openpnp.model.Panel;
@@ -232,13 +233,6 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
                 throw new JobProcessorException(part, String.format("No package set for part %s.",
                         part.getId()));                
             }
-            
-            // Verify that the part height is greater than zero. Catches a common configuration
-            // error.
-            if (placement.getPart().getHeight().getValue() <= 0D) {
-                throw new JobProcessorException(placement.getPart(), String.format("Part height for %s must be greater than 0.",
-                        placement.getPart().getId()));
-            }
 
             // Make sure there is at least one compatible nozzle tip available
             validatePartNozzleTip(head, placement.getPart());
@@ -258,16 +252,21 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
                     .getNozzles()
                     .stream()
                     .flatMap(nozzle -> {
-                        return nozzle.getCompatibleNozzleTips().stream();
-                    })
-                    .filter(nozzleTip -> {
-                        return part.getPackage().getCompatibleNozzleTips().contains(nozzleTip);
+                        return nozzle.getCompatibleNozzleTips(part).stream();
                     })
                     .collect(Collectors.toSet());
             
             if (compatibleNozzleTips.isEmpty()) {
-                throw new JobProcessorException(part, String.format("No compatible, loadable nozzle tip found for part %s.",
-                        part.getId()));                
+                if (part.isPartHeightUnknown()) {
+                    throw new JobProcessorException(part, String.format("No part height sensing method found for part %s. "
+                            + "Check camera, contact probe nozzle and compatible, loadable nozzle tips for height sensing "
+                            + "settings or set part height manually.",
+                            part.getId()));
+                }
+                else {
+                    throw new JobProcessorException(part, String.format("No compatible, loadable nozzle tip found for part %s.",
+                            part.getId()));
+                }
             }
         }
         
@@ -666,7 +665,7 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
             }
             try {
                 if (!nozzle.isPartOff()) {
-                    throw new JobProcessorException(nozzle, "Part detected on nozzle before pick.");
+                    throw new JobProcessorException(nozzle, "Part vacuum-detected on nozzle before pick.");
                 }
             }
             catch (JobProcessorException e) {
@@ -699,7 +698,7 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
                         placement.getId());
                 
                 // Move to pick location.
-                MovableUtils.moveToLocationAtSafeZ(nozzle, feeder.getPickLocation());
+                nozzle.moveToPickLocation(feeder);
 
                 // Pick
                 nozzle.pick(part);
@@ -727,7 +726,7 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
             }
             try {
                 if(!nozzle.isPartOn()) {
-                    throw new JobProcessorException(nozzle, "No part detected after pick.");
+                    throw new JobProcessorException(nozzle, "No part vacuum-detected after pick.");
                 }
             }
             catch (JobProcessorException e) {
@@ -802,7 +801,7 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
             }
             try {
                 if(!nozzle.isPartOn()) {
-                    throw new JobProcessorException(nozzle, "No part detected after alignment. Part may have been lost in transit.");
+                    throw new JobProcessorException(nozzle, "No part vacuum-detected after alignment. Part may have been lost in transit.");
                 }
             }
             catch (JobProcessorException e) {
@@ -859,7 +858,7 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
             
             try {
                 // Move to the placement location
-                MovableUtils.moveToLocationAtSafeZ(nozzle, placementLocation);
+               nozzle.moveToPlacementLocation(placementLocation, part);
 
                 // Place the part
                 nozzle.place();
@@ -878,7 +877,7 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
             }
             try {
                 if (!nozzle.isPartOn()) {
-                    throw new JobProcessorException(nozzle, "No part detected on nozzle before place.");
+                    throw new JobProcessorException(nozzle, "No part vacuum-detected on nozzle before place.");
                 }
             }
             catch (JobProcessorException e) {
@@ -895,7 +894,7 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
             }
             try {
                 if (!nozzle.isPartOff()) {
-                    throw new JobProcessorException(nozzle, "Part detected on nozzle after place.");
+                    throw new JobProcessorException(nozzle, "Part vacuum-detected on nozzle after place.");
                 }
             }
             catch (JobProcessorException e) {
@@ -912,6 +911,8 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
             final Placement placement = jobPlacement.getPlacement();
             final Part part = placement.getPart();
             final BoardLocation boardLocation = plannedPlacement.jobPlacement.getBoardLocation();
+            Length partHeight = part.getHeight();
+            Location placementLocationPart = placementLocation.add(new Location(partHeight.getUnits(), 0, 0, partHeight.getValue(), 0));
             try {
                 HashMap<String, Object> params = new HashMap<>();
                 params.put("job", job);
@@ -920,7 +921,8 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
                 params.put("nozzle", nozzle);
                 params.put("placement", placement);
                 params.put("boardLocation", boardLocation);
-                params.put("placementLocation", placementLocation);
+                params.put("placementLocationBase", placementLocation);
+                params.put("placementLocation", placementLocationPart);
                 params.put("alignmentOffsets", plannedPlacement.alignmentOffsets);
                 Configuration.get().getScripting().on("Job.Placement.BeforeAssembly", params);
             }
@@ -934,6 +936,8 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
             final Placement placement = jobPlacement.getPlacement();
             final Part part = placement.getPart();
             final BoardLocation boardLocation = plannedPlacement.jobPlacement.getBoardLocation();
+            Length partHeight = part.getHeight();
+            Location placementLocationPart = placementLocation.add(new Location(partHeight.getUnits(), 0, 0, partHeight.getValue(), 0));
             try {
                 HashMap<String, Object> params = new HashMap<>();
                 params.put("job", job);
@@ -942,7 +946,8 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
                 params.put("nozzle", nozzle);
                 params.put("placement", placement);
                 params.put("boardLocation", boardLocation);
-                params.put("placementLocation", placementLocation);
+                params.put("placementLocationBase", placementLocation);
+                params.put("placementLocation", placementLocationPart);
                 Configuration.get().getScripting().on("Job.Placement.Complete", params);
             }
             catch (Exception e) {
@@ -1000,10 +1005,8 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
                 }
             }
 
-            // Add the part's height to the placement location
-            placementLocation = placementLocation.add(new Location(part.getHeight().getUnits(), 0,
-                    0, part.getHeight().getValue(), 0));
-            
+            // Note, do not add the part's height to the placement location, this will be done later to allow
+            // for on-the-fly part height probing.  
             return placementLocation;
         }
     }

--- a/src/main/java/org/openpnp/machine/reference/camera/AutoFocusProvider.java
+++ b/src/main/java/org/openpnp/machine/reference/camera/AutoFocusProvider.java
@@ -26,6 +26,7 @@ import org.openpnp.gui.MainFrame;
 import org.openpnp.gui.components.CameraView;
 import org.openpnp.gui.support.Wizard;
 import org.openpnp.machine.reference.camera.wizards.AutoFocusProviderConfigurationWizard;
+import org.openpnp.model.Configuration;
 import org.openpnp.model.Length;
 import org.openpnp.model.LengthUnit;
 import org.openpnp.model.Location;
@@ -95,6 +96,7 @@ public class AutoFocusProvider implements FocusProvider {
         diameter = Math.min(Math.min(diameter, camera.getHeight()-50), camera.getWidth()-50);
         diameter &= ~1; // Must be an even number.
 
+        double speed = Configuration.get().getMachine().getSpeed();
         // Move the movable to the start location at safe Z.
         MovableUtils.moveToLocationAtSafeZ(movable, location0);
         // Switch on the light.
@@ -111,7 +113,7 @@ public class AutoFocusProvider implements FocusProvider {
                 Integer bestFocus = null;
                 for (int step = 0; step < curveSteps; step++) {
                     Location l = location0.add(focalStep.multiply(step));
-                    movable.moveTo(l, focusSpeed);
+                    movable.moveTo(l, focusSpeed*speed);
                     BufferedImage image = camera.settleAndCapture();
                     BufferedImage filteredImage = null;
                     if (showDiagnostics) {
@@ -138,7 +140,7 @@ public class AutoFocusProvider implements FocusProvider {
                 if (focalStep.getXyzLengthTo(Location.origin).divide(focalResolution) < 1.5) {
                     // We reached focal resolution, just take the best focus location.
                     Location l = location0.add(focalStep.multiply(bestFocus));
-                    movable.moveTo(l, focusSpeed);
+                    movable.moveTo(l, focusSpeed*speed);
                     return l; 
                 }
 

--- a/src/main/java/org/openpnp/machine/reference/camera/AutoFocusProvider.java
+++ b/src/main/java/org/openpnp/machine/reference/camera/AutoFocusProvider.java
@@ -1,0 +1,254 @@
+/*
+ * Copyright (C) 2021 <mark@makr.zone>
+ * 
+ * This file is part of OpenPnP.
+ * 
+ * OpenPnP is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * OpenPnP is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License along with OpenPnP. If not, see
+ * <http://www.gnu.org/licenses/>.
+ * 
+ * For more information about OpenPnP visit http://openpnp.org
+ */
+
+package org.openpnp.machine.reference.camera;
+
+import java.awt.Color;
+import java.awt.image.BufferedImage;
+
+import org.openpnp.gui.MainFrame;
+import org.openpnp.gui.components.CameraView;
+import org.openpnp.gui.support.Wizard;
+import org.openpnp.machine.reference.camera.wizards.AutoFocusProviderConfigurationWizard;
+import org.openpnp.model.Length;
+import org.openpnp.model.LengthUnit;
+import org.openpnp.model.Location;
+import org.openpnp.spi.Camera;
+import org.openpnp.spi.FocusProvider;
+import org.openpnp.spi.HeadMountable;
+import org.openpnp.util.ImageUtils;
+import org.openpnp.util.MovableUtils;
+import org.pmw.tinylog.Logger;
+import org.simpleframework.xml.Attribute;
+import org.simpleframework.xml.Element;
+
+public class AutoFocusProvider implements FocusProvider {
+    @Element(required = false)
+    Length focalResolution = new Length(0.05, LengthUnit.Millimeters);
+
+    @Attribute(required = false)
+    int averagedFrames = 1;
+
+    @Attribute(required = false)
+    double focusSpeed = 0.5;
+
+    @Attribute(required = false)
+    boolean showDiagnostics = true;
+
+    public Length getFocalResolution() {
+        return focalResolution;
+    }
+
+    public void setFocalResolution(Length focalResolution) {
+        this.focalResolution = focalResolution;
+    }
+
+    public int getAveragedFrames() {
+        return averagedFrames;
+    }
+
+    public void setAveragedFrames(int averagedFrames) {
+        this.averagedFrames = averagedFrames;
+    }
+
+    public double getFocusSpeed() {
+        return focusSpeed;
+    }
+
+    public void setFocusSpeed(double focusSpeed) {
+        this.focusSpeed = focusSpeed;
+    }
+
+    public boolean isShowDiagnostics() {
+        return showDiagnostics;
+    }
+
+    public void setShowDiagnostics(boolean showDiagnostics) {
+        this.showDiagnostics = showDiagnostics;
+    }
+
+    @Override
+    public Location autoFocus(Camera camera, HeadMountable movable,
+            Length subjectMaxSize,
+            Location location0, Location location1) throws Exception {
+        // Compute the pixel diameter of the subject maximum size.
+        Location unitsPerPixel = camera.getUnitsPerPixel();
+        int diameter = (int) Math.ceil(Math.max(
+                subjectMaxSize.divide(unitsPerPixel.getLengthX()),
+                subjectMaxSize.divide(unitsPerPixel.getLengthY())));
+        diameter = Math.min(Math.min(diameter, camera.getHeight()-50), camera.getWidth()-50);
+        diameter &= ~1; // Must be an even number.
+
+        // Move the movable to the start location at safe Z.
+        MovableUtils.moveToLocationAtSafeZ(movable, location0);
+        // Switch on the light.
+        camera.actuateLightBeforeCapture();
+        CameraView cameraView = MainFrame.get().getCameraViews().getCameraView(camera);
+        BufferedImage bestFilteredImage = null; 
+        try {
+            final int maxCurveSteps = 10+1;
+            while(true) {
+                int curveSteps = Math.max(2, Math.min(maxCurveSteps, 
+                        1+(int)Math.round(location1.getXyzLengthTo(location0).divide(focalResolution))));
+                Location focalStep = location1.subtractWithRotation(location0).multiply(1.0/(curveSteps-1));
+                double [] focusCurve = new double[curveSteps];
+                Integer bestFocus = null;
+                for (int step = 0; step < curveSteps; step++) {
+                    Location l = location0.add(focalStep.multiply(step));
+                    movable.moveTo(l, focusSpeed);
+                    BufferedImage image = camera.settleAndCapture();
+                    BufferedImage filteredImage = null;
+                    if (showDiagnostics) {
+                        final int xCrop = (image.getWidth() - diameter)/2;
+                        final int yCrop = (image.getHeight() - diameter)/2;
+                        filteredImage = ImageUtils.clone(image.getSubimage(xCrop, yCrop, diameter+1, diameter+1)); 
+                    }
+                    double focusScore = focusScore(image, diameter, filteredImage);
+                    for (int i = 1; i < averagedFrames; i++) {
+                        image = camera.capture();
+                        focusScore += focusScore(image, diameter, null);
+                    }
+                    focusCurve[step] = focusScore;
+                    if (bestFocus == null || focusCurve[bestFocus] < focusScore) {
+                        bestFocus = step;
+                        bestFilteredImage = filteredImage;
+                    }
+                    if (filteredImage != null) { 
+                        cameraView.showFilteredImage(filteredImage, "Auto Focus "+(bestFocus == step ? "▲" : "▼"), 1000);
+                    }
+                    Logger.trace("Focus score at "+l+" is "+focusScore+", step size "+focalStep);
+                }
+
+                if (focalStep.getXyzLengthTo(Location.origin).divide(focalResolution) < 1.5) {
+                    // We reached focal resolution, just take the best focus location.
+                    Location l = location0.add(focalStep.multiply(bestFocus));
+                    movable.moveTo(l, focusSpeed);
+                    return l; 
+                }
+
+                // Find the next iteration sub-range. 
+                // Note, we swap location0/location1 so the search direction changes.
+                double nextFocus = Math.max(1.0, Math.min(curveSteps-1-1.0, bestFocus));
+                location1 = location0.add(focalStep.multiply(nextFocus-1.0));
+                location0 = location0.add(focalStep.multiply(nextFocus+1.0));
+            }
+        }
+        finally {
+            // Whatever happens, switch off the light when done.
+            camera.actuateLightAfterCapture();
+            if (bestFilteredImage != null) { 
+                cameraView.showFilteredImage(bestFilteredImage, "Auto Focus \u26AB", 2000);
+            }
+        }   
+    }
+
+    /**
+     * The focus score is computed by detecting the hardest edges in the camera image for a specific fraction of the pixels  
+     * and then returning the lowest edge hardness of that group (fractile). 
+     * 
+     * @param image
+     * @param diameter
+     * @param filteredImage
+     * @return
+     */
+    public static double focusScore(BufferedImage image, int diameter, BufferedImage filteredImage) {
+        diameter &= ~1; // Must be an even number.
+        final int bands = image.getRaster().getNumBands();
+        final int width = image.getWidth();
+        final int height = image.getHeight();
+        final int wCrop = diameter+1;
+        final int hCrop = diameter+1;
+        final int xCrop = (width - diameter)/2;
+        final int yCrop = (height - diameter)/2;
+        // Get the pixels of a central crop.
+        int [] pixelSamples = image.getRaster().getPixels(xCrop, yCrop, wCrop, hCrop, 
+                new int[wCrop*hCrop*bands]);
+        final int maxSample = 255; // TODO: find out the effective sample range?
+        final int histogramSize = (int)Math.ceil(maxSample*Math.sqrt(bands*2));
+        int [] edgeHistogram = new int[histogramSize];
+        int xNext = bands;
+        int yNext = bands*wCrop;
+        int r = diameter/2;
+        int rSquare = r*r;
+        int rSquareBracket = (r-3)*(r-3);
+        int over = histogramSize;
+        int passes = filteredImage != null ? 2 : 1;
+        int markupRGB = new Color(0, 255, 0).getRGB(); 
+        for (int pass = 0; pass < passes; pass++) {
+            int i = 0;
+            for (int y = -r, yi = 0; y < r; y++, yi++) {
+                for (int x = -r, xi = 0; x < r; x++, xi++) {
+                    int distanceSquare = x*x + y*y;
+                    if (distanceSquare <= rSquare) {
+                        int edge = 0;
+                        for (int b = 0; b < bands; b++) {
+                            //assert (((x+r)+(y+r)*wCrop)*bands+b == i);
+                            int xEdge = pixelSamples[i] - pixelSamples[i+xNext];
+                            int yEdge = pixelSamples[i] - pixelSamples[i+yNext];
+                            edge += Math.pow(xEdge, 2) + Math.pow(yEdge, 2);
+                            i++;
+                        }
+                        edge = (int)Math.round(Math.sqrt(edge));
+                        edgeHistogram[edge]++;
+                        if (edge >= over) {// && xi > 0 && yi > 0) {
+                            filteredImage.setRGB(xi, yi, markupRGB);
+//                            filteredImage.setRGB(xi+1, yi, markupRGB);
+//                            filteredImage.setRGB(xi, yi+1, markupRGB);
+//                            filteredImage.setRGB(xi+1, yi+1, markupRGB);
+                            //filteredImage.setRGB(xi-1, yi, markupRGB);
+                            //filteredImage.setRGB(xi, yi-1, markupRGB);
+                        }
+                    }
+                    else {
+                        // Outside the mask, skip pixel.
+                        i += xNext;
+                    }
+                    if (filteredImage != null 
+                            && distanceSquare >= rSquareBracket
+                            && distanceSquare <= rSquare) {
+                        filteredImage.setRGB(xi, yi, 0);
+                    }
+                }
+                // On the edge, skip one more pixel.
+                i += xNext;
+            }
+            // the significant "feature" pixel amount should grow with the diameter to the power of 1.2.
+            final int significantPixels = (int)Math.pow(diameter, 1.3)/10; 
+            int fractile = significantPixels;
+            int exceeding = 0;
+            for (int h = histogramSize-1; h >= 0; h--) {
+                exceeding += edgeHistogram[h];
+                if (exceeding >= fractile) {
+                    double inter = (exceeding - fractile)/(double)edgeHistogram[h];
+                    if (pass == passes - 1) {
+                        return (h+inter);
+                    }
+                    over = h;
+                    break;
+                }
+            }
+        }
+        return 0;
+    }
+
+    @Override
+    public Wizard getConfigurationWizard(Camera camera) {
+        return new AutoFocusProviderConfigurationWizard(camera, this);
+    }
+}

--- a/src/main/java/org/openpnp/machine/reference/camera/SimulatedUpCamera.java
+++ b/src/main/java/org/openpnp/machine/reference/camera/SimulatedUpCamera.java
@@ -9,6 +9,8 @@ import java.awt.geom.AffineTransform;
 import java.awt.geom.Ellipse2D;
 import java.awt.geom.Rectangle2D;
 import java.awt.image.BufferedImage;
+import java.awt.image.ConvolveOp;
+import java.awt.image.Kernel;
 import java.util.List;
 
 import org.openpnp.gui.support.Wizard;
@@ -38,6 +40,9 @@ public class SimulatedUpCamera extends ReferenceCamera {
 
     @Attribute(required=false)
     protected int height = 480;
+    
+    @Attribute(required=false)
+    private boolean simulateFocalBlur;
 
     @Element(required=false)
     private Location errorOffsets = new Location(LengthUnit.Millimeters);
@@ -54,18 +59,17 @@ public class SimulatedUpCamera extends ReferenceCamera {
         }
         BufferedImage image = new BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB);
         Graphics2D g = (Graphics2D) image.getGraphics();
+        g.setColor(Color.black);
+        g.fillRect(0, 0, width, height);
         AffineTransform tx = g.getTransform();
         // invert the image in Y so that Y+ is up
         g.translate(0, height);
         g.scale(1, -1);
         g.translate(width / 2, height / 2);
 
-        g.setColor(Color.black);
-        g.fillRect(0, 0, width, height);
-
         // figure out our physical viewport size
         Location phySize = getUnitsPerPixel().convertToUnits(LengthUnit.Millimeters)
-                                             .multiply(width, height, 0, 0);
+                .multiply(width, height, 0, 0);
         double phyWidth = phySize.getX();
         double phyHeight = phySize.getY();
 
@@ -94,19 +98,42 @@ public class SimulatedUpCamera extends ReferenceCamera {
         return image;
     }
 
-    private void drawNozzle(Graphics2D g, Nozzle nozzle, Location l) {
+    private void drawNozzle(Graphics2D gView, Nozzle nozzle, Location l) {
+        BufferedImage frame;
+        Graphics2D g; 
+        if (isSimulateFocalBlur()) {
+            frame = new BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB);
+            g = frame.createGraphics();
+            g.setTransform(gView.getTransform());
+            // Clear with transparent background
+            g.setBackground(new Color(0, 0, 0, 0));
+            g.clearRect(-width/2, -height/2, width, height);
+        }
+        else {
+           frame = null;
+           g = gView;
+        }
+
         g.setStroke(new BasicStroke(2f));
         g.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
 
         LengthUnit units = LengthUnit.Millimeters;
         Location unitsPerPixel = getUnitsPerPixel().convertToUnits(units);
-        
+
         // Draw the nozzle
         // Get nozzle offsets from camera
         Location offsets = l.subtractWithRotation(getLocation());
-        
+
         // Create a nozzle shape
-        fillShape(g, new Ellipse2D.Double(-0.5, -0.5, 1, 1), Color.green, unitsPerPixel, offsets, false);
+        fillShape(g, new Ellipse2D.Double(-0.5, -0.5, 1, 1), new Color(0, 220, 0), unitsPerPixel, offsets, false);
+
+        blurObjectIntoView(gView, frame, nozzle, l);
+
+        if (frame != null) {
+            // Clear with transparent background
+            g.setBackground(new Color(0, 0, 0, 0));
+            g.clearRect(-width/2, -height/2, width, height);
+        }
 
         // Draw the part
         Part part = nozzle.getPart();
@@ -123,14 +150,62 @@ public class SimulatedUpCamera extends ReferenceCamera {
         if (footprint.getUnits() != units) {
             throw new Error("Not yet supported.");
         }
-        
+
         // First draw the body in dark grey.
         fillShape(g, footprint.getBodyShape(), new Color(60, 60, 60), unitsPerPixel, offsets, true);
-        
+
         // Then draw the pads in white
         fillShape(g, footprint.getPadsShape(), Color.white, unitsPerPixel, offsets, true);
+
+        blurObjectIntoView(gView, frame, nozzle, 
+                l.subtract(new Location(part.getHeight().getUnits(), 0, 0, Math.abs(part.getHeight().getValue()), 0)));
+
+        if (frame != null) {
+            g.dispose();
+        }
     }
-    
+
+    protected void blurObjectIntoView(Graphics2D gView, BufferedImage frame, Nozzle nozzle, Location l) {
+        if (frame == null) {
+            return;
+        }
+        // Blur according to Z coordinate
+        AffineTransform tx = gView.getTransform();
+        gView.setTransform(new AffineTransform());
+        double distanceMm = Math.abs(l.subtract(getLocation(nozzle)).convertToUnits(LengthUnit.Millimeters).getZ());
+        final double bokeh = 0.01/getUnitsPerPixel().convertToUnits(LengthUnit.Millimeters).getX();
+        double radius = distanceMm*bokeh;
+        ConvolveOp op = null;
+        if (radius > 0.01) {
+            int size = (int)Math.ceil(radius) * 2 + 1;
+            float[] data = new float[size * size];
+            double sum = 0;
+            int num = 0;
+            for (int i = 0; i < data.length; i++) {
+                double x = i/size - size/2.0 + 0.5;
+                double y = i%size - size/2.0 + 0.5;
+                double r = Math.sqrt(x*x+y*y);
+                // rough approximation
+                float weight = (float) Math.max(0, Math.min(1, radius + 1 - r));
+                data[i] = weight;
+                sum += weight;
+                if (weight > 0) {
+                    num++;
+                }
+            }
+            if (num > 1) {
+                for (int i = 0; i < data.length; i++) {
+                    data[i] /= sum;
+                }
+
+                Kernel kernel = new Kernel(size, size, data);
+                op = new ConvolveOp(kernel, ConvolveOp.EDGE_NO_OP, null);
+            }
+        }
+        gView.drawImage(frame, op, 0, 0);
+        gView.setTransform(tx);
+    }
+
     private void fillShape(Graphics2D g, Shape shape, Color color, Location unitsPerPixel, Location offsets, boolean addError) {
         AffineTransform tx = new AffineTransform();
         // Scale to pixels
@@ -164,6 +239,14 @@ public class SimulatedUpCamera extends ReferenceCamera {
 
     public void setHeight(int height) {
         this.height = height;
+    }
+
+    public boolean isSimulateFocalBlur() {
+        return simulateFocalBlur;
+    }
+
+    public void setSimulateFocalBlur(boolean simulateFocalBlur) {
+        this.simulateFocalBlur = simulateFocalBlur;
     }
 
     public Location getErrorOffsets() {

--- a/src/main/java/org/openpnp/machine/reference/camera/wizards/AutoFocusProviderConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/camera/wizards/AutoFocusProviderConfigurationWizard.java
@@ -27,6 +27,7 @@ import javax.swing.Action;
 import javax.swing.JButton;
 import javax.swing.JCheckBox;
 import javax.swing.JLabel;
+import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.JTextField;
 import javax.swing.border.EtchedBorder;
@@ -216,13 +217,22 @@ public class AutoFocusProviderConfigurationWizard extends AbstractConfigurationW
                 if (camera.getLocation(nozzle).getLinearLengthTo(nozzle.getLocation()).convertToUnits(LengthUnit.Millimeters).getValue() > 0.1) {
                     throw new Exception("Nozzle "+nozzle.getName()+" unexpected location. Please center and focus first.");
                 }
-                Length offsetZ = camera.getLocation(nozzle).getLengthZ().subtract(nozzle.getLocation().getLengthZ());
-                Location cameraHeadOffsets = ((ReferenceCamera) camera).getHeadOffsets();
-                Location cameraHeadOffsetsNew = cameraHeadOffsets.subtract(new Location(offsetZ.getUnits(), 0, 0, offsetZ.getValue(), 0));
-                Logger.info("Setting camera "+camera.getName()+" Z to "+cameraHeadOffsetsNew.getLengthZ()+" (previously "+cameraHeadOffsets.getLengthZ());
-                ((ReferenceCamera) camera).setHeadOffsets(cameraHeadOffsetsNew);
-                setLastFocusDistance(null);
-                MovableUtils.fireTargetedUserAction(camera);
+                int result = JOptionPane.showConfirmDialog(getTopLevelAncestor(),
+                        "<html>This will overwrite the current camera Z position and therefore<br/>"
+                                +"change the camera-to-subject distance and the subject scale.<br/>"
+                                +"<span color=\"red\">You will need to recalibrate the Units per Pixel!</span>"
+                                +"<br/><br/>"
+                                +"Are you sure?</html>",
+                                null, JOptionPane.YES_NO_OPTION, JOptionPane.WARNING_MESSAGE);
+                if (result == JOptionPane.YES_OPTION) {
+                    Length offsetZ = camera.getLocation(nozzle).getLengthZ().subtract(nozzle.getLocation().getLengthZ());
+                    Location cameraHeadOffsets = ((ReferenceCamera) camera).getHeadOffsets();
+                    Location cameraHeadOffsetsNew = cameraHeadOffsets.subtract(new Location(offsetZ.getUnits(), 0, 0, offsetZ.getValue(), 0));
+                    Logger.info("Setting camera "+camera.getName()+" Z to "+cameraHeadOffsetsNew.getLengthZ()+" (previously "+cameraHeadOffsets.getLengthZ());
+                    ((ReferenceCamera) camera).setHeadOffsets(cameraHeadOffsetsNew);
+                    setLastFocusDistance(null);
+                    MovableUtils.fireTargetedUserAction(camera);
+                }
             });
         }
     };

--- a/src/main/java/org/openpnp/machine/reference/camera/wizards/AutoFocusProviderConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/camera/wizards/AutoFocusProviderConfigurationWizard.java
@@ -1,0 +1,245 @@
+/*
+ * Copyright (C) 2021 <mark@makr.zone>
+ * 
+ * This file is part of OpenPnP.
+ * 
+ * OpenPnP is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * OpenPnP is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License along with OpenPnP. If not, see
+ * <http://www.gnu.org/licenses/>.
+ * 
+ * For more information about OpenPnP visit http://openpnp.org
+ */
+
+package org.openpnp.machine.reference.camera.wizards;
+
+import java.awt.Color;
+import java.awt.event.ActionEvent;
+
+import javax.swing.AbstractAction;
+import javax.swing.Action;
+import javax.swing.JButton;
+import javax.swing.JCheckBox;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JTextField;
+import javax.swing.border.EtchedBorder;
+import javax.swing.border.TitledBorder;
+
+import org.openpnp.gui.MainFrame;
+import org.openpnp.gui.components.ComponentDecorators;
+import org.openpnp.gui.support.AbstractConfigurationWizard;
+import org.openpnp.gui.support.DoubleConverter;
+import org.openpnp.gui.support.Icons;
+import org.openpnp.gui.support.IntegerConverter;
+import org.openpnp.gui.support.LengthConverter;
+import org.openpnp.machine.reference.ReferenceCamera;
+import org.openpnp.machine.reference.ReferenceNozzle;
+import org.openpnp.machine.reference.ReferenceNozzleTip;
+import org.openpnp.machine.reference.camera.AutoFocusProvider;
+import org.openpnp.model.Configuration;
+import org.openpnp.model.Length;
+import org.openpnp.model.LengthUnit;
+import org.openpnp.model.Location;
+import org.openpnp.spi.Camera;
+import org.openpnp.spi.FocusProvider;
+import org.openpnp.spi.Nozzle;
+import org.openpnp.util.MovableUtils;
+import org.openpnp.util.UiUtils;
+import org.pmw.tinylog.Logger;
+
+import com.jgoodies.forms.layout.ColumnSpec;
+import com.jgoodies.forms.layout.FormLayout;
+import com.jgoodies.forms.layout.FormSpecs;
+import com.jgoodies.forms.layout.RowSpec;
+
+@SuppressWarnings("serial")
+public class AutoFocusProviderConfigurationWizard extends AbstractConfigurationWizard {
+    private AutoFocusProvider focusProvider;
+    private Camera camera;
+
+    public AutoFocusProviderConfigurationWizard(Camera camera, FocusProvider focusProvider) {
+        this.camera = camera;
+        this.focusProvider = (AutoFocusProvider) focusProvider;
+
+        panelGeneral = new JPanel();
+        contentPanel.add(panelGeneral);
+        panelGeneral.setBorder(new TitledBorder(new EtchedBorder(EtchedBorder.LOWERED, null, null), "Auto Focus Settings", TitledBorder.LEADING, TitledBorder.TOP, null, new Color(0, 0, 0)));
+        panelGeneral.setLayout(new FormLayout(new ColumnSpec[] {
+                FormSpecs.RELATED_GAP_COLSPEC,
+                ColumnSpec.decode("max(70dlu;default)"),
+                FormSpecs.RELATED_GAP_COLSPEC,
+                FormSpecs.DEFAULT_COLSPEC,
+                FormSpecs.RELATED_GAP_COLSPEC,
+                ColumnSpec.decode("max(50dlu;default)"),
+                FormSpecs.RELATED_GAP_COLSPEC,
+                FormSpecs.DEFAULT_COLSPEC,},
+                new RowSpec[] {
+                        FormSpecs.RELATED_GAP_ROWSPEC,
+                        FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC,
+                        FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC,
+                        FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC,
+                        FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC,
+                        FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC,
+                        FormSpecs.DEFAULT_ROWSPEC,}));
+
+        lblFocalResolution = new JLabel("Focal Resolution");
+        lblFocalResolution.setToolTipText("Finest step length to seek the best focus.");
+        panelGeneral.add(lblFocalResolution, "2, 2, right, default");
+
+        focalResolution = new JTextField();
+        panelGeneral.add(focalResolution, "4, 2, fill, default");
+        focalResolution.setColumns(10);
+
+        btnTest = new JButton(testAutoFocusAction);
+        panelGeneral.add(btnTest, "6, 2, 1, 7");
+
+        lblAveragedFrames = new JLabel("Averaged Frames");
+        lblAveragedFrames.setToolTipText("Number of camera frames captured and averaged to reduce camera noise and improve the auto focus.");
+        panelGeneral.add(lblAveragedFrames, "2, 4, right, default");
+
+        averagedFrames = new JTextField();
+        panelGeneral.add(averagedFrames, "4, 4, fill, default");
+        averagedFrames.setColumns(10);
+
+        lblFocusSpeed = new JLabel("Focus Speed");
+        lblFocusSpeed.setToolTipText("Focus motion speed factor.");
+        panelGeneral.add(lblFocusSpeed, "2, 6, right, default");
+
+        focusSpeed = new JTextField();
+        panelGeneral.add(focusSpeed, "4, 6, fill, default");
+        focusSpeed.setColumns(10);
+
+        lblShowDiagnostics = new JLabel("Show Diagnostics?");
+        lblShowDiagnostics.setToolTipText("Show detected edges and Auto Focus status text in the camera view.");
+        panelGeneral.add(lblShowDiagnostics, "2, 8, right, default");
+
+        showDiagnostics = new JCheckBox("");
+        panelGeneral.add(showDiagnostics, "4, 8");
+
+        lblLastFocusDistance = new JLabel("Last Focus Distance");
+        panelGeneral.add(lblLastFocusDistance, "2, 12, right, default");
+
+        txtLastFocusDistance = new JTextField();
+        txtLastFocusDistance.setEditable(false);
+        panelGeneral.add(txtLastFocusDistance, "4, 12, fill, default");
+        txtLastFocusDistance.setColumns(10);
+        
+                btnSetCameraZ = new JButton(adjustCameraZAction);
+                panelGeneral.add(btnSetCameraZ, "6, 12");
+    }
+
+    @Override
+    public void createBindings() {
+        IntegerConverter intConverter = new IntegerConverter();
+        DoubleConverter doubleConverter = new DoubleConverter(Configuration.get().getLengthDisplayFormat());
+        LengthConverter lengthConverter = new LengthConverter();
+
+        addWrappedBinding(focusProvider, "focalResolution", focalResolution, "text", lengthConverter);
+        addWrappedBinding(focusProvider, "averagedFrames", averagedFrames, "text", intConverter);
+        addWrappedBinding(focusProvider, "focusSpeed", focusSpeed, "text", doubleConverter);
+        addWrappedBinding(focusProvider, "showDiagnostics", showDiagnostics, "selected");
+
+        addWrappedBinding(this, "lastFocusDistance", txtLastFocusDistance, "text", lengthConverter);
+
+        ComponentDecorators.decorateWithAutoSelectAndLengthConversion(focalResolution);
+        ComponentDecorators.decorateWithAutoSelect(averagedFrames);
+        ComponentDecorators.decorateWithAutoSelect(focusSpeed);
+        ComponentDecorators.decorateWithAutoSelectAndLengthConversion(txtLastFocusDistance);
+    }
+
+    public Length getLastFocusDistance() {
+        return lastFocusDistance;
+    }
+
+    public void setLastFocusDistance(Length lastFocusDistance) {
+        this.lastFocusDistance = lastFocusDistance;
+        firePropertyChange("lastFocusDistance", null, lastFocusDistance);
+    }
+
+    private Action testAutoFocusAction = new AbstractAction("", Icons.centerPin) {
+        {
+            putValue(Action.SHORT_DESCRIPTION, "<html>Auto-Focus the selected nozzle in this camera.<br/>If a part is on the nozzle, its height will be determined.</html>");
+        }
+
+        @Override
+        public void actionPerformed(ActionEvent e) {
+            applyAction.actionPerformed(e);
+            camera.ensureCameraVisible();
+            UiUtils.submitUiMachineTask(() -> {
+                Nozzle nozzle = MainFrame.get().getMachineControls().getSelectedNozzle();
+                if (!(nozzle instanceof ReferenceNozzle)) {
+                    throw new Exception("Expected "+nozzle.getName()+" to be a ReferenceNozzle");
+                }
+                ReferenceNozzleTip nt = (ReferenceNozzleTip) nozzle.getNozzleTip(); 
+                Location location1 = camera.getLocation(nozzle)
+                        .derive(nozzle.getLocation(), false, false, false, true); // Keep rotation
+                Location location0 = location1.add(new Location(nt.getMaxPartHeight().getUnits(), 
+                        0, 0, nt.getMaxPartHeight().getValue(), 0));
+                Location focus = focusProvider.autoFocus(camera, nozzle, nt.getMaxPartDiameter(), location0, location1);
+                setLastFocusDistance(focus.getXyzLengthTo(location1));
+                MovableUtils.fireTargetedUserAction(camera);
+            });
+        }
+    };
+
+    private Action adjustCameraZAction = new AbstractAction("Adjust Camera Z") {
+        {
+            putValue(Action.SHORT_DESCRIPTION, "<html>After having auto-focused, adjust the camera Z coordinate<br/>to match the focal distance i.e. make sure the camera is focused.</html>");
+        }
+
+        @Override
+        public void actionPerformed(ActionEvent e) {
+            applyAction.actionPerformed(e);
+            UiUtils.messageBoxOnException(() -> {
+                Nozzle nozzle = MainFrame.get().getMachineControls().getSelectedNozzle();
+                if (nozzle.getPart() != null) {
+                    throw new Exception("Nozzle "+nozzle.getName()+" has part on. Use nozzle tip to measure.");
+                }
+                if (!(nozzle instanceof ReferenceNozzle)) {
+                    throw new Exception("Expected "+nozzle.getName()+" to be a ReferenceNozzle");
+                }
+                if (!(camera instanceof ReferenceCamera)) {
+                    throw new Exception("Expected "+camera.getName()+" to be a ReferenceCamera");
+                }
+                if (camera.getLocation(nozzle).getLinearLengthTo(nozzle.getLocation()).convertToUnits(LengthUnit.Millimeters).getValue() > 0.1) {
+                    throw new Exception("Nozzle "+nozzle.getName()+" unexpected location. Please center and focus first.");
+                }
+                Length offsetZ = camera.getLocation(nozzle).getLengthZ().subtract(nozzle.getLocation().getLengthZ());
+                Location cameraHeadOffsets = ((ReferenceCamera) camera).getHeadOffsets();
+                Location cameraHeadOffsetsNew = cameraHeadOffsets.subtract(new Location(offsetZ.getUnits(), 0, 0, offsetZ.getValue(), 0));
+                Logger.info("Setting camera "+camera.getName()+" Z to "+cameraHeadOffsetsNew.getLengthZ()+" (previously "+cameraHeadOffsets.getLengthZ());
+                ((ReferenceCamera) camera).setHeadOffsets(cameraHeadOffsetsNew);
+                setLastFocusDistance(null);
+                MovableUtils.fireTargetedUserAction(camera);
+            });
+        }
+    };
+
+    private JPanel panelGeneral;
+    private JLabel lblFocalResolution;
+    private JTextField focalResolution;
+    private JLabel lblAveragedFrames;
+    private JTextField averagedFrames;
+    private JLabel lblFocusSpeed;
+    private JTextField focusSpeed;
+    private JButton btnTest;
+    private JLabel lblLastFocusDistance;
+    private JTextField txtLastFocusDistance;
+
+    private Length lastFocusDistance;
+    private JLabel lblShowDiagnostics;
+    private JCheckBox showDiagnostics;
+    private JButton btnSetCameraZ;
+}

--- a/src/main/java/org/openpnp/machine/reference/camera/wizards/SimulatedUpCameraConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/camera/wizards/SimulatedUpCameraConfigurationWizard.java
@@ -19,9 +19,8 @@
 
 package org.openpnp.machine.reference.camera.wizards;
 
-import java.awt.Color;
-
 import javax.swing.JButton;
+import javax.swing.JCheckBox;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JTextField;
@@ -62,6 +61,8 @@ public class SimulatedUpCameraConfigurationWizard extends AbstractConfigurationW
     private JTextField width;
     private JLabel lblHeight;
     private JTextField height;
+    private JLabel lblFocalBlur;
+    private JCheckBox simulateFocalBlur;
 
     public SimulatedUpCameraConfigurationWizard(SimulatedUpCamera camera) {
         this.camera = camera;
@@ -107,6 +108,13 @@ public class SimulatedUpCameraConfigurationWizard extends AbstractConfigurationW
         panelGeneral.add(height, "4, 4, fill, default");
         height.setColumns(10);
         
+        lblFocalBlur = new JLabel("Simulate Focal Blur?");
+        lblFocalBlur.setToolTipText("Simulate focal blur in order to test Auto Focus. This is very slow!");
+        panelGeneral.add(lblFocalBlur, "2, 6, right, default");
+        
+        simulateFocalBlur = new JCheckBox("");
+        panelGeneral.add(simulateFocalBlur, "4, 6");
+        
         lblX = new JLabel("X");
         panelGeneral.add(lblX, "4, 8, center, default");
         
@@ -148,6 +156,8 @@ public class SimulatedUpCameraConfigurationWizard extends AbstractConfigurationW
 
         addWrappedBinding(camera, "width", width, "text", intConverter);
         addWrappedBinding(camera, "height", height, "text", intConverter);
+
+        addWrappedBinding(camera, "simulateFocalBlur", simulateFocalBlur, "selected");
 
         MutableLocationProxy errorOffsets = new MutableLocationProxy();
         bind(UpdateStrategy.READ_WRITE, camera, "errorOffsets", errorOffsets,

--- a/src/main/java/org/openpnp/machine/reference/driver/GcodeDriverSolutions.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/GcodeDriverSolutions.java
@@ -57,7 +57,7 @@ import org.simpleframework.xml.stream.Style;
  * The idea is not to pollute the driver implementations themselves.
  *
  */
-class GcodeDriverSolutions implements Solutions.Subject {
+public class GcodeDriverSolutions implements Solutions.Subject {
     private final GcodeDriver gcodeDriver;
 
     GcodeDriverSolutions(GcodeDriver gcodeDriver) {
@@ -188,7 +188,7 @@ class GcodeDriverSolutions implements Solutions.Subject {
                     if (gcodeDriver.getConfiguredAxes().contains("(r)")) {
                         issues.add(new Solutions.PlainIssue(
                                 gcodeDriver,
-                                "Axes should be configured as linear in feedrate calculations on the Duet controller. See the linked web page.",
+                                "Axes should be configured as linear in feedrate calculations on the Duet controller. See the linked web page.", 
                                 "Use the M584 S0 option in your config.g file.",
                                 Severity.Error,
                                 "https://duet3d.dozuki.com/Wiki/Gcode#Section_M584_Set_drive_mapping"));
@@ -198,7 +198,7 @@ class GcodeDriverSolutions implements Solutions.Subject {
                     }
                 }
             }
-            else if (gcodeDriver.getDetectedFirmware().contains("Marlin")) {
+            else if (gcodeDriver.getFirmwareProperty("FIRMWARE_NAME", "").contains("Marlin")) {
                 isMarlin = true;
                 firmwareAxesCount = Integer.valueOf(gcodeDriver.getFirmwareProperty("AXIS_COUNT", "0"));
                 if (firmwareAxesCount > 3) { 
@@ -213,7 +213,7 @@ class GcodeDriverSolutions implements Solutions.Subject {
                             "https://github.com/openpnp/openpnp/wiki/Motion-Controller-Firmwares#marlin-20"));
                 }
             }
-            else if (gcodeDriver.getDetectedFirmware().contains("TinyG")) {
+            else if (gcodeDriver.getFirmwareProperty("FIRMWARE_NAME", "").contains("TinyG")) {
                 // Having a response already means we have a new firmware.
                 isTinyG = true;
             }
@@ -243,7 +243,7 @@ class GcodeDriverSolutions implements Solutions.Subject {
                                         ? "Location Confirmation recommended for extra features in homing, contact probing, etc."
                                                 : "Location Confirmation required when Confirmation Flow Control is off. Supports extra features in homing, contact probing, etc.")
                                         : "Location Confirmation usually not available when no axes present."),
-                        (locationConfirmationRecommended ? "Enable Location Confirmation" : "Disable Location Confirmation"),
+                        (locationConfirmationRecommended ? "Enable Location Confirmation" : "Disable Location Confirmation"), 
                         (confirmationFlowControl ? Severity.Suggestion : Severity.Error),
                         "https://github.com/openpnp/openpnp/wiki/GcodeAsyncDriver#advanced-settings") {
 
@@ -726,13 +726,14 @@ class GcodeDriverSolutions implements Solutions.Subject {
 
     /**
      * Add a solution for the given gcodeDriver to the issues, to suggest the given suggestedCommand instead of the currentCommand.
-     *
+     *  
      * @param gcodeDriver
+     * @param headMountable
      * @param issues
      * @param commandType
-     * @param currentCommand
      * @param suggestedCommand
-     * @param disallowHeadMountables Set true to disallow the commandType on HeadMountables. This is used when switching to axis letter variables.
+     * @param commandModified
+     * @param disallowHeadMountables
      */
     public static void suggestGcodeCommand(GcodeDriver gcodeDriver, HeadMountable headMountable, List<Solutions.Issue> issues,
             CommandType commandType, String suggestedCommand, boolean commandModified,

--- a/src/main/java/org/openpnp/machine/reference/feeder/AdvancedLoosePartFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/AdvancedLoosePartFeeder.java
@@ -72,6 +72,11 @@ public class AdvancedLoosePartFeeder extends ReferenceFeeder {
         }
     }
 
+    @Override
+    public boolean isPartHeightAbovePickLocation() {
+        return true;
+    }
+
     /**
      * Executes the vision pipeline to locate a part.
      * @param nozzle used nozzle
@@ -107,12 +112,10 @@ public class AdvancedLoosePartFeeder extends ReferenceFeeder {
             // Get the result's Location
             // Update the location with the result's rotation
             partLocation = partLocation.derive(null, null, null, -(result.angle + getLocation().getRotation()));
-            // Update the location with the correct Z, which is the configured Location's Z
-            // plus the part height.
+            // Update the location with the correct Z, which is the configured Location's Z.
             partLocation =
                     partLocation.derive(null, null,
-                            this.location.convertToUnits(partLocation.getUnits()).getZ()
-                            + part.getHeight().convertToUnits(partLocation.getUnits()).getValue(),
+                            this.location.convertToUnits(partLocation.getUnits()).getZ(),
                             null);
             MainFrame.get().getCameraViews().getCameraView(camera)
             .showFilteredImage(OpenCvUtils.toBufferedImage(pipeline.getWorkingImage()), 250);

--- a/src/main/java/org/openpnp/machine/reference/feeder/BlindsFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/BlindsFeeder.java
@@ -264,6 +264,11 @@ public class BlindsFeeder extends ReferenceFeeder {
         return getPickLocation(this.getFedPocketNumber());
     }
 
+    @Override
+    public boolean isPartHeightAbovePickLocation() {
+        return false;
+    }
+
     private int getFedPocketNumber() {
         return this.getFeedCount()+this.getFirstPocket()-1;
     }

--- a/src/main/java/org/openpnp/machine/reference/feeder/ReferenceAutoFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/ReferenceAutoFeeder.java
@@ -64,6 +64,11 @@ public class ReferenceAutoFeeder extends ReferenceFeeder {
         return location;
     }
 
+    @Override
+    public boolean isPartHeightAbovePickLocation() {
+        return false;
+    }
+
     public ReferenceAutoFeeder() {
         Configuration.get().addListener(new ConfigurationListener.Adapter() {
             @Override

--- a/src/main/java/org/openpnp/machine/reference/feeder/ReferenceDragFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/ReferenceDragFeeder.java
@@ -121,6 +121,11 @@ public class ReferenceDragFeeder extends ReferenceFeeder {
     }
 
     @Override
+    public boolean isPartHeightAbovePickLocation() {
+        return false;
+    }
+
+    @Override
     public void feed(Nozzle nozzle) throws Exception {
         Logger.debug("feed({})", nozzle);
 

--- a/src/main/java/org/openpnp/machine/reference/feeder/ReferenceHeapFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/ReferenceHeapFeeder.java
@@ -991,4 +991,9 @@ public class ReferenceHeapFeeder extends ReferenceFeeder {
         }
 
     }
+
+    @Override
+    public boolean isPartHeightAbovePickLocation() {
+        return false;
+    }
 }

--- a/src/main/java/org/openpnp/machine/reference/feeder/ReferenceLeverFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/ReferenceLeverFeeder.java
@@ -44,7 +44,6 @@ import org.openpnp.spi.Head;
 import org.openpnp.spi.Nozzle;
 import org.openpnp.spi.PropertySheetHolder;
 import org.openpnp.spi.VisionProvider;
-import org.openpnp.util.Utils2D;
 import org.pmw.tinylog.Logger;
 import org.simpleframework.xml.Attribute;
 import org.simpleframework.xml.Element;
@@ -110,6 +109,11 @@ public class ReferenceLeverFeeder extends ReferenceFeeder {
         }
 
         return pickLocation;
+    }
+
+    @Override
+    public boolean isPartHeightAbovePickLocation() {
+        return false;
     }
 
     @Override

--- a/src/main/java/org/openpnp/machine/reference/feeder/ReferenceLoosePartFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/ReferenceLoosePartFeeder.java
@@ -70,6 +70,11 @@ public class ReferenceLoosePartFeeder extends ReferenceFeeder {
         }
     }
 
+    @Override
+    public boolean isPartHeightAbovePickLocation() {
+        return true;
+    }
+
     private Location getPickLocation(CvPipeline pipeline, Camera camera, Nozzle nozzle)
             throws Exception {
         // Process the pipeline to extract RotatedRect results
@@ -95,10 +100,8 @@ public class ReferenceLoosePartFeeder extends ReferenceFeeder {
         Location location = VisionUtils.getPixelLocation(camera, result.center.x, result.center.y);
         // Update the location's rotation with the result's angle
         location = location.derive(null, null, null, result.angle + this.location.getRotation());
-        // Update the location with the correct Z, which is the configured Location's Z
-        // plus the part height.
-        double z = this.location.convertToUnits(location.getUnits()).getZ()
-                + part.getHeight().convertToUnits(location.getUnits()).getValue(); 
+        // Update the location with the correct Z, which is the configured Location's Z.
+        double z = this.location.convertToUnits(location.getUnits()).getZ(); 
         location = location.derive(null, null, z, null);
         return location;
     }

--- a/src/main/java/org/openpnp/machine/reference/feeder/ReferencePushPullFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/ReferencePushPullFeeder.java
@@ -333,6 +333,11 @@ public class ReferencePushPullFeeder extends ReferenceFeeder {
     }
 
     @Override
+    public boolean isPartHeightAbovePickLocation() {
+        return false;
+    }
+
+    @Override
     public void feed(Nozzle nozzle) throws Exception {
         Logger.debug("feed({})", nozzle);
 

--- a/src/main/java/org/openpnp/machine/reference/feeder/ReferenceRotatedTrayFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/ReferenceRotatedTrayFeeder.java
@@ -85,6 +85,11 @@ public class ReferenceRotatedTrayFeeder extends ReferenceFeeder {
 		return pickLocation;
 	}
 
+    @Override
+    public boolean isPartHeightAbovePickLocation() {
+        return false;
+    }
+
 	private void calculatePickLocation(int partX, int partY) throws Exception {
 
 		// Multiply the offsets by the X/Y part indexes to get the total offsets

--- a/src/main/java/org/openpnp/machine/reference/feeder/ReferenceStripFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/ReferenceStripFeeder.java
@@ -204,6 +204,11 @@ public class ReferenceStripFeeder extends ReferenceFeeder {
         return l;
     }
 
+    @Override
+    public boolean isPartHeightAbovePickLocation() {
+        return false;
+    }
+
     public Location[] getIdealLineLocations() {
         if (visionLocation == null) {
             return new Location[] {referenceHoleLocation, lastHoleLocation};

--- a/src/main/java/org/openpnp/machine/reference/feeder/ReferenceTrayFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/ReferenceTrayFeeder.java
@@ -63,6 +63,11 @@ public class ReferenceTrayFeeder extends ReferenceFeeder {
         return pickLocation;
     }
 
+    @Override
+    public boolean isPartHeightAbovePickLocation() {
+        return false;
+    }
+
     public void feed(Nozzle nozzle) throws Exception {
         Logger.debug("{}.feed({})", getName(), nozzle);
         int partX, partY;

--- a/src/main/java/org/openpnp/machine/reference/feeder/ReferenceTubeFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/ReferenceTubeFeeder.java
@@ -41,6 +41,11 @@ public class ReferenceTubeFeeder extends ReferenceFeeder {
     }
 
     @Override
+    public boolean isPartHeightAbovePickLocation() {
+        return false;
+    }
+
+    @Override
     public void feed(Nozzle nozzle) throws Exception {}
 
     @Override

--- a/src/main/java/org/openpnp/machine/reference/feeder/SchultzFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/SchultzFeeder.java
@@ -27,7 +27,6 @@ import org.openpnp.machine.reference.ReferenceFeeder;
 import org.openpnp.machine.reference.feeder.wizards.SchultzFeederConfigurationWizard;
 import org.openpnp.model.Configuration;
 import org.openpnp.model.Location;
-import org.openpnp.model.Part;
 import org.openpnp.spi.Actuator;
 import org.openpnp.spi.Nozzle;
 import org.openpnp.spi.PropertySheetHolder;
@@ -102,6 +101,11 @@ public class SchultzFeeder extends ReferenceFeeder {
     @Override
     public Location getPickLocation() throws Exception {
         return location;
+    }
+
+    @Override
+    public boolean isPartHeightAbovePickLocation() {
+        return false;
     }
 
     public SchultzFeeder() {

--- a/src/main/java/org/openpnp/machine/reference/feeder/wizards/ReferencePushPullFeederConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/wizards/ReferencePushPullFeederConfigurationWizard.java
@@ -22,7 +22,7 @@
 package org.openpnp.machine.reference.feeder.wizards;
 
 import java.awt.BorderLayout;
-import java.awt.Color;
+import java.awt.Dimension;
 import java.awt.GraphicsEnvironment;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
@@ -67,6 +67,7 @@ import org.openpnp.model.Configuration;
 import org.openpnp.model.RegionOfInterest;
 import org.openpnp.spi.Camera;
 import org.openpnp.spi.Head;
+import org.openpnp.spi.MotionPlanner.CompletionType;
 import org.openpnp.util.MovableUtils;
 import org.openpnp.util.UiUtils;
 import org.openpnp.vision.pipeline.CvPipeline;
@@ -77,7 +78,6 @@ import com.jgoodies.forms.layout.ColumnSpec;
 import com.jgoodies.forms.layout.FormLayout;
 import com.jgoodies.forms.layout.FormSpecs;
 import com.jgoodies.forms.layout.RowSpec;
-import java.awt.Dimension;
 
 @SuppressWarnings("serial")
 public class ReferencePushPullFeederConfigurationWizard
@@ -633,7 +633,8 @@ extends AbstractReferenceFeederConfigurationWizard {
                 UiUtils.submitUiMachineTask(() -> {
                     MovableUtils.moveToLocationAtSafeZ(feeder.getCamera(), feeder.getNominalVisionLocation());
                     MovableUtils.fireTargetedUserAction(feeder.getCamera());
-                    SwingUtilities.invokeAndWait(() -> {
+                    feeder.getCamera().waitForCompletion(CompletionType.WaitForStillstand);
+                    SwingUtilities.invokeLater(() -> {
                         UiUtils.messageBoxOnException(() -> {
                             editPipeline();
                         });

--- a/src/main/java/org/openpnp/machine/reference/vision/wizards/ReferenceBottomVisionPartConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/vision/wizards/ReferenceBottomVisionPartConfigurationWizard.java
@@ -5,6 +5,7 @@ import java.awt.event.ActionListener;
 
 import javax.swing.JButton;
 import javax.swing.JCheckBox;
+import javax.swing.JComboBox;
 import javax.swing.JDialog;
 import javax.swing.JLabel;
 import javax.swing.JOptionPane;
@@ -14,16 +15,13 @@ import javax.swing.border.TitledBorder;
 
 import org.openpnp.gui.MainFrame;
 import org.openpnp.gui.support.AbstractConfigurationWizard;
-import org.openpnp.gui.support.DoubleConverter;
 import org.openpnp.gui.support.IntegerConverter;
 import org.openpnp.gui.support.MessageBoxes;
 import org.openpnp.machine.reference.vision.ReferenceBottomVision;
 import org.openpnp.machine.reference.vision.ReferenceBottomVision.PartSettings;
-import org.openpnp.model.Configuration;
 import org.openpnp.model.LengthUnit;
 import org.openpnp.model.Location;
 import org.openpnp.model.Part;
-import org.openpnp.spi.Axis;
 import org.openpnp.spi.Nozzle;
 import org.openpnp.spi.PartAlignment;
 import org.openpnp.util.UiUtils;
@@ -36,7 +34,6 @@ import com.jgoodies.forms.layout.ColumnSpec;
 import com.jgoodies.forms.layout.FormLayout;
 import com.jgoodies.forms.layout.FormSpecs;
 import com.jgoodies.forms.layout.RowSpec;
-import javax.swing.JComboBox;
 
 public class ReferenceBottomVisionPartConfigurationWizard extends AbstractConfigurationWizard {
     private final ReferenceBottomVision bottomVision;
@@ -159,7 +156,7 @@ public class ReferenceBottomVisionPartConfigurationWizard extends AbstractConfig
 
         // perform the alignment
         PartAlignment.PartAlignmentOffset alignmentOffset = VisionUtils.findPartAlignmentOffsets(bottomVision, part,
-                null, new Location(LengthUnit.Millimeters), nozzle);
+                null, new Location(LengthUnit.Millimeters, 0, 0, 0, nozzle.getLocation().getRotation()), nozzle);
         Location offsets = alignmentOffset.getLocation();
 
         if (!chckbxCenterAfterTest.isSelected()) {
@@ -168,7 +165,7 @@ public class ReferenceBottomVisionPartConfigurationWizard extends AbstractConfig
 
         // position the part over camera center
         Location cameraLocation = bottomVision.getCameraLocationAtPartHeight(part, VisionUtils.getBottomVisionCamera(),
-                nozzle, 0.);
+                nozzle, nozzle.getLocation().getRotation());
 
         if (alignmentOffset.getPreRotated()) {
             // See https://github.com/openpnp/openpnp/pull/590 for explanations of the magic

--- a/src/main/java/org/openpnp/machine/reference/wizards/ContactProbeNozzleWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/wizards/ContactProbeNozzleWizard.java
@@ -21,28 +21,31 @@
 package org.openpnp.machine.reference.wizards;
 
 import java.awt.BorderLayout;
-import java.awt.Color;
+import java.awt.event.ActionEvent;
+import java.awt.event.ItemEvent;
+import java.awt.event.ItemListener;
 
-import javax.swing.JCheckBox;
+import javax.swing.AbstractAction;
+import javax.swing.Action;
+import javax.swing.JButton;
 import javax.swing.JComboBox;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JTextField;
-import javax.swing.border.EtchedBorder;
 import javax.swing.border.TitledBorder;
 
-import org.jdesktop.beansbinding.AutoBinding.UpdateStrategy;
 import org.openpnp.gui.components.ComponentDecorators;
 import org.openpnp.gui.support.AbstractConfigurationWizard;
 import org.openpnp.gui.support.ActuatorsComboBoxModel;
-import org.openpnp.gui.support.IntegerConverter;
+import org.openpnp.gui.support.Icons;
 import org.openpnp.gui.support.LengthConverter;
-import org.openpnp.gui.support.MutableLocationProxy;
+import org.openpnp.gui.support.LongConverter;
 import org.openpnp.machine.reference.ContactProbeNozzle;
+import org.openpnp.machine.reference.ContactProbeNozzle.ContactProbeMethod;
+import org.openpnp.machine.reference.ContactProbeNozzle.ContactProbeTrigger;
 import org.openpnp.machine.reference.ReferenceNozzle;
-import org.openpnp.model.AbstractModelObject;
+import org.openpnp.util.UiUtils;
 
-import com.jgoodies.forms.layout.CellConstraints;
 import com.jgoodies.forms.layout.ColumnSpec;
 import com.jgoodies.forms.layout.FormLayout;
 import com.jgoodies.forms.layout.FormSpecs;
@@ -54,42 +57,223 @@ public class ContactProbeNozzleWizard extends AbstractConfigurationWizard {
     private JPanel panel;
     private JLabel lblContactProbeActuator;
     private JComboBox comboBoxContactProbeActuator;
+    private JLabel lblStartOffset;
+    private JTextField contactProbeStartOffsetZ;
+    private JLabel lblProbeDepth;
+    private JTextField contactProbeDepthZ;
+    private JLabel lblSniffleIncrement;
+    private JTextField sniffleIncrementZ;
+    private JLabel lblFinalAdjustment;
+    private JTextField contactProbeAdjustZ;
+    private JLabel lblMethod;
+    private JComboBox contactProbeMethod;
+    private JLabel lblFeederHeightProbing;
+    private JComboBox feederHeightProbing;
+    private JLabel lblPartHeightProbing;
+    private JComboBox partHeightProbing;
+    private JLabel lblZCalibration;
+    private JTextField calibrationOffsetZ;
+    private JButton btnCalibrateNow;
 
     public ContactProbeNozzleWizard(ContactProbeNozzle nozzle) {
         this.nozzle = nozzle;
         createUi();
     }
     private void createUi() {
-        
+
         contentPanel.setLayout(new BorderLayout(0, 0));
-        
+
         panel = new JPanel();
+        panel.setBorder(new TitledBorder(null, "Contact Probing", TitledBorder.LEADING,
+                TitledBorder.TOP, null, null));
         contentPanel.add(panel);
         panel.setLayout(new FormLayout(new ColumnSpec[] {
+                FormSpecs.RELATED_GAP_COLSPEC,
+                ColumnSpec.decode("max(70dlu;default)"),
                 FormSpecs.RELATED_GAP_COLSPEC,
                 FormSpecs.DEFAULT_COLSPEC,
                 FormSpecs.RELATED_GAP_COLSPEC,
                 FormSpecs.DEFAULT_COLSPEC,},
             new RowSpec[] {
                 FormSpecs.RELATED_GAP_ROWSPEC,
-                RowSpec.decode("26px"),
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
                 FormSpecs.RELATED_GAP_ROWSPEC,
                 FormSpecs.DEFAULT_ROWSPEC,}));
-        
-        lblContactProbeActuator = new JLabel("Contact Probe Actuator");
-        panel.add(lblContactProbeActuator, "2, 2, left, center");
-        
+
+        lblMethod = new JLabel("Method");
+        panel.add(lblMethod, "2, 2, right, default");
+
+        contactProbeMethod = new JComboBox(ContactProbeMethod.values());
+        contactProbeMethod.addItemListener(new ItemListener() {
+            public void itemStateChanged(ItemEvent e) {
+                adaptDialog();
+            }
+        });
+        panel.add(contactProbeMethod, "4, 2, fill, default");
+
+        lblContactProbeActuator = new JLabel("Probe Actuator");
+        panel.add(lblContactProbeActuator, "2, 4, right, center");
+
         comboBoxContactProbeActuator = new JComboBox();
         comboBoxContactProbeActuator.setMaximumRowCount(15);
         comboBoxContactProbeActuator.setModel(new ActuatorsComboBoxModel(nozzle.getHead()));
-        panel.add(comboBoxContactProbeActuator, "4, 2, default, top");
+        panel.add(comboBoxContactProbeActuator, "4, 4, default, top");
+
+        lblStartOffset = new JLabel("Start Offset");
+        lblStartOffset.setToolTipText("<html>Contact probing start offset in Z above the nominal location.<br/>\r\nNote: for part height probing, the maximum part height on the NozzleTip <br/>\r\nis used instead, if the part height is not yet known. \r\n</html>");
+        panel.add(lblStartOffset, "2, 6, right, default");
+
+        contactProbeStartOffsetZ = new JTextField();
+        panel.add(contactProbeStartOffsetZ, "4, 6, fill, default");
+        contactProbeStartOffsetZ.setColumns(10);
+
+        lblProbeDepth = new JLabel("Probe Depth");
+        lblProbeDepth.setToolTipText("Maximum contact probing depth in Z, from the Start Offset.");
+        panel.add(lblProbeDepth, "2, 8, right, default");
+
+        contactProbeDepthZ = new JTextField();
+        panel.add(contactProbeDepthZ, "4, 8, fill, default");
+        contactProbeDepthZ.setColumns(10);
+
+        lblSniffleIncrement = new JLabel("Sniffle Increment");
+        lblSniffleIncrement.setToolTipText("Vacuum sensing \"sniffle\" increment in Z. ");
+        panel.add(lblSniffleIncrement, "2, 10, right, default");
+
+        sniffleIncrementZ = new JTextField();
+        panel.add(sniffleIncrementZ, "4, 10, fill, default");
+        sniffleIncrementZ.setColumns(10);
+        
+        lblSniffleDwellTime = new JLabel("Sniffle Dwell Time [ms]");
+        panel.add(lblSniffleDwellTime, "2, 12, right, default");
+        
+        sniffleDwellTime = new JTextField();
+        panel.add(sniffleDwellTime, "4, 12, fill, default");
+        sniffleDwellTime.setColumns(10);
+
+        lblFinalAdjustment = new JLabel("Final Adjustment");
+        lblFinalAdjustment.setToolTipText("<html>\r\nContact probing final adjustment in Z (positive values point upwards in Z).<br/>\r\n<ul>\r\n<li>Use positive values to compensate probing overshoot.</li>\r\n<li>Use negative values to add additional nozzle tip spring tensioning.</li>\r\n</ul>\r\n</html>");
+        panel.add(lblFinalAdjustment, "2, 14, right, default");
+
+        contactProbeAdjustZ = new JTextField();
+        panel.add(contactProbeAdjustZ, "4, 14, fill, default");
+        contactProbeAdjustZ.setColumns(10);
+
+        lblFeederHeightProbing = new JLabel("Feeder Height Probing");
+        panel.add(lblFeederHeightProbing, "2, 18, right, default");
+
+        feederHeightProbing = new JComboBox(ContactProbeTrigger.values());
+        panel.add(feederHeightProbing, "4, 18, fill, default");
+
+        lblPartHeightProbing = new JLabel("Part Height Probing");
+        panel.add(lblPartHeightProbing, "2, 20, right, default");
+
+        partHeightProbing = new JComboBox(ContactProbeTrigger.values());
+        panel.add(partHeightProbing, "4, 20, fill, default");
+        
+        lblZCalibration = new JLabel("Calibration Z Offset");
+        panel.add(lblZCalibration, "2, 24, right, default");
+        
+        calibrationOffsetZ = new JTextField();
+        calibrationOffsetZ.setEditable(false);
+        panel.add(calibrationOffsetZ, "4, 24, fill, default");
+        calibrationOffsetZ.setColumns(10);
+        
+        btnCalibrateNow = new JButton(calibrateZAction);
+        panel.add(btnCalibrateNow, "6, 24");
+    }
+
+    protected void adaptDialog() {
+        ContactProbeMethod method = (ContactProbeMethod) contactProbeMethod.getSelectedItem();
+        boolean isProbing = (method != ContactProbeMethod.None);
+        boolean isActuator = (method == ContactProbeMethod.ContactSenseActuator);
+        boolean isVacuum = (method == ContactProbeMethod.VacuumSense);
+
+        lblContactProbeActuator.setVisible(isActuator);
+        comboBoxContactProbeActuator.setVisible(isActuator);
+        lblStartOffset.setVisible(isProbing);
+        contactProbeStartOffsetZ.setVisible(isProbing);
+        lblSniffleIncrement.setVisible(isVacuum);
+        sniffleIncrementZ.setVisible(isVacuum);
+        lblSniffleDwellTime.setVisible(isVacuum);
+        sniffleDwellTime.setVisible(isVacuum);
+        lblProbeDepth.setVisible(isProbing);
+        contactProbeDepthZ.setVisible(isProbing);
+        lblFinalAdjustment.setVisible(isProbing);
+        contactProbeAdjustZ.setVisible(isProbing);
+
+        lblFeederHeightProbing.setVisible(isActuator);
+        feederHeightProbing.setVisible(isActuator);
+        lblPartHeightProbing.setVisible(isActuator);
+        partHeightProbing.setVisible(isActuator);
+
+        lblZCalibration.setVisible(isProbing);
+        calibrationOffsetZ.setVisible(isProbing);
+        btnCalibrateNow.setVisible(isProbing);
     }
 
     @Override
     public void createBindings() {
         LengthConverter lengthConverter = new LengthConverter();
-        IntegerConverter intConverter = new IntegerConverter();
+        LongConverter longConverter = new LongConverter();
 
+        addWrappedBinding(nozzle, "contactProbeMethod", contactProbeMethod, "selectedItem");
         addWrappedBinding(nozzle, "contactProbeActuatorName", comboBoxContactProbeActuator, "selectedItem");
+
+        addWrappedBinding(nozzle, "contactProbeStartOffsetZ", contactProbeStartOffsetZ, "text", lengthConverter);
+        addWrappedBinding(nozzle, "contactProbeDepthZ", contactProbeDepthZ, "text", lengthConverter);
+        addWrappedBinding(nozzle, "sniffleIncrementZ", sniffleIncrementZ, "text", lengthConverter);
+        addWrappedBinding(nozzle, "sniffleDwellTime", sniffleDwellTime, "text", longConverter);
+        addWrappedBinding(nozzle, "contactProbeAdjustZ", contactProbeAdjustZ, "text", lengthConverter);
+
+        addWrappedBinding(nozzle, "feederHeightProbing", feederHeightProbing, "selectedItem");
+        addWrappedBinding(nozzle, "partHeightProbing", partHeightProbing, "selectedItem");
+
+        addWrappedBinding(nozzle, "calibrationOffsetZ", calibrationOffsetZ, "text", lengthConverter);
+
+        ComponentDecorators.decorateWithAutoSelectAndLengthConversion(contactProbeStartOffsetZ);
+        ComponentDecorators.decorateWithAutoSelectAndLengthConversion(contactProbeDepthZ);
+        ComponentDecorators.decorateWithAutoSelectAndLengthConversion(sniffleIncrementZ);
+        ComponentDecorators.decorateWithAutoSelectAndLengthConversion(contactProbeAdjustZ);
+        ComponentDecorators.decorateWithAutoSelectAndLengthConversion(calibrationOffsetZ);
+        
+        adaptDialog();
     }
+
+    private Action calibrateZAction = new AbstractAction("Calibrate now", Icons.contactProbeNozzle) {
+        {
+            putValue(Action.SHORT_DESCRIPTION, "<html>Calibrate the nozzle Z offset by contact-probing against the <strong>Touch Location</strong> defined in the Nozzle Tip.</html>");
+        }
+
+        @Override
+        public void actionPerformed(ActionEvent e) {
+            applyAction.actionPerformed(e);
+            UiUtils.submitUiMachineTask(() -> {
+                ContactProbeNozzle contactProbeNozzle = (ContactProbeNozzle) nozzle;
+                contactProbeNozzle.calibrateZ(contactProbeNozzle.getCalibrationNozzleTip());
+            });
+        }
+    };
+    private JLabel lblSniffleDwellTime;
+    private JTextField sniffleDwellTime;
+
 }

--- a/src/main/java/org/openpnp/machine/reference/wizards/ContactProbeNozzleWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/wizards/ContactProbeNozzleWizard.java
@@ -131,7 +131,7 @@ public class ContactProbeNozzleWizard extends AbstractConfigurationWizard {
         });
         panel.add(contactProbeMethod, "4, 2, fill, default");
 
-        lblContactProbeActuator = new JLabel("Probe Actuator");
+        lblContactProbeActuator = new JLabel("Contact Sense Actuator");
         panel.add(lblContactProbeActuator, "2, 4, right, center");
 
         comboBoxContactProbeActuator = new JComboBox();

--- a/src/main/java/org/openpnp/machine/reference/wizards/ReferenceNozzleTipConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/wizards/ReferenceNozzleTipConfigurationWizard.java
@@ -22,10 +22,12 @@ package org.openpnp.machine.reference.wizards;
 import java.util.HashSet;
 import java.util.Set;
 
+import javax.swing.JCheckBox;
 import javax.swing.JComponent;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JTextField;
+import javax.swing.UIManager;
 import javax.swing.border.TitledBorder;
 
 import org.openpnp.gui.components.ComponentDecorators;
@@ -39,9 +41,6 @@ import com.jgoodies.forms.layout.ColumnSpec;
 import com.jgoodies.forms.layout.FormLayout;
 import com.jgoodies.forms.layout.FormSpecs;
 import com.jgoodies.forms.layout.RowSpec;
-import javax.swing.JCheckBox;
-import javax.swing.UIManager;
-import java.awt.Color;
 
 public class ReferenceNozzleTipConfigurationWizard extends AbstractConfigurationWizard {
     private final ReferenceNozzleTip nozzleTip;
@@ -61,6 +60,11 @@ public class ReferenceNozzleTipConfigurationWizard extends AbstractConfiguration
     private JLabel lblLowDiameter;
     private JTextField textFieldLowDiameter;
     private JCheckBox chckbxPushAndDragAllowed;
+    private JPanel panelPartDimensions;
+    private JLabel lblMaxPartHeight;
+    private JTextField maxPartHeight;
+    private JLabel lblMaxPartDiameter;
+    private JTextField maxPartDiameter;
 
 
     public ReferenceNozzleTipConfigurationWizard(ReferenceNozzleTip nozzleTip) {
@@ -71,7 +75,7 @@ public class ReferenceNozzleTipConfigurationWizard extends AbstractConfiguration
         contentPanel.add(panel);
         panel.setLayout(new FormLayout(new ColumnSpec[] {
                 FormSpecs.RELATED_GAP_COLSPEC,
-                FormSpecs.DEFAULT_COLSPEC,
+                ColumnSpec.decode("max(70dlu;default)"),
                 FormSpecs.RELATED_GAP_COLSPEC,
                 FormSpecs.DEFAULT_COLSPEC,},
             new RowSpec[] {
@@ -90,7 +94,7 @@ public class ReferenceNozzleTipConfigurationWizard extends AbstractConfiguration
         contentPanel.add(panelDwellTime);
         panelDwellTime.setLayout(new FormLayout(new ColumnSpec[] {
                 FormSpecs.RELATED_GAP_COLSPEC,
-                FormSpecs.DEFAULT_COLSPEC,
+                ColumnSpec.decode("max(70dlu;default)"),
                 FormSpecs.RELATED_GAP_COLSPEC,
                 FormSpecs.DEFAULT_COLSPEC,
                 FormSpecs.RELATED_GAP_COLSPEC,
@@ -126,7 +130,7 @@ public class ReferenceNozzleTipConfigurationWizard extends AbstractConfiguration
         contentPanel.add(panelPushAndDrag);
         panelPushAndDrag.setLayout(new FormLayout(new ColumnSpec[] {
                 FormSpecs.RELATED_GAP_COLSPEC,
-                FormSpecs.DEFAULT_COLSPEC,
+                ColumnSpec.decode("max(70dlu;default)"),
                 FormSpecs.RELATED_GAP_COLSPEC,
                 FormSpecs.DEFAULT_COLSPEC,
                 FormSpecs.RELATED_GAP_COLSPEC,
@@ -145,7 +149,7 @@ public class ReferenceNozzleTipConfigurationWizard extends AbstractConfiguration
                 FormSpecs.RELATED_GAP_ROWSPEC,
                 FormSpecs.DEFAULT_ROWSPEC,}));
         
-        lblLowDiameter = new JLabel("Lowest Outside Diameter");
+        lblLowDiameter = new JLabel("Outside Diameter");
         lblLowDiameter.setToolTipText("Outside diameter of the nozzle tip at the lowest ~0.75mm.");
         panelPushAndDrag.add(lblLowDiameter, "2, 4, right, default");
         
@@ -159,9 +163,49 @@ public class ReferenceNozzleTipConfigurationWizard extends AbstractConfiguration
         
         chckbxPushAndDragAllowed = new JCheckBox("");
         panelPushAndDrag.add(chckbxPushAndDragAllowed, "4, 2");
-        
+
+        panelPartDimensions= new JPanel();
+        panelPartDimensions.setBorder(new TitledBorder(UIManager.getBorder("TitledBorder.border"),
+                "Part Dimensions", TitledBorder.LEADING, TitledBorder.TOP, null));
+        contentPanel.add(panelPartDimensions);
+
+        panelPartDimensions.setLayout(new FormLayout(new ColumnSpec[] {
+                FormSpecs.RELATED_GAP_COLSPEC,
+                ColumnSpec.decode("max(70dlu;default)"),
+                FormSpecs.RELATED_GAP_COLSPEC,
+                FormSpecs.DEFAULT_COLSPEC,
+                FormSpecs.RELATED_GAP_COLSPEC,
+                FormSpecs.DEFAULT_COLSPEC,
+                FormSpecs.RELATED_GAP_COLSPEC,
+                FormSpecs.DEFAULT_COLSPEC,
+                FormSpecs.RELATED_GAP_COLSPEC,
+                ColumnSpec.decode("default:grow"),
+                FormSpecs.RELATED_GAP_COLSPEC,
+                FormSpecs.DEFAULT_COLSPEC,
+                FormSpecs.RELATED_GAP_COLSPEC,
+                FormSpecs.DEFAULT_COLSPEC,},
+                new RowSpec[] {FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,}));
+
+        lblMaxPartDiameter = new JLabel("Max. Part Diameter");
+        lblMaxPartDiameter.setToolTipText(
+                "Maximum diameter/diagonal of parts picked with this nozzle tip. Used for vision masking/auto-focus etc.");
+        panelPartDimensions.add(lblMaxPartDiameter, "2, 2, right, default");
+
+        maxPartDiameter = new JTextField();
+        panelPartDimensions.add(maxPartDiameter, "4, 2, fill, default");
+        maxPartDiameter.setColumns(10);
+
+        lblMaxPartHeight = new JLabel("Max. Part Height");
+        lblMaxPartHeight.setToolTipText(
+                "Maximum part heights picked with this nozzle tip. Used for part height probing/auto-focus/dynamic safe Z.");
+        panelPartDimensions.add(lblMaxPartHeight, "2, 4, right, default");
+
+        maxPartHeight = new JTextField();
+        panelPartDimensions.add(maxPartHeight, "4, 4, fill, default");
+        maxPartHeight.setColumns(10);
     }
-    
 
     @Override
     public void createBindings() {
@@ -169,20 +213,24 @@ public class ReferenceNozzleTipConfigurationWizard extends AbstractConfiguration
         LengthConverter lengthConverter = new LengthConverter();
 
         addWrappedBinding(nozzleTip, "name", nameTf, "text");
-        
+
         addWrappedBinding(nozzleTip, "pickDwellMilliseconds", pickDwellTf, "text", intConverter);
         addWrappedBinding(nozzleTip, "placeDwellMilliseconds", placeDwellTf, "text", intConverter);
-        
+
         addWrappedBinding(nozzleTip, "diameterLow", textFieldLowDiameter, "text", lengthConverter);
-        
+
         addWrappedBinding(nozzleTip, "pushAndDragAllowed", chckbxPushAndDragAllowed, "selected");
-        
+
+        addWrappedBinding(nozzleTip, "maxPartDiameter", maxPartDiameter, "text", lengthConverter);
+        addWrappedBinding(nozzleTip, "maxPartHeight", maxPartHeight, "text", lengthConverter);
+
         ComponentDecorators.decorateWithAutoSelect(nameTf);
-        
+
         ComponentDecorators.decorateWithAutoSelect(pickDwellTf);
         ComponentDecorators.decorateWithAutoSelect(placeDwellTf);
-        
-        ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldLowDiameter);
 
+        ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldLowDiameter);
+        ComponentDecorators.decorateWithAutoSelectAndLengthConversion(maxPartDiameter);
+        ComponentDecorators.decorateWithAutoSelectAndLengthConversion(maxPartHeight);
     }
 }

--- a/src/main/java/org/openpnp/machine/reference/wizards/ReferenceNozzleTipToolChangerWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/wizards/ReferenceNozzleTipToolChangerWizard.java
@@ -280,7 +280,7 @@ public class ReferenceNozzleTipToolChangerWizard extends AbstractConfigurationWi
         touchLocationButtonsPanel.setContactProbeReference(true);
         panelChanger.add(touchLocationButtonsPanel, "12, 14, fill, fill");
 
-        lblZCalibrate = new JLabel("Automatic Z Calibration");
+        lblZCalibrate = new JLabel("Auto Z Calibration");
         lblZCalibrate.setToolTipText(
                 "<html>\r\nCalibrate the nozzle/nozzle tip Z by probing against the <strong>Touch Location</strong> surface.<br/>\r\nZ calibration can be triggered manually using the <strong>Calibrate now</strong> button or automatically:<br/>\r\n<ul>\r\n<li><strong>Manual:</strong> No automatic Z calibration is done. Manual calibration is stored<br/>\r\npermanently in the configuration and remains valid through machine homing.</li>\r\n<li><strong>MachineHome:</strong> Automatic Z calibration is performed when the machine is homed.<br/>\r\nThe nozzle Z calibration is reused when another Nozzle Tip is loaded.</li>\r\n<li><strong>NozzleTipChange:</strong> Automatic Z calibration is done whenever this Nozzle Tip<br/>\r\nis changed or when the machine is homed and this Nozzle Tip is currently loaded.</li>\r\n</ul>\r\nNote, you can use a stand-in Nozzle Tip named \"unloaded\" to perform Z calibration of the naked nozzle. \r\n</html>");
         panelChanger.add(lblZCalibrate, "2, 18, right, default");
@@ -401,8 +401,8 @@ public class ReferenceNozzleTipToolChangerWizard extends AbstractConfigurationWi
         panelVision.add(visionTemplateTolerance, "4, 9, fill, default");
         visionTemplateTolerance.setColumns(10);
         
-        lblPrecision = new JLabel("Retry Precision");
-        lblPrecision.setToolTipText("If a calibration pass is further away than this distance, another pass is made.");
+        lblPrecision = new JLabel("Wanted Precision");
+        lblPrecision.setToolTipText("<html>If the detected template image match is further away than the <strong>Wanted Precision</strong>,<br/>\r\nthe camera is re-centered and another vision pass is made.</html>");
         panelVision.add(lblPrecision, "6, 9, right, default");
         
         visionCalibrationTolerance = new JTextField();
@@ -547,10 +547,10 @@ public class ReferenceNozzleTipToolChangerWizard extends AbstractConfigurationWi
                                                         cloneVisionCalibration.setSelected(true);
                                                         panel.add(cloneVisionCalibration, "12, 4");
                                                 
-                                                templateClones = new JRadioButton("Clones from Template");
-                                                templateClones.setToolTipText("This nozzle tip can clone its settings from the nozzle tip marked as the <strong>Template</strong>.");
-                                                behaviorButtonGroup.add(templateClones);
-                                                panelClone.add(templateClones, "4, 4");
+                                                templateClone = new JRadioButton("Clones from Template");
+                                                templateClone.setToolTipText("This nozzle tip can clone its settings from the nozzle tip marked as the <strong>Template</strong>.");
+                                                behaviorButtonGroup.add(templateClone);
+                                                panelClone.add(templateClone, "4, 4");
                                                 
                                                 templateLocked = new JRadioButton("Locked");
                                                 templateLocked.setToolTipText("<html>This nozzle tip is locked against cloning.<br/>Note, its touch location Z can still be calibrated against the template nozzle tip reference. </html>");
@@ -716,6 +716,7 @@ public class ReferenceNozzleTipToolChangerWizard extends AbstractConfigurationWi
         addWrappedBinding(nozzleTip, "zCalibrationFailHoming", zCalibrationFailHoming, "selected");
 
         addWrappedBinding(nozzleTip, "templateNozzleTip", templateNozzleTip, "selected");
+        addWrappedBinding(nozzleTip, "templateClone", templateClone, "selected");
         addWrappedBinding(nozzleTip, "templateLocked", templateLocked, "selected");
 
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldChangerStartX);
@@ -781,7 +782,7 @@ public class ReferenceNozzleTipToolChangerWizard extends AbstractConfigurationWi
         }
     }
 
-    private Action calibrateZAction = new AbstractAction("Calibrate now", Icons.contactProbeNozzle) {
+    private Action calibrateZAction = new AbstractAction("Calibrate now") {
         {
             putValue(Action.SHORT_DESCRIPTION, "<html>Calibrate the nozzle/nozzle tip Z by contact-probing against the <strong>Touch Location</strong> surface.</html>");
         }
@@ -1040,7 +1041,7 @@ public class ReferenceNozzleTipToolChangerWizard extends AbstractConfigurationWi
     private JLabel lblCalibrationTrigger;
     private JComboBox visionCalibrationTrigger;
     private JRadioButton templateNozzleTip;
-    private JRadioButton templateClones;
+    private JRadioButton templateClone;
     private JRadioButton templateLocked;
     private final ButtonGroup behaviorButtonGroup = new ButtonGroup();
 }

--- a/src/main/java/org/openpnp/machine/reference/wizards/ReferenceNozzleTipToolChangerWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/wizards/ReferenceNozzleTipToolChangerWizard.java
@@ -19,35 +19,51 @@
 
 package org.openpnp.machine.reference.wizards;
 
+import java.awt.Color;
 import java.awt.event.ActionEvent;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.Set;
+import java.awt.event.ItemEvent;
+import java.awt.event.ItemListener;
+import java.awt.image.BufferedImage;
 
 import javax.swing.AbstractAction;
 import javax.swing.Action;
+import javax.swing.ButtonGroup;
 import javax.swing.JButton;
+import javax.swing.JCheckBox;
 import javax.swing.JComboBox;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
+import javax.swing.JRadioButton;
 import javax.swing.JTextField;
+import javax.swing.UIManager;
 import javax.swing.border.TitledBorder;
 
 import org.jdesktop.beansbinding.AutoBinding.UpdateStrategy;
+import org.openpnp.gui.MainFrame;
 import org.openpnp.gui.components.ComponentDecorators;
 import org.openpnp.gui.components.LocationButtonsPanel;
+import org.openpnp.gui.components.TemplateImageControl;
 import org.openpnp.gui.support.AbstractConfigurationWizard;
 import org.openpnp.gui.support.ActuatorsComboBoxModel;
 import org.openpnp.gui.support.DoubleConverter;
 import org.openpnp.gui.support.Icons;
+import org.openpnp.gui.support.IntegerConverter;
 import org.openpnp.gui.support.LengthConverter;
 import org.openpnp.gui.support.MutableLocationProxy;
+import org.openpnp.machine.reference.ContactProbeNozzle;
+import org.openpnp.machine.reference.ReferenceNozzle;
 import org.openpnp.machine.reference.ReferenceNozzleTip;
+import org.openpnp.machine.reference.ReferenceNozzleTip.VisionCalibration;
+import org.openpnp.machine.reference.ReferenceNozzleTip.VisionCalibrationTrigger;
+import org.openpnp.machine.reference.ReferenceNozzleTip.ZCalibrationTrigger;
 import org.openpnp.model.Configuration;
 import org.openpnp.model.Location;
+import org.openpnp.spi.Camera;
 import org.openpnp.spi.Machine;
 import org.openpnp.spi.NozzleTip;
+import org.openpnp.util.MovableUtils;
 import org.openpnp.util.UiUtils;
+import org.openpnp.vision.TemplateImage;
 import org.pmw.tinylog.Logger;
 
 import com.jgoodies.forms.layout.ColumnSpec;
@@ -57,49 +73,7 @@ import com.jgoodies.forms.layout.RowSpec;
 
 public class ReferenceNozzleTipToolChangerWizard extends AbstractConfigurationWizard {
     private final ReferenceNozzleTip nozzleTip;
-    private JPanel panelChanger;
-    private JLabel lblY_1;
-    private JLabel lblZ_1;
-    private LocationButtonsPanel changerStartLocationButtonsPanel;
-    private JLabel lblStartLocation;
-    private JTextField textFieldChangerStartX;
-    private JTextField textFieldChangerStartY;
-    private JTextField textFieldChangerStartZ;
-    private JLabel lblMiddleLocation;
-    private JTextField textFieldChangerMidX;
-    private JTextField textFieldChangerMidY;
-    private JTextField textFieldChangerMidZ;
-    private JLabel lblEndLocation;
-    private JTextField textFieldChangerEndX;
-    private JTextField textFieldChangerEndY;
-    private JTextField textFieldChangerEndZ;
-    private LocationButtonsPanel changerMidLocationButtonsPanel;
-    private LocationButtonsPanel changerEndLocationButtonsPanel;
 
-    private Set<org.openpnp.model.Package> compatiblePackages = new HashSet<>();
-    private JLabel lblMiddleLocation_1;
-    private JTextField textFieldMidX2;
-    private JTextField textFieldMidY2;
-    private JTextField textFieldMidZ2;
-    private LocationButtonsPanel changerMidButtons2;
-    private JTextField textFieldChangerStartToMidSpeed;
-    private JTextField textFieldChangerMidToMid2Speed;
-    private JTextField textFieldChangerMid2ToEndSpeed;
-    private JLabel lblSpeed;
-    private JLabel lblX;
-    private JLabel lblSpeed1_2;
-    private JLabel lblSpeed2_3;
-    private JLabel lblSpeed3_4;
-    private JLabel label;
-    private JPanel panel;
-    private JComboBox tcPostOneComboBoxActuator;
-    private JComboBox tcPostTwoComboBoxActuator;
-    private JComboBox tcPostThreeComboBoxActuator;
-    private JComboBox copyFromNozzleTip;
-    private JLabel lblCopyFrom;
-    private JButton btnNewButton;
-
-    private ArrayList<ReferenceNozzleTip> nozzleTips;
     public ReferenceNozzleTipToolChangerWizard(ReferenceNozzleTip nozzleTip) {
         this.nozzleTip = nozzleTip;
 
@@ -109,7 +83,7 @@ public class ReferenceNozzleTipToolChangerWizard extends AbstractConfigurationWi
         contentPanel.add(panelChanger);
         panelChanger.setLayout(new FormLayout(new ColumnSpec[] {
                 FormSpecs.RELATED_GAP_COLSPEC,
-                FormSpecs.DEFAULT_COLSPEC,
+                ColumnSpec.decode("max(70dlu;default)"),
                 FormSpecs.RELATED_GAP_COLSPEC,
                 FormSpecs.DEFAULT_COLSPEC,
                 FormSpecs.RELATED_GAP_COLSPEC,
@@ -136,9 +110,13 @@ public class ReferenceNozzleTipToolChangerWizard extends AbstractConfigurationWi
                 FormSpecs.RELATED_GAP_ROWSPEC,
                 FormSpecs.DEFAULT_ROWSPEC,
                 FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
                 FormSpecs.DEFAULT_ROWSPEC,}));
-        
-        
+
+
         label = new JLabel("Post 1 Actuator");
         panelChanger.add(label, "2, 5, right, center");
         label = new JLabel("Post 2 Actuator");
@@ -151,43 +129,44 @@ public class ReferenceNozzleTipToolChangerWizard extends AbstractConfigurationWi
             myMachine = Configuration.get().getMachine();
         }
         catch (Exception e){
-        	Logger.error(e, "Cannot determine Name of machine.");
+            Logger.error(e, "Cannot determine Name of machine.");
         }
-        
+
         tcPostOneComboBoxActuator = new JComboBox();
         tcPostOneComboBoxActuator.setModel(new ActuatorsComboBoxModel(myMachine));
         panelChanger.add(tcPostOneComboBoxActuator, "4, 5, 3, 1");
-        
+
         tcPostTwoComboBoxActuator = new JComboBox();
         tcPostTwoComboBoxActuator.setModel(new ActuatorsComboBoxModel(myMachine));
         panelChanger.add(tcPostTwoComboBoxActuator, "4, 7, 3, 1");
-        
+
         tcPostThreeComboBoxActuator = new JComboBox();
         tcPostThreeComboBoxActuator.setModel(new ActuatorsComboBoxModel(myMachine));
         panelChanger.add(tcPostThreeComboBoxActuator, "4, 9, 3, 1");
-        
+
         lblX = new JLabel("X");
-        panelChanger.add(lblX, "4, 2");
+        panelChanger.add(lblX, "4, 2, center, default");
 
         lblY_1 = new JLabel("Y");
-        panelChanger.add(lblY_1, "6, 2");
+        panelChanger.add(lblY_1, "6, 2, center, default");
 
         lblZ_1 = new JLabel("Z");
-        panelChanger.add(lblZ_1, "8, 2");
-        
+        panelChanger.add(lblZ_1, "8, 2, center, default");
+
         lblSpeed = new JLabel("Speed");
-        panelChanger.add(lblSpeed, "10, 2");
-        
+        panelChanger.add(lblSpeed, "10, 2, center, default");
+
         lblSpeed1_2 = new JLabel("1 ↔ 2");
         panelChanger.add(lblSpeed1_2, "8, 5, right, default");
-        
+
         lblSpeed2_3 = new JLabel("2 ↔ 3");
         panelChanger.add(lblSpeed2_3, "8, 7, right, default");
-        
+
         lblSpeed3_4 = new JLabel("3 ↔ 4");
         panelChanger.add(lblSpeed3_4, "8, 9, right, default");
-        
+
         lblStartLocation = new JLabel("First Location");
+        lblStartLocation.setToolTipText("<html>First location in a nozzle tip loading motion sequence.<br/>\r\nThis is the first way-point when loading the nozzle tip and the<br/>\r\nlast way-point when unloading it.\r\n</hml>");
         panelChanger.add(lblStartLocation, "2, 4, right, default");
 
         textFieldChangerStartX = new JTextField();
@@ -201,7 +180,7 @@ public class ReferenceNozzleTipToolChangerWizard extends AbstractConfigurationWi
         textFieldChangerStartZ = new JTextField();
         panelChanger.add(textFieldChangerStartZ, "8, 4, fill, default");
         textFieldChangerStartZ.setColumns(8);
-        
+
         textFieldChangerStartToMidSpeed = new JTextField();
         textFieldChangerStartToMidSpeed.setToolTipText("Speed between First location and Second location");
         panelChanger.add(textFieldChangerStartToMidSpeed, "10, 5, fill, default");
@@ -226,7 +205,7 @@ public class ReferenceNozzleTipToolChangerWizard extends AbstractConfigurationWi
         textFieldChangerMidZ = new JTextField();
         panelChanger.add(textFieldChangerMidZ, "8, 6, fill, default");
         textFieldChangerMidZ.setColumns(8);
-        
+
         textFieldChangerMidToMid2Speed = new JTextField();
         textFieldChangerMidToMid2Speed.setToolTipText("Speed between Second location and Third location");
         textFieldChangerMidToMid2Speed.setColumns(8);
@@ -236,27 +215,27 @@ public class ReferenceNozzleTipToolChangerWizard extends AbstractConfigurationWi
                 textFieldChangerMidY, textFieldChangerMidZ, (JTextField) null);
         changerMidLocationButtonsPanel.setShowPositionToolNoSafeZ(true);
         panelChanger.add(changerMidLocationButtonsPanel, "12, 6, fill, default");
-        
+
         lblMiddleLocation_1 = new JLabel("Third Location");
         panelChanger.add(lblMiddleLocation_1, "2, 8, right, default");
-        
+
         textFieldMidX2 = new JTextField();
         textFieldMidX2.setColumns(8);
         panelChanger.add(textFieldMidX2, "4, 8, fill, default");
-        
+
         textFieldMidY2 = new JTextField();
         textFieldMidY2.setColumns(8);
         panelChanger.add(textFieldMidY2, "6, 8, fill, default");
-        
+
         textFieldMidZ2 = new JTextField();
         textFieldMidZ2.setColumns(8);
         panelChanger.add(textFieldMidZ2, "8, 8, fill, default");
-        
+
         textFieldChangerMid2ToEndSpeed = new JTextField();
         textFieldChangerMid2ToEndSpeed.setToolTipText("Speed between Third location and Last location");
         textFieldChangerMid2ToEndSpeed.setColumns(8);
         panelChanger.add(textFieldChangerMid2ToEndSpeed, "10, 9, fill, default");
-        
+
         changerMidButtons2 = new LocationButtonsPanel(textFieldMidX2, textFieldMidY2, textFieldMidZ2, (JTextField) null);
         changerMidButtons2.setShowPositionToolNoSafeZ(true);
         panelChanger.add(changerMidButtons2, "12, 8, fill, default");
@@ -281,34 +260,375 @@ public class ReferenceNozzleTipToolChangerWizard extends AbstractConfigurationWi
         changerEndLocationButtonsPanel.setShowPositionToolNoSafeZ(true);
         panelChanger.add(changerEndLocationButtonsPanel, "12, 10, fill, default");
 
-        lblCopyFrom = new JLabel("Template");
-        panelChanger.add(lblCopyFrom, "2, 16, right, default");
+        lblTouchLocation = new JLabel("Touch Location");
+        panelChanger.add(lblTouchLocation, "2, 14, right, default");
 
-        nozzleTips = new ArrayList<>();
-        copyFromNozzleTip = new JComboBox();
-        if (myMachine != null) {
-            for (NozzleTip nt : myMachine.getNozzleTips()) {
-                if (nt instanceof ReferenceNozzleTip 
-                        && nt != nozzleTip) {
-                    nozzleTips.add((ReferenceNozzleTip) nt);
-                    copyFromNozzleTip.addItem(nt.getName());
-                }
+        touchLocationX = new JTextField();
+        panelChanger.add(touchLocationX, "4, 14, fill, default");
+        touchLocationX.setColumns(10);
+
+        touchLocationY = new JTextField();
+        panelChanger.add(touchLocationY, "6, 14, fill, default");
+        touchLocationY.setColumns(10);
+
+        touchLocationZ = new JTextField();
+        panelChanger.add(touchLocationZ, "8, 14, fill, default");
+        touchLocationZ.setColumns(10);
+
+        touchLocationButtonsPanel = new LocationButtonsPanel(touchLocationX, touchLocationY, touchLocationZ, (JTextField) null);
+        touchLocationButtonsPanel.setShowContactProbeTool(true);
+        touchLocationButtonsPanel.setContactProbeReference(true);
+        panelChanger.add(touchLocationButtonsPanel, "12, 14, fill, fill");
+
+        lblZCalibrate = new JLabel("Automatic Z Calibration");
+        lblZCalibrate.setToolTipText(
+                "<html>\r\nCalibrate the nozzle/nozzle tip Z by probing against the <strong>Touch Location</strong> surface.<br/>\r\nZ calibration can be triggered manually using the <strong>Calibrate now</strong> button or automatically:<br/>\r\n<ul>\r\n<li><strong>Manual:</strong> No automatic Z calibration is done. Manual calibration is stored<br/>\r\npermanently in the configuration and remains valid through machine homing.</li>\r\n<li><strong>MachineHome:</strong> Automatic Z calibration is performed when the machine is homed.<br/>\r\nThe nozzle Z calibration is reused when another Nozzle Tip is loaded.</li>\r\n<li><strong>NozzleTipChange:</strong> Automatic Z calibration is done whenever this Nozzle Tip<br/>\r\nis changed or when the machine is homed and this Nozzle Tip is currently loaded.</li>\r\n</ul>\r\nNote, you can use a stand-in Nozzle Tip named \"unloaded\" to perform Z calibration of the naked nozzle. \r\n</html>");
+        panelChanger.add(lblZCalibrate, "2, 18, right, default");
+
+        zCalibrationTrigger = new JComboBox(ZCalibrationTrigger.values());
+        zCalibrationTrigger.addItemListener(new ItemListener() {
+            public void itemStateChanged(ItemEvent e) {
+                adaptDialog();
             }
-        }
-        panelChanger.add(copyFromNozzleTip, "4, 16, 7, 1, fill, default");
+        });
+        panelChanger.add(zCalibrationTrigger, "4, 18, 3, 1, fill, default");
+        
+                calibrationOffsetZ = new JTextField();
+                calibrationOffsetZ.setToolTipText("Calibrated Z offset of the nozzle");
+                calibrationOffsetZ.setEditable(false);
+                panelChanger.add(calibrationOffsetZ, "8, 18, fill, default");
+                calibrationOffsetZ.setColumns(10);
+        
+                btnReset = new JButton(resetZCalibrationAction);
+                panelChanger.add(btnReset, "10, 18, default, fill");
 
-        btnNewButton = new JButton(cloneFromNozzleTipAction);
-        panelChanger.add(btnNewButton, "12, 16");
-        if (nozzleTips.size() == 0) {
-            copyFromNozzleTip.setEnabled(false);
-            btnNewButton.setEnabled(false);
-        }
+        btnCalibrateNow = new JButton(calibrateZAction);
+        panelChanger.add(btnCalibrateNow, "12, 18");
+        
+                lblFailHoming = new JLabel("Fail Homing?");
+                lblFailHoming.setToolTipText(
+                        "When the Z calibration fails during homing, also fail the homing cycle.");
+                panelChanger.add(lblFailHoming, "2, 20, right, default");
+        
+                zCalibrationFailHoming = new JCheckBox("");
+                panelChanger.add(zCalibrationFailHoming, "4, 20");
+        
+        panelVision = new JPanel();
+        panelVision.setBorder(new TitledBorder(null, "Vision Calibration", TitledBorder.LEADING,
+                TitledBorder.TOP, null, null));
+        contentPanel.add(panelVision);
+        
+        panelVision.setLayout(new FormLayout(new ColumnSpec[] {
+                FormSpecs.RELATED_GAP_COLSPEC,
+                ColumnSpec.decode("max(70dlu;default)"),
+                FormSpecs.RELATED_GAP_COLSPEC,
+                ColumnSpec.decode("max(50dlu;default)"),
+                FormSpecs.RELATED_GAP_COLSPEC,
+                ColumnSpec.decode("max(50dlu;default)"),
+                FormSpecs.RELATED_GAP_COLSPEC,
+                FormSpecs.DEFAULT_COLSPEC,
+                FormSpecs.RELATED_GAP_COLSPEC,
+                ColumnSpec.decode("max(50dlu;default)"),
+                FormSpecs.RELATED_GAP_COLSPEC,
+                FormSpecs.DEFAULT_COLSPEC,
+                FormSpecs.RELATED_GAP_COLSPEC,
+                FormSpecs.DEFAULT_COLSPEC,
+                FormSpecs.RELATED_GAP_COLSPEC,
+                FormSpecs.DEFAULT_COLSPEC,},
+            new RowSpec[] {
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.LABEL_COMPONENT_GAP_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,}));
+        
+        lblVisionCalibration = new JLabel("Vision Location");
+        lblVisionCalibration.setToolTipText("<html>Location for vision calibration, or None for no calibration.<br/>\r\nChoose a location where the nozzle tip in the slot is visible. \r\n</html>");
+        panelVision.add(lblVisionCalibration, "2, 2, right, default");
+        
+        visionCalibration = new JComboBox(VisionCalibration.values());
+        visionCalibration.addItemListener(new ItemListener() {
+            public void itemStateChanged(ItemEvent e) {
+                adaptDialog();
+            }
+        });
+        panelVision.add(visionCalibration, "4, 2, 3, 1");
+        
+        lblVisionCalibrationHelp = new JLabel("<html>\r\nCapture two template images of your nozzle tip changer slot<br/>\r\nboth in empty and occupied state.<br/>\r\nUsing the templates, vision calibration will then calibrate the<br/>\r\nchanger locations in X/Y and also make sure the slot is empty<br/>\r\nor occupied as expected.\r\n</html>");
+        panelVision.add(lblVisionCalibrationHelp, "10, 2, 1, 10, default, top");
+        
+        lblCalibrationTrigger = new JLabel("Calibration Trigger");
+        panelVision.add(lblCalibrationTrigger, "2, 5, right, default");
+        
+        visionCalibrationTrigger = new JComboBox(VisionCalibrationTrigger.values());
+        panelVision.add(visionCalibrationTrigger, "4, 5, 3, 1, fill, default");
+        
+        lblTemplateDimX = new JLabel("Template Width");
+        lblTemplateDimX.setToolTipText("<html>\r\nTemplate image width (X). The template is centered around the selected Vision Location.<br/>\r\nChoose dimensions as small as possible, but the templates should include tell-tale horizontal and vertical<br/>\r\nedges. Furthermore, the nozzle tip should be visible when it occupies the changer slot.\r\n</html>");
+        panelVision.add(lblTemplateDimX, "2, 7, right, default");
+        
+        visionTemplateDimensionX = new JTextField();
+        panelVision.add(visionTemplateDimensionX, "4, 7");
+        visionTemplateDimensionX.setColumns(10);
+        
+        lblTemplateDimY = new JLabel("Template Height");
+        lblTemplateDimY.setToolTipText("<html>\r\nTemplate image width (X). The template is centered around the selected Vision Location.<br/>\r\nChoose dimensions as small as possible, but the templates should include tell-tale horizontal and vertical<br/>\r\nedges. Furthermore, the nozzle tip should be visible when it occupies the changer slot.\r\n</html>");
+        panelVision.add(lblTemplateDimY, "6, 7, right, default");
+        
+        visionTemplateDimensionY = new JTextField();
+        panelVision.add(visionTemplateDimensionY, "8, 7");
+        visionTemplateDimensionY.setColumns(10);
+        
+        lblTolerance = new JLabel("Tolerance");
+        lblTolerance.setToolTipText("Maximum calibration tolerance i.e. how far away from the nominal location the calibrated location can be.");
+        panelVision.add(lblTolerance, "2, 9, right, default");
+        
+        visionTemplateTolerance = new JTextField();
+        panelVision.add(visionTemplateTolerance, "4, 9, fill, default");
+        visionTemplateTolerance.setColumns(10);
+        
+        lblPrecision = new JLabel("Retry Precision");
+        lblPrecision.setToolTipText("If a calibration pass is further away than this distance, another pass is made.");
+        panelVision.add(lblPrecision, "6, 9, right, default");
+        
+        visionCalibrationTolerance = new JTextField();
+        panelVision.add(visionCalibrationTolerance, "8, 9, fill, default");
+        visionCalibrationTolerance.setColumns(10);
+        
+        lblMaxPasses = new JLabel("Max. Passes");
+        panelVision.add(lblMaxPasses, "2, 11, right, default");
+        
+        visionCalibrationMaxPasses = new JTextField();
+        panelVision.add(visionCalibrationMaxPasses, "4, 11, fill, default");
+        visionCalibrationMaxPasses.setColumns(10);
+        
+        lblMinScore = new JLabel("Minimum Score");
+        lblMinScore.setToolTipText("<html>\r\nWhen the template images are matched against the camera image, a score is computed<br/>\r\nindicating the quality of the match. If the obtained score is smaller than the Minimum Score<br/>\r\ngiven here, the calibration fails. This should stop the machine from atempting a nozzle tip <br/>\r\nchange, when the position is wrong. \r\n</html>");
+        panelVision.add(lblMinScore, "2, 13, right, default");
+        
+        visionMatchMinimumScore = new JTextField();
+        panelVision.add(visionMatchMinimumScore, "4, 13, fill, default");
+        visionMatchMinimumScore.setColumns(10);
+        
+        lblLastScore = new JLabel("Last Score");
+        panelVision.add(lblLastScore, "6, 13, right, default");
+        
+        visionMatchLastScore = new JTextField();
+        visionMatchLastScore.setEditable(false);
+        panelVision.add(visionMatchLastScore, "8, 13, fill, default");
+        visionMatchLastScore.setColumns(10);
+        
+        btnTest = new JButton(visionCalibrateTestAction);
+        panelVision.add(btnTest, "10, 13");
+        
+        lblTemplateEmpty = new JLabel("Template Empty");
+        panelVision.add(lblTemplateEmpty, "2, 17, right, top");
+        
+        btnCaptureEmpty = new JButton(captureTemplateImageEmptyAction);
+        panelVision.add(btnCaptureEmpty, "4, 17, default, top");
+        
+        btnResetEmpty = new JButton(resetTemplateImageEmptyAction);
+        panelVision.add(btnResetEmpty, "6, 17, default, top");
+       
+        visionTemplateImageEmpty = new TemplateImageControl();
+        visionTemplateImageEmpty.setName("Empty");
+        visionTemplateImageEmpty.setCamera(getCamera());
+        panelVision.add(visionTemplateImageEmpty, "8, 17, 3, 1");
+        
+        lblTemplateOccupied = new JLabel("Template Occupied");
+        panelVision.add(lblTemplateOccupied, "2, 19, right, top");
+        
+        btnCaptureOccupied = new JButton(captureTemplateImageOccupiedAction);
+        panelVision.add(btnCaptureOccupied, "4, 19, default, top");
+        
+        btnResetOccupied = new JButton(resetTemplateImageOccupiedAction);
+        panelVision.add(btnResetOccupied, "6, 19, default, top");
+        visionTemplateImageOccupied = new TemplateImageControl();
+        visionTemplateImageOccupied.setName("Occupied");
+        visionTemplateImageOccupied.setCamera(getCamera());
+        panelVision.add(visionTemplateImageOccupied, "8, 19, 3, 1");
+        visionTemplateImageOccupied.setBackground(Color.DARK_GRAY);
+
+        panelClone = new JPanel();
+        panelClone.setBorder(new TitledBorder(UIManager.getBorder("TitledBorder.border"), "Cloning Settings", TitledBorder.LEADING, TitledBorder.TOP, null, new Color(0, 0, 0)));
+        contentPanel.add(panelClone);
+        
+        panelClone.setLayout(new FormLayout(new ColumnSpec[] {
+                FormSpecs.RELATED_GAP_COLSPEC,
+                ColumnSpec.decode("max(70dlu;default)"),
+                FormSpecs.RELATED_GAP_COLSPEC,
+                FormSpecs.DEFAULT_COLSPEC,
+                FormSpecs.RELATED_GAP_COLSPEC,
+                FormSpecs.DEFAULT_COLSPEC,
+                FormSpecs.RELATED_GAP_COLSPEC,
+                FormSpecs.DEFAULT_COLSPEC,},
+            new RowSpec[] {
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.LINE_GAP_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,}));
+        
+                lblTemplate = new JLabel("Behavior");
+                panelClone.add(lblTemplate, "2, 2, right, default");
+                lblTemplate.setToolTipText("<html>\r\nOne nozzle tip can become the <strong>Template</strong> for others to be cloned from.<br/>\r\nOpenPnP will automatically translate Locations relative to the First Location.<br/>\r\nIf individual nozzle tips are special, mark them as <strong>Locked</strong>to prevent cloning.\r\n</html>");
+                                                
+                                                templateNozzleTip = new JRadioButton("Template");
+                                                templateNozzleTip.setToolTipText("Mark this nozzle tip as the template that can be cloned to and from the other nozzle tips.");
+                                                templateNozzleTip.addItemListener(new ItemListener() {
+                                                    public void itemStateChanged(ItemEvent e) {
+                                                        adaptDialog();
+                                                    }
+                                                });
+                                                behaviorButtonGroup.add(templateNozzleTip);
+                                                panelClone.add(templateNozzleTip, "4, 2");
+                                                
+                                                panel = new JPanel();
+                                                panel.setBorder(new TitledBorder(UIManager.getBorder("TitledBorder.border"), "", TitledBorder.LEADING, TitledBorder.TOP, null, new Color(0, 0, 0)));
+                                                panelClone.add(panel, "8, 2, 1, 5, fill, fill");
+                                                panel.setLayout(new FormLayout(new ColumnSpec[] {
+                                                        FormSpecs.LABEL_COMPONENT_GAP_COLSPEC,
+                                                        ColumnSpec.decode("max(70dlu;default)"),
+                                                        FormSpecs.RELATED_GAP_COLSPEC,
+                                                        FormSpecs.DEFAULT_COLSPEC,
+                                                        FormSpecs.RELATED_GAP_COLSPEC,
+                                                        ColumnSpec.decode("max(70dlu;default)"),
+                                                        FormSpecs.RELATED_GAP_COLSPEC,
+                                                        FormSpecs.DEFAULT_COLSPEC,
+                                                        FormSpecs.RELATED_GAP_COLSPEC,
+                                                        ColumnSpec.decode("max(70dlu;default)"),
+                                                        FormSpecs.RELATED_GAP_COLSPEC,
+                                                        FormSpecs.DEFAULT_COLSPEC,},
+                                                    new RowSpec[] {
+                                                        FormSpecs.LABEL_COMPONENT_GAP_ROWSPEC,
+                                                        RowSpec.decode("33px"),
+                                                        FormSpecs.RELATED_GAP_ROWSPEC,
+                                                        FormSpecs.DEFAULT_ROWSPEC,}));
+                                                
+                                                        btnCloneButton = new JButton(cloneFromNozzleTipAction);
+                                                        panel.add(btnCloneButton, "2, 2, 11, 1, fill, top");
+                                                        
+                                                        lblLocations = new JLabel("Locations?");
+                                                        panel.add(lblLocations, "2, 4, right, default");
+                                                        
+                                                        cloneLocations = new JCheckBox("");
+                                                        cloneLocations.setSelected(true);
+                                                        panel.add(cloneLocations, "4, 4");
+                                                        
+                                                        lblZCalibration = new JLabel("Z Calibration?");
+                                                        panel.add(lblZCalibration, "6, 4, right, default");
+                                                        
+                                                        cloneZCalibration = new JCheckBox("");
+                                                        cloneZCalibration.setSelected(true);
+                                                        panel.add(cloneZCalibration, "8, 4");
+                                                        
+                                                        lblCloneVisionCalibration = new JLabel("Vision Calibration?");
+                                                        panel.add(lblCloneVisionCalibration, "10, 4, right, default");
+                                                        
+                                                        cloneVisionCalibration = new JCheckBox("");
+                                                        cloneVisionCalibration.setSelected(true);
+                                                        panel.add(cloneVisionCalibration, "12, 4");
+                                                
+                                                templateClones = new JRadioButton("Clones from Template");
+                                                templateClones.setToolTipText("This nozzle tip can clone its settings from the nozzle tip marked as the <strong>Template</strong>.");
+                                                behaviorButtonGroup.add(templateClones);
+                                                panelClone.add(templateClones, "4, 4");
+                                                
+                                                templateLocked = new JRadioButton("Locked");
+                                                templateLocked.setToolTipText("<html>This nozzle tip is locked against cloning.<br/>Note, its touch location Z can still be calibrated against the template nozzle tip reference. </html>");
+                                                templateLocked.addItemListener(new ItemListener() {
+                                                    public void itemStateChanged(ItemEvent e) {
+                                                        adaptDialog();
+                                                    }
+                                                });
+                                                behaviorButtonGroup.add(templateLocked);
+                                                panelClone.add(templateLocked, "4, 6");
+                                        
+                                                btnLevelZ = new JButton(referenceZAction);
+                                                panelClone.add(btnLevelZ, "8, 9");
+        
+        adaptDialog();
     }
-    
+
+    private void adaptDialog() {
+        boolean isTemplate = templateNozzleTip.isSelected();
+        boolean isLocked = templateLocked.isSelected();
+        btnCloneButton.setAction(isTemplate ? cloneToAllNozzleTipsAction : cloneFromNozzleTipAction);
+        cloneFromNozzleTipAction.setEnabled(!isLocked);
+        referenceZAction.setEnabled(isTemplate);
+
+        boolean zProbing = (ContactProbeNozzle.isConfigured());
+        lblTouchLocation.setVisible(zProbing);
+        touchLocationX.setVisible(zProbing);
+        touchLocationY.setVisible(zProbing);
+        touchLocationZ.setVisible(zProbing);
+        
+        touchLocationButtonsPanel.setVisible(zProbing);
+        lblZCalibrate.setVisible(zProbing);
+        zCalibrationTrigger.setVisible(zProbing);
+        calibrationOffsetZ.setVisible(zProbing);
+        btnCalibrateNow.setVisible(zProbing);
+        btnReset.setVisible(zProbing);
+
+        ZCalibrationTrigger trigger = (ZCalibrationTrigger) zCalibrationTrigger.getSelectedItem();
+        lblFailHoming.setVisible(zProbing && trigger != ZCalibrationTrigger.Manual);
+        zCalibrationFailHoming.setVisible(zProbing && trigger != ZCalibrationTrigger.Manual);
+
+        lblZCalibration.setVisible(zProbing);
+        cloneZCalibration.setVisible(zProbing);
+
+        boolean visionCalib = visionCalibration.getSelectedItem() != VisionCalibration.None;
+        lblCalibrationTrigger.setVisible(visionCalib);
+        visionCalibrationTrigger.setVisible(visionCalib);
+        lblVisionCalibrationHelp.setVisible(visionCalib);
+        lblTemplateDimX.setVisible(visionCalib);
+        visionTemplateDimensionX.setVisible(visionCalib);
+        lblTemplateDimY.setVisible(visionCalib);
+        visionTemplateDimensionY.setVisible(visionCalib);
+        lblTolerance.setVisible(visionCalib);
+        visionTemplateTolerance.setVisible(visionCalib);
+        lblPrecision.setVisible(visionCalib);
+        visionCalibrationTolerance.setVisible(visionCalib);
+        lblMaxPasses.setVisible(visionCalib);
+        visionCalibrationMaxPasses.setVisible(visionCalib);
+        lblMinScore.setVisible(visionCalib);
+        visionMatchMinimumScore.setVisible(visionCalib);
+        lblLastScore.setVisible(visionCalib);
+        visionMatchLastScore.setVisible(visionCalib);
+        btnTest.setVisible(visionCalib);
+        lblTemplateEmpty.setVisible(visionCalib);
+        btnCaptureEmpty.setVisible(visionCalib);
+        btnResetEmpty.setVisible(visionCalib);
+        visionTemplateImageEmpty.setVisible(visionCalib);
+        lblTemplateOccupied.setVisible(visionCalib);
+        btnCaptureOccupied.setVisible(visionCalib);
+        btnResetOccupied.setVisible(visionCalib);
+        visionTemplateImageOccupied.setVisible(visionCalib);
+    }
+
     @Override
     public void createBindings() {
         LengthConverter lengthConverter = new LengthConverter();
         DoubleConverter doubleConverter = new DoubleConverter(Configuration.get().getLengthDisplayFormat());
+        IntegerConverter intConverter = new IntegerConverter();
 
         MutableLocationProxy changerStartLocation = new MutableLocationProxy();
         bind(UpdateStrategy.READ_WRITE, nozzleTip, "changerStartLocation", changerStartLocation,
@@ -355,13 +675,49 @@ public class ReferenceNozzleTipToolChangerWizard extends AbstractConfigurationWi
                 lengthConverter);
         addWrappedBinding(changerEndLocation, "lengthZ", textFieldChangerEndZ, "text",
                 lengthConverter);
-        
-        // bert start
+
+        MutableLocationProxy touchLocation = new MutableLocationProxy();
+        bind(UpdateStrategy.READ_WRITE, nozzleTip, "touchLocation", touchLocation,
+                "location");
+        addWrappedBinding(touchLocation, "lengthX", touchLocationX, "text",
+                lengthConverter);
+        addWrappedBinding(touchLocation, "lengthY", touchLocationY, "text",
+                lengthConverter);
+        addWrappedBinding(touchLocation, "lengthZ", touchLocationZ, "text",
+                lengthConverter);
+
         addWrappedBinding(nozzleTip, "changerActuatorPostStepOne", tcPostOneComboBoxActuator, "selectedItem");
         addWrappedBinding(nozzleTip, "changerActuatorPostStepTwo", tcPostTwoComboBoxActuator, "selectedItem");
         addWrappedBinding(nozzleTip, "changerActuatorPostStepThree", tcPostThreeComboBoxActuator, "selectedItem");
-        // bert stop
-        
+
+        addWrappedBinding(nozzleTip, "visionCalibration", visionCalibration, "selectedItem");
+        addWrappedBinding(nozzleTip, "visionCalibrationTrigger", visionCalibrationTrigger, "selectedItem");
+        addWrappedBinding(nozzleTip, "visionTemplateDimensionX", visionTemplateDimensionX, "text",
+                lengthConverter);
+        addWrappedBinding(nozzleTip, "visionTemplateDimensionY", visionTemplateDimensionY, "text",
+                lengthConverter);
+        addWrappedBinding(nozzleTip, "visionTemplateTolerance", visionTemplateTolerance, "text",
+                lengthConverter);
+        addWrappedBinding(nozzleTip, "visionCalibrationTolerance", visionCalibrationTolerance, "text",
+                lengthConverter);
+        addWrappedBinding(nozzleTip, "visionCalibrationMaxPasses", visionCalibrationMaxPasses, "text", 
+                intConverter);
+        addWrappedBinding(nozzleTip, "visionMatchMinimumScore", visionMatchMinimumScore, "text",
+                doubleConverter);
+        addWrappedBinding(nozzleTip, "visionMatchLastScore", visionMatchLastScore, "text",
+                doubleConverter);
+
+        addWrappedBinding(nozzleTip, "visionTemplateImageEmpty", visionTemplateImageEmpty, "templateImage");
+        addWrappedBinding(nozzleTip, "visionTemplateImageOccupied", visionTemplateImageOccupied, "templateImage");
+
+        addWrappedBinding(nozzleTip, "zCalibrationTrigger", zCalibrationTrigger, "selectedItem");
+        addWrappedBinding(nozzleTip, "calibrationOffsetZ", calibrationOffsetZ, "text",
+                lengthConverter);
+        addWrappedBinding(nozzleTip, "zCalibrationFailHoming", zCalibrationFailHoming, "selected");
+
+        addWrappedBinding(nozzleTip, "templateNozzleTip", templateNozzleTip, "selected");
+        addWrappedBinding(nozzleTip, "templateLocked", templateLocked, "selected");
+
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldChangerStartX);
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldChangerStartY);
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldChangerStartZ);
@@ -380,38 +736,311 @@ public class ReferenceNozzleTipToolChangerWizard extends AbstractConfigurationWi
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldChangerEndX);
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldChangerEndY);
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldChangerEndZ);
+
+        ComponentDecorators.decorateWithAutoSelectAndLengthConversion(touchLocationX);
+        ComponentDecorators.decorateWithAutoSelectAndLengthConversion(touchLocationY);
+        ComponentDecorators.decorateWithAutoSelectAndLengthConversion(touchLocationZ);
+
+        ComponentDecorators.decorateWithAutoSelectAndLengthConversion(visionTemplateDimensionX);
+        ComponentDecorators.decorateWithAutoSelectAndLengthConversion(visionTemplateDimensionY);
+        ComponentDecorators.decorateWithAutoSelectAndLengthConversion(visionTemplateTolerance);
+        ComponentDecorators.decorateWithAutoSelectAndLengthConversion(visionCalibrationTolerance);
+        ComponentDecorators.decorateWithAutoSelect(visionCalibrationMaxPasses);
+        ComponentDecorators.decorateWithAutoSelect(visionMatchMinimumScore);
+        ComponentDecorators.decorateWithAutoSelect(visionMatchLastScore);
     }
 
-    private Action cloneFromNozzleTipAction = new AbstractAction("Clone Tool Changer Setting", Icons.importt) {
+    protected BufferedImage captureTemplateImage() throws Exception {
+        Location location = nozzleTip.getVisionCalibration().getLocation(nozzleTip);
+        if (location == null) {
+            throw new Exception("Select a vision calibration location first.");
+        }
+        Camera camera = getCamera();
+        if (camera == null) {
+            throw new Exception("No down-looking camera found.");
+        }
+        MovableUtils.moveToLocationAtSafeZ(camera, location);
+        BufferedImage image = camera.lightSettleAndCapture();
+        Location upp = camera.getUnitsPerPixel();
+        int width = ((int) Math.ceil(nozzleTip.getVisionTemplateDimensionX().divide(upp.getLengthX()))) & ~1; // divisible by 2
+        int height = ((int) Math.ceil(nozzleTip.getVisionTemplateDimensionY().divide(upp.getLengthY()))) & ~1; // divisible by 2
+        int x = (image.getWidth() - width)/2;
+        int y = (image.getHeight() - height)/2;
+        BufferedImage templateImage = image.getSubimage(x, y, width, height);
+        return templateImage;
+    }
+
+    protected Camera getCamera() {
+        try {
+            Camera camera = MainFrame.get().getMachineControls().getSelectedTool().getHead()
+                    .getDefaultCamera();
+            return camera;
+        }
+        catch (Exception e) {
+           return null;
+        }
+    }
+
+    private Action calibrateZAction = new AbstractAction("Calibrate now", Icons.contactProbeNozzle) {
         {
-            putValue(Action.SHORT_DESCRIPTION, "<html>Clone the Tool Changer settings from the selected Template nozzle tip,<br/>"
-                    +"but offset the locations relative to the First Location.</html>");
+            putValue(Action.SHORT_DESCRIPTION, "<html>Calibrate the nozzle/nozzle tip Z by contact-probing against the <strong>Touch Location</strong> surface.</html>");
         }
 
         @Override
         public void actionPerformed(ActionEvent e) {
-            UiUtils.messageBoxOnException(() -> {
-                applyAction.actionPerformed(e);
-                String name = (String)copyFromNozzleTip.getSelectedItem();
-                ReferenceNozzleTip templateNozzleTip= null;
-                for (ReferenceNozzleTip nt : nozzleTips) {
-                    if (name.equals(nt.getName())) {
-                        templateNozzleTip = nt;
-                    }
+            applyAction.actionPerformed(e);
+            UiUtils.submitUiMachineTask(() -> {
+                ReferenceNozzle nozzle = ReferenceNozzleTipCalibrationWizard.getUiCalibrationNozzle(nozzleTip);
+                if (nozzle instanceof ContactProbeNozzle) {
+                    ((ContactProbeNozzle) nozzle).calibrateZ(nozzleTip);
+                    nozzle.moveToSafeZ();
                 }
-                if (templateNozzleTip != null) {
-                    Location offsets = nozzleTip.getChangerStartLocation().subtract(templateNozzleTip.getChangerStartLocation());
-                    nozzleTip.setChangerMidLocation(templateNozzleTip.getChangerMidLocation().add(offsets));
-                    nozzleTip.setChangerMidLocation2(templateNozzleTip.getChangerMidLocation2().add(offsets));
-                    nozzleTip.setChangerEndLocation(templateNozzleTip.getChangerEndLocation().add(offsets));
-                    nozzleTip.setChangerActuatorPostStepOne(templateNozzleTip.getChangerActuatorPostStepOne());
-                    nozzleTip.setChangerActuatorPostStepTwo(templateNozzleTip.getChangerActuatorPostStepTwo());
-                    nozzleTip.setChangerActuatorPostStepThree(templateNozzleTip.getChangerActuatorPostStepThree());
-                    nozzleTip.setChangerStartToMidSpeed(templateNozzleTip.getChangerStartToMidSpeed());
-                    nozzleTip.setChangerMidToMid2Speed(templateNozzleTip.getChangerMidToMid2Speed());
-                    nozzleTip.setChangerMid2ToEndSpeed(templateNozzleTip.getChangerMid2ToEndSpeed());
+                else {
+                    throw new Exception("Nozzle "+nozzle.getName()+" is no ContactProbeNozzle.");
                 }
             });
         }
     };
+
+    private Action resetZCalibrationAction = new AbstractAction("Reset") {
+        {
+            putValue(Action.SHORT_DESCRIPTION, "<html>Reset the Z calibration.</html>");
+        }
+
+        @Override
+        public void actionPerformed(ActionEvent e) {
+            applyAction.actionPerformed(e);
+            UiUtils.submitUiMachineTask(() -> {
+                ReferenceNozzle nozzle = ReferenceNozzleTipCalibrationWizard.getUiCalibrationNozzle(nozzleTip);
+                if (nozzle instanceof ContactProbeNozzle) {
+                    ((ContactProbeNozzle) nozzle).resetZCalibration();
+                }
+                else {
+                    throw new Exception("Nozzle "+nozzle.getName()+" is no ContactProbeNozzle.");
+                }
+            });
+        }
+    };
+
+    private Action cloneFromNozzleTipAction = new AbstractAction("Clone Tool Changer Settings from Template", Icons.importt) {
+        {
+            putValue(Action.SHORT_DESCRIPTION, "<html>Clone the tool changer settings from the nozzle tip marked as <strong>Template</strong>.<br/>"
+                    +"All the locations are translated relative to First Location.</html>");
+        }
+
+        @Override
+        public void actionPerformed(ActionEvent e) {
+            applyAction.actionPerformed(e);
+            UiUtils.messageBoxOnException(() -> {
+                ReferenceNozzleTip templateNozzleTip = ReferenceNozzleTip.getTemplateNozzleTip();
+                nozzleTip.assignNozzleTipChangerSettings(templateNozzleTip, 
+                        cloneLocations.isSelected(), cloneZCalibration.isSelected(), cloneVisionCalibration.isSelected());
+            });
+        }
+    };
+
+    private Action cloneToAllNozzleTipsAction = new AbstractAction("Clone Tool Changer Settings to all Nozzle Tips", Icons.export) {
+        {
+            putValue(Action.SHORT_DESCRIPTION, "<html>Clone the Tool Changer settings from this <strong>Template</strong> nozzle tip,<br/>"
+                    +"to all the others. Locations are translated relative to First Locations.</html>");
+        }
+
+        @Override
+        public void actionPerformed(ActionEvent e) {
+            applyAction.actionPerformed(e);
+            UiUtils.messageBoxOnException(() -> {
+                for (NozzleTip nt : Configuration.get().getMachine().getNozzleTips()) {
+                    if (nt != nozzleTip 
+                            && nt instanceof ReferenceNozzleTip) {
+                        ((ReferenceNozzleTip) nt).assignNozzleTipChangerSettings(nozzleTip, 
+                                cloneLocations.isSelected(), cloneZCalibration.isSelected(), cloneVisionCalibration.isSelected());
+                    }
+                }
+            });
+        }
+    };
+
+    private Action referenceZAction = new AbstractAction("Calibrate all Touch Locations' Z to Template", Icons.contactProbeNozzle) {
+        {
+            putValue(Action.SHORT_DESCRIPTION, 
+                    "<html>Calibrate all the nozzle tip's touch location Z to the <strong>Template</strong> reference.<br/>"
+                            + "This will load the template nozzle tip on the default probing nozzle, recalibrate<br/>"
+                            + "the template's touch location Z and then probe and reference all the others to it.<br/>"
+                            + "Note, unlike cloning this does include nozzle tips marked as <strong>Locked</strong>.</html>");
+        }
+
+        @Override
+        public void actionPerformed(ActionEvent e) {
+            applyAction.actionPerformed(e);
+            UiUtils.submitUiMachineTask(() -> {
+                ContactProbeNozzle.referenceAllTouchLocationsZ();
+            });
+        }
+    };
+
+    private Action captureTemplateImageEmptyAction = new AbstractAction("Capture") {
+        {
+            putValue(Action.SHORT_DESCRIPTION, 
+                    "<html>Capture the template image for the empty nozzle tip holder slot.</html>");
+        }
+
+        @Override
+        public void actionPerformed(ActionEvent e) {
+            applyAction.actionPerformed(e);
+            UiUtils.submitUiMachineTask(() -> {
+                BufferedImage templateImage = captureTemplateImage();
+                nozzleTip.setVisionTemplateImageEmpty(new TemplateImage(templateImage));
+            });
+        }
+    };
+
+    private Action resetTemplateImageEmptyAction = new AbstractAction("Reset") {
+        {
+            putValue(Action.SHORT_DESCRIPTION, 
+                    "<html>Reset the template image for the empty nozzle tip holder slot.</html>");
+        }
+
+        @Override
+        public void actionPerformed(ActionEvent e) {
+            applyAction.actionPerformed(e);
+            nozzleTip.setVisionTemplateImageEmpty(null);
+        }
+    };
+
+    private Action captureTemplateImageOccupiedAction = new AbstractAction("Capture") {
+        {
+            putValue(Action.SHORT_DESCRIPTION, 
+                    "<html>Capture the template image for the occupied nozzle tip holder slot.</html>");
+        }
+
+        @Override
+        public void actionPerformed(ActionEvent e) {
+            applyAction.actionPerformed(e);
+            UiUtils.submitUiMachineTask(() -> {
+                BufferedImage templateImage = captureTemplateImage();
+                nozzleTip.setVisionTemplateImageOccupied(new TemplateImage(templateImage));
+            });
+        }
+    };
+
+    private Action resetTemplateImageOccupiedAction = new AbstractAction("Reset") {
+        {
+            putValue(Action.SHORT_DESCRIPTION, 
+                    "<html>Reset the template image for the occupied nozzle tip holder slot.</html>");
+        }
+
+        @Override
+        public void actionPerformed(ActionEvent e) {
+            applyAction.actionPerformed(e);
+            nozzleTip.setVisionTemplateImageOccupied(null);
+        }
+    };
+    private Action visionCalibrateTestAction = new AbstractAction("Test") {
+        {
+            putValue(Action.SHORT_DESCRIPTION, 
+                    "<html>Test the vision calibration.</html>");
+        }
+
+        @Override
+        public void actionPerformed(ActionEvent e) {
+            applyAction.actionPerformed(e);
+            UiUtils.submitUiMachineTask(() -> {
+                nozzleTip.resetVisionCalibration();
+                nozzleTip.ensureVisionCalibration(true);
+                nozzleTip.resetVisionCalibration();
+            });
+        }
+    };
+
+    private JPanel panelChanger;
+    private JLabel lblY_1;
+    private JLabel lblZ_1;
+    private LocationButtonsPanel changerStartLocationButtonsPanel;
+    private JLabel lblStartLocation;
+    private JTextField textFieldChangerStartX;
+    private JTextField textFieldChangerStartY;
+    private JTextField textFieldChangerStartZ;
+    private JLabel lblMiddleLocation;
+    private JTextField textFieldChangerMidX;
+    private JTextField textFieldChangerMidY;
+    private JTextField textFieldChangerMidZ;
+    private JLabel lblEndLocation;
+    private JTextField textFieldChangerEndX;
+    private JTextField textFieldChangerEndY;
+    private JTextField textFieldChangerEndZ;
+    private LocationButtonsPanel changerMidLocationButtonsPanel;
+    private LocationButtonsPanel changerEndLocationButtonsPanel;
+    private JLabel lblMiddleLocation_1;
+    private JTextField textFieldMidX2;
+    private JTextField textFieldMidY2;
+    private JTextField textFieldMidZ2;
+    private LocationButtonsPanel changerMidButtons2;
+    private JTextField textFieldChangerStartToMidSpeed;
+    private JTextField textFieldChangerMidToMid2Speed;
+    private JTextField textFieldChangerMid2ToEndSpeed;
+    private JLabel lblSpeed;
+    private JLabel lblX;
+    private JLabel lblSpeed1_2;
+    private JLabel lblSpeed2_3;
+    private JLabel lblSpeed3_4;
+    private JLabel label;
+    private JComboBox tcPostOneComboBoxActuator;
+    private JComboBox tcPostTwoComboBoxActuator;
+    private JComboBox tcPostThreeComboBoxActuator;
+    private JLabel lblTemplate;
+    private JButton btnCloneButton;
+    private JLabel lblTouchLocation;
+    private JTextField touchLocationX;
+    private JTextField touchLocationY;
+    private JTextField touchLocationZ;
+    private LocationButtonsPanel touchLocationButtonsPanel;
+    private JComboBox zCalibrationTrigger;
+    private JLabel lblZCalibrate;
+    private JButton btnCalibrateNow;
+    private JButton btnReset;
+    private JTextField calibrationOffsetZ;
+    private JLabel lblFailHoming;
+    private JCheckBox zCalibrationFailHoming;
+    private JButton btnLevelZ;
+    private JPanel panelVision;
+    private JPanel panelClone;
+    private JLabel lblVisionCalibration;
+    private JComboBox visionCalibration;
+    private TemplateImageControl visionTemplateImageEmpty;
+    private TemplateImageControl visionTemplateImageOccupied;
+    private JLabel lblTemplateDimX;
+    private JTextField visionTemplateDimensionX;
+    private JTextField visionTemplateDimensionY;
+    private JLabel lblTemplateEmpty;
+    private JLabel lblTemplateOccupied;
+    private JButton btnCaptureEmpty;
+    private JButton btnCaptureOccupied;
+    private JButton btnResetEmpty;
+    private JButton btnResetOccupied;
+    private JLabel lblMinScore;
+    private JTextField visionMatchMinimumScore;
+    private JLabel lblLocations;
+    private JCheckBox cloneLocations;
+    private JLabel lblZCalibration;
+    private JCheckBox cloneZCalibration;
+    private JLabel lblCloneVisionCalibration;
+    private JCheckBox cloneVisionCalibration;
+    private JPanel panel;
+    private JLabel lblVisionCalibrationHelp;
+    private JLabel lblLastScore;
+    private JTextField visionMatchLastScore;
+    private JButton btnTest;
+    private JLabel lblTolerance;
+    private JTextField visionTemplateTolerance;
+    private JLabel lblPrecision;
+    private JTextField visionCalibrationTolerance;
+    private JLabel lblTemplateDimY;
+    private JLabel lblMaxPasses;
+    private JTextField visionCalibrationMaxPasses;
+    private JLabel lblCalibrationTrigger;
+    private JComboBox visionCalibrationTrigger;
+    private JRadioButton templateNozzleTip;
+    private JRadioButton templateClones;
+    private JRadioButton templateLocked;
+    private final ButtonGroup behaviorButtonGroup = new ButtonGroup();
 }

--- a/src/main/java/org/openpnp/model/Length.java
+++ b/src/main/java/org/openpnp/model/Length.java
@@ -326,4 +326,10 @@ public class Length {
         return setLocationField(configuration, location, length, field, false);
     }
 
+    public int compareTo(Length other) {
+        if (other == null) {
+            return Double.valueOf(getValue()).compareTo(Double.valueOf(0));
+        }
+        return Double.valueOf(getValue()).compareTo(Double.valueOf(other.convertToUnits(units).getValue()));
+    }
 }

--- a/src/main/java/org/openpnp/model/Location.java
+++ b/src/main/java/org/openpnp/model/Location.java
@@ -64,6 +64,8 @@ public class Location {
         this.rotation = rotation;
     }
 
+    static final public Location origin = new Location(LengthUnit.Millimeters);
+
     public double getX() {
         return x;
     }
@@ -94,6 +96,11 @@ public class Location {
 
     public Length getLinearLengthTo(Location location) {
         double distance = getLinearDistanceTo(location);
+        return new Length(distance, getUnits());
+    }
+
+    public Length getXyzLengthTo(Location location) {
+        double distance = getXyzDistanceTo(location);
         return new Length(distance, getUnits());
     }
 
@@ -253,6 +260,18 @@ public class Location {
     public Location multiply(double x, double y, double z, double rotation) {
         return new Location(getUnits(), x * getX(), y * getY(), z * getZ(),
                 rotation * getRotation());
+    }
+
+    /**
+     * Returns a new Location based on this Location with values multiplied by the specified factor.
+     * Units are the same as this Location.
+     * 
+     * @param factor
+     * @return
+     */
+    public Location multiply(double factor) {
+        return new Location(getUnits(), factor * getX(), factor * getY(), factor * getZ(),
+                factor * getRotation());
     }
 
     /**

--- a/src/main/java/org/openpnp/model/Part.java
+++ b/src/main/java/org/openpnp/model/Part.java
@@ -149,4 +149,8 @@ public class Part extends AbstractModelObject implements Identifiable {
         return String.format("id %s, name %s, heightUnits %s, height %f, packageId (%s)", id, name,
                 heightUnits, height, packageId);
     }
+
+    public boolean isPartHeightUnknown() {
+        return getHeight().getValue() <= 0.0;
+    }
 }

--- a/src/main/java/org/openpnp/spi/Camera.java
+++ b/src/main/java/org/openpnp/spi/Camera.java
@@ -206,4 +206,6 @@ public interface Camera extends HeadMountable, WizardConfigurable,
      * @return True if this Camera should be shown in multi camera view panels. 
      */
     boolean isShownInMultiCameraView();
+
+    public FocusProvider getFocusProvider();
 }

--- a/src/main/java/org/openpnp/spi/Feeder.java
+++ b/src/main/java/org/openpnp/spi/Feeder.java
@@ -19,8 +19,6 @@
 
 package org.openpnp.spi;
 
-import java.util.List;
-
 import org.openpnp.model.Identifiable;
 import org.openpnp.model.Location;
 import org.openpnp.model.Named;
@@ -59,11 +57,18 @@ public interface Feeder extends Identifiable, Named, WizardConfigurable, Propert
     /**
      * Gets the Location from which the currently available Part should be picked from. This value
      * may not be valid until after a feed has been performed for Feeders who update the pick
-     * location.
+     * location. The location Z might mean part underside or part surface, depending on the feeder
+     * type, as determined by {@link #isPartHeightAbovePickLocation()}. 
      * 
      * @return
      */
     public Location getPickLocation() throws Exception;
+
+    /**
+     * @return True if the part height needs to be added to the pick location. The distinction is
+     * needed for part height probing 
+     */
+    boolean isPartHeightAbovePickLocation();
 
     /**
      * Some feeders need preparation for a Job that is best done up front and in bulk, such as vision 

--- a/src/main/java/org/openpnp/spi/FocusProvider.java
+++ b/src/main/java/org/openpnp/spi/FocusProvider.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2021 <mark@makr.zone>
+ * 
+ * This file is part of OpenPnP.
+ * 
+ * OpenPnP is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * OpenPnP is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License along with OpenPnP. If not, see
+ * <http://www.gnu.org/licenses/>.
+ * 
+ * For more information about OpenPnP visit http://openpnp.org
+ */
+
+package org.openpnp.spi;
+
+import org.openpnp.gui.support.Wizard;
+import org.openpnp.model.Length;
+import org.openpnp.model.Location;
+
+public interface FocusProvider {
+
+    /**
+     * Focus the camera to the subject by moving the movable (this might move the subject or the camera).
+     *  
+     * @param camera
+     * @param movable
+     * @param subjectMaxSize
+     * @param location0
+     * @param location1
+     * @throws Exception
+     */
+    Location autoFocus(Camera camera, HeadMountable movable, Length subjectMaxSize, Location location0,
+            Location location1) throws Exception;
+
+    Wizard getConfigurationWizard(Camera camera);
+
+}

--- a/src/main/java/org/openpnp/spi/Head.java
+++ b/src/main/java/org/openpnp/spi/Head.java
@@ -108,9 +108,11 @@ public interface Head extends Identifiable, Named, WizardConfigurable, PropertyS
 
     public void removeCamera(Camera camera);
 
-    public void permutateCamera(Camera driver, int direction);
+    public void permutateCamera(Camera camera, int direction);
 
     public void addNozzle(Nozzle nozzle) throws Exception;
+
+    public void permutateNozzle(Nozzle nozzle, int direction);
 
     public void removeNozzle(Nozzle nozzle);
 

--- a/src/main/java/org/openpnp/spi/Nozzle.java
+++ b/src/main/java/org/openpnp/spi/Nozzle.java
@@ -2,6 +2,7 @@ package org.openpnp.spi;
 
 import java.util.Set;
 
+import org.openpnp.model.Length;
 import org.openpnp.model.Location;
 import org.openpnp.model.Part;
 
@@ -21,6 +22,17 @@ public interface Nozzle
     NozzleTip getNozzleTip();
 
     /**
+     * Move the Nozzle to the given feeder pick location. This will move at safe Z and position the Nozzle
+     * so it is ready for {@link #pick(Part)}. This might or might not involve offsets and actions for 
+     * contact-probing e.g. to determine the feeder's calibrated Z. 
+     * 
+     * @param feeder 
+     * 
+     * @throws Exception
+     */
+    public void moveToPickLocation(Feeder feeder) throws Exception;
+
+    /**
      * Commands the Nozzle to perform it's pick operation. Generally this just consists of turning
      * on the vacuum. When this is called during job processing the processor will have already
      * positioned the nozzle over the part to be picked and lowered it to the correct height. Some
@@ -30,6 +42,17 @@ public interface Nozzle
      * @throws Exception
      */
     public void pick(Part part) throws Exception;
+
+    /**
+     * Move the Nozzle to the given placementLocation. This will move at safe Z and position the Nozzle
+     * so it is ready for {@link #place()}. This might or might not involve offsets and actions for 
+     * contact-probing. 
+     * 
+     * @param placementLocation
+     * @param part Part to be placed, null on discard. 
+     * @throws Exception
+     */
+    void moveToPlacementLocation(Location placementLocation, Part part) throws Exception;
 
     /**
      * Commands the Nozzle to perform it's place operation. Generally this just consists of
@@ -121,8 +144,17 @@ public interface Nozzle
      */
     public boolean isPartOff() throws Exception;
     
+    /**
+     * @return A set of nozzle tips compatible with this nozzle. 
+     */
     public Set<NozzleTip> getCompatibleNozzleTips();
-    
+
+    /**
+     * @param part
+     * @return A set of nozzle tips compatible with this nozzle and the given part.
+     */
+    public Set<NozzleTip> getCompatibleNozzleTips(Part part);
+
     public void addCompatibleNozzleTip(NozzleTip nt);
     
     public void removeCompatibleNozzleTip(NozzleTip nt);
@@ -131,4 +163,20 @@ public interface Nozzle
 
     public void calibrate() throws Exception;
     public boolean isCalibrated();
+
+    /**
+     * @return The height of the part currently on the nozzle. If the part height is not yet 
+     * known (to be probed), the maximum part height configured on the nozzle tip is returned.
+     * If no part is on the nozzle, a zero Length is returned.  
+     */
+    default Length getSafePartHeight(){
+        return getSafePartHeight(getPart());
+    }
+
+    /**
+     * @return The height of the given part. If the part height is not yet 
+     * known (to be probed), the maximum part height configured on the nozzle tip is returned.
+     * If part is null, a zero Length is returned.  
+     */
+    Length getSafePartHeight(Part part);
 }

--- a/src/main/java/org/openpnp/spi/NozzleTip.java
+++ b/src/main/java/org/openpnp/spi/NozzleTip.java
@@ -19,4 +19,12 @@ public interface NozzleTip extends Identifiable, Named, WizardConfigurable, Prop
      * NozzleTips that are sturdy enough to take the lateral forces.  
      */
     public boolean isPushAndDragAllowed();
+
+    /**
+     * Perform any homing operation on each nozzle tip. The head and driver have already been homed
+     * at this time. 
+     * 
+     * @throws Exception
+     */
+    void home() throws Exception;
 }

--- a/src/main/java/org/openpnp/spi/base/AbstractHead.java
+++ b/src/main/java/org/openpnp/spi/base/AbstractHead.java
@@ -41,7 +41,7 @@ public abstract class AbstractHead extends AbstractModelObject implements Head {
 
     @Element(required = false)
     protected Location parkLocation = new Location(LengthUnit.Millimeters);
-    
+
     @Deprecated
     @Element(required=false)
     protected boolean softLimitsEnabled = false;
@@ -63,7 +63,7 @@ public abstract class AbstractHead extends AbstractModelObject implements Head {
     /**
      * Choice of Visual Homing Method.
      * 
-     * Previous Visual Homing reset the controller to home coordinates not to the fiducial coordinates as one
+     * Previous Visual Homing reset the controller to home coordinates, not to the fiducial coordinates as one
      * might expect. As a consequence the fiducial location may shift its meaning before/after homing i.e. it cannot be captured. 
      * This behavior has been called a bug by Jason. But we absolutely need to migrate this behavior in order not to 
      * break all the captured coordinates on a machine!
@@ -78,13 +78,12 @@ public abstract class AbstractHead extends AbstractModelObject implements Head {
         ResetToFiducialLocation,
         ResetToHomeLocation
     }
-    
+
     @Attribute(required = false)
     private VisualHomingMethod visualHomingMethod = VisualHomingMethod.None;
 
     @Element(required = false)
     protected Location homingFiducialLocation = new Location(LengthUnit.Millimeters);
-
 
     protected Machine machine;
 
@@ -213,6 +212,18 @@ public abstract class AbstractHead extends AbstractModelObject implements Head {
         int index = nozzles.indexOf(nozzle);
         if (nozzles.remove(nozzle)) {
             fireIndexedPropertyChange("nozzles", index, nozzle, null);
+        }
+    }
+
+    @Override 
+    public void permutateNozzle(Nozzle nozzle, int direction) {
+        int index0 = nozzles.indexOf(nozzle);
+        int index1 = direction > 0 ? index0+1 : index0-1;
+        if (0 <= index1 && nozzles.size() > index1) {
+            nozzles.remove(nozzle);
+            nozzles.add(index1, nozzle);
+            fireIndexedPropertyChange("nozzles", index0, nozzle, nozzles.get(index0));
+            fireIndexedPropertyChange("nozzles", index1, nozzles.get(index0), nozzle);
         }
     }
 

--- a/src/main/java/org/openpnp/spi/base/AbstractHeadMountable.java
+++ b/src/main/java/org/openpnp/spi/base/AbstractHeadMountable.java
@@ -42,12 +42,16 @@ public abstract class AbstractHeadMountable extends AbstractModelObject implemen
 
             @Override
             public void configurationLoaded(Configuration configuration) throws Exception {
-                axisX = (AbstractAxis) configuration.getMachine().getAxis(axisXId);
-                axisY = (AbstractAxis) configuration.getMachine().getAxis(axisYId);
-                axisZ = (AbstractAxis) configuration.getMachine().getAxis(axisZId);
-                axisRotation = (AbstractAxis) configuration.getMachine().getAxis(axisRotationId);
+                applyConfiguration(configuration);
             }
         });
+    }
+
+    public void applyConfiguration(Configuration configuration) {
+        axisX = (AbstractAxis) configuration.getMachine().getAxis(axisXId);
+        axisY = (AbstractAxis) configuration.getMachine().getAxis(axisYId);
+        axisZ = (AbstractAxis) configuration.getMachine().getAxis(axisZId);
+        axisRotation = (AbstractAxis) configuration.getMachine().getAxis(axisRotationId);
     }
 
     @Override
@@ -287,16 +291,18 @@ public abstract class AbstractHeadMountable extends AbstractModelObject implemen
     }
 
     public Location toHeadLocation(Location location, Location currentLocation, LocationOption... options) {
-        // Shortcut Double.NaN. Sending Double.NaN in a Location is an old API that should no
-        // longer be used. It will be removed eventually:
-        // https://github.com/openpnp/openpnp/issues/255
-        // In the mean time, since Double.NaN would cause a problem for transformations, we shortcut
-        // it here by replacing any NaN values with the current value from the axes.
-        location = location.derive(currentLocation, 
-                Double.isNaN(location.getX()), 
-                Double.isNaN(location.getY()), 
-                Double.isNaN(location.getZ()), 
-                Double.isNaN(location.getRotation())); 
+        if (currentLocation != null) {
+            // Shortcut Double.NaN. Sending Double.NaN in a Location is an old API that should no
+            // longer be used. It will be removed eventually:
+            // https://github.com/openpnp/openpnp/issues/255
+            // In the mean time, since Double.NaN would cause a problem for transformations, we shortcut
+            // it here by replacing any NaN values with the current value from the axes.
+            location = location.derive(currentLocation, 
+                    Double.isNaN(location.getX()), 
+                    Double.isNaN(location.getY()), 
+                    Double.isNaN(location.getZ()), 
+                    Double.isNaN(location.getRotation())); 
+        }
         // Subtract the Head offset.
         location = location.subtract(getHeadOffsets());
         return location;

--- a/src/main/java/org/openpnp/spi/base/AbstractMachine.java
+++ b/src/main/java/org/openpnp/spi/base/AbstractMachine.java
@@ -290,6 +290,9 @@ public abstract class AbstractMachine extends AbstractModelObject implements Mac
         for (Head head : heads) {
             head.home();
         }
+        for (NozzleTip nt : getNozzleTips()) {
+            nt.home();
+        }
     }
 
     @Override

--- a/src/main/java/org/openpnp/spi/base/AbstractNozzle.java
+++ b/src/main/java/org/openpnp/spi/base/AbstractNozzle.java
@@ -9,7 +9,6 @@ import java.util.Set;
 import javax.swing.Icon;
 
 import org.openpnp.gui.support.Icons;
-import org.openpnp.model.AbstractModelObject;
 import org.openpnp.model.Configuration;
 import org.openpnp.model.Location;
 import org.openpnp.model.Part;
@@ -106,6 +105,23 @@ public abstract class AbstractNozzle extends AbstractHeadMountable implements No
             }
         }
         return Collections.unmodifiableSet(compatibleNozzleTips);
+    }
+
+    @Override
+    public Set<NozzleTip> getCompatibleNozzleTips(Part part) {
+        Set<NozzleTip> partCompatibleNozzleTips = new HashSet<>();
+        if (part != null && part.getPackage() != null) {
+            for (NozzleTip nt : getCompatibleNozzleTips()) {
+                if (isNozzleTipAndPartCompatible(nt, part)) {
+                    partCompatibleNozzleTips.add(nt);
+                }
+            }
+        }
+        return partCompatibleNozzleTips;
+    }
+
+    protected boolean isNozzleTipAndPartCompatible(NozzleTip nt, Part part) {
+        return part.getPackage().getCompatibleNozzleTips().contains(nt);
     }
 
     @Override

--- a/src/main/java/org/openpnp/spi/base/AbstractPnpJobProcessor.java
+++ b/src/main/java/org/openpnp/spi/base/AbstractPnpJobProcessor.java
@@ -45,8 +45,7 @@ public abstract class AbstractPnpJobProcessor extends AbstractJobProcessor
         }
         try {
             // move to the discard location
-            MovableUtils.moveToLocationAtSafeZ(nozzle,
-                    Configuration.get().getMachine().getDiscardLocation());
+            nozzle.moveToPlacementLocation(Configuration.get().getMachine().getDiscardLocation(), null);
             // discard the part
             nozzle.place();
             nozzle.moveToSafeZ();

--- a/src/main/java/org/openpnp/util/ImageUtils.java
+++ b/src/main/java/org/openpnp/util/ImageUtils.java
@@ -2,6 +2,8 @@ package org.openpnp.util;
 
 import java.awt.Graphics2D;
 import java.awt.image.BufferedImage;
+import java.awt.image.ColorModel;
+import java.awt.image.WritableRaster;
 
 public class ImageUtils {
 
@@ -25,4 +27,16 @@ public class ImageUtils {
         return img;
     }
 
+    /**
+     * Clone an image for independent manipulation.  
+     * 
+     * @param image
+     * @return
+     */
+    public static BufferedImage clone(BufferedImage image) {
+        ColorModel colorModel = image.getColorModel();
+        WritableRaster raster = image.copyData(image.getRaster().createCompatibleWritableRaster());
+        boolean isAlphaPremultiplied = colorModel.isAlphaPremultiplied();
+        return new BufferedImage(colorModel, raster, isAlphaPremultiplied, null);
+    }
 }

--- a/src/main/java/org/openpnp/util/UiUtils.java
+++ b/src/main/java/org/openpnp/util/UiUtils.java
@@ -47,7 +47,8 @@ public class UiUtils {
     public static <T> Future<T> submitUiMachineTask(final Callable<T> callable) {
         return submitUiMachineTask(callable, (result) -> {
         } , (t) -> {
-            MessageBoxes.errorBox(MainFrame.get(), "Error", t);
+            MessageBoxes.errorBox(MainFrame.get(), "Error",
+                    t);
         });
     }
 
@@ -101,5 +102,8 @@ public class UiUtils {
         }
     }
 
+    public static void messageBoxOnExceptionLater(Thrunnable thrunnable) {
+        SwingUtilities.invokeLater(() -> messageBoxOnException(thrunnable));
+    }
 
 }

--- a/src/main/java/org/openpnp/vision/TemplateImage.java
+++ b/src/main/java/org/openpnp/vision/TemplateImage.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (C) 2021 <mark@makr.zone>
+ * 
+ * This file is part of OpenPnP.
+ * 
+ * OpenPnP is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * OpenPnP is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License along with OpenPnP. If not, see
+ * <http://www.gnu.org/licenses/>.
+ * 
+ * For more information about OpenPnP visit http://openpnp.org
+ */
+
+package org.openpnp.vision;
+
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.imageio.ImageIO;
+
+import org.apache.commons.codec.digest.DigestUtils;
+import org.openpnp.model.Configuration;
+import org.simpleframework.xml.Attribute;
+import org.simpleframework.xml.core.Commit;
+import org.simpleframework.xml.core.Persist;
+
+/**
+ * A simple wrapper for a vision template image. This will make sure only one instance is maintained
+ * and persisted even if it is referenced many times by different OpenPnP objects. Also provides
+ * transparent XML serialization, so a TempateImage can simply be added as an @Element.
+ * 
+ */
+public class TemplateImage {
+    //TODO: perhaps support serialization inside the XML (base64 encoded).
+    private final static String FILE_ENCODING_TYPE = "png";
+
+    private static class ImageSlot {
+        final private String hash;
+        final private BufferedImage image;
+        final private byte[] filedata;
+        private boolean dirty;
+
+        public ImageSlot(String hash, BufferedImage image, byte[] filedata, boolean dirty) {
+            this.hash = hash;
+            this.image = image;
+            this.filedata = filedata;
+            this.dirty = dirty;
+        }
+
+        public ImageSlot(String hash) throws IOException {
+            File file = getFile(hash);
+            byte[] filedata = Files.readAllBytes(file.toPath());
+            ByteArrayInputStream stream = new ByteArrayInputStream(filedata);
+            BufferedImage image = ImageIO.read(stream);
+            this.hash = hash;
+            this.image = image;
+            this.filedata = filedata;
+            this.dirty = false;
+        }
+
+        protected File getFile(String hash) throws IOException {
+            return Configuration.get()
+                                .getResourceFile(TemplateImage.class,
+                                        hash + "." + FILE_ENCODING_TYPE);
+        }
+
+        public BufferedImage getImage() {
+            return image;
+        }
+
+        public void persist() throws IOException {
+            if (dirty) {
+                File file = getFile(hash);
+                Files.write(file.toPath(), filedata);
+                dirty = false;
+            }
+        }
+    }
+
+    private static Map<String, ImageSlot> imageRegister = new HashMap<>();
+
+    @Attribute
+    private String hash;
+
+    public TemplateImage() {}
+    
+    public TemplateImage(BufferedImage image) throws IOException {
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        ImageIO.write(image, FILE_ENCODING_TYPE, outputStream);
+        byte[] filedata = outputStream.toByteArray();
+        hash = DigestUtils.shaHex(filedata);
+        if (!imageRegister.containsKey(hash)) {
+            // We re-read the file from the compressed filedata. 
+            // This way we also get rid of subImage -> OpenCv Mat incompatibility. 
+            ByteArrayInputStream stream = new ByteArrayInputStream(filedata);
+            image = ImageIO.read(stream);
+            imageRegister.put(hash, new ImageSlot(hash, image, filedata, true));
+        }
+    }
+
+    @Commit
+    private void commit() throws IOException {
+        if (!imageRegister.containsKey(hash)) {
+            imageRegister.put(hash, new ImageSlot(hash));
+        }
+    }
+
+    @Persist
+    private void persist() throws IOException {
+        imageRegister.get(hash)
+                     .persist();
+    }
+
+    public BufferedImage getImage() throws Exception {
+        ImageSlot slot = imageRegister.get(hash);
+        if (slot == null) {
+            throw new Exception("Template Image is missing");
+        }
+        return slot.getImage();
+    }
+}

--- a/src/main/java/org/openpnp/vision/pipeline/CvPipeline.java
+++ b/src/main/java/org/openpnp/vision/pipeline/CvPipeline.java
@@ -16,6 +16,7 @@ import org.opencv.core.Scalar;
 import org.opencv.imgproc.Imgproc;
 import org.openpnp.vision.FluentCv.ColorSpace;
 import org.openpnp.vision.pipeline.CvStage.Result;
+import org.pmw.tinylog.Logger;
 import org.simpleframework.xml.ElementList;
 import org.simpleframework.xml.Root;
 import org.simpleframework.xml.Serializer;
@@ -241,6 +242,9 @@ public class CvPipeline implements AutoCloseable {
             }
             catch (Exception e) {
                 result = new Result(null, e);
+                if (stage.isEnabled()) {
+                    Logger.debug("Stage \""+stage.getName()+"\" throws "+e);
+                }
             }
             processingTimeNs = System.nanoTime() - processingTimeNs;
             totalProcessingTimeNs += processingTimeNs;

--- a/src/main/java/org/openpnp/vision/pipeline/CvStage.java
+++ b/src/main/java/org/openpnp/vision/pipeline/CvStage.java
@@ -11,9 +11,8 @@ import java.util.List;
 
 import org.opencv.core.Mat;
 import org.openpnp.model.LengthUnit;
-import org.openpnp.vision.pipeline.ui.PipelinePropertySheetTable;
-import org.openpnp.vision.FluentCv;
 import org.openpnp.vision.FluentCv.ColorSpace;
+import org.openpnp.vision.pipeline.ui.PipelinePropertySheetTable;
 import org.simpleframework.xml.Attribute;
 
 /**

--- a/src/main/java/org/openpnp/vision/pipeline/ui/PipelinePanel.java
+++ b/src/main/java/org/openpnp/vision/pipeline/ui/PipelinePanel.java
@@ -39,7 +39,10 @@ import org.openpnp.util.MovableUtils;
 import org.openpnp.vision.pipeline.CvPipeline;
 import org.openpnp.vision.pipeline.CvStage;
 
-import com.l2fprod.common.propertysheet.*;
+import com.l2fprod.common.propertysheet.Property;
+import com.l2fprod.common.propertysheet.PropertySheetPanel;
+import com.l2fprod.common.propertysheet.PropertySheetTableModel;
+import com.l2fprod.common.swing.renderer.DefaultCellRenderer;
 
 public class PipelinePanel extends JPanel {
     private final CvPipelineEditor editor;
@@ -193,6 +196,8 @@ public class PipelinePanel extends JPanel {
             try {
                 propertySheetPanel.setBeanInfo(stage.getBeanInfo());
                 propertySheetPanel.readFromObject(stage);
+                // Set the Object.class DefaultCellRenderer, it might have been customized in a previously selected stage.
+                pipelinePropertySheetTable.getRendererRegistry().registerRenderer(Object.class, new DefaultCellRenderer());
                 stage.customizePropertySheet(pipelinePropertySheetTable, editor.getPipeline());
             }
             catch (Exception ex) {

--- a/src/main/resources/icons/contact-probe-nozzle.svg
+++ b/src/main/resources/icons/contact-probe-nozzle.svg
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:sketch="http://www.bohemiancoding.com/sketch/ns"
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   width="25.6"
+   height="25.6"
+   viewBox="0 0 24 24"
+   version="1.1"
+   id="svg2">
+  <metadata
+     id="metadata15">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>contact-probe-nozzle</dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <!-- Generator: Sketch 3.2.2 (9983) - http://www.bohemiancoding.com/sketch -->
+  <title
+     id="title4">contact-probe-nozzle</title>
+  <desc
+     id="desc6">Created with Sketch.</desc>
+  <defs
+     id="defs8" />
+  <g
+     sketch:type="MSPage"
+     id="g4315-0"
+     style="fill:none;fill-rule:evenodd;stroke:none;stroke-width:1"
+     transform="matrix(1.0094828,0,0,0.96871686,-0.1158968,0.13175717)">
+    <g
+       transform="matrix(1,0,0,1.0322934,4.3125528e-8,-0.13601214)"
+       sketch:type="MSLayerGroup"
+       id="g4323-0"
+       style="fill:#bd0404;fill-opacity:1">
+      <path
+         style="fill:#bd0404;fill-opacity:1"
+         sketch:type="MSShapeGroup"
+         id="path4325-6"
+         d="M 15.244067,9 17.945721,4 H 6.0584458 l 2.7016534,5 z m -4.23259,1 h 1.981213 v 9 h -1.981213 z" />
+      <rect
+         y="11.25"
+         x="14.230947"
+         height="0.93749994"
+         width="5.9884486"
+         id="rect828"
+         style="fill:#005bdc;fill-opacity:0.99215686;stroke:none;stroke-width:2.03517914;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.99215686" />
+      <rect
+         y="15.28125"
+         x="14.230947"
+         height="0.93749988"
+         width="5.9884486"
+         id="rect828-5"
+         style="fill:#005bdc;fill-opacity:0.99215686;fill-rule:evenodd;stroke:none;stroke-width:2.03517914;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.99215686" />
+      <rect
+         y="19.40625"
+         x="14.230947"
+         height="0.93749988"
+         width="5.9884486"
+         id="rect828-5-9"
+         style="fill:#005bdc;fill-opacity:0.99215686;fill-rule:evenodd;stroke:none;stroke-width:2.03517914;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.99215686" />
+    </g>
+  </g>
+</svg>

--- a/src/main/resources/icons/contact-probe-nozzle_dark.svg
+++ b/src/main/resources/icons/contact-probe-nozzle_dark.svg
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:sketch="http://www.bohemiancoding.com/sketch/ns"
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   width="25.6"
+   height="25.6"
+   viewBox="0 0 24 24"
+   version="1.1"
+   id="svg2">
+  <metadata
+     id="metadata15">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>contact-probe-nozzle</dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <!-- Generator: Sketch 3.2.2 (9983) - http://www.bohemiancoding.com/sketch -->
+  <title
+     id="title4">contact-probe-nozzle</title>
+  <desc
+     id="desc6">Created with Sketch.</desc>
+  <defs
+     id="defs8" />
+  <g
+     sketch:type="MSPage"
+     id="g4315-0"
+     style="fill:none;fill-rule:evenodd;stroke:none;stroke-width:1"
+     transform="matrix(1.0094828,0,0,0.96871686,-0.1158968,0.13175717)">
+    <g
+       transform="matrix(1,0,0,1.0322934,4.3125528e-8,-0.13601214)"
+       sketch:type="MSLayerGroup"
+       id="g4323-0"
+       style="fill:#FF2222;fill-opacity:1">
+      <path
+         style="fill:#FF2222;fill-opacity:1"
+         sketch:type="MSShapeGroup"
+         id="path4325-6"
+         d="M 15.244067,9 17.945721,4 H 6.0584458 l 2.7016534,5 z m -4.23259,1 h 1.981213 v 9 h -1.981213 z" />
+      <rect
+         y="11.25"
+         x="14.230947"
+         height="0.93749994"
+         width="5.9884486"
+         id="rect828"
+         style="fill:#0070FF;fill-opacity:0.99215686;stroke:none;stroke-width:2.03517914;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.99215686" />
+      <rect
+         y="15.28125"
+         x="14.230947"
+         height="0.93749988"
+         width="5.9884486"
+         id="rect828-5"
+         style="fill:#0070FF;fill-opacity:0.99215686;fill-rule:evenodd;stroke:none;stroke-width:2.03517914;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.99215686" />
+      <rect
+         y="19.40625"
+         x="14.230947"
+         height="0.93749988"
+         width="5.9884486"
+         id="rect828-5-9"
+         style="fill:#0070FF;fill-opacity:0.99215686;fill-rule:evenodd;stroke:none;stroke-width:2.03517914;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.99215686" />
+    </g>
+  </g>
+</svg>

--- a/src/test/java/ReferenceJobProcessorRetryTests.java
+++ b/src/test/java/ReferenceJobProcessorRetryTests.java
@@ -223,6 +223,11 @@ public class ReferenceJobProcessorRetryTests {
         }
 
         @Override
+        public boolean isPartHeightAbovePickLocation() {
+            return false;
+        }
+
+        @Override
         public void feed(Nozzle nozzle) throws Exception {
             System.out.format("feed(%s) -> %s %s\n", nozzle.getName(), getName(), getPart().getId());
             if (++feedCount > partCount) {

--- a/src/test/java/VisionUtilsTest.java
+++ b/src/test/java/VisionUtilsTest.java
@@ -2,7 +2,6 @@ import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.IOException;
 
-
 import javax.swing.Action;
 import javax.swing.Icon;
 
@@ -17,6 +16,7 @@ import org.openpnp.model.LengthUnit;
 import org.openpnp.model.Location;
 import org.openpnp.spi.Actuator;
 import org.openpnp.spi.Camera;
+import org.openpnp.spi.FocusProvider;
 import org.openpnp.spi.Head;
 import org.openpnp.spi.HeadMountable;
 import org.openpnp.spi.PropertySheetHolder;
@@ -264,6 +264,11 @@ public class VisionUtilsTest {
         @Override
         public boolean isShownInMultiCameraView() {
             return false;
+        }
+
+        @Override
+        public FocusProvider getFocusProvider() {
+            return null;
         }
     }
 }


### PR DESCRIPTION
# Description
This adds Nozzle tip changer XY and Z calibration using vision and probing. Used to calibrate the nozzle to be able to precisely contact probe part heights, feeder heights and placements. Also adds Auto-Focus based part height sensing for parts with enabled bottom vision. 

Watch the video:
https://youtu.be/9uFxV1-vnXw

## Main Features

* Vision calibrated nozzle changer slot locations (XY) based on template images. Also detects nozzle changer slot empty/occupied status and prevents collisions.
* Manual and automatic nozzle/nozzle tip/slot Z calibration for precision multi-nozzle leveling and nozzle tip length calibration.
* Adds Focus sensing method to cameras (FocusProvider interface). AutoFocusProvider default implementation.
* Bottom vision uses Focus sensing to determine the part height, if unknown 
* ContactProbeNozzle provides on-the-fly part height probing/learning, feeder Z calibration, placement height calibration. 

![Nozzle Tip Changer Calibration, Height Sensing](https://user-images.githubusercontent.com/9963310/113490380-c33fae80-94c9-11eb-91bf-12a7d062744e.jpg)

## Feature Details

* Nozzle tip specific touch location for faster after-loading Z calibration and varied tip lengths. Configurable triggers/options. Touch locations can be "Z-leveled" to single reference. 
* Adds _experimental_ "sniffle" method for contact probing _without_ dedicated sensor. May be useful for nozzle/nozzle tip Z calibration but obviously not feasible with part on the nozzle, i.e. pick and place height sensing is not possible.
* Nozzle tips have (practical) maximum part height and maximum part diameter settings to enable proper operation with unknown part dimensions.
* Dynamic Safe Z uses the maximum part height as long as a part height is unknown.
* Auto-Focus servos from maximum part height down and masks itself to maximum part diameter. Future usage with CircleMask possible.
* Job processor allows running jobs with part heights not yet set, it will only complain when no part height sensing method is available for parts without height. 
* Nozzle contact probing capability becomes part compatibility criteria in the planner. Multi-nozzle machines might only have one nozzle with probing sensor, so parts with unknown height will have to be loaded on that nozzle. Only relevant if Auto-Focus does not apply. 
* The placementLocation in the job processor is now the base location (i.e. underneath the part), in order to allow part height sensing on the fly (backwards-compatible Scripting, i.e. parameter works as before, new parameter placementLocationBase). 
* Feeders have new isPartHeightAbovePickLocation() method to determine if part height is above the pick location and must be sensed when part height is unknown (loose part feeder classes).
* As predicted long ago, the Nozzle now has overridable moveToPickLocation() and moveToPlacementLocation() methods. Plain moveToLocationAtSafeZ() calls in job processor and GUI actions were replaced.
* ContactProbeNozzle now overrides these methods to provide on-the-fly probing. Can be done each time or only once and learned (faster Z moves without probing).
* Auto focus of a Z calibrated nozzle tip can be used to set precise focal plane of bottom camera,
* Calibrations triggered by machine homing now have an option to enable/disable failing the homing cycle.
* UiUtils.messageBoxOnExceptionLater allows for deferred/multiple GUI related actions. Needed in the homing cycle when multiple calibrations can fail (and failing the homing cycle is disabled).
* Some improved diagnostic messages on errors.
* Test Alignment GUI action now uses the current nozzle rotation angle (to test pre-rotate + Auto-focus).
* Visual homing fiducial locator vision Test button.
* Made LocationsButtonsPanel more configurable to use in situations when some buttons are unwanted. Removed duplicate buttons/actions definitions (in ReferenceHeadConfigurationWizard). Added proper setEnabled() handling.
* Simple depth of focus (blur) simulated in the SimulatedUpCamera to test Auto-Focus. Checkbox on the Wizard (slow!)
* Issues&Solutions for ContactProbing was improved/adapted.
* Issues&Solutions can convert ReferenceNozzles into ContactProbeNozzles while preserving configuration.

## Bugfixes during testing

These bugs hindered testing, therefore I presume inclusion is justified.

* Edit pipeline on ReferencePushPullFeeder did not wait for motion completion, therefore camera capture lighting failed.
* Polymorphic Object type property sheet handlers need resetting when switching stages.
* Recycle part to feeder feature: Missing null handler when feeder has no part.
* Pipeline stages now at least record exceptions in the log. Issue of swallowed machine exceptions is still not solved.
* various.

## Breaking Changes

* ContactProbeNozzle retraction (Actuator `false` actuation) now happens immediately after probing. Previously it was `false`-actuated after picking/placing. Default Gcode for `{False}` is now empty, retraction is controlled by GUI and done by normal Z move.
* moveToLocationAtSafeZ() will only move to safe Z if the location changes in X, Y or C. This allows for quick Z only relocation. Happens when bottom vision follows auto-focus or when pick follows BlindsFeeder push-cover opening etc.

# Justification
To justify that these very different parts belong together into one PR, one must look at the dependencies.  

This started out as a better-contact-probing PR. But it soon became evident, that nozzle tip Z needs to be calibrated for the required precision (0402 parts are very thin). 

Hence, probing Z calibration was also needed. Different nozzle tips may have different lengths (certainly the "unloaded" nozzle tip (stand-in for the naked nozzle) needs a different touch reference Z). And the extra move to a common touch location also seemed quite slow. Hence, it was integrated in the changer locations series and into automatic cloning/translating (see also #1107). 

But now that Z was calibrated it seemed odd not to calibrate X, Y as well. This was emphasized by a few nasty collisions when setting things up and testing. Hence, the template image based X, Y slot calibration. As a bonus, it can also detect if the slot is empty or occupied and prevent the painful collisions I had. 

When I finally started to implement part height auto-learning, I realized that for parts with bottom vision, the part height is required _before_ it can be probed in placement (except for the loose part feeders, where it can be probed in the pick). Hence, the Auto-Focus was needed. This also immediately made this PR much more widely useful, i.e. part height sensing/learning is now available for all parts with vision enabled, even if you don't have a contact probing nozzle. 

But you still need Z calibrated tips for Auto-focus to be precise enough, hence "sniffle" probing using the vacuum system. Though that turned out "experimental" on my machine (using a stiff vacuum reservoir and no flow restriction, the tests do not work reliably on the finest nozzle tips). Maybe it will work on direct pumps.

# Instructions for Use
In preparation for the Wiki. I'm partially using Wiki markup links here, they won't work until in the Wiki. 

## ContactProbeNozzle

### What is it?
The ContactProbeNozzle can probe the surface of things in Z. This can simply be used to perform probing picks and places all the time, i.e. Z coordinates do not need to be very precise, the nozzle will automatically stop when contact is sensed. 

But this does not cover other applications where Z coordinates must be quite precise without making contact. Examples are sideways nozzle tip tool changing, special feeder movements like the [[BlindsFeeder]] cover actuation or even part picking where spring-loaded/hard contact is not desired ([suspended tape feeders](https://docs.mgrl.de/maschine:pickandplace:feeder:manualfeeders)). 

Machines that home the Z axis with easily shifted Zmax switches ([e.g.](https://liteplacer.com/the-machine/assembly-instructions/pnp-head-step-11-attach-z-high-limit-switch/) Liteplacer), hard to balance dual-nozzle mid-axis sensors or even by just letting springs retract unpowered Z motors, may not provide a precise and repeatable Z reference eternally.  

A ContactProbeNozzle can then be used to calibrate the Nozzle in Z, more specifically the point of the loaded Nozzle Tip. By probing a known reference Z touch surface, it can then apply the obtained calibration offset to all future Z movements. 

For multi-nozzle machines, the nozzles can therefore be perfectly harmonized in Z. This can (optionally) be extended to individual nozzle tips if these have varying heights, or if the coupling to the nozzle is not very consistent. 

Having a calibrated Z not only establishes precision in movements, but also in capturing or probing other locations. 

### Enable the ContactProbeNozzle 
If you don't have a ContactProbeNozzle yet, let [[Issues and Solutions]] replace the existing ReferenceNozzle for you:
 
![Replace nozzle](https://user-images.githubusercontent.com/9963310/113565652-9bf0fa80-960b-11eb-8bac-b15591a0ddc7.png)

This extends the Nozzle with a new tab **Contact Probe**.

### Method Selection

![Contact Probe Method](https://user-images.githubusercontent.com/9963310/113565832-f25e3900-960b-11eb-9146-8d72be48e0af.png)

**Method** lets you select the probing method. 

- **None** switches contact probing off. The nozzle behaves as if it were a regular ReferenceNozzle. 
- **Vacuum Sense** uses the Vacuum Sensing setup of the nozzle to perform "sniffle probing". More specifically, the [Part Off](https://github.com/openpnp/openpnp/wiki/Setup-and-Calibration%3A-Vacuum-Sensing#measurement-method) detection method is used to sense if the nozzle tip has touched the surface. 
- **ContactSensingActuator** uses a separate Actuator to probe and sense for contact. This is a setup made popular by the Liteplacer kit. 

Notes: The Wizard will show different fields according to the selection. If at least one nozzle has an active **Method** selected, other parts of the OpenPnP GUI will also show additional elements for contact probing. 

### Vacuum Sense Method

![Vacuum Sense](https://user-images.githubusercontent.com/9963310/113567748-77971d00-960f-11eb-996f-8ccd6828b488.png)

**Start Offset** determines how high above the nominal probing location, the sensing should start. For the **Vacuum Sense** method, this must be high enough to get a clear "Part Off" result on the first sniffle.

**Probe Depth** determines how far the probing should go. 

**Sniffle Increment** determines the step in Z. 

**Sniffle Dwell Time [ms]** sets the waiting time between two sniffles. This is needed to clear out any under-pressure from the previous sniffle.

**Final Adjustment** after contact was sensed, add this adjustment to the Z position. Positive values retract the nozzle, negative values add spring loading. You should aim for a light touch with barely any spring loading.  This way the tip Z reference can also be used to push things sideways such as with the [[BlindsFeeder]] cover actuation. 

**Calibration Z Offset** shows the last calibration result. 

**Calibrate Now** performs the Z calibration. You must first setup a **Touch Location** on all the noozle tip's **Tool Changer** tab. 

### Contact Sense Method

![ContactSenseActuator](https://user-images.githubusercontent.com/9963310/113569966-ac0cd800-9613-11eb-9b02-da625610db6d.png)

**Start Offset** determines how high above the nominal probing location, the sensing should start. For the **Vacuum Sense** method, this must be high enough to get a clear "Part Off" result on the first sniffle.

**Probe Depth** determines how far the probing should go. In fact it may go further but if the probing result is beyond the given depth an exception is thrown. 

**Final Adjustment** after contact was sensed, add this adjustment to the Z position. Positive values retract the nozzle, negative values add spring loading. You should aim for a light touch with barely any spring loading. This way the tip Z reference can also be used to push things sideways such as with the [[BlindsFeeder]] cover actuation. 

**Feeder Height Probing** determines when feeders should be probed for pick location Z offsets. 

**Part Height Probing** determines when parts should be probed for placement location Z offsets. 

![Probing Triggers](https://user-images.githubusercontent.com/9963310/113590798-6102bd00-9633-11eb-83df-8fc04a234680.png)

* **Off** switches off any probing.
* **Once** probes for a Z offset only once. The offset is stored in the configuration (machine.xml). 
* **AfterHoming** probes for a Z offset once after homing the machine.  
* **Each Time** probes for contact in all picks and placements. This is the most tolerant setting.  

**Calibration Z Offset** shows the last Z calibration result for this nozzle with the current nozzle tip attached. See also the Nozzle Tip Probing Configuration.

**Calibrate Now** performs the Z calibration. You must first setup the Nozzle Tip Probing Configuration.

### Part Height Auto-Learning

With a ContactProbeNozzle and enabled feeder and part height probing, OpenPnP can now also learn part heights automatically. Whenever a part with unknown height is picked or placed for the first time, the probed height will be stored on the part. 

* Part height auto-learning works for feeders that have the part height _above_ the pick location Z (ReferenceLoosePartFeeder and AdvancedLoosePartFeeeder). 
* Part height auto-learning also works in all placements, as obviously all parts are above the known board location Z. 

The job processor knows when a ContactProbeNozzle has this capability and will in this case allow starting a Job with unknown part heights. If only one nozzle in a multi-nozzle setup has probing capabilities, the planner will automatically restrict parts with unknown heights to this nozzle. As an alternative, part heights can also be auto-learned using auto focus, if bottom vision is enabled for the part. 

![Part height unknown](https://user-images.githubusercontent.com/9963310/113597986-c313f000-963c-11eb-84e9-b0bedb797185.png)


## Nozzle Tip Probing Configuration

### Part Dimensions

The first pre-requisite for probing are the maximum **Part Dimensions**, defined in the **Configuration** tab:

![Part Dimensions](https://user-images.githubusercontent.com/9963310/113574803-1d9d5400-961d-11eb-860e-bd391d797f16.png)

**Max. Part Diameter** determines the diameter (or diagonal) of the largest part you ever expect to pick with this nozzle tip. Add a few millimeters on top of data sheet dimension for tolerances. This property will be used in present and future up-looking camera operations to restrict the region of interest (Auto-Focus, MaskCircle etc.). 

**Max. Part Height** determines the height of the tallest part you ever expect to pick with this nozzle tip. Add a few tenths of a millimeter on top of data sheet dimension for tolerances. This property will be used to start probing above a part with unknown height. Furthermore, it will be used for dynamic Safe Z, again as long as a part height is unknown. 

### Tool Changer 

As soon as at least one ContactProbeNozzle has an active probing method, the Tool Changer tab will show extra elements:

![Tool Changer](https://user-images.githubusercontent.com/9963310/113617535-b8feeb00-9656-11eb-977e-6b4b4c8840bc.png)

**Touch Location** lets you define a special Z probing touch location. It will be the reference for all other Z coordinates on your machine, therefore it should represent a fundamental and "eternal" reference surface for your machine.  At the same time it should be very close to the changer locations so the extra moves for Z calibration do not take much time.  

![Nozzle Tip Change and Z Calibrate](https://user-images.githubusercontent.com/9963310/113582499-c00f0480-9628-11eb-8e7d-db51b25813cd.gif)

After capturing the X, Y coordinates with the camera, you must initially probe the reference Z coordinate with the middle button:

![Probe](https://user-images.githubusercontent.com/9963310/113576642-3824fc80-9620-11eb-8fae-ad1f35913c60.png) 

___
**CAUTION**: do not do this again later. You will lose your "eternal" Z reference! 
___

**Auto Z Calibration** determines when the Z calibration happens. 

![Auto Z Calibration](https://user-images.githubusercontent.com/9963310/113577217-3576d700-9621-11eb-9971-94a9fd2eca94.png)

* **Manual** switches automatic Z calibration off. You can manually calibrate and the obtained Z offset will be stored in the configuration (machine.xml).
* **MachineHome** performs automatic Z calibration if this nozzle tip is loaded when the machine is homed. When other nozzles are later loaded to the same nozzle, no additional Z calibration is triggered. **Z calibration is per nozzle**. This can handle uneven nozzles in multi-nozzle machines. 
* **NozzleTipChange** performs automatic Z calibration whenever this nozzle tip is loaded to a nozzle. In addition, Z calibration also happens if this nozzle tip is loaded when the machine is homed. **Z calibration is per nozzle tip**.  This can handle uneven nozzle tips with different heights or inconsistent coupling. 

**Fail Homing?** If enabled, aborts the homing cycle when Z Calibration fails as part of it. If disabled, continues the homing cycle and only displays an error message. 

**Z** (behind the **Auto Z Calibration**) indicates the last obtained Z calibration offset. 

**Reset** removes the current Z calibration offset. 

**Calibrate now** performs manual Z calibration. 

**Note:** the Z calibration affects all the nozzle Z motion as well as the capturing of coordinates from the current nozzle position. But it does not affect Safe Z, as Safe Z is relative to the raw axis coordinate system, not the calibrated nozzle Z coordinate system. To balance a multi-nozzle machine's nozzles, use the [Axis capture buttons](https://github.com/openpnp/openpnp/wiki/Machine-Axes#kinematic-settings--axis-limits) instead.  

### Cloning Settings

![Cloning Settings](https://user-images.githubusercontent.com/9963310/113582934-49bed200-9629-11eb-9340-fa6b391f77dd.png)

Among the other settings, the **Z Calibration** settings can be cloned to/from other nozzle tips, so you need to configure them only once. The **Touch Location** is automatically translated according to the **First Location** (along with the other locations). 

Marking this nozzle tip as the **Template** makes the **Touch Location Z** the global machine reference Z. 

Use the **Clone Tool Changer Settings to all Nozzle Tips** button to distribute the Z calibration settings to all the other nozzles. 

Use the  **Callibrate all Touch Locations' Z to Template** to reference them to the global machine reference Z.

## Vision Calibration

Using computer vision Nozzle Tip Changer locations can be calibrated in X and Y. The process uses two template images, of the empty and occupied changer slot respectively. It can therefore also detect if the slot is empty/occupied as expected.

**Vision Location** determines the changer location at which the template images are taken. Chose a location where the nozzle tip is visible when it occupies the slot. 
 
![Vision Location](https://user-images.githubusercontent.com/9963310/113585531-a2dc3500-962c-11eb-8395-f8fe1db1b30b.png)

**Calibration Trigger** determines when the vision calibration takes places:

![Calibration Trigger](https://user-images.githubusercontent.com/9963310/113585861-11b98e00-962d-11eb-9d97-9356a55fbd4f.png)

* **Manual** allows only manual calibration. The calibration will be stored in the configuration (machine.xml)
* **Machine Home** invalidates the calibration when the machine is homed. As soon as nozzle tip load/unload is requested, the slot will first be vision calibrated. 
* **NozzleTipChange** recalibrates the the locations on each nozzle tip change. 

![Vision Calibration](https://user-images.githubusercontent.com/9963310/113588193-1b90c080-9630-11eb-9564-2a81e315c90a.png)

**Template Width** and **Template Height** determine the dimensions of the template image. Use a crop that includes relevant horizontal and vertical edges of the changer slot surrounded by an extra millimeter or so. The nozzle tip must be visible, when it occupies the slot. You can use the **Capture** buttons to optimize.  

**Tolerance** determines by how far from the nominal location the vision detected location may be. 

**Wanted Precision** determines at what distance the obtained template image match location is close enough. Otherwise, the camera is centered to the detected location and another vision pass is made (drill down).

**Max. passes** limits the maximum number of vision passes. 

**Minimum Score** determines how similar the camera image must be in comparison with the template image (0.0 ... 1.0). If the score is not reached, the calibration fails. 

**Last Score** shows the template match score obtained from last live or test calibration. 

Use the **Test** button to test the calibration. 

Use the **Capture** button to capture the respective **Template Empty** or **Template Occupied** image. The camera will automatically move to the selected **Vision Location**. You can hover over the captured template thumbnail to see it enlarged in the camera view. 

Use the **Reset** button to remove templates images. 

The two images are both used and the better match tells OpenPnP if the slot in question is empty or occupied. If this does not correspond to the state internally stored by OpenPnP, it will abort the calibration and therefore the nozzle tip load/unload operation. Nasty collisions can be safely prevented. 

![Found occupied](https://user-images.githubusercontent.com/9963310/113589665-f00ed580-9631-11eb-9522-272dbf86ee64.png)

## Up-looking Camera Auto-Focus

Unknown part heights can automatically be detected by auto focussing its underside. The nozzle will servo up and down to find the optimum. 

As a pre-requisite, the **Part Dimensions** must be defined on each nozzle tip (Configuration tab). Both the **Max. Part Diameter** and **Max. Part Height** are used to determine the autofocus range and senstive area. 

![Part Dimensions](https://user-images.githubusercontent.com/9963310/113574803-1d9d5400-961d-11eb-860e-bd391d797f16.png)

To enable the auto focus on the camera, select the **Focus Sensing Method**. It is only available on up-looking cameras: 

![Enable Auto-Focus](https://user-images.githubusercontent.com/9963310/113592481-84c70280-9635-11eb-9b4d-c3dcef2d8c33.png)

Once you press **Apply**, a new **Auto Focus** tab appears:

![grafik](https://user-images.githubusercontent.com/9963310/113593256-7f1dec80-9636-11eb-840c-18f01ab0ff54.png)

**Focal Resolution** determines the maximum step size for the Auto Focus servo. 

**Averages Frames** lets you run the autofocus for multiple frames and average the results. This will improve the accuracy by effectively averaging out image noise etc. 

**Focus Speed** sets the relative motion speed for the focus stepping. 
 
**Show Diagnostics?** switches on auto focus edge highlighting and status info in the camera view.  

**Last Focus Distance** indicates the last live or test focus distance measured. If there is a part on the nozzle, this is the part height. 

Press the ![red dot](https://user-images.githubusercontent.com/9963310/113594994-b42b3e80-9638-11eb-870d-f32a728bd8e8.png) button to test the auto focus.  

![Auto Focus](https://user-images.githubusercontent.com/9963310/113595736-b4780980-9639-11eb-8e13-1b9a3c58f65d.gif)

### Calibrating the Up-looking Camera Z

The auto focus can help you calibrate the precise up-looking camera Z position. This will make sure your bottom vision happens at optimum distance. 

___
**CAUTION**: this procedure will change the subject to camera distance, which will change the scale of subjects. You will need to readjust the **Units per Pixel** after performing it. 
___

1. Use a Z calibrated nozzle tip with no part on. 
2. Auto focus it, using the ![red dot](https://user-images.githubusercontent.com/9963310/113594994-b42b3e80-9638-11eb-870d-f32a728bd8e8.png) button in the **Auto Focus** camera tab. . 
3. Press the **Adjust Camera Z** button to set the camera Z Position to the detected distance. 
4. Go to the **General Configuration** tab to adjust **Units per Pixel**.


### Part Height Auto-Learning

Whenever Alignment (a.k.a. Bottom Vision) encounters a part with unknown part height, it will employ the auto focus. The detected part height is then stored on the part. This will take some additional time (but hardly longer than manually measuring and entering the data). All subsequent vision and placement operations will reuse the height directly, with no further speed penalty incurred. 

The job processor knows when a camera has auto focus capability and bottom vision is enabled for the part. It will then allow starting a Job with unknown part heights.  As an alternative, part heights can also be auto-learned using a ContactProbeNozzle.  

![Part height unknown](https://user-images.githubusercontent.com/9963310/113597986-c313f000-963c-11eb-84e9-b0bedb797185.png)


# Implementation Details
1. Code was first tested on the simulation machine, hence the simulation of depth of focus. Then it was tested and tuned on my machine. Since I was also mechanically changing my machine (tool changer relocated), this turned out to be quite instructive. 
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. Made changes in the `org.openpnp.spi` or `org.openpnp.model` packages, as described, i.e. see Feeder.isPartHeightAbovePickLocation(), Nozzle.moveToPickLocation(), Nozzle.moveToPlacementLocation().
4. Successful `mvn test` before submitting the Pull Request. 

