### PR TITLE
Fix/Round-up of Bug-Fixes and some Missing Utility Features

### DIFF
--- a/src/main/java/org/openpnp/gui/JogControlsPanel.java
+++ b/src/main/java/org/openpnp/gui/JogControlsPanel.java
@@ -26,7 +26,6 @@ import java.awt.FocusTraversalPolicy;
 import java.awt.Font;
 import java.awt.Window;
 import java.awt.event.ActionEvent;
-import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.util.HashMap;
 import java.util.Hashtable;
@@ -809,16 +808,21 @@ public class JogControlsPanel extends JPanel {
             // add property listener for recycle button
             // enable recycle only if part on current head
             PropertyChangeListener recyclePropertyListener = (e) -> {
-                    boolean canTakeBack = false;
-                    Part part = machineControlsPanel.getSelectedNozzle().getPart();
-                    if (part != null) {
-                        for (Feeder feeder : Configuration.get().getMachine().getFeeders()) {
-                            if (feeder.isEnabled() && feeder.getPart().equals(part) && feeder.canTakeBackPart()) {
-                                canTakeBack = true;
+                    Nozzle selectedNozzle = machineControlsPanel.getSelectedNozzle();
+                    if (selectedNozzle != null) {
+                        boolean canTakeBack = false;
+                        Part part = selectedNozzle.getPart();
+                        if (part != null) {
+                            for (Feeder feeder : Configuration.get().getMachine().getFeeders()) {
+                                if (feeder.isEnabled() 
+                                        && feeder.getPart() == part
+                                        && feeder.canTakeBackPart()) {
+                                    canTakeBack = true;
+                                }
                             }
                         }
+                        recycleAction.setEnabled(canTakeBack);
                     }
-                    recycleAction.setEnabled(canTakeBack);
                 };
             // add to all nozzles
             for (Head head : Configuration.get().getMachine().getHeads()) {

--- a/src/main/java/org/openpnp/gui/tablemodel/PartsTableModel.java
+++ b/src/main/java/org/openpnp/gui/tablemodel/PartsTableModel.java
@@ -128,7 +128,22 @@ public class PartsTableModel extends AbstractTableModel implements PropertyChang
 
     @Override
     public void propertyChange(PropertyChangeEvent arg0) {
-        parts = new ArrayList<>(Configuration.get().getParts());
-        fireTableDataChanged();
+        if (arg0.getSource() instanceof Part) {
+            // Only single part data changed, but sort order might change, so still need fireTableDataChanged().
+            fireTableDataChanged();
+        }
+        else  {
+            // Parts list itself changes.
+            if (parts != null) { 
+                for (Part part : parts) {
+                    part.removePropertyChangeListener(this);
+                }
+            }
+            parts = new ArrayList<>(Configuration.get().getParts());
+            fireTableDataChanged();
+            for (Part part : parts) {
+                part.addPropertyChangeListener(this);
+            }
+        }
     }
 }

--- a/src/main/java/org/openpnp/machine/reference/ReferenceNozzle.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceNozzle.java
@@ -37,10 +37,10 @@ import org.openpnp.spi.base.AbstractActuator;
 import org.openpnp.spi.base.AbstractNozzle;
 import org.openpnp.util.MovableUtils;
 import org.openpnp.util.SimpleGraph;
+import org.openpnp.util.UiUtils;
 import org.pmw.tinylog.Logger;
 import org.simpleframework.xml.Attribute;
 import org.simpleframework.xml.Element;
-import org.simpleframework.xml.core.Commit;
 
 public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMountable {
     @Element
@@ -474,8 +474,20 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
                 if (calibrationNozzleTip.getCalibration().isRecalibrateOnHomeNeeded(this)) {
                     if (calibrationNozzleTip == this.getCalibrationNozzleTip()) {
                         // The currently mounted nozzle tip.
-                        Logger.debug("{}.home() nozzle tip {} calibration neeeded", getName(), calibrationNozzleTip.getName());
-                        calibrationNozzleTip.getCalibration().calibrate(this, true, false);
+                        try {
+                            Logger.debug("{}.home() nozzle tip {} calibration neeeded", getName(), calibrationNozzleTip.getName());
+                            calibrationNozzleTip.getCalibration().calibrate(this, true, false);
+                        }
+                        catch (Exception e) {
+                            if (calibrationNozzleTip.getCalibration().isFailHoming()) {
+                                throw e; 
+                            }
+                            else {
+                                UiUtils.messageBoxOnExceptionLater(() -> {
+                                    throw e;
+                                });
+                            }
+                        }
                     }
                     else {
                         // Not currently mounted so just reset.

--- a/src/main/java/org/openpnp/machine/reference/ReferenceNozzleTip.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceNozzleTip.java
@@ -712,4 +712,7 @@ public class ReferenceNozzleTip extends AbstractNozzleTip {
             }
         }
     };
+    @Override
+    public void home() throws Exception {
+    }
 }

--- a/src/main/java/org/openpnp/machine/reference/ReferenceNozzleTipCalibration.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceNozzleTipCalibration.java
@@ -20,7 +20,6 @@ import org.openpnp.model.LengthUnit;
 import org.openpnp.model.Location;
 import org.openpnp.model.Point;
 import org.openpnp.spi.Camera;
-import org.openpnp.spi.Nozzle;
 import org.openpnp.spi.NozzleTip;
 import org.openpnp.util.MovableUtils;
 import org.openpnp.util.OpenCvUtils;
@@ -459,7 +458,6 @@ public class ReferenceNozzleTipCalibration extends AbstractModelObject {
         @Override
         public Location getCameraOffset() {
             // Return the axis offset as the camera tool specific calibration offset.
-            Logger.debug("[nozzleTipCalibration] getCameraOffset() returns: {}, {}", this.centerX, this.centerY);
             return new Location(this.units, this.centerX, this.centerY, 0., 0.);
         }
     }
@@ -482,6 +480,8 @@ public class ReferenceNozzleTipCalibration extends AbstractModelObject {
 
     @Attribute(required = false)
     private boolean enabled;
+    @Attribute(required = false)
+    private boolean failHoming = true;
 
     private boolean calibrating;
 
@@ -660,13 +660,15 @@ public class ReferenceNozzleTipCalibration extends AbstractModelObject {
                 } else {
                     misdetects++;
                     if (misdetects > this.allowMisdetections) {
-                        throw new Exception("Too many vision misdetects. Check pipeline and threshold.");
+                        throw new Exception(
+                                "Nozzle tip calibration: too many vision misdetects. Check pipeline and threshold.");
                     }
                 }
             }
 
             if (nozzleTipMeasuredLocations.size() < Math.max(3, angleSubdivisions + 1 - this.allowMisdetections)) {
-                throw new Exception("Not enough results from vision. Check pipeline and threshold."); 
+                throw new Exception(
+                        "Nozzle tip calibration: not enough results from vision. Check pipeline and threshold.");
             }
 
             Configuration.get().getScripting().on("NozzleCalibration.Finished", params);
@@ -1015,6 +1017,14 @@ public class ReferenceNozzleTipCalibration extends AbstractModelObject {
 
     public void setEnabled(boolean enabled) {
         this.enabled = enabled;
+    }
+
+    public boolean isFailHoming() {
+        return failHoming;
+    }
+
+    public void setFailHoming(boolean failHoming) {
+        this.failHoming = failHoming;
     }
 
     public CvPipeline getPipeline() throws Exception {

--- a/src/main/java/org/openpnp/machine/reference/driver/GcodeDriverSolutions.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/GcodeDriverSolutions.java
@@ -57,7 +57,7 @@ import org.simpleframework.xml.stream.Style;
  * The idea is not to pollute the driver implementations themselves.
  *
  */
-class GcodeDriverSolutions implements Solutions.Subject {
+public class GcodeDriverSolutions implements Solutions.Subject {
     private final GcodeDriver gcodeDriver;
 
     GcodeDriverSolutions(GcodeDriver gcodeDriver) {
@@ -198,7 +198,7 @@ class GcodeDriverSolutions implements Solutions.Subject {
                     }
                 }
             }
-            else if (gcodeDriver.getDetectedFirmware().contains("Marlin")) {
+            else if (gcodeDriver.getFirmwareProperty("FIRMWARE_NAME", "").contains("Marlin")) {
                 isMarlin = true;
                 firmwareAxesCount = Integer.valueOf(gcodeDriver.getFirmwareProperty("AXIS_COUNT", "0"));
                 if (firmwareAxesCount > 3) { 
@@ -213,7 +213,7 @@ class GcodeDriverSolutions implements Solutions.Subject {
                             "https://github.com/openpnp/openpnp/wiki/Motion-Controller-Firmwares#marlin-20"));
                 }
             }
-            else if (gcodeDriver.getDetectedFirmware().contains("TinyG")) {
+            else if (gcodeDriver.getFirmwareProperty("FIRMWARE_NAME", "").contains("TinyG")) {
                 // Having a response already means we have a new firmware.
                 isTinyG = true;
             }
@@ -728,10 +728,11 @@ class GcodeDriverSolutions implements Solutions.Subject {
      * Add a solution for the given gcodeDriver to the issues, to suggest the given suggestedCommand instead of the currentCommand.
      *
      * @param gcodeDriver
+     * @param headMountable
      * @param issues
      * @param commandType
-     * @param currentCommand
      * @param suggestedCommand
+     * @param commandModified
      * @param disallowHeadMountables Set true to disallow the commandType on HeadMountables. This is used when switching to axis letter variables.
      */
     public static void suggestGcodeCommand(GcodeDriver gcodeDriver, HeadMountable headMountable, List<Solutions.Issue> issues,

--- a/src/main/java/org/openpnp/machine/reference/feeder/wizards/ReferencePushPullFeederConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/wizards/ReferencePushPullFeederConfigurationWizard.java
@@ -22,7 +22,7 @@
 package org.openpnp.machine.reference.feeder.wizards;
 
 import java.awt.BorderLayout;
-import java.awt.Color;
+import java.awt.Dimension;
 import java.awt.GraphicsEnvironment;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
@@ -67,6 +67,7 @@ import org.openpnp.model.Configuration;
 import org.openpnp.model.RegionOfInterest;
 import org.openpnp.spi.Camera;
 import org.openpnp.spi.Head;
+import org.openpnp.spi.MotionPlanner.CompletionType;
 import org.openpnp.util.MovableUtils;
 import org.openpnp.util.UiUtils;
 import org.openpnp.vision.pipeline.CvPipeline;
@@ -77,7 +78,6 @@ import com.jgoodies.forms.layout.ColumnSpec;
 import com.jgoodies.forms.layout.FormLayout;
 import com.jgoodies.forms.layout.FormSpecs;
 import com.jgoodies.forms.layout.RowSpec;
-import java.awt.Dimension;
 
 @SuppressWarnings("serial")
 public class ReferencePushPullFeederConfigurationWizard
@@ -633,7 +633,8 @@ extends AbstractReferenceFeederConfigurationWizard {
                 UiUtils.submitUiMachineTask(() -> {
                     MovableUtils.moveToLocationAtSafeZ(feeder.getCamera(), feeder.getNominalVisionLocation());
                     MovableUtils.fireTargetedUserAction(feeder.getCamera());
-                    SwingUtilities.invokeAndWait(() -> {
+                    feeder.getCamera().waitForCompletion(CompletionType.WaitForStillstand);
+                    SwingUtilities.invokeLater(() -> {
                         UiUtils.messageBoxOnException(() -> {
                             editPipeline();
                         });

--- a/src/main/java/org/openpnp/machine/reference/vision/wizards/ReferenceBottomVisionPartConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/vision/wizards/ReferenceBottomVisionPartConfigurationWizard.java
@@ -5,6 +5,7 @@ import java.awt.event.ActionListener;
 
 import javax.swing.JButton;
 import javax.swing.JCheckBox;
+import javax.swing.JComboBox;
 import javax.swing.JDialog;
 import javax.swing.JLabel;
 import javax.swing.JOptionPane;
@@ -14,16 +15,13 @@ import javax.swing.border.TitledBorder;
 
 import org.openpnp.gui.MainFrame;
 import org.openpnp.gui.support.AbstractConfigurationWizard;
-import org.openpnp.gui.support.DoubleConverter;
 import org.openpnp.gui.support.IntegerConverter;
 import org.openpnp.gui.support.MessageBoxes;
 import org.openpnp.machine.reference.vision.ReferenceBottomVision;
 import org.openpnp.machine.reference.vision.ReferenceBottomVision.PartSettings;
-import org.openpnp.model.Configuration;
 import org.openpnp.model.LengthUnit;
 import org.openpnp.model.Location;
 import org.openpnp.model.Part;
-import org.openpnp.spi.Axis;
 import org.openpnp.spi.Nozzle;
 import org.openpnp.spi.PartAlignment;
 import org.openpnp.util.UiUtils;
@@ -36,7 +34,6 @@ import com.jgoodies.forms.layout.ColumnSpec;
 import com.jgoodies.forms.layout.FormLayout;
 import com.jgoodies.forms.layout.FormSpecs;
 import com.jgoodies.forms.layout.RowSpec;
-import javax.swing.JComboBox;
 
 public class ReferenceBottomVisionPartConfigurationWizard extends AbstractConfigurationWizard {
     private final ReferenceBottomVision bottomVision;
@@ -159,7 +156,7 @@ public class ReferenceBottomVisionPartConfigurationWizard extends AbstractConfig
 
         // perform the alignment
         PartAlignment.PartAlignmentOffset alignmentOffset = VisionUtils.findPartAlignmentOffsets(bottomVision, part,
-                null, new Location(LengthUnit.Millimeters), nozzle);
+                null, new Location(LengthUnit.Millimeters, 0, 0, 0, nozzle.getLocation().getRotation()), nozzle);
         Location offsets = alignmentOffset.getLocation();
 
         if (!chckbxCenterAfterTest.isSelected()) {
@@ -168,7 +165,7 @@ public class ReferenceBottomVisionPartConfigurationWizard extends AbstractConfig
 
         // position the part over camera center
         Location cameraLocation = bottomVision.getCameraLocationAtPartHeight(part, VisionUtils.getBottomVisionCamera(),
-                nozzle, 0.);
+                nozzle, nozzle.getLocation().getRotation());
 
         if (alignmentOffset.getPreRotated()) {
             // See https://github.com/openpnp/openpnp/pull/590 for explanations of the magic

--- a/src/main/java/org/openpnp/model/Length.java
+++ b/src/main/java/org/openpnp/model/Length.java
@@ -326,4 +326,10 @@ public class Length {
         return setLocationField(configuration, location, length, field, false);
     }
 
+    public int compareTo(Length other) {
+        if (other == null) {
+            return Double.valueOf(getValue()).compareTo(Double.valueOf(0));
+        }
+        return Double.valueOf(getValue()).compareTo(Double.valueOf(other.convertToUnits(units).getValue()));
+    }
 }

--- a/src/main/java/org/openpnp/model/Location.java
+++ b/src/main/java/org/openpnp/model/Location.java
@@ -64,6 +64,8 @@ public class Location {
         this.rotation = rotation;
     }
 
+    static final public Location origin = new Location(LengthUnit.Millimeters);
+
     public double getX() {
         return x;
     }
@@ -94,6 +96,11 @@ public class Location {
 
     public Length getLinearLengthTo(Location location) {
         double distance = getLinearDistanceTo(location);
+        return new Length(distance, getUnits());
+    }
+
+    public Length getXyzLengthTo(Location location) {
+        double distance = getXyzDistanceTo(location);
         return new Length(distance, getUnits());
     }
 
@@ -253,6 +260,18 @@ public class Location {
     public Location multiply(double x, double y, double z, double rotation) {
         return new Location(getUnits(), x * getX(), y * getY(), z * getZ(),
                 rotation * getRotation());
+    }
+
+    /**
+     * Returns a new Location based on this Location with values multiplied by the specified factor.
+     * Units are the same as this Location.
+     * 
+     * @param factor
+     * @return
+     */
+    public Location multiply(double factor) {
+        return new Location(getUnits(), factor * getX(), factor * getY(), factor * getZ(),
+                factor * getRotation());
     }
 
     /**

--- a/src/main/java/org/openpnp/spi/Head.java
+++ b/src/main/java/org/openpnp/spi/Head.java
@@ -108,9 +108,11 @@ public interface Head extends Identifiable, Named, WizardConfigurable, PropertyS
 
     public void removeCamera(Camera camera);
 
-    public void permutateCamera(Camera driver, int direction);
+    public void permutateCamera(Camera camera, int direction);
 
     public void addNozzle(Nozzle nozzle) throws Exception;
+
+    public void permutateNozzle(Nozzle nozzle, int direction);
 
     public void removeNozzle(Nozzle nozzle);
 

--- a/src/main/java/org/openpnp/spi/NozzleTip.java
+++ b/src/main/java/org/openpnp/spi/NozzleTip.java
@@ -19,4 +19,12 @@ public interface NozzleTip extends Identifiable, Named, WizardConfigurable, Prop
      * NozzleTips that are sturdy enough to take the lateral forces.  
      */
     public boolean isPushAndDragAllowed();
+
+    /**
+     * Perform any homing operation on each nozzle tip. The head and driver have already been homed
+     * at this time. 
+     * 
+     * @throws Exception
+     */
+    void home() throws Exception;
 }

--- a/src/main/java/org/openpnp/spi/base/AbstractHead.java
+++ b/src/main/java/org/openpnp/spi/base/AbstractHead.java
@@ -41,7 +41,7 @@ public abstract class AbstractHead extends AbstractModelObject implements Head {
 
     @Element(required = false)
     protected Location parkLocation = new Location(LengthUnit.Millimeters);
-    
+
     @Deprecated
     @Element(required=false)
     protected boolean softLimitsEnabled = false;
@@ -63,7 +63,7 @@ public abstract class AbstractHead extends AbstractModelObject implements Head {
     /**
      * Choice of Visual Homing Method.
      * 
-     * Previous Visual Homing reset the controller to home coordinates not to the fiducial coordinates as one
+     * Previous Visual Homing reset the controller to home coordinates, not to the fiducial coordinates as one
      * might expect. As a consequence the fiducial location may shift its meaning before/after homing i.e. it cannot be captured. 
      * This behavior has been called a bug by Jason. But we absolutely need to migrate this behavior in order not to 
      * break all the captured coordinates on a machine!
@@ -78,13 +78,12 @@ public abstract class AbstractHead extends AbstractModelObject implements Head {
         ResetToFiducialLocation,
         ResetToHomeLocation
     }
-    
+
     @Attribute(required = false)
     private VisualHomingMethod visualHomingMethod = VisualHomingMethod.None;
 
     @Element(required = false)
     protected Location homingFiducialLocation = new Location(LengthUnit.Millimeters);
-
 
     protected Machine machine;
 
@@ -213,6 +212,18 @@ public abstract class AbstractHead extends AbstractModelObject implements Head {
         int index = nozzles.indexOf(nozzle);
         if (nozzles.remove(nozzle)) {
             fireIndexedPropertyChange("nozzles", index, nozzle, null);
+        }
+    }
+
+    @Override 
+    public void permutateNozzle(Nozzle nozzle, int direction) {
+        int index0 = nozzles.indexOf(nozzle);
+        int index1 = direction > 0 ? index0+1 : index0-1;
+        if (0 <= index1 && nozzles.size() > index1) {
+            nozzles.remove(nozzle);
+            nozzles.add(index1, nozzle);
+            fireIndexedPropertyChange("nozzles", index0, nozzle, nozzles.get(index0));
+            fireIndexedPropertyChange("nozzles", index1, nozzles.get(index0), nozzle);
         }
     }
 

--- a/src/main/java/org/openpnp/spi/base/AbstractHeadMountable.java
+++ b/src/main/java/org/openpnp/spi/base/AbstractHeadMountable.java
@@ -42,12 +42,17 @@ public abstract class AbstractHeadMountable extends AbstractModelObject implemen
 
             @Override
             public void configurationLoaded(Configuration configuration) throws Exception {
-                axisX = (AbstractAxis) configuration.getMachine().getAxis(axisXId);
-                axisY = (AbstractAxis) configuration.getMachine().getAxis(axisYId);
-                axisZ = (AbstractAxis) configuration.getMachine().getAxis(axisZId);
-                axisRotation = (AbstractAxis) configuration.getMachine().getAxis(axisRotationId);
+                applyConfiguration(configuration);
             }
         });
+    }
+
+    public void applyConfiguration(Configuration configuration) {
+        Machine machine = configuration.getMachine();
+        axisX = (AbstractAxis) machine.getAxis(axisXId);
+        axisY = (AbstractAxis) machine.getAxis(axisYId);
+        axisZ = (AbstractAxis) machine.getAxis(axisZId);
+        axisRotation = (AbstractAxis) machine.getAxis(axisRotationId);
     }
 
     @Override
@@ -287,16 +292,18 @@ public abstract class AbstractHeadMountable extends AbstractModelObject implemen
     }
 
     public Location toHeadLocation(Location location, Location currentLocation, LocationOption... options) {
-        // Shortcut Double.NaN. Sending Double.NaN in a Location is an old API that should no
-        // longer be used. It will be removed eventually:
-        // https://github.com/openpnp/openpnp/issues/255
-        // In the mean time, since Double.NaN would cause a problem for transformations, we shortcut
-        // it here by replacing any NaN values with the current value from the axes.
-        location = location.derive(currentLocation, 
-                Double.isNaN(location.getX()), 
-                Double.isNaN(location.getY()), 
-                Double.isNaN(location.getZ()), 
-                Double.isNaN(location.getRotation())); 
+        if (currentLocation != null) {
+            // Shortcut Double.NaN. Sending Double.NaN in a Location is an old API that should no
+            // longer be used. It will be removed eventually:
+            // https://github.com/openpnp/openpnp/issues/255
+            // In the mean time, since Double.NaN would cause a problem for transformations, we shortcut
+            // it here by replacing any NaN values with the current value from the axes.
+            location = location.derive(currentLocation, 
+                    Double.isNaN(location.getX()), 
+                    Double.isNaN(location.getY()), 
+                    Double.isNaN(location.getZ()), 
+                    Double.isNaN(location.getRotation())); 
+        }
         // Subtract the Head offset.
         location = location.subtract(getHeadOffsets());
         return location;

--- a/src/main/java/org/openpnp/spi/base/AbstractMachine.java
+++ b/src/main/java/org/openpnp/spi/base/AbstractMachine.java
@@ -290,6 +290,9 @@ public abstract class AbstractMachine extends AbstractModelObject implements Mac
         for (Head head : heads) {
             head.home();
         }
+        for (NozzleTip nt : getNozzleTips()) {
+            nt.home();
+        }
     }
 
     @Override

--- a/src/main/java/org/openpnp/util/ImageUtils.java
+++ b/src/main/java/org/openpnp/util/ImageUtils.java
@@ -2,6 +2,8 @@ package org.openpnp.util;
 
 import java.awt.Graphics2D;
 import java.awt.image.BufferedImage;
+import java.awt.image.ColorModel;
+import java.awt.image.WritableRaster;
 
 public class ImageUtils {
 
@@ -25,4 +27,16 @@ public class ImageUtils {
         return img;
     }
 
+    /**
+     * Clone an image for independent manipulation.  
+     * 
+     * @param image
+     * @return
+     */
+    public static BufferedImage clone(BufferedImage image) {
+        ColorModel colorModel = image.getColorModel();
+        WritableRaster raster = image.copyData(image.getRaster().createCompatibleWritableRaster());
+        boolean isAlphaPremultiplied = colorModel.isAlphaPremultiplied();
+        return new BufferedImage(colorModel, raster, isAlphaPremultiplied, null);
+    }
 }

--- a/src/main/java/org/openpnp/util/UiUtils.java
+++ b/src/main/java/org/openpnp/util/UiUtils.java
@@ -101,5 +101,8 @@ public class UiUtils {
         }
     }
 
+    public static void messageBoxOnExceptionLater(Thrunnable thrunnable) {
+        SwingUtilities.invokeLater(() -> messageBoxOnException(thrunnable));
+    }
 
 }

--- a/src/main/java/org/openpnp/vision/pipeline/CvPipeline.java
+++ b/src/main/java/org/openpnp/vision/pipeline/CvPipeline.java
@@ -16,6 +16,7 @@ import org.opencv.core.Scalar;
 import org.opencv.imgproc.Imgproc;
 import org.openpnp.vision.FluentCv.ColorSpace;
 import org.openpnp.vision.pipeline.CvStage.Result;
+import org.pmw.tinylog.Logger;
 import org.simpleframework.xml.ElementList;
 import org.simpleframework.xml.Root;
 import org.simpleframework.xml.Serializer;
@@ -241,6 +242,9 @@ public class CvPipeline implements AutoCloseable {
             }
             catch (Exception e) {
                 result = new Result(null, e);
+                if (stage.isEnabled()) {
+                    Logger.debug("Stage \""+stage.getName()+"\" throws "+e);
+                }
             }
             processingTimeNs = System.nanoTime() - processingTimeNs;
             totalProcessingTimeNs += processingTimeNs;

--- a/src/main/java/org/openpnp/vision/pipeline/ui/PipelinePanel.java
+++ b/src/main/java/org/openpnp/vision/pipeline/ui/PipelinePanel.java
@@ -39,7 +39,10 @@ import org.openpnp.util.MovableUtils;
 import org.openpnp.vision.pipeline.CvPipeline;
 import org.openpnp.vision.pipeline.CvStage;
 
-import com.l2fprod.common.propertysheet.*;
+import com.l2fprod.common.propertysheet.Property;
+import com.l2fprod.common.propertysheet.PropertySheetPanel;
+import com.l2fprod.common.propertysheet.PropertySheetTableModel;
+import com.l2fprod.common.swing.renderer.DefaultCellRenderer;
 
 public class PipelinePanel extends JPanel {
     private final CvPipelineEditor editor;
@@ -193,6 +196,8 @@ public class PipelinePanel extends JPanel {
             try {
                 propertySheetPanel.setBeanInfo(stage.getBeanInfo());
                 propertySheetPanel.readFromObject(stage);
+                // Set the Object.class DefaultCellRenderer, it might have been customized in a previously selected stage.
+                pipelinePropertySheetTable.getRendererRegistry().registerRenderer(Object.class, new DefaultCellRenderer());
                 stage.customizePropertySheet(pipelinePropertySheetTable, editor.getPipeline());
             }
             catch (Exception ex) {


### PR DESCRIPTION
# Description
This is a round-up of bug-fixes and conceptually missing utility features. These have popped up while working on #1164 (which will likely be re-submitted as a new one later). 

## Bug-fixes
* Bug-fix for #1143 (null pointer exception when part is missing in feeder)
* Parts table does not update on part property changes.
* Inconsistent FIRMWARE detection in `GcodeDriverSolutions`.
* Edit Pipeline does not wait for machine in `ReferencePushPullFeederConfigurationWizard`, resulting in the lighting actuator failing.
* Test Alignment in `ReferenceBottomVisionPartConfigurationWizard` did not conserve rotation of selected nozzle.
* Nozzle tip calibration failed the homing cycle if enabled on homing, creating a chicken egg situation during machine setup. Added an option to switch off. Improved error messages. This required  `UiUtils.messageBoxOnExceptionLater()` for deferred GUI tasks (in this case deferred throws/error messages).
* `null` check missing in `AbstractHeadMountable.toHeadLocation()`, refactored/extracted `AbstractHeadMountable.applyConfiguration()` for future use.
* Pipeline stages that throw exceptions are logged for easier diagnostics. The underlying issue that some exceptions should fail the pipeline immediately is still open.
* In the Pipeline Editor: custom `Object` type property sheet handlers need resetting when switching stages.

## Missing conceptual/utility features
* Missing `NozzleTip.home()` for Machine Setup tree topological homing.
* Missing `Length.compareTo()` 
* Missing `Location.getXyzLengthTo()` i.e. length including Z coordinate.
* Added `Location.origin` constant as the (0, 0, 0, 0) coordinate, for easy use in the form `vector.getXyzLengthTo(Location.origin)` to measure vector length.
* Missing `Location.multiply()` similar to the other operations.
* Missing `Head.permutateNozzle()` same as for cameras, Also fixed parameter name in `permutateCamera()`
* Missing `ImageUtils.clone()` to deep copy a `BufferedImage`.

# Justification
This is the first break-out of #1164 trying to implement [this input by @vonnieda](https://github.com/openpnp/openpnp/pull/1164#issuecomment-813675599).

I found it acceptable to put these in one PR as these are almost entirely **one class = one fix** and small (counting class+Wizards as one). 

# Instructions for Use
The only visible change is the new option **Fail Homing?** on the nozzle tip calibration.

![Fail Homing](https://user-images.githubusercontent.com/9963310/114310051-aae31b80-9ae9-11eb-94e3-5280b5892a57.png)

# Implementation Details
1. The bug-fixes were tested in #1164. After extraction just `mvn test`. 
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. Changes in the `org.openpnp.spi` or `org.openpnp.model` packages:  `Head.permutateNozzle()` and `NozzleTip.home()` and `Length` and `Location` additions as documented.
4. Successful `mvn test` before submitting the Pull Request. 
