### PR TITLE
Bugfix: Only call "partOff" if configured during recyling

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/feeder/AdvancedLoosePartFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/AdvancedLoosePartFeeder.java
@@ -179,7 +179,7 @@ public class AdvancedLoosePartFeeder extends ReferenceFeeder {
         MovableUtils.moveToLocationAtSafeZ(nozzle, putLocation);
         nozzle.place();
         nozzle.moveToSafeZ();
-        if (!nozzle.isPartOff()) {
+        if (nozzle.isPartOffEnabled(Nozzle.PartOffStep.AfterPlace) && !nozzle.isPartOff()) {
             throw new Exception("Feeder: " + getName() + " - Putting part back failed, check nozzle tip");
         }
         // set pickLocation to null, avoid putting a second part on the same location

--- a/src/main/java/org/openpnp/machine/reference/feeder/BlindsFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/BlindsFeeder.java
@@ -382,7 +382,7 @@ public class BlindsFeeder extends ReferenceFeeder {
         // put the part back
         nozzle.place();
         nozzle.moveToSafeZ();
-        if (!nozzle.isPartOff()) {
+        if (nozzle.isPartOffEnabled(Nozzle.PartOffStep.AfterPlace) && !nozzle.isPartOff()) {
             throw new Exception("Feeder: " + getName() + " - Putting part back failed, check nozzle tip");
         }
         // change FeedCount

--- a/src/main/java/org/openpnp/machine/reference/feeder/ReferenceLoosePartFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/ReferenceLoosePartFeeder.java
@@ -138,7 +138,7 @@ public class ReferenceLoosePartFeeder extends ReferenceFeeder {
         MovableUtils.moveToLocationAtSafeZ(nozzle, putLocation);
         nozzle.place();
         nozzle.moveToSafeZ();
-        if (!nozzle.isPartOff()) {
+        if (nozzle.isPartOffEnabled(Nozzle.PartOffStep.AfterPlace) && !nozzle.isPartOff()) {
             throw new Exception("Feeder: " + getName() + " - Putting part back failed, check nozzle tip");
         }
         // set pickLocation to null, avoid putting a second part on the same location

--- a/src/main/java/org/openpnp/machine/reference/feeder/ReferenceRotatedTrayFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/ReferenceRotatedTrayFeeder.java
@@ -162,7 +162,7 @@ public class ReferenceRotatedTrayFeeder extends ReferenceFeeder {
         MovableUtils.moveToLocationAtSafeZ(nozzle, putLocation);
         nozzle.place();
         nozzle.moveToSafeZ();
-        if (!nozzle.isPartOff()) {
+        if (nozzle.isPartOffEnabled(Nozzle.PartOffStep.AfterPlace) && !nozzle.isPartOff()) {
             throw new Exception("Feeder: " + getName() + " - Putting part back failed, check nozzle tip");
         }
         // change FeedCount

--- a/src/main/java/org/openpnp/machine/reference/feeder/ReferenceStripFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/ReferenceStripFeeder.java
@@ -347,7 +347,7 @@ public class ReferenceStripFeeder extends ReferenceFeeder {
         // put the part back
         nozzle.place();
         nozzle.moveToSafeZ();
-        if (!nozzle.isPartOff()) {
+        if (nozzle.isPartOffEnabled(Nozzle.PartOffStep.AfterPlace) && !nozzle.isPartOff()) {
             throw new Exception("Feeder: " + getName() + " - Putting part back failed, check nozzle tip");
         }
         // change FeedCount

--- a/src/main/java/org/openpnp/machine/reference/feeder/ReferenceTrayFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/ReferenceTrayFeeder.java
@@ -132,7 +132,7 @@ public class ReferenceTrayFeeder extends ReferenceFeeder {
         MovableUtils.moveToLocationAtSafeZ(nozzle, putLocation);
         nozzle.place();
         nozzle.moveToSafeZ();
-        if (!nozzle.isPartOff()) {
+        if (nozzle.isPartOffEnabled(Nozzle.PartOffStep.AfterPlace) && !nozzle.isPartOff()) {
             throw new Exception("Feeder: " + getName() + " - Putting part back failed, check nozzle tip");
         }
         // change FeedCount


### PR DESCRIPTION
# Description
It was wrongfully assumed, that partOff() always works. (Since Simulator and test machine are equipped with vacuum sensor it didn't show during tests). This results in exceptions after recycling the part as on the mailing list reported.

# Justification
Fixed the behavior to the expected-

# Instructions for Use
No change.

# Implementation Details
1. How did you test the change? Tested in simulator. No feedback (yet) from the reporter of the problem.
2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)? yes
3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing. no changes, only in the feeders
4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted.
