### PR TITLE
Fixing empty location in location buttons panel

### DIFF
--- a/src/main/java/org/openpnp/gui/components/LocationButtonsPanel.java
+++ b/src/main/java/org/openpnp/gui/components/LocationButtonsPanel.java
@@ -1,19 +1,19 @@
 /*
  * Copyright (C) 2011 Jason von Nieda <jason@vonnieda.org>
- * 
+ *
  * This file is part of OpenPnP.
- * 
+ *
  * OpenPnP is free software: you can redistribute it and/or modify it under the terms of the GNU
  * General Public License as published by the Free Software Foundation, either version 3 of the
  * License, or (at your option) any later version.
- * 
+ *
  * OpenPnP is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
  * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
  * Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along with OpenPnP. If not, see
  * <http://www.gnu.org/licenses/>.
- * 
+ *
  * For more information about OpenPnP visit http://openpnp.org
  */
 
@@ -80,7 +80,7 @@ public class LocationButtonsPanel extends JPanel {
         this.textFieldY = textFieldY;
         this.textFieldZ = textFieldZ;
         this.textFieldC = textFieldC;
-        
+
         buttonCenterCamera = new JButton(positionCameraAction);
         buttonCenterCamera.setHideActionText(true);
         add(buttonCenterCamera);
@@ -109,7 +109,7 @@ public class LocationButtonsPanel extends JPanel {
 
         setActuatorName(null);
     }
-    
+
     public Location getBaseLocation() {
         return baseLocation;
     }
@@ -118,7 +118,7 @@ public class LocationButtonsPanel extends JPanel {
         this.baseLocation = baseLocation;
     }
 
-    @Override 
+    @Override
     public void setEnabled(boolean enabled) {
         buttonCenterCamera.setEnabled(enabled);
         buttonCenterTool.setEnabled(enabled);
@@ -210,7 +210,7 @@ public class LocationButtonsPanel extends JPanel {
     /**
      * Get the Actuator with the name provided by setActuatorName() that is on the same Head as the
      * tool from getTool().
-     * 
+     *
      * @return
      * @throws Exception
      */
@@ -230,16 +230,16 @@ public class LocationButtonsPanel extends JPanel {
 
     private Location getParsedLocation() {
         double x = 0, y = 0, z = 0, rotation = 0;
-        if (textFieldX != null) {
+        if (textFieldX != null && ! textFieldX.getText().isEmpty()) {
             x = Length.parse(textFieldX.getText()).getValue();
         }
-        if (textFieldY != null) {
+        if (textFieldY != null && ! textFieldY.getText().isEmpty()) {
             y = Length.parse(textFieldY.getText()).getValue();
         }
-        if (textFieldZ != null) {
+        if (textFieldZ != null && ! textFieldZ.getText().isEmpty()) {
             z = Length.parse(textFieldZ.getText()).getValue();
         }
-        if (textFieldC != null) {
+        if (textFieldC != null && ! textFieldC.getText().isEmpty()) {
             rotation = Double.parseDouble(textFieldC.getText());
         }
         return new Location(Configuration.get().getSystemUnits(), x, y, z, rotation);
@@ -266,9 +266,9 @@ public class LocationButtonsPanel extends JPanel {
                         }
                         final Location lf = l;
                         SwingUtilities.invokeAndWait(() -> {
-                            Helpers.copyLocationIntoTextFields(lf, 
-                                    textFieldX, 
-                                    textFieldY, 
+                            Helpers.copyLocationIntoTextFields(lf,
+                                    textFieldX,
+                                    textFieldY,
                                     lz == null ? null : textFieldZ,
                                     textFieldC);
                         });


### PR DESCRIPTION
# Description
If the text field for a location is empty, it'll return a null value when you parse the length. This fixes that.

# Justification
See Description

# Instructions for Use
This should have no impact the user has to worry about. It essentially treats an empty text field as a 0 for the location.

# Implementation Details
1. How did you test the change? Be descriptive. Untested code will not be accepted.
Manual testing.
2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)?
Yes
3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing.
Nope, just the GUI.
4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted.
👍 
