### PR TITLE
Fix/ContactProbeNozzle Height Maps must be persisted with IDs, not Objects

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/ContactProbeNozzle.java
+++ b/src/main/java/org/openpnp/machine/reference/ContactProbeNozzle.java
@@ -125,10 +125,10 @@ public class ContactProbeNozzle extends ReferenceNozzle {
     private double maxZOffsetMm = 2.0;
 
     @ElementMap(required = false)
-    private HashMap<Feeder, Length> probedFeederHeightOffsets = new HashMap<>();
+    private HashMap<String, Length> probedFeederHeightOffsets = new HashMap<>();
 
     @ElementMap(required = false)
-    private HashMap<Part, Length> probedPartHeightOffsets = new HashMap<>();
+    private HashMap<String, Length> probedPartHeightOffsets = new HashMap<>();
 
     private ReferenceNozzleTip zCalibratedNozzleTip;
 
@@ -188,7 +188,7 @@ public class ContactProbeNozzle extends ReferenceNozzle {
                 && feeder.getPart().isPartHeightUnknown()) {
             return true;
         }
-        Length z = probedFeederHeightOffsets.get(feeder);
+        Length z = probedFeederHeightOffsets.get(feeder.getId());
         return (z == null);
     }
 
@@ -206,7 +206,7 @@ public class ContactProbeNozzle extends ReferenceNozzle {
         if (part.isPartHeightUnknown()) {
             return true;
         }
-        Length z = probedPartHeightOffsets.get(part);
+        Length z = probedPartHeightOffsets.get(part.getId());
         return (z == null);
     }
 
@@ -255,7 +255,7 @@ public class ContactProbeNozzle extends ReferenceNozzle {
                 Logger.debug("Nozzle "+getName()+" probed feeder "+feeder.getName()+" Z at offset "+offsetZ);
             }
             // Store the probed location offset.
-            probedFeederHeightOffsets.put(feeder, offsetZ);
+            probedFeederHeightOffsets.put(feeder.getId(), offsetZ);
 
             // Retract from probing e.g. until the probe sensor is released.
             contactProbe(false, contactProbeDepthZ);
@@ -263,7 +263,7 @@ public class ContactProbeNozzle extends ReferenceNozzle {
             Configuration.get().getScripting().on("Nozzle.AfterPickProbe", globals);
         }
         else {
-            Length offsetZ = probedFeederHeightOffsets.get(feeder);
+            Length offsetZ = probedFeederHeightOffsets.get(feeder.getId());
             if (offsetZ != null) {
                 // Apply the probed offset.
                 Logger.trace("Nozzle "+getName()+" applies feeder "+feeder.getName()+" height offset "+offsetZ);
@@ -317,14 +317,14 @@ public class ContactProbeNozzle extends ReferenceNozzle {
                 Logger.debug("Nozzle "+getName()+" probed part "+part.getId()+" height at offset "+offsetZ);
             }
             // Store the probed location offset.
-            probedPartHeightOffsets.put(part, offsetZ);
+            probedPartHeightOffsets.put(part.getId(), offsetZ);
 
             contactProbe(false, contactProbeDepthZ);
 
             Configuration.get().getScripting().on("Nozzle.AfterPlaceProbe", globals);
         }
         else {
-            Length offsetZ = probedPartHeightOffsets.get(part);
+            Length offsetZ = probedPartHeightOffsets.get(part.getId());
             if (offsetZ != null) {
                 // Apply the probed offset.
                 Logger.trace("Nozzle "+getName()+" applies part "+part.getId()+" height offset "+offsetZ);


### PR DESCRIPTION

# Description
This refers to automatic feeder and part height probing using the ContactProbeNozzle, see #1174 and the Wiki:

https://github.com/openpnp/openpnp/wiki/Contact-Probing-Nozzle

Bug: The ContactProbeNozzle persisted height maps with objects as map keys instead of their IDs. 

# Justification
Plain stupid bug.

# Instructions for Use
If users used the ContactProbeNozzle and have in-deed probed heights on parts and feeders, their `machine.xml` structure is wrong. It will look similar to this:

```XML
                  <probed-feeder-height-offsets>
                     <entry>
                        <feeder class="org.openpnp.machine.reference.feeder.ReferenceTubeFeeder" version="1.1" id="FDR1682b249cd43b798" name="ReferenceTubeFeeder" enabled="false" part-id="TEST-OBJECT" feed-retry-count="3" pick-retry-count="0">
                           <location units="Millimeters" x="253.39191389757997" y="260.32085144101774" z="-26.60000000000001" rotation="150.0"/>
                        </feeder>
                        <length value="-0.16299999999999315" units="Millimeters"/>
                     </entry>
                     ...
                  </probed-feeder-height-offsets>
```

```XML
                  <probed-part-height-offsets>
                        <part id="TEST-OBJECT" height-units="Millimeters" height="0.01" package-id="TEST-OBJECT-PACKAGE" speed="1.0" pick-retry-count="0"/>
                        <length value="-0.1929999999999943" units="Millimeters"/>
                     </entry>
                     ...
                  </probed-part-height-offsets>
```
After upgrading to this version they will get an error like this:
![XML Error](https://user-images.githubusercontent.com/9963310/119879727-d13f0800-bf2b-11eb-83eb-ad05face4091.png)

Unfortunately, the user must remove these sections from the `machine.xml` manually. The height calibration information will be lost, but it will just be probed again on next use.

# Implementation Details
1. Testing on machine pending. 
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. Successful `mvn test` before submitting the Pull Request. 
