### PR TITLE
Fix/Axis must not fire live Coordinate Property Changes

### DIFF
--- a/src/main/java/org/openpnp/gui/MachineSetupPanel.java
+++ b/src/main/java/org/openpnp/gui/MachineSetupPanel.java
@@ -44,6 +44,7 @@ import javax.swing.JTabbedPane;
 import javax.swing.JTextField;
 import javax.swing.JToolBar;
 import javax.swing.JTree;
+import javax.swing.SwingUtilities;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 import javax.swing.event.DocumentEvent;
@@ -281,15 +282,17 @@ public class MachineSetupPanel extends JPanel implements WizardContainer {
              * property name somewhere.
              */
             BeanUtils.addPropertyChangeListener(obj, (PropertyChangeListener) (e) -> {
-                if (e instanceof IndexedPropertyChangeEvent) {
-                    for (PropertySheetHolderTreeNode node : children) {
-                        node.loadChildren();
-                        treeModel.nodeStructureChanged(node);
+                SwingUtilities.invokeLater(() -> {
+                    if (e instanceof IndexedPropertyChangeEvent) {
+                        for (PropertySheetHolderTreeNode node : children) {
+                            node.loadChildren();
+                            treeModel.nodeStructureChanged(node);
+                        }
                     }
-                }
-                else {
-                    treeModel.nodeChanged(this);
-                }
+                    else {
+                        treeModel.nodeChanged(this);
+                    }
+                });
             }); 
         }
 

--- a/src/main/java/org/openpnp/spi/base/AbstractControllerAxis.java
+++ b/src/main/java/org/openpnp/spi/base/AbstractControllerAxis.java
@@ -73,10 +73,9 @@ public abstract class AbstractControllerAxis extends AbstractCoordinateAxis impl
 
     @Override
     public void setDriverCoordinate(double driverCoordinate) {
-        Object oldValue = this.driverCoordinate;
         this.driverCoordinate = driverCoordinate;
-        firePropertyChange("driverCoordinate", oldValue, driverCoordinate);
-        firePropertyChange("driverLengthCoordinate", null, getDriverLengthCoordinate());
+        // Note, we do not firePropertyChange() as these changes are live from the machine thread,
+        // and coordinate changes are handled through MachineListener.machineHeadActivity(Machine, Head).
     }
     @Override
     public void setDriverLengthCoordinate(Length driverCoordinate) {

--- a/src/main/java/org/openpnp/spi/base/AbstractCoordinateAxis.java
+++ b/src/main/java/org/openpnp/spi/base/AbstractCoordinateAxis.java
@@ -30,8 +30,8 @@ import org.openpnp.spi.Axis;
 import org.openpnp.spi.CoordinateAxis;
 import org.openpnp.spi.Head;
 import org.openpnp.spi.HeadMountable;
-import org.openpnp.spi.Machine;
 import org.openpnp.spi.Locatable.LocationOption;
+import org.openpnp.spi.Machine;
 import org.openpnp.util.MovableUtils;
 import org.simpleframework.xml.Element;
 
@@ -67,10 +67,9 @@ public abstract class AbstractCoordinateAxis extends AbstractAxis implements Coo
 
     @Override
     public void setCoordinate(double coordinate) {
-        Object oldValue = this.coordinate;
         this.coordinate = coordinate;
-        firePropertyChange("coordinate", oldValue, coordinate);
-        firePropertyChange("lengthCoordinate", null, getLengthCoordinate());
+        // Note, we do not firePropertyChange() as these changes are live from the machine thread,
+        // and coordinate changes are handled through MachineListener.machineHeadActivity(Machine, Head).
     }
 
     @Override


### PR DESCRIPTION
# Description
Users reported sporadic GUI related exception. The issue was traced back to mullti-threading. 

`AbstractCoordinateAxis.setCoordinate(double)` and `AbstractControllerAxis.setDriverCoordinate(double)` must not `firePropertyChange()` as these changes are live from the machine thread. Coordinate changes must instead be handled through `MachineListener.machineHeadActivity(Machine, Head)`. 

A search revealed that these property names are not used in the source. These were introduced by me, copying the pattern over from other (GUI visible) properties on the axis, purely for completeness. 

# Justification
Bug-fix.

See user case:
https://groups.google.com/g/openpnp/c/ULaw9j_t8-k/m/AvAd1iWSAgAJ

# Instructions for Use
No visible changes.

# Implementation Details
1. Tested with extended simulation machine.
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. Changes in the `org.openpnp.spi` `base` package.
4. Successful `mvn test` before submitting the Pull Request. 
