### PR TITLE
Fix/Exceptions from Pipeline Stages, Scripts not propagated 

### DIFF
--- a/src/main/java/org/openpnp/gui/JobPanel.java
+++ b/src/main/java/org/openpnp/gui/JobPanel.java
@@ -70,12 +70,12 @@ import org.openpnp.events.BoardLocationSelectedEvent;
 import org.openpnp.events.JobLoadedEvent;
 import org.openpnp.events.PlacementSelectedEvent;
 import org.openpnp.gui.components.AutoSelectTextTable;
-import org.openpnp.gui.support.CustomBooleanRenderer;
 import org.openpnp.gui.importer.BoardImporter;
 import org.openpnp.gui.panelization.DlgAutoPanelize;
 import org.openpnp.gui.panelization.DlgPanelXOut;
 import org.openpnp.gui.processes.MultiPlacementBoardLocationProcess;
 import org.openpnp.gui.support.ActionGroup;
+import org.openpnp.gui.support.CustomBooleanRenderer;
 import org.openpnp.gui.support.Helpers;
 import org.openpnp.gui.support.Icons;
 import org.openpnp.gui.support.MessageBoxes;
@@ -97,7 +97,6 @@ import org.openpnp.spi.Machine;
 import org.openpnp.spi.MachineListener;
 import org.openpnp.util.MovableUtils;
 import org.openpnp.util.UiUtils;
-import org.pmw.tinylog.Logger;
 
 import com.google.common.eventbus.Subscribe;
 
@@ -1255,14 +1254,10 @@ public class JobPanel extends JPanel {
                         Location location = getSelection().getLocation();
                         MovableUtils.moveToLocationAtSafeZ(camera, location);
                         MovableUtils.fireTargetedUserAction(camera);
-                        try {
-                            Map<String, Object> globals = new HashMap<>();
-                            globals.put("camera", camera);
-                            Configuration.get().getScripting().on("Camera.AfterPosition", globals);
-                        }
-                        catch (Exception e) {
-                            Logger.warn(e);
-                        }
+
+                        Map<String, Object> globals = new HashMap<>();
+                        globals.put("camera", camera);
+                        Configuration.get().getScripting().on("Camera.AfterPosition", globals);
                     });
                 }
             };
@@ -1289,15 +1284,10 @@ public class JobPanel extends JPanel {
                         Location location = getSelection().getLocation();
                         MovableUtils.moveToLocationAtSafeZ(camera, location);
                         MovableUtils.fireTargetedUserAction(camera);
-                       
-                        try {
-                            Map<String, Object> globals = new HashMap<>();
-                            globals.put("camera", camera);
-                            Configuration.get().getScripting().on("Camera.AfterPosition", globals);
-                        }
-                        catch (Exception e) {
-                            Logger.warn(e);
-                        }
+
+                        Map<String, Object> globals = new HashMap<>();
+                        globals.put("camera", camera);
+                        Configuration.get().getScripting().on("Camera.AfterPosition", globals);
                     });
                 }
             };

--- a/src/main/java/org/openpnp/gui/JobPlacementsPanel.java
+++ b/src/main/java/org/openpnp/gui/JobPlacementsPanel.java
@@ -16,7 +16,23 @@ import java.util.List;
 import java.util.Map;
 import java.util.regex.PatternSyntaxException;
 
-import javax.swing.*;
+import javax.swing.AbstractAction;
+import javax.swing.Action;
+import javax.swing.DefaultCellEditor;
+import javax.swing.JButton;
+import javax.swing.JComboBox;
+import javax.swing.JLabel;
+import javax.swing.JMenu;
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+import javax.swing.JPopupMenu;
+import javax.swing.JScrollPane;
+import javax.swing.JTable;
+import javax.swing.JTextField;
+import javax.swing.JToolBar;
+import javax.swing.ListSelectionModel;
+import javax.swing.RowFilter;
+import javax.swing.UIManager;
 import javax.swing.border.LineBorder;
 import javax.swing.border.TitledBorder;
 import javax.swing.event.DocumentEvent;
@@ -28,8 +44,8 @@ import javax.swing.table.TableRowSorter;
 
 import org.openpnp.events.PlacementSelectedEvent;
 import org.openpnp.gui.components.AutoSelectTextTable;
-import org.openpnp.gui.support.CustomBooleanRenderer;
 import org.openpnp.gui.support.ActionGroup;
+import org.openpnp.gui.support.CustomBooleanRenderer;
 import org.openpnp.gui.support.Helpers;
 import org.openpnp.gui.support.Icons;
 import org.openpnp.gui.support.IdentifiableListCellRenderer;
@@ -53,7 +69,6 @@ import org.openpnp.spi.Nozzle;
 import org.openpnp.util.MovableUtils;
 import org.openpnp.util.UiUtils;
 import org.openpnp.util.Utils2D;
-import org.pmw.tinylog.Logger;
 
 public class JobPlacementsPanel extends JPanel {
     private JTable table;
@@ -477,14 +492,10 @@ public class JobPlacementsPanel extends JPanel {
                         .getDefaultCamera();
                 MovableUtils.moveToLocationAtSafeZ(camera, location);
                 MovableUtils.fireTargetedUserAction(camera);
-                try {
-                    Map<String, Object> globals = new HashMap<>();
-                    globals.put("camera", camera);
-                    Configuration.get().getScripting().on("Camera.AfterPosition", globals);
-                }
-                catch (Exception e) {
-                    Logger.warn(e);
-                }
+
+                Map<String, Object> globals = new HashMap<>();
+                globals.put("camera", camera);
+                Configuration.get().getScripting().on("Camera.AfterPosition", globals);
             });
         }
     };
@@ -502,24 +513,19 @@ public class JobPlacementsPanel extends JPanel {
                 // Need to keep current focus owner so that the space bar can be
                 // used after the initial click. Otherwise, button focus is lost
                 // when table is updated
-               	Component comp = MainFrame.get().getFocusOwner();
-               	Helpers.selectNextTableRow(table);
+                Component comp = MainFrame.get().getFocusOwner();
+                Helpers.selectNextTableRow(table);
                 comp.requestFocus();
-               	Location location = Utils2D.calculateBoardPlacementLocation(boardLocation,
+                Location location = Utils2D.calculateBoardPlacementLocation(boardLocation,
                         getSelection().getLocation());
                 Camera camera = MainFrame.get().getMachineControls().getSelectedTool().getHead()
                         .getDefaultCamera();
                 MovableUtils.moveToLocationAtSafeZ(camera, location);
                 MovableUtils.fireTargetedUserAction(camera);
-                
-                try {
-                    Map<String, Object> globals = new HashMap<>();
-                    globals.put("camera", camera);
-                    Configuration.get().getScripting().on("Camera.AfterPosition", globals);
-                }
-                catch (Exception e) {
-                    Logger.warn(e);
-                }
+
+                Map<String, Object> globals = new HashMap<>();
+                globals.put("camera", camera);
+                Configuration.get().getScripting().on("Camera.AfterPosition", globals);
             });
         };
     };

--- a/src/main/java/org/openpnp/gui/JogControlsPanel.java
+++ b/src/main/java/org/openpnp/gui/JogControlsPanel.java
@@ -66,7 +66,6 @@ import org.openpnp.spi.base.AbstractNozzle;
 import org.openpnp.util.BeanUtils;
 import org.openpnp.util.MovableUtils;
 import org.openpnp.util.UiUtils;
-import org.pmw.tinylog.Logger;
 
 import com.jgoodies.forms.layout.ColumnSpec;
 import com.jgoodies.forms.layout.FormLayout;
@@ -632,28 +631,18 @@ public class JogControlsPanel extends JPanel {
             UiUtils.submitUiMachineTask(() -> {
                 Nozzle nozzle = machineControlsPanel.getSelectedNozzle();
                 // move to the discard location
-                try {
-                    Map<String, Object> globals = new HashMap<>();
-                    globals.put("nozzle", nozzle);
-                    Configuration.get().getScripting().on("Job.BeforeDiscard", globals);
-                }
-                catch (Exception e) {
-                    Logger.warn(e);
-                }
+                Map<String, Object> globals = new HashMap<>();
+                globals.put("nozzle", nozzle);
+                Configuration.get().getScripting().on("Job.BeforeDiscard", globals);
+
                 MovableUtils.moveToLocationAtSafeZ(nozzle, Configuration.get()
                         .getMachine()
                         .getDiscardLocation());
                 // discard the part
                 nozzle.place();
                 nozzle.moveToSafeZ();
-                try {
-                    Map<String, Object> globals = new HashMap<>();
-                    globals.put("nozzle", nozzle);
-                    Configuration.get().getScripting().on("Job.AfterDiscard", globals);
-                }
-                catch (Exception e) {
-                    Logger.warn(e);
-                }
+
+                Configuration.get().getScripting().on("Job.AfterDiscard", globals);
             });
         }
     };

--- a/src/main/java/org/openpnp/gui/ScriptAction.java
+++ b/src/main/java/org/openpnp/gui/ScriptAction.java
@@ -1,13 +1,13 @@
 package org.openpnp.gui;
 
 import java.awt.event.ActionEvent;
-import java.util.Map;
 import java.util.HashMap;
+import java.util.Map;
 
 import javax.swing.AbstractAction;
 
 import org.openpnp.model.Configuration;
-import org.pmw.tinylog.Logger;
+import org.openpnp.util.UiUtils;
 
 @SuppressWarnings("serial")
 public class ScriptAction extends AbstractAction{
@@ -19,14 +19,11 @@ public class ScriptAction extends AbstractAction{
 
     @Override
     public void actionPerformed(ActionEvent arg0) {
-        try {
+        UiUtils.messageBoxOnException(() -> {
             Map<String, Object> globals = new HashMap<>();
             Configuration.get()
                         .getScripting()
                         .on(this.eventName, globals);
-        }
-        catch (Exception e) {
-            Logger.warn(e);
-        }
+        });
     }
 }

--- a/src/main/java/org/openpnp/gui/components/LocationButtonsPanel.java
+++ b/src/main/java/org/openpnp/gui/components/LocationButtonsPanel.java
@@ -48,7 +48,6 @@ import org.openpnp.spi.HeadMountable;
 import org.openpnp.util.Cycles;
 import org.openpnp.util.MovableUtils;
 import org.openpnp.util.UiUtils;
-import org.pmw.tinylog.Logger;
 
 /**
  * A JPanel of 4 small buttons that assist in setting locations. The buttons are Capture Camera
@@ -348,14 +347,10 @@ public class LocationButtonsPanel extends JPanel {
                         }
                         MovableUtils.moveToLocationAtSafeZ(camera, location);
                         MovableUtils.fireTargetedUserAction(camera);
-                        try {
-                            Map<String, Object> globals = new HashMap<>();
-                            globals.put("camera", camera);
-                            Configuration.get().getScripting().on("Camera.AfterPosition", globals);
-                        }
-                        catch (Exception e) {
-                            Logger.warn(e);
-                        }
+
+                        Map<String, Object> globals = new HashMap<>();
+                        globals.put("camera", camera);
+                        Configuration.get().getScripting().on("Camera.AfterPosition", globals);
                     });
                 }
             };

--- a/src/main/java/org/openpnp/machine/reference/ContactProbeNozzle.java
+++ b/src/main/java/org/openpnp/machine/reference/ContactProbeNozzle.java
@@ -225,15 +225,11 @@ public class ContactProbeNozzle extends ReferenceNozzle {
         if (isFeederHeightProbingNeeded(feeder)) {
             moveAboveProbingLocation(pickLocationPart);
 
-            try {
-                Map<String, Object> globals = new HashMap<>();
-                globals.put("nozzle", this);
-                globals.put("feeder", feeder);
-                globals.put("part", part);
-                Configuration.get().getScripting().on("Nozzle.BeforePickProbe", globals);
-            } catch (Exception e) {
-                Logger.warn(e);
-            }
+            Map<String, Object> globals = new HashMap<>();
+            globals.put("nozzle", this);
+            globals.put("feeder", feeder);
+            globals.put("part", part);
+            Configuration.get().getScripting().on("Nozzle.BeforePickProbe", globals);
 
             Length depthZ;
             if (partHeightProbing) {
@@ -264,15 +260,7 @@ public class ContactProbeNozzle extends ReferenceNozzle {
             // Retract from probing e.g. until the probe sensor is released.
             contactProbe(false, contactProbeDepthZ);
 
-            try {
-                Map<String, Object> globals = new HashMap<>();
-                globals.put("nozzle", this);
-                globals.put("feeder", feeder);
-                globals.put("part", part);
-                Configuration.get().getScripting().on("Nozzle.AfterPickProbe", globals);
-            } catch (Exception e) {
-                Logger.warn(e);
-            }
+            Configuration.get().getScripting().on("Nozzle.AfterPickProbe", globals);
         }
         else {
             Length offsetZ = probedFeederHeightOffsets.get(feeder);
@@ -297,14 +285,10 @@ public class ContactProbeNozzle extends ReferenceNozzle {
             // Calculate the probe starting location.
             moveAboveProbingLocation(placementLocationPart);
 
-            try {
-                Map<String, Object> globals = new HashMap<>();
-                globals.put("nozzle", this);
-                globals.put("part", getPart());
-                Configuration.get().getScripting().on("Nozzle.BeforePlaceProbe", globals);
-            } catch (Exception e) {
-                Logger.warn(e);
-            }
+            Map<String, Object> globals = new HashMap<>();
+            globals.put("nozzle", this);
+            globals.put("part", getPart());
+            Configuration.get().getScripting().on("Nozzle.BeforePlaceProbe", globals);
 
             Length depthZ;
             if (partHeightProbing) {
@@ -337,14 +321,7 @@ public class ContactProbeNozzle extends ReferenceNozzle {
 
             contactProbe(false, contactProbeDepthZ);
 
-            try {
-                Map<String, Object> globals = new HashMap<>();
-                globals.put("nozzle", this);
-                globals.put("part", getPart());
-                Configuration.get().getScripting().on("Nozzle.AfterPlaceProbe", globals);
-            } catch (Exception e) {
-                Logger.warn(e);
-            }
+            Configuration.get().getScripting().on("Nozzle.AfterPlaceProbe", globals);
         }
         else {
             Length offsetZ = probedPartHeightOffsets.get(part);

--- a/src/main/java/org/openpnp/machine/reference/ReferenceCamera.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceCamera.java
@@ -178,26 +178,17 @@ public abstract class ReferenceCamera extends AbstractBroadcastingCamera impleme
     /**
      * Captures an image using captureTransformed() and performs scripting and lighting events
      * before and after the capture.
+     * @throws Exception 
      */
     @Override
-    public BufferedImage capture() {
-        try {
-            Map<String, Object> globals = new HashMap<>();
-            globals.put("camera", this);
-            Configuration.get().getScripting().on("Camera.BeforeCapture", globals);
-        }
-        catch (Exception e) {
-            Logger.warn(e);
-        }
+    public BufferedImage capture() throws Exception {
+        Map<String, Object> globals = new HashMap<>();
+        globals.put("camera", this);
+        Configuration.get().getScripting().on("Camera.BeforeCapture", globals);
+
         BufferedImage image = captureTransformed();
-        try {
-            Map<String, Object> globals = new HashMap<>();
-            globals.put("camera", this);
-            Configuration.get().getScripting().on("Camera.AfterCapture", globals);
-        }
-        catch (Exception e) {
-            Logger.warn(e);
-        }
+
+        Configuration.get().getScripting().on("Camera.AfterCapture", globals);
         return image;
     }
     

--- a/src/main/java/org/openpnp/machine/reference/ReferenceMachine.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceMachine.java
@@ -423,12 +423,7 @@ public class ReferenceMachine extends AbstractMachine {
         getMotionPlanner().home();
         super.home();
 
-        try {
-            Configuration.get().getScripting().on("Machine.AfterHoming", null);
-        }
-        catch (Exception e) {
-            Logger.warn(e);
-        }
+        Configuration.get().getScripting().on("Machine.AfterHoming", null);
 
         // if homing went well, set machine homed-flag true
         this.setHomed(true);     

--- a/src/main/java/org/openpnp/machine/reference/ReferenceNozzle.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceNozzle.java
@@ -286,17 +286,12 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
         if (nozzleTip == null) {
             throw new Exception("Can't pick, no nozzle tip loaded");
         }
-        
-        try {
-            Map<String, Object> globals = new HashMap<>();
-            globals.put("nozzle", this);
-            globals.put("part", part);
-            Configuration.get().getScripting().on("Nozzle.BeforePick", globals);
-        }
-        catch (Exception e) {
-            Logger.warn(e);
-        }
-        
+
+        Map<String, Object> globals = new HashMap<>();
+        globals.put("nozzle", this);
+        globals.put("part", part);
+        Configuration.get().getScripting().on("Nozzle.BeforePick", globals);
+
         setPart(part);
 
         // if the method needs it, store one measurement up front
@@ -314,16 +309,8 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
         establishPickVacuumLevel(this.getPickDwellMilliseconds() + nozzleTip.getPickDwellMilliseconds());
 
         getMachine().fireMachineHeadActivity(head);
-        
-        try {
-            Map<String, Object> globals = new HashMap<>();
-            globals.put("nozzle", this);
-            globals.put("part", part);
-            Configuration.get().getScripting().on("Nozzle.AfterPick", globals);
-        }
-        catch (Exception e) {
-            Logger.warn(e);
-        }
+
+        Configuration.get().getScripting().on("Nozzle.AfterPick", globals);
     }
 
     @Override
@@ -342,15 +329,10 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
         if (nozzleTip == null) {
             throw new Exception("Can't place, no nozzle tip loaded");
         }
-        
-        try {
-            Map<String, Object> globals = new HashMap<>();
-            globals.put("nozzle", this);
-            Configuration.get().getScripting().on("Nozzle.BeforePlace", globals);
-        }
-        catch (Exception e) {
-            Logger.warn(e);
-        }
+
+        Map<String, Object> globals = new HashMap<>();
+        globals.put("nozzle", this);
+        Configuration.get().getScripting().on("Nozzle.BeforePlace", globals);
 
         // if the method needs it, store one measurement up front
         storeBeforePlaceVacuumLevel();
@@ -367,24 +349,16 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
         else {
             actuateVacuumValve(false);
         }
-        
 
         // wait for the Dwell Time and/or make sure the vacuum level decays to the desired range (with timeout)
         establishPlaceVacuumLevel(this.getPlaceDwellMilliseconds() + nozzleTip.getPlaceDwellMilliseconds());
 
         setPart(null);
         getMachine().fireMachineHeadActivity(head);
-        
-        try {
-            Map<String, Object> globals = new HashMap<>();
-            globals.put("nozzle", this);
-            Configuration.get().getScripting().on("Nozzle.AfterPlace", globals);
-        }
-        catch (Exception e) {
-            Logger.warn(e);
-        }
+
+        Configuration.get().getScripting().on("Nozzle.AfterPlace", globals);
     }
-    
+
     private ReferenceNozzleTip getUnloadedNozzleTipStandin() {
         for (NozzleTip nozzleTip : this.getCompatibleNozzleTips()) {
             if (nozzleTip instanceof ReferenceNozzleTip) {
@@ -565,18 +539,14 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
             if (changerEnabled) {
                 Logger.debug("{}.loadNozzleTip({}): Start", getName(), nozzleTip.getName());
 
-                try {
-                    Map<String, Object> globals = new HashMap<>();
-                    globals.put("head", getHead());
-                    globals.put("nozzle", this);
-                    globals.put("nozzleTip", nt);
-                    Configuration.get()
-                    .getScripting()
-                    .on("NozzleTip.BeforeLoad", globals);
-                }
-                catch (Exception e) {
-                    Logger.warn(e);
-                }
+                Map<String, Object> globals = new HashMap<>();
+                globals.put("head", getHead());
+                globals.put("nozzle", this);
+                globals.put("nozzleTip", nt);
+
+                Configuration.get()
+                .getScripting()
+                .on("NozzleTip.BeforeLoad", globals);
 
                 ensureZCalibrated();
 
@@ -611,26 +581,16 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
 
                 Logger.debug("{}.loadNozzleTip({}): Finished",
                         new Object[] {getName(), nozzleTip.getName()});
+
+                Configuration.get()
+                .getScripting()
+                .on("NozzleTip.Loaded", globals);
             }
             else {
                 Logger.debug("{}.loadNozzleTip({}): moveTo manual Location",
                         new Object[] {getName(), nozzleTip.getName()});
                 assertManualChangeLocation();
                 MovableUtils.moveToLocationAtSafeZ(this, getManualNozzleTipChangeLocation());
-            }
-
-            if (changerEnabled) {
-                try {
-                    Map<String, Object> globals = new HashMap<>();
-                    globals.put("head", getHead());
-                    globals.put("nozzle", this);
-                    Configuration.get()
-                    .getScripting()
-                    .on("NozzleTip.Loaded", globals);
-                }
-                catch (Exception e) {
-                    Logger.warn(e);
-                }
             }
         }
 
@@ -679,24 +639,17 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
         if (!nt.isUnloadedNozzleTipStandin()) {
             Logger.debug("{}.unloadNozzleTip(): Start", getName());
 
-            if (changerEnabled) {
-                 try {
-                    Map<String, Object> globals = new HashMap<>();
-                    globals.put("head", getHead());
-                    globals.put("nozzle", this);
-                    globals.put("nozzleTip", nt);
-                    Configuration.get()
-                    .getScripting()
-                    .on("NozzleTip.BeforeUnload", globals);
-                }
-                catch (Exception e) {
-                    Logger.warn(e);
-                }
-            }
-
             double speed = getHead().getMachine().getSpeed();
 
             if (changerEnabled) {
+                Map<String, Object> globals = new HashMap<>();
+                globals.put("head", getHead());
+                globals.put("nozzle", this);
+                globals.put("nozzleTip", nt);
+                Configuration.get()
+                .getScripting()
+                .on("NozzleTip.BeforeUnload", globals);
+
                 ensureZCalibrated();
 
                 Logger.debug("{}.unloadNozzleTip(): moveTo End Location", getName());
@@ -726,17 +679,9 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
 
                 Logger.debug("{}.unloadNozzleTip(): Finished", getName());
 
-                try {
-                    Map<String, Object> globals = new HashMap<>();
-                    globals.put("head", getHead());
-                    globals.put("nozzle", this);
-                    Configuration.get()
-                    .getScripting()
-                    .on("NozzleTip.Unloaded", globals);
-                }
-                catch (Exception e) {
-                    Logger.warn(e);
-                }
+                Configuration.get()
+                .getScripting()
+                .on("NozzleTip.Unloaded", globals);
             }
             else {
                 Logger.debug("{}.unloadNozzleTip({}): moveTo manual Location",

--- a/src/main/java/org/openpnp/machine/reference/ReferencePnpJobProcessor.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferencePnpJobProcessor.java
@@ -927,6 +927,7 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
                 Configuration.get().getScripting().on("Job.Placement.BeforeAssembly", params);
             }
             catch (Exception e) {
+                throw new JobProcessorException(null, e);
             }
         }
         

--- a/src/main/java/org/openpnp/spi/Camera.java
+++ b/src/main/java/org/openpnp/spi/Camera.java
@@ -91,8 +91,9 @@ public interface Camera extends HeadMountable, WizardConfigurable,
      * Immediately captures an image from the camera and returns it in it's native format. Fires
      * the Camera.BeforeCapture and Camera.AfterCapture scripting events before and after.
      * @return
+     * @throws Exception 
      */
-    public BufferedImage capture();
+    public BufferedImage capture() throws Exception;
     
     public BufferedImage captureTransformed();
     

--- a/src/main/java/org/openpnp/spi/base/AbstractCamera.java
+++ b/src/main/java/org/openpnp/spi/base/AbstractCamera.java
@@ -676,7 +676,7 @@ public abstract class AbstractCamera extends AbstractHeadMountable implements Ca
         }
     }
 
-    private BufferedImage autoSettleAndCapture() {
+    private BufferedImage autoSettleAndCapture() throws Exception {
         Mat mask = null;
         Mat maskFullsize = null;
         Mat lastSettleMat = null;
@@ -1027,14 +1027,9 @@ public abstract class AbstractCamera extends AbstractHeadMountable implements Ca
 
     @Override
     public BufferedImage settleAndCapture() throws Exception {
-        try {
-            Map<String, Object> globals = new HashMap<>();
-            globals.put("camera", this);
-            Configuration.get().getScripting().on("Camera.BeforeSettle", globals);
-        }
-        catch (Exception e) {
-            Logger.warn(e);
-        }
+        Map<String, Object> globals = new HashMap<>();
+        globals.put("camera", this);
+        Configuration.get().getScripting().on("Camera.BeforeSettle", globals);
 
         try {
             // Make sure the camera (or its subject) stands still.
@@ -1059,14 +1054,7 @@ public abstract class AbstractCamera extends AbstractHeadMountable implements Ca
         }
         finally {
 
-            try {
-                Map<String, Object> globals = new HashMap<>();
-                globals.put("camera", this);
-                Configuration.get().getScripting().on("Camera.AfterSettle", globals);
-            }
-            catch (Exception e) {
-                Logger.warn(e);
-            }
+            Configuration.get().getScripting().on("Camera.AfterSettle", globals);
         }
     }
 

--- a/src/main/java/org/openpnp/spi/base/AbstractPnpJobProcessor.java
+++ b/src/main/java/org/openpnp/spi/base/AbstractPnpJobProcessor.java
@@ -11,8 +11,6 @@ import org.openpnp.spi.Machine;
 import org.openpnp.spi.Nozzle;
 import org.openpnp.spi.PartAlignment;
 import org.openpnp.spi.PnpJobProcessor;
-import org.openpnp.util.MovableUtils;
-import org.pmw.tinylog.Logger;
 
 public abstract class AbstractPnpJobProcessor extends AbstractJobProcessor
         implements PnpJobProcessor {
@@ -35,28 +33,19 @@ public abstract class AbstractPnpJobProcessor extends AbstractJobProcessor
         if (nozzle.getPart() == null) {
             return;
         }
+
         try {
             Map<String, Object> globals = new HashMap<>();
             globals.put("nozzle", nozzle);
             Configuration.get().getScripting().on("Job.BeforeDiscard", globals);
-        }
-        catch (Exception e) {
-            Logger.warn(e);
-        }
-        try {
+
             // move to the discard location
             nozzle.moveToPlacementLocation(Configuration.get().getMachine().getDiscardLocation(), null);
             // discard the part
             nozzle.place();
             nozzle.moveToSafeZ();
-            try {
-                Map<String, Object> globals = new HashMap<>();
-                globals.put("nozzle", nozzle);
-                Configuration.get().getScripting().on("Job.AfterDiscard", globals);
-            }
-            catch (Exception e) {
-                Logger.warn(e);
-            }
+
+            Configuration.get().getScripting().on("Job.AfterDiscard", globals);
         }
         catch (Exception e) {
             throw new JobProcessorException(nozzle, e);

--- a/src/main/java/org/openpnp/util/VisionUtils.java
+++ b/src/main/java/org/openpnp/util/VisionUtils.java
@@ -18,7 +18,6 @@ import org.openpnp.spi.HeadMountable;
 import org.openpnp.spi.Nozzle;
 import org.openpnp.spi.PartAlignment;
 import org.openpnp.spi.PartAlignment.PartAlignmentOffset;
-import org.pmw.tinylog.Logger;
 
 import com.google.zxing.BinaryBitmap;
 import com.google.zxing.MultiFormatReader;
@@ -206,31 +205,19 @@ public class VisionUtils {
     }
     
     public static PartAlignment.PartAlignmentOffset findPartAlignmentOffsets(PartAlignment p, Part part, BoardLocation boardLocation, Location placementLocation, Nozzle nozzle) throws Exception {
-        try {
-            Map<String, Object> globals = new HashMap<>();
-            globals.put("part", part);
-            globals.put("nozzle", nozzle);
-            Configuration.get().getScripting().on("Vision.PartAlignment.Before", globals);
-        }
-        catch (Exception e) {
-            Logger.warn(e);
-        }
+        Map<String, Object> globals = new HashMap<>();
+        globals.put("part", part);
+        globals.put("nozzle", nozzle);
+        Configuration.get().getScripting().on("Vision.PartAlignment.Before", globals);
+
         PartAlignmentOffset offsets = null;
         try {
             offsets = p.findOffsets(part, boardLocation, placementLocation, nozzle);
             return offsets;
         }
         finally {
-            try {
-                Map<String, Object> globals = new HashMap<>();
-                globals.put("part", part);
-                globals.put("nozzle", nozzle);
-                globals.put("offsets", offsets);
-                Configuration.get().getScripting().on("Vision.PartAlignment.After", globals);
-            }
-            catch (Exception e) {
-                Logger.warn(e);
-            }
+            globals.put("offsets", offsets);
+            Configuration.get().getScripting().on("Vision.PartAlignment.After", globals);
         }
     }
 }

--- a/src/main/java/org/openpnp/vision/pipeline/CvPipeline.java
+++ b/src/main/java/org/openpnp/vision/pipeline/CvPipeline.java
@@ -60,6 +60,7 @@ public class CvPipeline implements AutoCloseable {
 
     private Mat workingImage;
     private Object workingModel;
+    private Exception terminalException;
     private ColorSpace workingColorSpace;
     
     private long totalProcessingTimeNs;
@@ -219,6 +220,14 @@ public class CvPipeline implements AutoCloseable {
         workingColorSpace = colorSpace;
     }
 
+    Exception getTerminalException() {
+        return terminalException;
+    }
+
+    void setTerminalException(Exception exception) {
+        this.terminalException = exception;
+    }
+
     public long getTotalProcessingTimeNs() {
       return totalProcessingTimeNs;
     }
@@ -227,7 +236,8 @@ public class CvPipeline implements AutoCloseable {
       this.totalProcessingTimeNs = totalProcessingTimeNs;
     }
 
-    public void process() {
+    public void process() throws Exception {
+        terminalException = null;
         totalProcessingTimeNs = 0;
         release();
         for (CvStage stage : stages) {
@@ -239,6 +249,11 @@ public class CvPipeline implements AutoCloseable {
                     throw new Exception(String.format("Stage \"%s\"not enabled.", stage.getName()));
                 }
                 result = stage.process(this);
+            }
+            catch (TerminalException e) {
+                result = new Result(null, e.getOriginalException());
+                setTerminalException(e.getOriginalException());
+                Logger.debug("Stage \""+stage.getName()+"\" throws "+e.getOriginalException());
             }
             catch (Exception e) {
                 result = new Result(null, e);
@@ -291,6 +306,9 @@ public class CvPipeline implements AutoCloseable {
             }
 
             results.put(stage, new Result(image, colorSpace, model, processingTimeNs, stage));
+        }
+        if (terminalException != null) {
+            throw (terminalException);
         }
     }
 

--- a/src/main/java/org/openpnp/vision/pipeline/TerminalException.java
+++ b/src/main/java/org/openpnp/vision/pipeline/TerminalException.java
@@ -1,0 +1,14 @@
+package org.openpnp.vision.pipeline;
+
+public class TerminalException extends Exception{
+    private final Exception originalException;
+
+    public TerminalException(Exception originalException) {
+        super(originalException.getMessage(), originalException);
+        this.originalException = originalException;
+    }
+
+    public Exception getOriginalException() {
+        return originalException;
+    }
+}

--- a/src/main/java/org/openpnp/vision/pipeline/stages/ActuatorWrite.java
+++ b/src/main/java/org/openpnp/vision/pipeline/stages/ActuatorWrite.java
@@ -10,6 +10,7 @@ import org.openpnp.spi.base.AbstractActuator;
 import org.openpnp.vision.pipeline.CvPipeline;
 import org.openpnp.vision.pipeline.CvStage;
 import org.openpnp.vision.pipeline.Stage;
+import org.openpnp.vision.pipeline.TerminalException;
 import org.openpnp.vision.pipeline.ui.PipelinePropertySheetTable;
 import org.pmw.tinylog.Logger;
 import org.simpleframework.xml.Attribute;
@@ -59,11 +60,17 @@ public class ActuatorWrite extends CvStage {
             {
                 throw new Exception("Actuator writing (CvStage operation) failed. Unable to find an actuator named " + actuatorName);
             }
-            // Make sure this happens in a machine task, but wait for completion.
-            Configuration.get().getMachine().execute(() -> {
-                actuator.actuate(actuatorWriteValue);
-                return null;
-                });
+            try {
+                // Make sure this happens in a machine task, but wait for completion.
+                Configuration.get().getMachine().execute(() -> {
+                    actuator.actuate(actuatorWriteValue);
+                    return null;
+                    });
+            }
+            catch (Exception e) {
+                // These machine exceptions are terminal to the pipeline.
+                throw new TerminalException(e);
+            }
         }
         return null;
     }

--- a/src/main/java/org/openpnp/vision/pipeline/ui/CvPipelineEditor.java
+++ b/src/main/java/org/openpnp/vision/pipeline/ui/CvPipelineEditor.java
@@ -10,14 +10,16 @@ import java.util.Set;
 import javax.swing.JPanel;
 import javax.swing.JSplitPane;
 
+import org.openpnp.util.UiUtils;
 import org.openpnp.vision.pipeline.CvPipeline;
 import org.openpnp.vision.pipeline.CvStage;
-import org.openpnp.vision.pipeline.stages.BlurGaussian;
-import org.openpnp.vision.pipeline.stages.BlurMedian;
-import org.openpnp.vision.pipeline.stages.ClosestModel;
+import org.openpnp.vision.pipeline.stages.ActuatorWrite;
 import org.openpnp.vision.pipeline.stages.Add;
 import org.openpnp.vision.pipeline.stages.AffineUnwarp;
 import org.openpnp.vision.pipeline.stages.AffineWarp;
+import org.openpnp.vision.pipeline.stages.BlurGaussian;
+import org.openpnp.vision.pipeline.stages.BlurMedian;
+import org.openpnp.vision.pipeline.stages.ClosestModel;
 import org.openpnp.vision.pipeline.stages.ComposeResult;
 import org.openpnp.vision.pipeline.stages.ConvertColor;
 import org.openpnp.vision.pipeline.stages.ConvertModelToKeyPoints;
@@ -26,11 +28,11 @@ import org.openpnp.vision.pipeline.stages.CreateFootprintTemplateImage;
 import org.openpnp.vision.pipeline.stages.CreateModelTemplateImage;
 import org.openpnp.vision.pipeline.stages.CreateShapeTemplateImage;
 import org.openpnp.vision.pipeline.stages.DetectCirclesHough;
-import org.openpnp.vision.pipeline.stages.DetectLinesHough;
 import org.openpnp.vision.pipeline.stages.DetectEdgesCanny;
 import org.openpnp.vision.pipeline.stages.DetectEdgesLaplacian;
 import org.openpnp.vision.pipeline.stages.DetectEdgesRobertsCross;
 import org.openpnp.vision.pipeline.stages.DetectFixedCirclesHough;
+import org.openpnp.vision.pipeline.stages.DetectLinesHough;
 import org.openpnp.vision.pipeline.stages.DilateModel;
 import org.openpnp.vision.pipeline.stages.DrawCircles;
 import org.openpnp.vision.pipeline.stages.DrawContours;
@@ -42,6 +44,7 @@ import org.openpnp.vision.pipeline.stages.DrawTemplateMatches;
 import org.openpnp.vision.pipeline.stages.FilterContours;
 import org.openpnp.vision.pipeline.stages.FilterRects;
 import org.openpnp.vision.pipeline.stages.FindContours;
+import org.openpnp.vision.pipeline.stages.FitEllipseContours;
 import org.openpnp.vision.pipeline.stages.GrabCut;
 import org.openpnp.vision.pipeline.stages.HistogramEqualize;
 import org.openpnp.vision.pipeline.stages.HistogramEqualizeAdaptive;
@@ -60,7 +63,6 @@ import org.openpnp.vision.pipeline.stages.MatchPartsTemplate;
 import org.openpnp.vision.pipeline.stages.MatchTemplate;
 import org.openpnp.vision.pipeline.stages.MinAreaRect;
 import org.openpnp.vision.pipeline.stages.MinAreaRectContours;
-import org.openpnp.vision.pipeline.stages.FitEllipseContours;
 import org.openpnp.vision.pipeline.stages.Normalize;
 import org.openpnp.vision.pipeline.stages.OrientRotatedRects;
 import org.openpnp.vision.pipeline.stages.ReadModelProperty;
@@ -75,7 +77,6 @@ import org.openpnp.vision.pipeline.stages.SizeCheck;
 import org.openpnp.vision.pipeline.stages.Threshold;
 import org.openpnp.vision.pipeline.stages.ThresholdAdaptive;
 import org.openpnp.vision.pipeline.stages.WritePartTemplateImage;
-import org.openpnp.vision.pipeline.stages.ActuatorWrite;
 
 /**
  * A JPanel based component for editing a CvPipeline. Allows the user to add and remove stages,
@@ -206,7 +207,7 @@ public class CvPipelineEditor extends JPanel {
     }
 
     public void process() {
-        getPipeline().process();
+        UiUtils.messageBoxOnException(() -> getPipeline().process());
         resultsPanel.refresh();
     }
 


### PR DESCRIPTION
# Description
Exceptions from pipeline stages and from script calls are not propagated. See also ##1191.

In case of pipeline stages this is benign/wanted behavior in most cases i.e. when it signals failure of the vision stage itself, but some exceptions, such as those originating from machine motion control (most notably timeout exceptions) must not be ignored and should be propagated. 

In case of scripting, I guess it was never correct behavior to swallow exceptions. 

# Justification
See a real case and discussion:
https://groups.google.com/g/openpnp/c/jc8u42qINM8/m/7lLk5GSLAAAJ

# Instructions for Use

Context in which the issue has increasingly popped up:
1. Use advanced motion control, most notably the ReferenceAdvancedMotionPlanner with continuous motion enabled. 
2. This will only queue motion commands until OpenPnP actually requires the machine to really be at the target (lazy eval). 
3. This is typically the case when the camera wants to capture an image. 
4. Capturing occurs from withing a pipeline stage. If the motion now generates an exception (such as a timeout), it will be swallowed by the stage. 
5. The user never sees an error message, until recently it wasn't even logged. 
6. OpenPnP could get out of sync with the machine without the user/machine task noticing.  

A similar scenario is possible when motion is triggered (lazy evaluated) by script action. 

# Implementation Details
1. Tested/provoked in simulation before/after the fixes. This now correctly aborts the machine task if critical exceptions occur in lazily evaluated motion control inside pipeline stages. In the Pipeline Editor it is indicated by message box. 
   **NOTE**: I did **not** test/provoke scripting exceptions. I must leave that to somebody with existing scripts / scripting experience. **Therefore, I propose merging to `test`, for somebody else to test this.** 
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. Changes in the `org.openpnp.spi` concern `capture()` and `autoSettleAndCapture()` methods now throwing Exceptions from scripting.
4. Did run `mvn test` before submitting the Pull Request. 

Please note that the changes are structured in three commits for easier review etc..

- Pipeline stages
- Scripting
- ScriptAction (unused?)