### PR TITLE
Fix/Keep the Z in ReferenceStripFeederConfigurationWizard Auto Setup.

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/feeder/wizards/ReferenceStripFeederConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/wizards/ReferenceStripFeederConfigurationWizard.java
@@ -599,11 +599,15 @@ public class ReferenceStripFeederConfigurationWizard extends AbstractConfigurati
                                          firstPartLocation, secondPartLocation,
                                          part1HoleLocations, part2HoleLocations);
                                  final Location referenceHole1 = referenceHoles.get(0)
-                                                                               .derive(null, null,
-                                                                                       null, 0d);
+                                         .derive(null, null,
+                                                 null, 0d)
+                                         .derive(feeder.getReferenceHoleLocation(), 
+                                                 false,  false,  true, false);
                                  final Location referenceHole2 = referenceHoles.get(1)
-                                                                               .derive(null, null,
-                                                                                       null, 0d);
+                                         .derive(null, null,
+                                                 null, 0d)
+                                         .derive(feeder.getLastHoleLocation(), 
+                                                 false,  false,  true, false);
 
                                  feeder.setReferenceHoleLocation(referenceHole1);
                                  feeder.setLastHoleLocation(referenceHole2);


### PR DESCRIPTION
# Description
This keeps the Z coordinate of the two reference hole locations intact through **Auto Setup**.

The bug appears to haven been brought in by adding property change firing here:

![diff](https://user-images.githubusercontent.com/9963310/116545810-279b3580-a8f1-11eb-8977-10fd79652ca8.png)
https://github.com/openpnp/openpnp/commit/ee7ea6fd1b402c4a9fe6fc7eca180ca5b8004f0b#diff-b348cb0fe5f0f395b42e79116b72ea0253f5343f07f653fd186850362bc83f25

Which is benign, of course. But Auto-Setup uses mixed direct model _and_ Wizard controls modifications here (see the `invokeLater`):

https://github.com/openpnp/openpnp/blob/e4f983f76f716593b7fedf72c9b75c68c9c95fc5/src/main/java/org/openpnp/machine/reference/feeder/wizards/ReferenceStripFeederConfigurationWizard.java#L608-L629

... which in earlier versions caused overwriting the zeroed Z with the old coordinate when Apply was pressed. Today the property change firing causes the zeroed Z to be updated into the Wizard immediately.

It is still inconsistent now, i.e. pressing **Reset** on the Wizard will only undo half of the Auto-Setup. So this should be revisited in the future to either do all modifications only on the Wizard, or only on the model. 

# Justification
See #1184.

This PR intends to be minimal, so it does not address the mixed modification.

# Instructions for Use
See #1184.

# Implementation Details
1. Tested in simulation.
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. Successful `mvn test` before submitting the Pull Request. 
