### PR TITLE
Fix/Issues & Solutions HOME_COMMAND for TinyG: only home axes XYZ, not ABC

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/driver/GcodeDriverSolutions.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/GcodeDriverSolutions.java
@@ -646,7 +646,9 @@ public class GcodeDriverSolutions implements Solutions.Subject {
                                     else if (isTinyG) {
                                         commandBuilt = "G28.2 ";
                                         for (String variable : gcodeDriver.getAxisVariables(machine)) {
-                                            commandBuilt += variable+"0 "; // In TinyG you need to indicate the axis and only 0 is possible. 
+                                            if ("XYZ".indexOf(variable) >= 0) {
+                                                commandBuilt += variable+"0 "; // In TinyG you need to indicate the axis and only 0 is possible. 
+                                            }
                                         }
                                         commandBuilt += "; Home all axes";
                                     }


### PR DESCRIPTION
# Description
The [Issues & Solutions](https://github.com/openpnp/openpnp/wiki/Issues-and-Solutions) `HOME_COMMAND` suggested for TinyG should only include/home axes XYZ, not ABC.

# Justification
TinyG will issue an error if an axis named is not configured for end-stop homing. 

# Instructions for Use
The `HOME_COMMAND` is suggested by Issues & Solutions, when it is not yet set i.e. an existing `HOME_COMMAND` will **not** be overwritten, therefore this fix will only be effective... 

1. For a fresh configuration.
2. After the user manually deleted (emptied) the `HOME_COMMAND` from the GcodeDriver. 
 
# Implementation Details
1. Tested on TinyG rig.
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. Successful `mvn test` before submitting the Pull Request. 
