### PR TITLE
MutableLocationProxy: fix firePropertyChange with lengthZ

### DIFF
--- a/src/main/java/org/openpnp/gui/support/MutableLocationProxy.java
+++ b/src/main/java/org/openpnp/gui/support/MutableLocationProxy.java
@@ -107,7 +107,7 @@ public class MutableLocationProxy extends AbstractModelObject {
         }
         else {
             location = location.derive(null, null, l.getValue(), null);
-            firePropertyChange("lengthZ", null, getLengthY());
+            firePropertyChange("lengthZ", null, getLengthZ());
             firePropertyChange("location", null, getLocation());
         }
     }


### PR DESCRIPTION
Simple typo on MutableLocationProxy