### PR TITLE
Fixes use of JPanel in property sheet in FeedersPanel

### DIFF
--- a/src/main/java/org/openpnp/gui/FeedersPanel.java
+++ b/src/main/java/org/openpnp/gui/FeedersPanel.java
@@ -275,9 +275,12 @@ public class FeedersPanel extends JPanel implements WizardContainer {
                         priorFeederId = feeder.getId();
                         PropertySheet[] propertySheets = feeder.getPropertySheets();
                         for (PropertySheet ps : propertySheets) {
-                            AbstractConfigurationWizard wizard = (AbstractConfigurationWizard) ps.getPropertySheetPanel();
-                            wizard.setWizardContainer(FeedersPanel.this);
-                            configurationPanel.addTab(ps.getPropertySheetTitle(), wizard);
+                            JPanel panel = ps.getPropertySheetPanel();
+                            if(panel instanceof AbstractConfigurationWizard) {
+                                AbstractConfigurationWizard wizard = (AbstractConfigurationWizard) ps.getPropertySheetPanel();
+                                wizard.setWizardContainer(FeedersPanel.this);
+                            }
+                            configurationPanel.addTab(ps.getPropertySheetTitle(), panel);
                         }
                     }
                     
@@ -304,10 +307,13 @@ public class FeedersPanel extends JPanel implements WizardContainer {
     private boolean keepUnAppliedFeederConfigurationChanges() {
         Feeder priorFeeder = configuration.getMachine().getFeeder(priorFeederId);
         boolean feederConfigurationIsDirty = false;
-        int i = 0;
-        while (!feederConfigurationIsDirty && (i<configurationPanel.getComponentCount())) {
-            feederConfigurationIsDirty = ((AbstractConfigurationWizard) configurationPanel.getComponent(i)).isDirty();
-            i++;
+        for (Component component : configurationPanel.getComponents()) {
+            if(component instanceof AbstractConfigurationWizard) {
+                feederConfigurationIsDirty = ((AbstractConfigurationWizard) component).isDirty();
+                if(feederConfigurationIsDirty) {
+                    break;
+                }
+            }
         }
         if (feederConfigurationIsDirty && (priorFeeder != null)) {
             int selection = JOptionPane.showConfirmDialog(null,
@@ -319,14 +325,14 @@ public class FeedersPanel extends JPanel implements WizardContainer {
                     );
             switch (selection) {
 				case JOptionPane.YES_OPTION:
-				    int j = 0;
-				    while ((j<configurationPanel.getComponentCount())) {
-				    	AbstractConfigurationWizard wizard = ((AbstractConfigurationWizard) configurationPanel.getComponent(j));
-				        if (wizard.isDirty()) {
-							wizard.apply();
-				        }
-				        j++;
-				    }
+                    for (Component component : configurationPanel.getComponents()) {
+                        if(component instanceof AbstractConfigurationWizard) {
+                            AbstractConfigurationWizard wizard = (AbstractConfigurationWizard) component;
+                            if(wizard.isDirty()) {
+                                wizard.apply();
+                            }
+                        }
+                    }
 				    return false;
 				case JOptionPane.NO_OPTION:
 					return false;


### PR DESCRIPTION
# Description
I noticed when working on the IndexFeeder's configuration panel that a PropertySheet has a getPropertySheetPanel method which returns a JPanel. The FeedersPanel always assumes that the return from that method can be cast to AbstractConfigurationWizard which is not 100% true for all tabs in my case. I have a "search" tab that will search for feeders, and therefore doesn't need revert/apply buttons. I decided to return just a raw JPanel which had the effect that my tabs showed up under the machine configuration panel, but not under the feeders tab. This caused an exception in the FeedersPanel class.

# Justification
I'd say this just cleans up a mismatched interface. Since a developer can return just a JPanel (which I think is the correct behavior for property sheets), making FeedersPanel more intelligently handle the case when the JPanel isn't secretly an AbstractConfigurationWizard seemed like the appropriate behavior.

# Instructions for Use
There is no user facing change here.

# Implementation Details
1. How did you test the change? Be descriptive. Untested code will not be accepted.
I originally tested this in my index feeder branch where I have a property sheet that just uses a JPanel directly. Then I ported it back to the develop branch.

2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)?
✅ I did
3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing.
🙅 No changes there
4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted.
✅ I did
