### PR TITLE
Test output doesn't go to files anymore

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -379,7 +379,6 @@
 				<version>2.22.2</version>
 				<configuration>
 					<argLine>-Xmx512m</argLine>
-					<redirectTestOutputToFile>true</redirectTestOutputToFile>
 				</configuration>
 			</plugin>
 


### PR DESCRIPTION
Based on the conversation in #1189, removing the parameter to write output to a file.