### PR TITLE
Fixed duplicate property panel creation in some circumstances

### DIFF
--- a/src/main/java/org/openpnp/gui/FeedersPanel.java
+++ b/src/main/java/org/openpnp/gui/FeedersPanel.java
@@ -277,7 +277,7 @@ public class FeedersPanel extends JPanel implements WizardContainer {
                         for (PropertySheet ps : propertySheets) {
                             JPanel panel = ps.getPropertySheetPanel();
                             if(panel instanceof AbstractConfigurationWizard) {
-                                AbstractConfigurationWizard wizard = (AbstractConfigurationWizard) ps.getPropertySheetPanel();
+                                AbstractConfigurationWizard wizard = (AbstractConfigurationWizard) panel;
                                 wizard.setWizardContainer(FeedersPanel.this);
                             }
                             configurationPanel.addTab(ps.getPropertySheetTitle(), panel);


### PR DESCRIPTION
For the configuration wizard property sheet wrapper, it'd return the same instance every time getPropertySheetPanel was called. However, in my case, I was returning "new X" every time which was causing some really strange behavior because one instance had all the bindings and the other was what was displayed on the screen.