### PR TITLE
Fix/

### DIFF
--- a/src/main/java/org/openpnp/gui/IssuesAndSolutionsPanel.java
+++ b/src/main/java/org/openpnp/gui/IssuesAndSolutionsPanel.java
@@ -31,7 +31,6 @@ import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.net.URI;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.prefs.Preferences;
 
@@ -310,7 +309,7 @@ public class IssuesAndSolutionsPanel extends JPanel {
 
     public void updateIssueIndicator() {
         JTabbedPane tabs = frame.getTabs();
-        int index = Arrays.asList(tabs.getComponents()).indexOf(frame.getIssuesAndSolutionsTab());
+        int index = tabs.indexOfComponent(frame.getIssuesAndSolutionsTab());
         Solutions.Severity maxSeverity = Solutions.Severity.None;
         for (Solutions.Issue issue : machine.getSolutions().getIssues()) {
             if (issue.getSeverity().ordinal() >= maxSeverity.ordinal() 


### PR DESCRIPTION
# Description
Addresses #1199.

![grafik](https://user-images.githubusercontent.com/9963310/119097201-bf81d000-ba14-11eb-8624-efe323eeaa71.png)

Not beeing able to reproduce the error, this is only an attempt to solve the issue.

Using the special `JTabbedPane.indexOfComponent(Component)` method, instead of `indexOf()` on `getComponents()`.

# Justification
See #1199 

# Instructions for Use
No change.

# Implementation Details
1. No conclusive test possible (could not reproduce the error before).
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. Successful `mvn test` before submitting the Pull Request. 
