### PR TITLE
Kicad importer: Assume UTF8 as charset

### DIFF
--- a/src/main/java/org/openpnp/gui/importer/KicadPosImporter.java
+++ b/src/main/java/org/openpnp/gui/importer/KicadPosImporter.java
@@ -24,6 +24,7 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Matcher;
@@ -71,7 +72,7 @@ public class KicadPosImporter implements BoardImporter {
     		boolean useOnlyValueAsPartId)
             throws Exception {
         BufferedReader reader =
-                new BufferedReader(new InputStreamReader(new FileInputStream(file)));
+                new BufferedReader(new InputStreamReader(new FileInputStream(file), StandardCharsets.UTF_8));
         ArrayList<Placement> placements = new ArrayList<>();
         String line;
 


### PR DESCRIPTION
# Description
Assume UTF8 encoding when importing a kicad .pos file.

# Justification
If non-ASCII character like "µ" are used, importing fails. See bug #1176 

# Instructions for Use
No change in the behaviour. Only assumption is, that the file is now in UTF8, and not in an undefined character set.

# Implementation Details
1. How did you test the change? Tested from the bug reporting person
2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)? yes
3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing. no
4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted. yes
