### PR TITLE
Rotated tray feeder fix

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/feeder/ReferenceRotatedTrayFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/ReferenceRotatedTrayFeeder.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2017 Sebastian Pichelhofer & Jason von Nieda <jason@vonnieda.org>
+ * Rotation Matrix corrections by Martin Gyurkó <nospam@gyurma.de> in 2021
  * 
  * This file is part of OpenPnP.
  * 
@@ -89,19 +90,18 @@ public class ReferenceRotatedTrayFeeder extends ReferenceFeeder {
 
 		// Multiply the offsets by the X/Y part indexes to get the total offsets
 		// and then add the pickLocation to offset the final value.
+		// and then rotate it with the correct rotation matrix.
 		// and then add them to the location to get the final pickLocation.
-		// pickLocation = location.add(offsets.multiply(partX, partY, 0.0,
-		// 0.0));
+		// pickLocation = location.add(offsets.multiply(partX, partY, 0.0, 0.0));
 
-		double delta_x1 = partX * offsets.getX() * Math.cos(Math.toRadians(trayRotation));
-		double delta_y1 = Math.sqrt((partX * offsets.getX() * partX * offsets.getX()) - (delta_x1 * delta_x1));
-		Location delta1 = new Location(LengthUnit.Millimeters, delta_x1, delta_y1, 0, 0);
+		double sin = Math.sin(Math.toRadians(trayRotation));
+		double cos = Math.cos(Math.toRadians(trayRotation));
 
-		double delta_y2 = partY * offsets.getY() * Math.cos(Math.toRadians(trayRotation)) * -1;
-		double delta_x2 = Math.sqrt((partY * offsets.getY() * partY * offsets.getY()) - (delta_y2 * delta_y2));
-		Location delta2 = new Location(LengthUnit.Millimeters, delta_x2, delta_y2, 0, 0);
+		double delta_x = partX * offsets.getX() * cos + partY * offsets.getY() * sin;
+		double delta_y = partX * offsets.getX() * sin - partY * offsets.getY() * cos;
+		Location delta = new Location(LengthUnit.Millimeters, delta_x, delta_y, 0, 0);
 
-		pickLocation = location.add(delta1.add(delta2));
+		pickLocation = location.add(delta);
 	}
 
 	public void feed(Nozzle nozzle) throws Exception {

--- a/src/main/java/org/openpnp/machine/reference/feeder/ReferenceRotatedTrayFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/ReferenceRotatedTrayFeeder.java
@@ -89,7 +89,6 @@ public class ReferenceRotatedTrayFeeder extends ReferenceFeeder {
 	private void calculatePickLocation(int partX, int partY) throws Exception {
 
 		// Multiply the offsets by the X/Y part indexes to get the total offsets
-		// and then add the pickLocation to offset the final value.
 		// and then rotate it with the correct rotation matrix.
 		// and then add them to the location to get the final pickLocation.
 		// pickLocation = location.add(offsets.multiply(partX, partY, 0.0, 0.0));


### PR DESCRIPTION
# Description
Just implemented the correct way of rotating a position matrix

# Justification
to solve issue with the Reference Rotated tray Feeder
https://github.com/openpnp/openpnp/issues/1157

# Instructions for Use

Just use the Reference Rotated tray feeder, now it will move the tool to the correct position even if the rotation is negative angle.

# Implementation Details
1. How did you test the change? Be descriptive. Untested code will not be accepted.

Tested it with a fresh installation of openpnp and used the slanted strips to virtually try out the rotation and feed positions

2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)?

as far as I know...

3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing.

No change there

4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted.

Did a complete mvn package, and mvn test
Did not see errors 
Tested with
java 15.0.2 2021-01-19
Java(TM) SE Runtime Environment (build 15.0.2+7-27)
Java HotSpot(TM) 64-Bit Server VM (build 15.0.2+7-27, mixed mode, sharing)