### PR TITLE
Feature/blinds feeder named group 

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/feeder/BlindsFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/BlindsFeeder.java
@@ -171,7 +171,8 @@ public class BlindsFeeder extends ReferenceFeeder {
     private boolean calibrating = false;
     private boolean calibrated = false;
 
-    private static final List<String> noGroupNamesList = Arrays.asList(new String[]{"Location", "LOCATION", "location", "", "None", "none", "NONE"});
+    private static final String defaultGroupName = "Location";
+    private static final List<String> noGroupNamesList = Arrays.asList(new String[]{defaultGroupName, "LOCATION", "location", "", "None", "none", "NONE"});
     
     private void checkHomedState(Machine machine) {
         if (!machine.isHomed()) {
@@ -1614,6 +1615,20 @@ public class BlindsFeeder extends ReferenceFeeder {
             }
         }
         return false;
+    }
+    
+    public static List<String> getBlindsFeederGroupNames() {
+    	List<String> list = new ArrayList<>();
+        for (Feeder feeder : Configuration.get().getMachine().getFeeders()) {
+            if (feeder instanceof BlindsFeeder) {
+                BlindsFeeder blindsFeeder = (BlindsFeeder) feeder;
+                String feederGroupName = blindsFeeder.getFeederGroupName();
+            	if (!list.contains(feederGroupName)) {
+            		list.add(feederGroupName);
+            	}
+            }
+        }
+        return list;
     }
 
     public static List<BlindsFeeder> getAllBlindsFeeders() {

--- a/src/main/java/org/openpnp/machine/reference/feeder/BlindsFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/BlindsFeeder.java
@@ -1619,6 +1619,8 @@ public class BlindsFeeder extends ReferenceFeeder {
 
     public static List<String> getBlindsFeederGroupNames() {
         List<String> list = new ArrayList<>();
+        list.add(defaultGroupName);
+        
         for (Feeder feeder : Configuration.get().getMachine().getFeeders()) {
             if (feeder instanceof BlindsFeeder) {
                 BlindsFeeder blindsFeeder = (BlindsFeeder) feeder;
@@ -2111,7 +2113,7 @@ public class BlindsFeeder extends ReferenceFeeder {
         boolean location_is_null = 
                 fiducial1Location.equals(nullLocation) ||
                 fiducial2Location.equals(nullLocation) ||
-                fiducial3Location.equals(nullLocation); 
+                fiducial3Location.equals(nullLocation);
 
         if (location_is_null) {
             // Set fiducials to existing feeder with new group name if one exits
@@ -2119,7 +2121,7 @@ public class BlindsFeeder extends ReferenceFeeder {
                 BlindsFeeder copyFeeder = feedersWithNewGroupName.get(0);
                 this.updateFromConnectedFeeder(copyFeeder);
             } else {
-                // Do not allow null located feeder to get a non default group name
+                // Do not allow null located feeder to get a non-existent group name
                 proposedGroupName = defaultGroupName;
                 this.feederGroupName = proposedGroupName;
             }
@@ -2132,7 +2134,11 @@ public class BlindsFeeder extends ReferenceFeeder {
                     BlindsFeeder copyFeeder = feedersWithNewGroupName.get(0);
                     this.updateFromConnectedFeeder(copyFeeder);
                 } else {
-                    proposedGroupName = oldName;
+                    if (proposedGroupName.contentEquals(defaultGroupName)) {
+                        this.feederGroupName = proposedGroupName;
+                    } else {
+                        proposedGroupName = oldName;                        
+                    }
                 }
             } else {
                 for (BlindsFeeder feeder : connected_feeders) {

--- a/src/main/java/org/openpnp/machine/reference/feeder/BlindsFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/BlindsFeeder.java
@@ -2093,68 +2093,58 @@ public class BlindsFeeder extends ReferenceFeeder {
     }
 
     public void setFeederGroupName(String newFeederGroupName) {
-        //Filter out a no change to group name.
-        if(this.feederGroupName.equals(newFeederGroupName)) {
+        // Filter out a no change to group name.
+        if (this.feederGroupName.equals(newFeederGroupName)) {
             return;
         }
-        
+
         String oldName = this.feederGroupName;
         String proposedGroupName = newFeederGroupName;
-        
-        //Check if the group name is one of the location keywords. If so reset name to default location.
+
+        // Check if the group name is one of the location keywords. If so reset name to
+        // default location.
         if (locationGroupNamesList.contains(newFeederGroupName.toUpperCase())) {
             proposedGroupName = defaultGroupName;
         }
-        
+
         List<BlindsFeeder> connected_feeders = getConnectedFeeders();
         List<BlindsFeeder> feedersWithNewGroupName = getBlindsFeedersWithGroupName(proposedGroupName);
         List<String> feederGroupNames = getBlindsFeederGroupNames();
-        
-        boolean proposed_is_default = proposedGroupName.contentEquals(defaultGroupName);
-        boolean proposed_is_existing_group = feederGroupNames.contains(proposedGroupName);
-        
-        boolean location_is_null = 
-                fiducial1Location.equals(nullLocation) ||
-                fiducial2Location.equals(nullLocation) ||
-                fiducial3Location.equals(nullLocation);
-        
-        boolean can_join_named_group =  
-                (location_is_null &&  (feedersWithNewGroupName.size() > 0));
 
-        boolean can_rename_group = (
-                !location_is_null 
-                && !proposed_is_default
-                && !proposed_is_existing_group);
+        boolean proposedIsDefault = proposedGroupName.contentEquals(defaultGroupName);
+        boolean proposedIsExistingGroup = feederGroupNames.contains(proposedGroupName);
 
-        boolean single_can_join_named_group = (
-                !location_is_null 
-                && feederGroupNames.contains(proposedGroupName)
-                && (connected_feeders.size() <= 1) );
-        
-        boolean can_leave_group_for_default = (
-                !location_is_null
-                && feederGroupNames.contains(oldName)
-                && proposed_is_default);
+        boolean locationIsNull = fiducial1Location.equals(nullLocation) || fiducial2Location.equals(nullLocation)
+                || fiducial3Location.equals(nullLocation);
 
-        if (can_join_named_group) {
+        boolean canJoinNamedGroup = (locationIsNull && (feedersWithNewGroupName.size() > 0));
+
+        boolean canRenameGroup = (!locationIsNull && !proposedIsDefault && !proposedIsExistingGroup);
+
+        boolean single_can_join_named_group = (!locationIsNull && feederGroupNames.contains(proposedGroupName)
+                && (connected_feeders.size() <= 1));
+
+        boolean can_leave_group_for_default = (!locationIsNull && feederGroupNames.contains(oldName)
+                && proposedIsDefault);
+
+        if (canJoinNamedGroup) {
             BlindsFeeder copyFeeder = feedersWithNewGroupName.get(0);
             this.updateFromConnectedFeeder(copyFeeder);
         } else if (single_can_join_named_group) {
             BlindsFeeder copyFeeder = feedersWithNewGroupName.get(0);
             this.updateFromConnectedFeeder(copyFeeder);
-        } else if (can_rename_group) {
+        } else if (canRenameGroup) {
             for (BlindsFeeder feeder : connected_feeders) {
                 feeder.setFeederGroupNameFromOther(proposedGroupName);
             }
         } else if (can_leave_group_for_default) {
             proposedGroupName = defaultGroupName;
             this.feederGroupName = proposedGroupName;
-        }
-        else {
+        } else {
             proposedGroupName = oldName;
         }
-        
-        //Ensure this feeder group is changed if connected feeders is empty.
+
+        // Ensure this feeder group is changed if connected feeders is empty.
         firePropertyChange("feederGroupName", oldName, proposedGroupName);
     }
 

--- a/src/main/java/org/openpnp/machine/reference/feeder/BlindsFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/BlindsFeeder.java
@@ -2121,23 +2121,23 @@ public class BlindsFeeder extends ReferenceFeeder {
 
         boolean canRenameGroup = (!locationIsNull && !proposedIsDefault && !proposedIsExistingGroup);
 
-        boolean single_can_join_named_group = (!locationIsNull && feederGroupNames.contains(proposedGroupName)
+        boolean singleCanJoinNamedGroup = (!locationIsNull && feederGroupNames.contains(proposedGroupName)
                 && (connected_feeders.size() <= 1));
 
-        boolean can_leave_group_for_default = (!locationIsNull && feederGroupNames.contains(oldName)
+        boolean canLeaveGroupForDefault = (!locationIsNull && feederGroupNames.contains(oldName)
                 && proposedIsDefault);
 
         if (canJoinNamedGroup) {
             BlindsFeeder copyFeeder = feedersWithNewGroupName.get(0);
             this.updateFromConnectedFeeder(copyFeeder);
-        } else if (single_can_join_named_group) {
+        } else if (singleCanJoinNamedGroup) {
             BlindsFeeder copyFeeder = feedersWithNewGroupName.get(0);
             this.updateFromConnectedFeeder(copyFeeder);
         } else if (canRenameGroup) {
             for (BlindsFeeder feeder : connected_feeders) {
                 feeder.setFeederGroupNameFromOther(proposedGroupName);
             }
-        } else if (can_leave_group_for_default) {
+        } else if (canLeaveGroupForDefault) {
             proposedGroupName = defaultGroupName;
             this.feederGroupName = proposedGroupName;
         } else {

--- a/src/main/java/org/openpnp/machine/reference/feeder/BlindsFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/BlindsFeeder.java
@@ -1692,11 +1692,8 @@ public class BlindsFeeder extends ReferenceFeeder {
         return list;
     }
 
-    public List<BlindsFeeder> getConnectedFeeders(Location location) {
-        return getConnectedFeeders(location, true);
-    }
-
     public List<BlindsFeeder> getConnectedFeeders() {
+        // Get all the feeders with the same fiducial 1 location.
         return getConnectedFeeders(fiducial1Location, true);
     }
 

--- a/src/main/java/org/openpnp/machine/reference/feeder/BlindsFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/BlindsFeeder.java
@@ -128,7 +128,7 @@ public class BlindsFeeder extends ReferenceFeeder {
     private int feedersTotal = 0;
 
     @Attribute(required = false)
-    private String feederGroupName = defaultLocationGroupName;
+    private String feederGroupName = defaultGroupName;
 
     @Attribute(required = false)
     private int pocketCount = 0;
@@ -171,8 +171,8 @@ public class BlindsFeeder extends ReferenceFeeder {
     private boolean calibrating = false;
     private boolean calibrated = false;
 
-    private static final String defaultLocationGroupName = "Location";
-    private static final List<String> locationGroupNamesList = Arrays.asList(new String[]{defaultLocationGroupName, "LOCATION", "location", "", "None", "none", "NONE"});
+    public static final String defaultGroupName = "Default";
+    private static final List<String> locationGroupNamesList = Arrays.asList(new String[]{defaultGroupName, "Location", "LOCATION", "location", "", "None", "none", "NONE"});
     
     private void checkHomedState(Machine machine) {
         if (!machine.isHomed()) {
@@ -2074,7 +2074,7 @@ public class BlindsFeeder extends ReferenceFeeder {
 
     public String getFeederGroupName() {
         if (locationGroupNamesList.contains(feederGroupName)) {
-            return defaultLocationGroupName;
+            return defaultGroupName;
         }
         return feederGroupName;
     }
@@ -2085,7 +2085,7 @@ public class BlindsFeeder extends ReferenceFeeder {
         
         //Check if the group name is one of the location keywords. If so reset name to default location.
         if (locationGroupNamesList.contains(feederGroupName)) {
-            feederGroupName = defaultLocationGroupName;
+            feederGroupName = defaultGroupName;
         }
         List<BlindsFeeder> connected_feeders = getConnectedFeeders();
 

--- a/src/main/java/org/openpnp/machine/reference/feeder/BlindsFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/BlindsFeeder.java
@@ -1616,16 +1616,16 @@ public class BlindsFeeder extends ReferenceFeeder {
         }
         return false;
     }
-    
+
     public static List<String> getBlindsFeederGroupNames() {
-    	List<String> list = new ArrayList<>();
+        List<String> list = new ArrayList<>();
         for (Feeder feeder : Configuration.get().getMachine().getFeeders()) {
             if (feeder instanceof BlindsFeeder) {
                 BlindsFeeder blindsFeeder = (BlindsFeeder) feeder;
                 String feederGroupName = blindsFeeder.getFeederGroupName();
-            	if (!list.contains(feederGroupName)) {
-            		list.add(feederGroupName);
-            	}
+                if (!list.contains(feederGroupName)) {
+                    list.add(feederGroupName);
+                }
             }
         }
         return list;
@@ -1653,19 +1653,19 @@ public class BlindsFeeder extends ReferenceFeeder {
         for (Feeder feeder : Configuration.get().getMachine().getFeeders()) {
             if (feeder instanceof BlindsFeeder) {
                 BlindsFeeder blindsFeeder = (BlindsFeeder) feeder;
-                if(groupedByLocation(blindsFeeder)) {
+                if (groupedByLocation(blindsFeeder)) {
                     if (blindsFeeder.isLocationInFeeder(location, fiducial1MatchOnly)) {
                         list.add(blindsFeeder);
-                    }                	
+                    }
                 }
             }
         }
         // Sort by feeder tape centerline.
         Collections.sort(list, new Comparator<BlindsFeeder>() {
             @Override
-            public int compare(BlindsFeeder feeder1, BlindsFeeder feeder2)  {
-                return new Double(feeder1.getPocketCenterline().getValue())
-                        .compareTo(feeder2.getPocketCenterline().convertToUnits(feeder1.getPocketCenterline().getUnits()).getValue());
+            public int compare(BlindsFeeder feeder1, BlindsFeeder feeder2) {
+                return new Double(feeder1.getPocketCenterline().getValue()).compareTo(feeder2.getPocketCenterline()
+                        .convertToUnits(feeder1.getPocketCenterline().getUnits()).getValue());
             }
         });
         return list;
@@ -1694,21 +1694,20 @@ public class BlindsFeeder extends ReferenceFeeder {
     }
 
     public List<BlindsFeeder> getConnectedFeeders(Location location) {
-    	return getConnectedFeeders(location, true);
+        return getConnectedFeeders(location, true);
     }
 
     public List<BlindsFeeder> getConnectedFeeders() {
-    	return getConnectedFeeders(fiducial1Location, true);
+        return getConnectedFeeders(fiducial1Location, true);
     }
 
-    
     public List<BlindsFeeder> getConnectedFeeders(Location location, boolean fiducial1MatchOnly) {
-    	if (groupedByLocation(this)) {
+        if (groupedByLocation(this)) {
             // Get all the feeders with the same fiducial 1 location.
             return getConnectedFeedersByLocation(fiducial1Location, true);
-    	} else {
-    		return getConnectedFeedersByGroupName(this.feederGroupName);
-    	}
+        } else {
+            return getConnectedFeedersByGroupName(this.feederGroupName);
+        }
     }
 
     private boolean isUpdating = false;

--- a/src/main/java/org/openpnp/machine/reference/feeder/wizards/BlindsFeederConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/wizards/BlindsFeederConfigurationWizard.java
@@ -27,6 +27,7 @@ import java.awt.Color;
 import java.awt.event.ActionEvent;
 import java.io.File;
 import java.io.PrintWriter;
+import java.util.List;
 
 import javax.swing.AbstractAction;
 import javax.swing.Action;
@@ -120,7 +121,7 @@ public class BlindsFeederConfigurationWizard extends AbstractConfigurationWizard
     private JLabel lblPocketCenterline;
     private JTextField textFieldPocketCenterline;
     private JLabel lblBlindsFeederGroupName;
-    private JTextField textBlindsFeederGroupName;
+    private JComboBox comboBoxBlindsFeederName;
 
 
     public BlindsFeederConfigurationWizard(BlindsFeeder feeder) {
@@ -338,9 +339,10 @@ public class BlindsFeederConfigurationWizard extends AbstractConfigurationWizard
         lblBlindsFeederGroupName = new JLabel("Feeder Group Name");
         panelTapeSettings.add(lblBlindsFeederGroupName, "8, 12, right, default");
         
-        textBlindsFeederGroupName = new JTextField();
-        panelTapeSettings.add(textBlindsFeederGroupName, "10, 12");
-        textBlindsFeederGroupName.setColumns(5);
+        List<String> blindsFeederGroupNames = feeder.getBlindsFeederGroupNames();
+        comboBoxBlindsFeederName = new JComboBox(blindsFeederGroupNames.toArray());
+        comboBoxBlindsFeederName.setEditable(true);
+        panelTapeSettings.add(comboBoxBlindsFeederName, "10, 12, fill, default");
         
         btnResetFeedCount = new JButton(resetFeedCountAction);
         panelTapeSettings.add(btnResetFeedCount, "14, 12");
@@ -596,7 +598,7 @@ public class BlindsFeederConfigurationWizard extends AbstractConfigurationWizard
         addWrappedBinding(feeder, "firstPocket", textFieldFirstPocket, "text", intConverter);
         addWrappedBinding(feeder, "lastPocket", textFieldLastPocket, "text", intConverter);
         addWrappedBinding(feeder, "feedCount", textFieldFeedCount, "text", intConverter);
-        addWrappedBinding(feeder, "feederGroupName", textBlindsFeederGroupName, "text");
+        addWrappedBinding(feeder, "feederGroupName", comboBoxBlindsFeederName, "selectedItem");
 
         addWrappedBinding(feeder, "coverType", comboBoxCoverType, "selectedItem");
         addWrappedBinding(feeder, "coverActuation", comboBoxCoverActuation, "selectedItem");
@@ -641,7 +643,6 @@ public class BlindsFeederConfigurationWizard extends AbstractConfigurationWizard
         //ComponentDecorators.decorateWithAutoSelect(textFieldFirstPocket);
         //ComponentDecorators.decorateWithAutoSelect(textFieldLastPocket);
         ComponentDecorators.decorateWithAutoSelect(textFieldFeedCount);
-        ComponentDecorators.decorateWithAutoSelect(textBlindsFeederGroupName);
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldFiducial1X);
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldFiducial1Y);
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldFiducial2X);

--- a/src/main/java/org/openpnp/machine/reference/feeder/wizards/BlindsFeederConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/wizards/BlindsFeederConfigurationWizard.java
@@ -119,6 +119,8 @@ public class BlindsFeederConfigurationWizard extends AbstractConfigurationWizard
     private JTextField textFieldPocketSize;
     private JLabel lblPocketCenterline;
     private JTextField textFieldPocketCenterline;
+    private JLabel lblBlindsFeederGroupName;
+    private JTextField textBlindsFeederGroupName;
 
 
     public BlindsFeederConfigurationWizard(BlindsFeeder feeder) {
@@ -333,6 +335,13 @@ public class BlindsFeederConfigurationWizard extends AbstractConfigurationWizard
         panelTapeSettings.add(textFieldFeedCount, "4, 12");
         textFieldFeedCount.setColumns(5);
 
+        lblBlindsFeederGroupName = new JLabel("Feeder Group Name");
+        panelTapeSettings.add(lblBlindsFeederGroupName, "8, 12, right, default");
+        
+        textBlindsFeederGroupName = new JTextField();
+        panelTapeSettings.add(textBlindsFeederGroupName, "10, 12");
+        textBlindsFeederGroupName.setColumns(5);
+        
         btnResetFeedCount = new JButton(resetFeedCountAction);
         panelTapeSettings.add(btnResetFeedCount, "14, 12");
 
@@ -587,6 +596,7 @@ public class BlindsFeederConfigurationWizard extends AbstractConfigurationWizard
         addWrappedBinding(feeder, "firstPocket", textFieldFirstPocket, "text", intConverter);
         addWrappedBinding(feeder, "lastPocket", textFieldLastPocket, "text", intConverter);
         addWrappedBinding(feeder, "feedCount", textFieldFeedCount, "text", intConverter);
+        addWrappedBinding(feeder, "feederGroupName", textBlindsFeederGroupName, "text");
 
         addWrappedBinding(feeder, "coverType", comboBoxCoverType, "selectedItem");
         addWrappedBinding(feeder, "coverActuation", comboBoxCoverActuation, "selectedItem");
@@ -631,6 +641,7 @@ public class BlindsFeederConfigurationWizard extends AbstractConfigurationWizard
         //ComponentDecorators.decorateWithAutoSelect(textFieldFirstPocket);
         //ComponentDecorators.decorateWithAutoSelect(textFieldLastPocket);
         ComponentDecorators.decorateWithAutoSelect(textFieldFeedCount);
+        ComponentDecorators.decorateWithAutoSelect(textBlindsFeederGroupName);
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldFiducial1X);
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldFiducial1Y);
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldFiducial2X);

--- a/src/test/java/BlindsFeederTest.java
+++ b/src/test/java/BlindsFeederTest.java
@@ -1,4 +1,6 @@
 import java.io.File;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import org.apache.commons.io.FileUtils;
@@ -23,10 +25,106 @@ public class BlindsFeederTest {
         Location fiducial1;
         Location fiducial2;
         Location fiducial3;
+        
         BlindsFeederTestFiducials(double X1, double Y1, double X2, double Y2, double X3, double Y3){
             fiducial1  = new Location(LengthUnit.Millimeters, X1, Y1, 0, 0.0);
             fiducial2  = new Location(LengthUnit.Millimeters, X2, Y2, 0, 0.0);
             fiducial3  = new Location(LengthUnit.Millimeters, X3, Y3, 0, 0.0);
+        }
+        
+        BlindsFeederTestFiducials(){
+            fiducial1 = BlindsFeeder.nullLocation;
+            fiducial2 = BlindsFeeder.nullLocation;
+            fiducial3 = BlindsFeeder.nullLocation;
+        }
+    }
+    
+    public class BlindsFeederTestCondition {
+        private BlindsFeeder testFeeder;
+        private BlindsFeederTestFiducials testFiducials;
+        private String testGroupName;
+        private int testFeederID;
+        private int testFeederNumber;
+        private List<BlindsFeeder> testConnectedFeeders;
+        
+        BlindsFeederTestCondition(BlindsFeeder feeder, int feederID) {
+            testFeeder = feeder;
+            testFeederID  = feederID;
+            testFeederNumber = -1;
+            testFiducials = new BlindsFeederTestFiducials();
+            testGroupName = BlindsFeeder.defaultGroupName;
+            testConnectedFeeders = new ArrayList<BlindsFeeder>();  
+        }
+        
+        void addConnectedFeeder(BlindsFeeder feeder){
+            if (!testConnectedFeeders.contains(feeder)) {
+                testConnectedFeeders.add(feeder);
+            }
+        }
+        
+        void setFiducial1(Location location) {
+            testFiducials.fiducial1  = location;
+        }
+        
+        void setFiducials(BlindsFeederTestFiducials fiducials) {
+            testFiducials = fiducials;
+        }
+
+        BlindsFeederTestFiducials getFiducials() {
+            return testFiducials;
+        }
+        
+        void setGroupName(String groupName) {
+            testGroupName = groupName;
+        }
+        
+        String getGroupName() {
+            return testGroupName;
+        }
+
+        void setFeederNumber(int feederNo) {
+            testFeederNumber = feederNo;
+        }
+
+
+        public void testBlindsFeederCondition()  throws Exception {
+            assert (testFeeder.getFiducial1Location().equals(testFiducials.fiducial1)) : String.format("FeederID:%d : Fiducial 1 incorrect", testFeederID);
+            assert (testFeeder.getFiducial2Location().equals(testFiducials.fiducial2)) : String.format("FeederID:%d : Fiducial 2 incorrect", testFeederID);
+            assert (testFeeder.getFiducial3Location().equals(testFiducials.fiducial3)) : String.format("FeederID:%d : Fiducial 3 incorrect", testFeederID);
+            
+            assert (testFeeder.getFeederGroupName().equals(testGroupName)) : String.format("FeederID %d : Group name incorrect", testFeederID);
+            
+            List<BlindsFeeder> connectedFeeders = testFeeder.getConnectedFeeders();
+
+            assert (connectedFeeders.size() == testConnectedFeeders.size()+1) : String.format("FeederID:%d : %d connected, expected %d", testFeederID, connectedFeeders.size(), testConnectedFeeders.size()+1); 
+            assert (connectedFeeders.containsAll(testConnectedFeeders)) : String.format("FeederID %d : Incorrect feeders connected", testFeederID);
+            
+            if (testFeederNumber >= 0) {
+                assert(testFeeder.getFeederNo() == testFeederNumber) :  String.format("FeederID %d : Feeder number %d, expected %d", testFeederID, testFeeder.getFeederNo(), testFeederNumber);
+            }
+        }
+    }
+    
+    public void testAllBlindsFeederConditions(List<BlindsFeederTestCondition> testConditions)  throws Exception {
+        for (BlindsFeederTestCondition testCondition : testConditions) {
+            try {
+                testCondition.testBlindsFeederCondition();                
+            } catch (Exception e) {
+                System.out.println(e.getMessage());
+                System.out.flush();
+                throw(e);
+            }
+        }
+    }
+    
+    public void testConnectTestConditions(List<BlindsFeederTestCondition> connectList) {
+        for(BlindsFeederTestCondition testCond1 : connectList) {
+            for(BlindsFeederTestCondition testCond2 : connectList) {
+                if(testCond1 != testCond2) {
+                    testCond1.addConnectedFeeder(testCond2.testFeeder);
+                    testCond2.addConnectedFeeder(testCond1.testFeeder);
+                }
+            }
         }
     }
     
@@ -48,16 +146,19 @@ public class BlindsFeederTest {
         Configuration.initialize(workingDirectory);
         Configuration.get().load();
         // Save back migrated.
-        Configuration.get().save();        
-    }    
+        Configuration.get().save();
+    }
     
     @Test
-    public void testBlindsFeederBasics() throws Exception {        
+    public void testBlindsFeederBasics() throws Exception {
         Machine machine = Configuration.get().getMachine();
         List<Feeder> feeders = machine.getFeeders();
+        List<BlindsFeederTestCondition> testConditions = new ArrayList<BlindsFeederTestCondition>();  
         
         BlindsFeederTestFiducials feederFiducals1 = new BlindsFeederTestFiducials(180,100, 100,100, 100,165);
+//        BlindsFeederTestFiducials feederFiducals1_bad = new BlindsFeederTestFiducials(180,100, 100,100, 100,170);
         BlindsFeederTestFiducials feederFiducals2 = new BlindsFeederTestFiducials(280,100, 200,100, 200,165);
+        BlindsFeederTestFiducials feederFiducals2_partial = new BlindsFeederTestFiducials(280,100, 0,0, 0,0);
         BlindsFeederTestFiducials feederFiducals3 = new BlindsFeederTestFiducials(380,100, 300,100, 300,165);
 
         //********************************************************************************************//
@@ -65,188 +166,152 @@ public class BlindsFeederTest {
         //Create first blinds feeder and set and check its location
         BlindsFeeder blindsFeeder1 = new BlindsFeeder();
         machine.addFeeder(blindsFeeder1);
+        BlindsFeederTestCondition testConditionFeeder1 = new BlindsFeederTestCondition(blindsFeeder1, 1);
+        testConditions.add(testConditionFeeder1);
 
+        testConditionFeeder1.setFiducials(feederFiducals1);
         blindsFeeder1.setFiducial1Location(feederFiducals1.fiducial1);
         blindsFeeder1.setFiducial2Location(feederFiducals1.fiducial2);
         blindsFeeder1.setFiducial3Location(feederFiducals1.fiducial3);
-
-        assert(blindsFeeder1.getFiducial1Location().equals(feederFiducals1.fiducial1));
-        assert(blindsFeeder1.getFiducial2Location().equals(feederFiducals1.fiducial2));
-        assert(blindsFeeder1.getFiducial3Location().equals(feederFiducals1.fiducial3));
-        
-        assert(blindsFeeder1.getFeedersTotal() == 1);
-
+        testAllBlindsFeederConditions(testConditions);
         
         //********************************************************************************************//
         //Test creating another feeder and connect it in the same location using fiducial 1 only
         BlindsFeeder blindsFeeder2 = new BlindsFeeder();
         machine.addFeeder(blindsFeeder2);
+        BlindsFeederTestCondition testConditionFeeder2 = new BlindsFeederTestCondition(blindsFeeder2, 1);
+        testConditions.add(testConditionFeeder2);
 
+        testConditionFeeder2.setFiducials(feederFiducals1);
+        testConditionFeeder2.addConnectedFeeder(blindsFeeder1);
+        testConditionFeeder1.addConnectedFeeder(blindsFeeder2);
         blindsFeeder2.setFiducial1Location(feederFiducals1.fiducial1);
-        
-        //Check all fiducials match
-        assert(blindsFeeder2.getFiducial1Location().equals(feederFiducals1.fiducial1));
-        assert(blindsFeeder2.getFiducial2Location().equals(feederFiducals1.fiducial2));
-        assert(blindsFeeder2.getFiducial3Location().equals(feederFiducals1.fiducial3));
-        
-        //Check the two feeders are connected in both directions
-        assert(blindsFeeder1.getConnectedFeeders().contains(blindsFeeder2));
-        assert(blindsFeeder2.getConnectedFeeders().contains(blindsFeeder1));
-
-        assert(blindsFeeder1.getFeedersTotal() == 2);
+        testAllBlindsFeederConditions(testConditions);
 
         //********************************************************************************************//
         //Test creating a feeder at a different location and that it does not connect to the othres
         BlindsFeeder blindsFeeder3 = new BlindsFeeder();
         machine.addFeeder(blindsFeeder3);
+        BlindsFeederTestCondition testConditionFeeder3 = new BlindsFeederTestCondition(blindsFeeder3, 1);
+        testConditions.add(testConditionFeeder3);
 
+        testConditionFeeder3.setFiducials(feederFiducals2_partial);
         //Set the feeder 3 first fiducial to location 2
         blindsFeeder3.setFiducial1Location(feederFiducals2.fiducial1);
+        testAllBlindsFeederConditions(testConditions);
         
-        //Check feeder 3 is not connected to feeder 1/2
-        assert(!blindsFeeder1.getConnectedFeeders().contains(blindsFeeder3));
-        assert(!blindsFeeder3.getConnectedFeeders().contains(blindsFeeder1));
-
-        //Check the count of connected feeders
-        assert(blindsFeeder1.getFeedersTotal() == 2);
-        assert(blindsFeeder3.getFeedersTotal() == 1);
-
+        testConditionFeeder3.setFiducials(feederFiducals2);
         //Set fiducials 2&3 and check connected feeders again.
         blindsFeeder3.setFiducial2Location(feederFiducals2.fiducial2);
         blindsFeeder3.setFiducial3Location(feederFiducals2.fiducial3);
- 
-        assert(!blindsFeeder1.getConnectedFeeders().contains(blindsFeeder3));
-        assert(!blindsFeeder3.getConnectedFeeders().contains(blindsFeeder1));
+        testAllBlindsFeederConditions(testConditions);
 
         //********************************************************************************************//
         //Test setting feeder pockets
         final double pocketSizeMm = 2.8;
-        final double pocketPositionMm = -1.0;
+//        final double pocketPositionMm = -1.0;
         final double pocketPitchMm = 4.0;
         final double pocketCenterline1Mm = 9.0;
         final double pocketCenterline2Mm = 19.0;
 
+        testConditionFeeder1.setFeederNumber(2);
+        testConditionFeeder2.setFeederNumber(1);
         //Set feeder1 to first position
         blindsFeeder1.setPocketCenterline(new Length(pocketCenterline1Mm, LengthUnit.Millimeters));
         blindsFeeder1.setPocketPitch(new Length(pocketPitchMm, LengthUnit.Millimeters));
         blindsFeeder1.setPocketSize(new Length(pocketSizeMm, LengthUnit.Millimeters));
 
-        assert(blindsFeeder1.getFeederNo() == 2);
-        assert(blindsFeeder2.getFeederNo() == 1);
+        testAllBlindsFeederConditions(testConditions);
         
+        testConditionFeeder1.setFeederNumber(1);
+        testConditionFeeder2.setFeederNumber(2);
         //Set feeder2 to second position
         blindsFeeder2.setPocketCenterline(new Length(pocketCenterline2Mm, LengthUnit.Millimeters));
         blindsFeeder2.setPocketPitch(new Length(pocketPitchMm, LengthUnit.Millimeters));
         blindsFeeder2.setPocketSize(new Length(pocketSizeMm, LengthUnit.Millimeters));
 
-        assert(blindsFeeder1.getFeederNo() == 1);
-        assert(blindsFeeder2.getFeederNo() == 2);
-        
-        assert(blindsFeeder1.getConnectedFeeders().contains(blindsFeeder2));
-        assert(blindsFeeder2.getConnectedFeeders().contains(blindsFeeder1));
+        testAllBlindsFeederConditions(testConditions);
 
         //********************************************************************************************//
         //Test moving connected feeder fiducial 1 results in fiducials for conencted feeder moving relatively
         
-        //Check before moving that feeder 1|2 fiducials are at location 1
-        assert(blindsFeeder1.getFiducial1Location().equals(feederFiducals1.fiducial1));
-        assert(blindsFeeder1.getFiducial2Location().equals(feederFiducals1.fiducial2));
-        assert(blindsFeeder1.getFiducial3Location().equals(feederFiducals1.fiducial3));        
-        assert(blindsFeeder2.getFiducial1Location().equals(feederFiducals1.fiducial1));
-        assert(blindsFeeder2.getFiducial2Location().equals(feederFiducals1.fiducial2));
-        assert(blindsFeeder2.getFiducial3Location().equals(feederFiducals1.fiducial3));
-        
+        testConditionFeeder1.setFiducials(feederFiducals3);
+        testConditionFeeder2.setFiducials(feederFiducals3);
         // Change feeder 1 fiducial 1 to location 3 and check all connected feeders are moved
         blindsFeeder1.setFiducial1Location(feederFiducals3.fiducial1);
         
-        assert(blindsFeeder1.getFiducial1Location().equals(feederFiducals3.fiducial1));
-        assert(blindsFeeder1.getFiducial2Location().equals(feederFiducals3.fiducial2));
-        assert(blindsFeeder1.getFiducial3Location().equals(feederFiducals3.fiducial3));
-
-        assert(blindsFeeder2.getFiducial1Location().equals(feederFiducals3.fiducial1));
-        assert(blindsFeeder2.getFiducial2Location().equals(feederFiducals3.fiducial2));
-        assert(blindsFeeder2.getFiducial3Location().equals(feederFiducals3.fiducial3));
-        
-        assert(blindsFeeder1.getConnectedFeeders().contains(blindsFeeder2));
-        assert(blindsFeeder2.getConnectedFeeders().contains(blindsFeeder1));
+        testAllBlindsFeederConditions(testConditions);
     }
     
     @Test
     public void testBlindsFeederGroups() throws Exception {
         Machine machine = Configuration.get().getMachine();
         List<Feeder> feeders = machine.getFeeders();
-        
+        List<BlindsFeederTestCondition> testConditions = new ArrayList<BlindsFeederTestCondition>();  
+        List<BlindsFeederTestCondition> testConditionsGroup1 = new ArrayList<BlindsFeederTestCondition>();  
+
         BlindsFeederTestFiducials feederFiducals1 = new BlindsFeederTestFiducials(180,100, 100,100, 100,165);
         BlindsFeederTestFiducials feederFiducals2 = new BlindsFeederTestFiducials(280,100, 200,100, 200,165);
         BlindsFeederTestFiducials feederFiducals3 = new BlindsFeederTestFiducials(380,100, 300,100, 300,165);
         
         BlindsFeeder blindsFeeder1 = new BlindsFeeder();
         machine.addFeeder(blindsFeeder1);
+        BlindsFeederTestCondition testConditionFeeder1 = new BlindsFeederTestCondition(blindsFeeder1, 1);
+        testConditions.add(testConditionFeeder1);
+        testConditionsGroup1.add(testConditionFeeder1);
+
+        testConditionFeeder1.setFiducials(feederFiducals1);
         blindsFeeder1.setFiducial1Location(feederFiducals1.fiducial1);
         blindsFeeder1.setFiducial2Location(feederFiducals1.fiducial2);
         blindsFeeder1.setFiducial3Location(feederFiducals1.fiducial3);
         
-        assert(blindsFeeder1.getFeederGroupName().equals(BlindsFeeder.defaultGroupName)); 
+        testAllBlindsFeederConditions(testConditions);
         
+        //********************************************************************************************//
+        //Test conecting a second feeder using fiducial1 and that it gets the right group name 
         BlindsFeeder blindsFeeder2 = new BlindsFeeder();
         machine.addFeeder(blindsFeeder2);
-        blindsFeeder2.setFiducial1Location(feederFiducals1.fiducial1);
+        BlindsFeederTestCondition testConditionFeeder2 = new BlindsFeederTestCondition(blindsFeeder2, 2);
+        testConditions.add(testConditionFeeder2);
+        testConditionsGroup1.add(testConditionFeeder2);
         
-        //Check feeders are connected
-        assert(blindsFeeder1.getConnectedFeeders().contains(blindsFeeder2));
-        assert(blindsFeeder2.getConnectedFeeders().contains(blindsFeeder1));
+        testConnectTestConditions(testConditionsGroup1);
+        testConditionFeeder2.setFiducials(feederFiducals1);
+        blindsFeeder2.setFiducial1Location(feederFiducals1.fiducial1);
+        testAllBlindsFeederConditions(testConditions);
 
         //Change group name of feeder1, check feeder 2 at same location also changes group name
+        testConditionFeeder1.setGroupName("BlindsFeederTestGroup1");
+        testConditionFeeder2.setGroupName("BlindsFeederTestGroup1");
         blindsFeeder1.setFeederGroupName("BlindsFeederTestGroup1");
-        assert(blindsFeeder1.getFeederGroupName().equals("BlindsFeederTestGroup1"));
-        assert(blindsFeeder2.getFeederGroupName().equals(blindsFeeder1.getFeederGroupName()));
         
-        //Check feeders are connected
-        assert(blindsFeeder1.getConnectedFeeders().contains(blindsFeeder2));
-        assert(blindsFeeder2.getConnectedFeeders().contains(blindsFeeder1));
+        testAllBlindsFeederConditions(testConditions);
         
-        //Create a new feeder at the same location but with default group name
+        //Create a new feeder at the same location
         BlindsFeeder blindsFeeder3 = new BlindsFeeder();
         machine.addFeeder(blindsFeeder3);
+        BlindsFeederTestCondition testConditionFeeder3 = new BlindsFeederTestCondition(blindsFeeder3, 3);
+        testConditions.add(testConditionFeeder3);
 
-        //Set the first fiducial and check the others are not set and it is not in the same group
+        //Set the first fiducial and check the others are not set and it is not in the same group as above at the same location
+        testConditionFeeder3.setFiducial1(feederFiducals1.fiducial1);
         blindsFeeder3.setFiducial1Location(feederFiducals1.fiducial1);
-        //Check it is not connected to the other feeders at the same location
-        assert(!blindsFeeder3.getConnectedFeeders().contains(blindsFeeder1));
-        //And the previous named feeders don't connect to it
-        assert(!blindsFeeder1.getConnectedFeeders().contains(blindsFeeder3));
-
-        //Check again that the first two feeders are still connected
-        assert(blindsFeeder1.getConnectedFeeders().contains(blindsFeeder2));
-        assert(blindsFeeder2.getConnectedFeeders().contains(blindsFeeder1));
+        testAllBlindsFeederConditions(testConditions);
         
         //Set the remaining fiducials to the same location and check again that it is not part of the named group
-        assert(!blindsFeeder3.getFiducial2Location().equals(feederFiducals1.fiducial2));
-        assert(!blindsFeeder3.getFiducial3Location().equals(feederFiducals1.fiducial3));
-        assert(!blindsFeeder3.getConnectedFeeders().contains(blindsFeeder1));
-        assert(!blindsFeeder1.getConnectedFeeders().contains(blindsFeeder3));
-
-        //Set remaining fiducials and check again
+        testConditionFeeder3.setFiducials(feederFiducals1);
         blindsFeeder3.setFiducial2Location(feederFiducals1.fiducial2);
         blindsFeeder3.setFiducial3Location(feederFiducals1.fiducial3);
-        assert(!blindsFeeder3.getConnectedFeeders().contains(blindsFeeder1));
-        assert(!blindsFeeder1.getConnectedFeeders().contains(blindsFeeder3));
 
+        testAllBlindsFeederConditions(testConditions);
+        
+        testConditionFeeder3.setFiducials(feederFiducals2);
         //Move feeder 3 to second fiducials and check that it has moved and that the non connected have not.
         blindsFeeder3.setFiducial1Location(feederFiducals2.fiducial1);
         blindsFeeder3.setFiducial2Location(feederFiducals2.fiducial2);
         blindsFeeder3.setFiducial3Location(feederFiducals2.fiducial3);
         
-        assert(!blindsFeeder2.getFiducial1Location().equals(feederFiducals2.fiducial1));
-        assert(!blindsFeeder2.getFiducial2Location().equals(feederFiducals2.fiducial2));
-        assert(!blindsFeeder2.getFiducial3Location().equals(feederFiducals2.fiducial3));
-
-        assert(blindsFeeder3.getFiducial1Location().equals(feederFiducals2.fiducial1));
-        assert(blindsFeeder3.getFiducial2Location().equals(feederFiducals2.fiducial2));
-        assert(blindsFeeder3.getFiducial3Location().equals(feederFiducals2.fiducial3));
-        
-        assert(!blindsFeeder3.getConnectedFeeders().contains(blindsFeeder1));
-        assert(!blindsFeeder1.getConnectedFeeders().contains(blindsFeeder3));
+        testAllBlindsFeederConditions(testConditions);
 
         //********************************************************************************************//
         //Test assigning an existing group to a feeder at default location.
@@ -254,94 +319,108 @@ public class BlindsFeederTest {
         //Create a new feeder at the first location with default group name
         BlindsFeeder blindsFeeder4 = new BlindsFeeder();
         machine.addFeeder(blindsFeeder4);
-        
-        //Set group name with default location to existing group
+        BlindsFeederTestCondition testConditionFeeder4 = new BlindsFeederTestCondition(blindsFeeder4, 4);
+        testConditions.add(testConditionFeeder4);
+
+        testConditionsGroup1.add(testConditionFeeder4);
+        testConnectTestConditions(testConditionsGroup1);
+        testConditionFeeder4.setFiducials(feederFiducals1);
+        testConditionFeeder4.setGroupName("BlindsFeederTestGroup1");
         blindsFeeder4.setFeederGroupName("BlindsFeederTestGroup1");
         
-        //Check it is connected to the group and has the expected fiducials
-        assert(blindsFeeder4.getConnectedFeeders().contains(blindsFeeder1));
-        assert(blindsFeeder1.getConnectedFeeders().contains(blindsFeeder4));
-        assert(blindsFeeder4.getFiducial1Location().equals(blindsFeeder1.getFiducial1Location()));
-        assert(blindsFeeder4.getFiducial2Location().equals(blindsFeeder1.getFiducial2Location()));
-        assert(blindsFeeder4.getFiducial3Location().equals(blindsFeeder1.getFiducial3Location()));
+        testAllBlindsFeederConditions(testConditions);
         
         //********************************************************************************************//
         //Test assigning an existing group to a placed feeder that has no connected feeders.
         //Create a new feeder at the third location
         BlindsFeeder blindsFeeder5 = new BlindsFeeder();
         machine.addFeeder(blindsFeeder5);
+        BlindsFeederTestCondition testConditionFeeder5 = new BlindsFeederTestCondition(blindsFeeder5, 5);
+        testConditions.add(testConditionFeeder5);
         
+        testConditionFeeder5.setFiducials(feederFiducals3);
         blindsFeeder5.setFiducial1Location(feederFiducals3.fiducial1);
         blindsFeeder5.setFiducial2Location(feederFiducals3.fiducial2);
         blindsFeeder5.setFiducial3Location(feederFiducals3.fiducial3);
-        
-        //Set group name with default location to existing group
-        blindsFeeder5.setFeederGroupName("BlindsFeederTestGroup1");
-        assert(blindsFeeder5.getConnectedFeeders().contains(blindsFeeder1));
-        assert(blindsFeeder1.getConnectedFeeders().contains(blindsFeeder5));
-        assert(blindsFeeder5.getFiducial1Location().equals(blindsFeeder1.getFiducial1Location()));
-        assert(blindsFeeder5.getFiducial2Location().equals(blindsFeeder1.getFiducial2Location()));
-        assert(blindsFeeder5.getFiducial3Location().equals(blindsFeeder1.getFiducial3Location()));
+        testAllBlindsFeederConditions(testConditions);
 
+        //Set group name with default location to existing group
+        testConditionsGroup1.add(testConditionFeeder5);
+        testConnectTestConditions(testConditionsGroup1);
+        testConditionFeeder5.setFiducials(feederFiducals1);
+        testConditionFeeder5.setGroupName("BlindsFeederTestGroup1");
+        blindsFeeder5.setFeederGroupName("BlindsFeederTestGroup1");
+        testAllBlindsFeederConditions(testConditions);
+        
         //********************************************************************************************//
         //Test assigning an existing group to a placed feeder with a non default name that has no connected feeders.
         //Create a new feeder at the third location
         BlindsFeeder blindsFeeder6 = new BlindsFeeder();
         machine.addFeeder(blindsFeeder6);
-        
+        BlindsFeederTestCondition testConditionFeeder6 = new BlindsFeederTestCondition(blindsFeeder6, 6);
+        testConditions.add(testConditionFeeder6);
+
+        testConditionFeeder6.setFiducials(feederFiducals3);
         blindsFeeder6.setFiducial1Location(feederFiducals3.fiducial1);
         blindsFeeder6.setFiducial2Location(feederFiducals3.fiducial2);
         blindsFeeder6.setFiducial3Location(feederFiducals3.fiducial3);
 
+        testConditionFeeder6.setGroupName("BlindsFeederTemporaryTestGroup");
         blindsFeeder6.setFeederGroupName("BlindsFeederTemporaryTestGroup");
+        testAllBlindsFeederConditions(testConditions);
+        
         assert(blindsFeeder6.getFeederGroupName().equals("BlindsFeederTemporaryTestGroup"));
         assert(blindsFeeder6.getConnectedFeeders().size() == 1);
         
         //Set group name with default location to existing group
+        testConditionsGroup1.add(testConditionFeeder6);
+        testConnectTestConditions(testConditionsGroup1);
+        testConditionFeeder6.setFiducials(feederFiducals1);
+        testConditionFeeder6.setGroupName("BlindsFeederTestGroup1");
         blindsFeeder6.setFeederGroupName("BlindsFeederTestGroup1");
-        assert(blindsFeeder6.getConnectedFeeders().contains(blindsFeeder1));
-        assert(blindsFeeder1.getConnectedFeeders().contains(blindsFeeder6));
-        assert(blindsFeeder6.getFiducial1Location().equals(blindsFeeder1.getFiducial1Location()));
-        assert(blindsFeeder6.getFiducial2Location().equals(blindsFeeder1.getFiducial2Location()));
-        assert(blindsFeeder6.getFiducial3Location().equals(blindsFeeder1.getFiducial3Location()));
-
+        
+        testAllBlindsFeederConditions(testConditions);
+        
         //********************************************************************************************//
         //Test that a group of more than one named feeders will not join to another group at  the same location
         BlindsFeeder blindsFeeder7 = new BlindsFeeder();
         machine.addFeeder(blindsFeeder7);
+        BlindsFeederTestCondition testConditionFeeder7 = new BlindsFeederTestCondition(blindsFeeder7, 7);
+        testConditions.add(testConditionFeeder7);
+        
         BlindsFeeder blindsFeeder8 = new BlindsFeeder();
         machine.addFeeder(blindsFeeder8);
+        BlindsFeederTestCondition testConditionFeeder8 = new BlindsFeederTestCondition(blindsFeeder8, 8);
+        testConditions.add(testConditionFeeder8);
 
+        testConditionFeeder7.setFiducials(feederFiducals2);
+        testConditionFeeder8.setFiducials(feederFiducals2);
         blindsFeeder7.setFiducial1Location(feederFiducals2.fiducial1);
         blindsFeeder7.setFiducial2Location(feederFiducals2.fiducial2);
         blindsFeeder7.setFiducial3Location(feederFiducals2.fiducial3);
         
+        testConditionFeeder7.setGroupName("BlindsFeederTestGroup2");
+        testConditionFeeder8.setGroupName("BlindsFeederTestGroup2");
         blindsFeeder7.setFeederGroupName("BlindsFeederTestGroup2");
         blindsFeeder8.setFeederGroupName("BlindsFeederTestGroup2");
         
-        assert(blindsFeeder7.getConnectedFeeders().contains(blindsFeeder8));
-        assert(blindsFeeder8.getConnectedFeeders().contains(blindsFeeder7));
-        assert(blindsFeeder7.getFeederGroupName().contentEquals("BlindsFeederTestGroup2"));
-
-        assert(blindsFeeder7.getFiducial1Location().equals(feederFiducals2.fiducial1));
-        assert(blindsFeeder7.getFiducial2Location().equals(feederFiducals2.fiducial2));
-        assert(blindsFeeder7.getFiducial3Location().equals(feederFiducals2.fiducial3));
+        testAllBlindsFeederConditions(testConditions);
         
         //Try setting this feeder group name to the name of a different group.  Check that this is blocked.
         blindsFeeder7.setFeederGroupName("BlindsFeederTestGroup1");
-        assert(!blindsFeeder7.getFeederGroupName().contentEquals("BlindsFeederTestGroup1"));
-        assert(!blindsFeeder7.getFeederGroupName().contentEquals("BlindsFeederTestGroup1"));
+        testAllBlindsFeederConditions(testConditions);
         
 
         //********************************************************************************************//
         ///Test that a group of more than one named feeders will not join to another group at different location
+        testConditionFeeder7.setFiducials(feederFiducals3);
+        testConditionFeeder8.setFiducials(feederFiducals3);
         blindsFeeder7.setFiducial1Location(feederFiducals3.fiducial1);
         blindsFeeder7.setFiducial2Location(feederFiducals3.fiducial2);
         blindsFeeder7.setFiducial3Location(feederFiducals3.fiducial3);
 
         blindsFeeder7.setFeederGroupName("BlindsFeederTestGroup1");
-        assert(!blindsFeeder7.getFeederGroupName().contentEquals("BlindsFeederTestGroup1"));
-        assert(!blindsFeeder7.getFeederGroupName().contentEquals("BlindsFeederTestGroup1"));
+        testAllBlindsFeederConditions(testConditions);
 
     }
     

--- a/src/test/java/BlindsFeederTest.java
+++ b/src/test/java/BlindsFeederTest.java
@@ -382,10 +382,12 @@ public class BlindsFeederTest {
         testAllBlindsFeederConditions(testConditions);
         
         //********************************************************************************************//
-        //Test that a group of more than one named feeders will not join to another group at  the same location
+        //Test that a group of more than one named feeders will not join to another group at the same location
         BlindsFeeder blindsFeeder7 = new BlindsFeeder();
         machine.addFeeder(blindsFeeder7);
         BlindsFeederTestCondition testConditionFeeder7 = new BlindsFeederTestCondition(blindsFeeder7, 7);
+        List<BlindsFeederTestCondition> testConditionsGroup2 = new ArrayList<BlindsFeederTestCondition>();  
+        
         testConditions.add(testConditionFeeder7);
         
         BlindsFeeder blindsFeeder8 = new BlindsFeeder();
@@ -393,14 +395,18 @@ public class BlindsFeederTest {
         BlindsFeederTestCondition testConditionFeeder8 = new BlindsFeederTestCondition(blindsFeeder8, 8);
         testConditions.add(testConditionFeeder8);
 
-        testConditionFeeder7.setFiducials(feederFiducals2);
-        testConditionFeeder8.setFiducials(feederFiducals2);
-        blindsFeeder7.setFiducial1Location(feederFiducals2.fiducial1);
-        blindsFeeder7.setFiducial2Location(feederFiducals2.fiducial2);
-        blindsFeeder7.setFiducial3Location(feederFiducals2.fiducial3);
+        testConditionFeeder7.setFiducials(feederFiducals1);
+        blindsFeeder7.setFiducial1Location(feederFiducals1.fiducial1);
+        blindsFeeder7.setFiducial2Location(feederFiducals1.fiducial2);
+        blindsFeeder7.setFiducial3Location(feederFiducals1.fiducial3);
         
+        testConditionsGroup2.add(testConditionFeeder7);
+        testConditionsGroup2.add(testConditionFeeder8);
+        testConnectTestConditions(testConditionsGroup2);
+        testConditionFeeder8.setFiducials(feederFiducals1);
         testConditionFeeder7.setGroupName("BlindsFeederTestGroup2");
         testConditionFeeder8.setGroupName("BlindsFeederTestGroup2");
+        
         blindsFeeder7.setFeederGroupName("BlindsFeederTestGroup2");
         blindsFeeder8.setFeederGroupName("BlindsFeederTestGroup2");
         

--- a/src/test/java/BlindsFeederTest.java
+++ b/src/test/java/BlindsFeederTest.java
@@ -1,0 +1,256 @@
+import java.io.File;
+import java.util.List;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.Test;
+import org.opencv.core.RotatedRect;
+import org.junit.jupiter.api.BeforeEach;
+import org.openpnp.model.Configuration;
+import org.openpnp.model.Length;
+import org.openpnp.spi.Machine;
+import org.openpnp.vision.Ransac.Line;
+import org.openpnp.spi.Camera;
+import org.openpnp.spi.Feeder;
+import org.openpnp.machine.reference.feeder.BlindsFeeder;
+import org.openpnp.machine.reference.feeder.BlindsFeeder.FindFeatures;
+import org.openpnp.model.Location;
+import org.openpnp.model.LengthUnit;
+
+import com.google.common.io.Files;
+
+public class BlindsFeederTest {
+    public class BlindsFeederTestFiducials{
+        Location fiducial1;
+        Location fiducial2;
+        Location fiducial3;
+        BlindsFeederTestFiducials(double X1, double Y1, double X2, double Y2, double X3, double Y3){
+            fiducial1  = new Location(LengthUnit.Millimeters, X1, Y1, 0, 0.0);
+            fiducial2  = new Location(LengthUnit.Millimeters, X2, Y2, 0, 0.0);
+            fiducial3  = new Location(LengthUnit.Millimeters, X3, Y3, 0, 0.0);
+        }
+    }
+    
+    @BeforeEach
+    private void testBlindsFeederLoadConfiguration() throws Exception {
+        File workingDirectory = Files.createTempDir();
+        workingDirectory = new File(workingDirectory, ".openpnp");
+        System.out.println("Configuration directory: " + workingDirectory);
+
+        // Copy the required configuration files over to the new configuration
+        // directory.
+        FileUtils.copyURLToFile(ClassLoader.getSystemResource("config/BasicJobTest/machine.xml"),
+                new File(workingDirectory, "machine.xml"));
+        FileUtils.copyURLToFile(ClassLoader.getSystemResource("config/BasicJobTest/packages.xml"),
+                new File(workingDirectory, "packages.xml"));
+        FileUtils.copyURLToFile(ClassLoader.getSystemResource("config/BasicJobTest/parts.xml"),
+                new File(workingDirectory, "parts.xml"));
+
+        Configuration.initialize(workingDirectory);
+        Configuration.get().load();
+        // Save back migrated.
+        Configuration.get().save();        
+    }    
+    
+    @Test
+    public void testBlindsFeederBasics() throws Exception {        
+        Machine machine = Configuration.get().getMachine();
+        List<Feeder> feeders = machine.getFeeders();
+        
+        BlindsFeederTestFiducials feederFiducals1 = new BlindsFeederTestFiducials(180,100, 100,100, 100,165);
+        BlindsFeederTestFiducials feederFiducals2 = new BlindsFeederTestFiducials(280,100, 200,100, 200,165);
+        BlindsFeederTestFiducials feederFiducals3 = new BlindsFeederTestFiducials(380,100, 300,100, 300,165);
+
+        //Create first blinds feeder and set and check its location
+        BlindsFeeder blindsFeeder1 = new BlindsFeeder();
+        machine.addFeeder(blindsFeeder1);
+
+        blindsFeeder1.setFiducial1Location(feederFiducals1.fiducial1);
+        blindsFeeder1.setFiducial2Location(feederFiducals1.fiducial2);
+        blindsFeeder1.setFiducial3Location(feederFiducals1.fiducial3);
+
+        assert(blindsFeeder1.getFiducial1Location().equals(feederFiducals1.fiducial1));
+        assert(blindsFeeder1.getFiducial2Location().equals(feederFiducals1.fiducial2));
+        assert(blindsFeeder1.getFiducial3Location().equals(feederFiducals1.fiducial3));
+        
+        assert(blindsFeeder1.getFeedersTotal() == 1);
+
+        //Create a new feeder and connect it using fiducial 1 only
+        BlindsFeeder blindsFeeder2 = new BlindsFeeder();
+        machine.addFeeder(blindsFeeder2);
+
+        blindsFeeder2.setFiducial1Location(feederFiducals1.fiducial1);
+        
+        //Check all fiducials match
+        assert(blindsFeeder2.getFiducial1Location().equals(feederFiducals1.fiducial1));
+        assert(blindsFeeder2.getFiducial2Location().equals(feederFiducals1.fiducial2));
+        assert(blindsFeeder2.getFiducial3Location().equals(feederFiducals1.fiducial3));
+        
+        //Check the two feeders are connected in both directions
+        assert(blindsFeeder1.getConnectedFeeders().contains(blindsFeeder2));
+        assert(blindsFeeder2.getConnectedFeeders().contains(blindsFeeder1));
+
+        assert(blindsFeeder1.getFeedersTotal() == 2);
+
+        //Create a new feeder at a different location
+        BlindsFeeder blindsFeeder3 = new BlindsFeeder();
+        machine.addFeeder(blindsFeeder3);
+
+        //Set the feeder 3 first fiducial to location 2
+        blindsFeeder3.setFiducial1Location(feederFiducals2.fiducial1);
+        
+        //Check feeder 3 is not connected to feeder 1/2
+        assert(!blindsFeeder1.getConnectedFeeders().contains(blindsFeeder3));
+        assert(!blindsFeeder3.getConnectedFeeders().contains(blindsFeeder1));
+
+        //Check the count of connected feeders
+        assert(blindsFeeder1.getFeedersTotal() == 2);
+        assert(blindsFeeder3.getFeedersTotal() == 1);
+
+        //Set fiducials 2&3 and check connected feeders again.
+        blindsFeeder3.setFiducial2Location(feederFiducals2.fiducial2);
+        blindsFeeder3.setFiducial3Location(feederFiducals2.fiducial3);
+ 
+        assert(!blindsFeeder1.getConnectedFeeders().contains(blindsFeeder3));
+        assert(!blindsFeeder3.getConnectedFeeders().contains(blindsFeeder1));
+
+        final double pocketSizeMm = 2.8;
+        final double pocketPositionMm = -1.0;
+        final double pocketPitchMm = 4.0;
+        final double pocketCenterline1Mm = 9.0;
+        final double pocketCenterline2Mm = 19.0;
+
+        //Set feeder1 to first position
+        blindsFeeder1.setPocketCenterline(new Length(pocketCenterline1Mm, LengthUnit.Millimeters));
+        blindsFeeder1.setPocketPitch(new Length(pocketPitchMm, LengthUnit.Millimeters));
+        blindsFeeder1.setPocketSize(new Length(pocketSizeMm, LengthUnit.Millimeters));
+
+        assert(blindsFeeder1.getFeederNo() == 2);
+        assert(blindsFeeder2.getFeederNo() == 1);
+        
+        //Set feeder2 to second position
+        blindsFeeder2.setPocketCenterline(new Length(pocketCenterline2Mm, LengthUnit.Millimeters));
+        blindsFeeder2.setPocketPitch(new Length(pocketPitchMm, LengthUnit.Millimeters));
+        blindsFeeder2.setPocketSize(new Length(pocketSizeMm, LengthUnit.Millimeters));
+
+        assert(blindsFeeder1.getFeederNo() == 1);
+        assert(blindsFeeder2.getFeederNo() == 2);
+        
+        assert(blindsFeeder1.getConnectedFeeders().contains(blindsFeeder2));
+        assert(blindsFeeder2.getConnectedFeeders().contains(blindsFeeder1));
+
+        //Check before moving that feeder 1/2 fiducials are at location 1
+        assert(blindsFeeder1.getFiducial1Location().equals(feederFiducals1.fiducial1));
+        assert(blindsFeeder1.getFiducial2Location().equals(feederFiducals1.fiducial2));
+        assert(blindsFeeder1.getFiducial3Location().equals(feederFiducals1.fiducial3));        
+        assert(blindsFeeder2.getFiducial1Location().equals(feederFiducals1.fiducial1));
+        assert(blindsFeeder2.getFiducial2Location().equals(feederFiducals1.fiducial2));
+        assert(blindsFeeder2.getFiducial3Location().equals(feederFiducals1.fiducial3));
+        
+        // Change feeder 1 fiducial 1 to location 3 and check all connected feeders are moved
+        blindsFeeder1.setFiducial1Location(feederFiducals3.fiducial1);
+        
+        assert(blindsFeeder1.getFiducial1Location().equals(feederFiducals3.fiducial1));
+        assert(blindsFeeder1.getFiducial2Location().equals(feederFiducals3.fiducial2));
+        assert(blindsFeeder1.getFiducial3Location().equals(feederFiducals3.fiducial3));
+
+        assert(blindsFeeder2.getFiducial1Location().equals(feederFiducals3.fiducial1));
+        assert(blindsFeeder2.getFiducial2Location().equals(feederFiducals3.fiducial2));
+        assert(blindsFeeder2.getFiducial3Location().equals(feederFiducals3.fiducial3));
+        
+        assert(blindsFeeder1.getConnectedFeeders().contains(blindsFeeder2));
+        assert(blindsFeeder2.getConnectedFeeders().contains(blindsFeeder1));
+    }
+    
+    @Test
+    public void testBlindsFeederGroups() throws Exception {
+        Machine machine = Configuration.get().getMachine();
+        List<Feeder> feeders = machine.getFeeders();
+        
+        BlindsFeederTestFiducials feederFiducals1 = new BlindsFeederTestFiducials(180,100, 100,100, 100,165);
+        BlindsFeederTestFiducials feederFiducals2 = new BlindsFeederTestFiducials(280,100, 200,100, 200,165);
+        
+        BlindsFeeder blindsFeeder1 = new BlindsFeeder();
+        machine.addFeeder(blindsFeeder1);
+        blindsFeeder1.setFiducial1Location(feederFiducals1.fiducial1);
+        blindsFeeder1.setFiducial2Location(feederFiducals1.fiducial2);
+        blindsFeeder1.setFiducial3Location(feederFiducals1.fiducial3);
+        
+        assert(blindsFeeder1.getFeederGroupName().equals(BlindsFeeder.defaultGroupName)); 
+        
+        BlindsFeeder blindsFeeder2 = new BlindsFeeder();
+        machine.addFeeder(blindsFeeder2);
+        blindsFeeder2.setFiducial1Location(feederFiducals1.fiducial1);
+        
+        //Check feeders are connected
+        assert(blindsFeeder1.getConnectedFeeders().contains(blindsFeeder2));
+        assert(blindsFeeder2.getConnectedFeeders().contains(blindsFeeder1));
+
+        //Change group name of feeder1, check feeder 2 at same location also changes group name
+        blindsFeeder1.setFeederGroupName("BlindsFeederTestGroup1");        
+        assert(blindsFeeder2.getFeederGroupName().equals(blindsFeeder1.getFeederGroupName()));
+        
+        //Check feeders are connected
+        assert(blindsFeeder1.getConnectedFeeders().contains(blindsFeeder2));
+        assert(blindsFeeder2.getConnectedFeeders().contains(blindsFeeder1));
+        
+        //Create a new feeder at the same location but with default group name
+        BlindsFeeder blindsFeeder3 = new BlindsFeeder();
+        machine.addFeeder(blindsFeeder3);
+
+        //Set the first fiducial and check the others are not set and it is not in the same group
+        blindsFeeder3.setFiducial1Location(feederFiducals1.fiducial1);
+        //Check it is not connected to the other feeders at the same location
+        assert(!blindsFeeder3.getConnectedFeeders().contains(blindsFeeder1));
+        //And the previous named feeders don't connect to it
+        assert(!blindsFeeder1.getConnectedFeeders().contains(blindsFeeder3));
+
+        //Check again that the first two feeders are still connected
+        assert(blindsFeeder1.getConnectedFeeders().contains(blindsFeeder2));
+        assert(blindsFeeder2.getConnectedFeeders().contains(blindsFeeder1));
+        
+        //Set the remaining fiducials to the same location and check again that it is not part of the named group
+        assert(!blindsFeeder3.getFiducial2Location().equals(feederFiducals1.fiducial2));
+        assert(!blindsFeeder3.getFiducial3Location().equals(feederFiducals1.fiducial3));
+        assert(!blindsFeeder3.getConnectedFeeders().contains(blindsFeeder1));
+        assert(!blindsFeeder1.getConnectedFeeders().contains(blindsFeeder3));
+
+        //Set remaining fiducials and check again
+        blindsFeeder3.setFiducial2Location(feederFiducals1.fiducial2);
+        blindsFeeder3.setFiducial3Location(feederFiducals1.fiducial3);
+        assert(!blindsFeeder3.getConnectedFeeders().contains(blindsFeeder1));
+        assert(!blindsFeeder1.getConnectedFeeders().contains(blindsFeeder3));
+
+        //Move feeder 3 to second fiducials and check that it has moved and that the non connected have not.
+        blindsFeeder3.setFiducial1Location(feederFiducals2.fiducial1);
+        blindsFeeder3.setFiducial2Location(feederFiducals2.fiducial2);
+        blindsFeeder3.setFiducial3Location(feederFiducals2.fiducial3);
+        
+        assert(!blindsFeeder1.getFiducial1Location().equals(feederFiducals2.fiducial1));
+        assert(!blindsFeeder1.getFiducial2Location().equals(feederFiducals2.fiducial2));
+        assert(!blindsFeeder1.getFiducial3Location().equals(feederFiducals2.fiducial3));
+
+        assert(!blindsFeeder2.getFiducial1Location().equals(feederFiducals2.fiducial1));
+        assert(!blindsFeeder2.getFiducial2Location().equals(feederFiducals2.fiducial2));
+        assert(!blindsFeeder2.getFiducial3Location().equals(feederFiducals2.fiducial3));
+
+        assert(blindsFeeder3.getFiducial1Location().equals(feederFiducals2.fiducial1));
+        assert(blindsFeeder3.getFiducial2Location().equals(feederFiducals2.fiducial2));
+        assert(blindsFeeder3.getFiducial3Location().equals(feederFiducals2.fiducial3));
+        
+        assert(!blindsFeeder3.getConnectedFeeders().contains(blindsFeeder1));
+        assert(!blindsFeeder1.getConnectedFeeders().contains(blindsFeeder3));
+
+//        //Create a new feeder at the first location with default group name
+//        BlindsFeeder blindsFeeder4 = new BlindsFeeder();
+//        machine.addFeeder(blindsFeeder4);
+//        
+//        //Set group name with default location.
+//        blindsFeeder4.setFeederGroupName("BlindsFeederTestGroup1");
+//        assert(blindsFeeder4.getConnectedFeeders().contains(blindsFeeder1));
+//        assert(blindsFeeder1.getConnectedFeeders().contains(blindsFeeder4));
+
+
+    }
+    
+
+}

--- a/src/test/java/BlindsFeederTest.java
+++ b/src/test/java/BlindsFeederTest.java
@@ -60,6 +60,8 @@ public class BlindsFeederTest {
         BlindsFeederTestFiducials feederFiducals2 = new BlindsFeederTestFiducials(280,100, 200,100, 200,165);
         BlindsFeederTestFiducials feederFiducals3 = new BlindsFeederTestFiducials(380,100, 300,100, 300,165);
 
+        //********************************************************************************************//
+        //Test creating a new feeder
         //Create first blinds feeder and set and check its location
         BlindsFeeder blindsFeeder1 = new BlindsFeeder();
         machine.addFeeder(blindsFeeder1);
@@ -74,7 +76,9 @@ public class BlindsFeederTest {
         
         assert(blindsFeeder1.getFeedersTotal() == 1);
 
-        //Create a new feeder and connect it using fiducial 1 only
+        
+        //********************************************************************************************//
+        //Test creating another feeder and connect it in the same location using fiducial 1 only
         BlindsFeeder blindsFeeder2 = new BlindsFeeder();
         machine.addFeeder(blindsFeeder2);
 
@@ -91,7 +95,8 @@ public class BlindsFeederTest {
 
         assert(blindsFeeder1.getFeedersTotal() == 2);
 
-        //Create a new feeder at a different location
+        //********************************************************************************************//
+        //Test creating a feeder at a different location and that it does not connect to the othres
         BlindsFeeder blindsFeeder3 = new BlindsFeeder();
         machine.addFeeder(blindsFeeder3);
 
@@ -113,6 +118,8 @@ public class BlindsFeederTest {
         assert(!blindsFeeder1.getConnectedFeeders().contains(blindsFeeder3));
         assert(!blindsFeeder3.getConnectedFeeders().contains(blindsFeeder1));
 
+        //********************************************************************************************//
+        //Test setting feeder pockets
         final double pocketSizeMm = 2.8;
         final double pocketPositionMm = -1.0;
         final double pocketPitchMm = 4.0;
@@ -138,7 +145,10 @@ public class BlindsFeederTest {
         assert(blindsFeeder1.getConnectedFeeders().contains(blindsFeeder2));
         assert(blindsFeeder2.getConnectedFeeders().contains(blindsFeeder1));
 
-        //Check before moving that feeder 1/2 fiducials are at location 1
+        //********************************************************************************************//
+        //Test moving connected feeder fiducial 1 results in fiducials for conencted feeder moving relatively
+        
+        //Check before moving that feeder 1|2 fiducials are at location 1
         assert(blindsFeeder1.getFiducial1Location().equals(feederFiducals1.fiducial1));
         assert(blindsFeeder1.getFiducial2Location().equals(feederFiducals1.fiducial2));
         assert(blindsFeeder1.getFiducial3Location().equals(feederFiducals1.fiducial3));        
@@ -168,6 +178,7 @@ public class BlindsFeederTest {
         
         BlindsFeederTestFiducials feederFiducals1 = new BlindsFeederTestFiducials(180,100, 100,100, 100,165);
         BlindsFeederTestFiducials feederFiducals2 = new BlindsFeederTestFiducials(280,100, 200,100, 200,165);
+        BlindsFeederTestFiducials feederFiducals3 = new BlindsFeederTestFiducials(380,100, 300,100, 300,165);
         
         BlindsFeeder blindsFeeder1 = new BlindsFeeder();
         machine.addFeeder(blindsFeeder1);
@@ -186,7 +197,8 @@ public class BlindsFeederTest {
         assert(blindsFeeder2.getConnectedFeeders().contains(blindsFeeder1));
 
         //Change group name of feeder1, check feeder 2 at same location also changes group name
-        blindsFeeder1.setFeederGroupName("BlindsFeederTestGroup1");        
+        blindsFeeder1.setFeederGroupName("BlindsFeederTestGroup1");
+        assert(blindsFeeder1.getFeederGroupName().equals("BlindsFeederTestGroup1"));
         assert(blindsFeeder2.getFeederGroupName().equals(blindsFeeder1.getFeederGroupName()));
         
         //Check feeders are connected
@@ -225,10 +237,6 @@ public class BlindsFeederTest {
         blindsFeeder3.setFiducial2Location(feederFiducals2.fiducial2);
         blindsFeeder3.setFiducial3Location(feederFiducals2.fiducial3);
         
-        assert(!blindsFeeder1.getFiducial1Location().equals(feederFiducals2.fiducial1));
-        assert(!blindsFeeder1.getFiducial2Location().equals(feederFiducals2.fiducial2));
-        assert(!blindsFeeder1.getFiducial3Location().equals(feederFiducals2.fiducial3));
-
         assert(!blindsFeeder2.getFiducial1Location().equals(feederFiducals2.fiducial1));
         assert(!blindsFeeder2.getFiducial2Location().equals(feederFiducals2.fiducial2));
         assert(!blindsFeeder2.getFiducial3Location().equals(feederFiducals2.fiducial3));
@@ -240,15 +248,100 @@ public class BlindsFeederTest {
         assert(!blindsFeeder3.getConnectedFeeders().contains(blindsFeeder1));
         assert(!blindsFeeder1.getConnectedFeeders().contains(blindsFeeder3));
 
-//        //Create a new feeder at the first location with default group name
-//        BlindsFeeder blindsFeeder4 = new BlindsFeeder();
-//        machine.addFeeder(blindsFeeder4);
-//        
-//        //Set group name with default location.
-//        blindsFeeder4.setFeederGroupName("BlindsFeederTestGroup1");
-//        assert(blindsFeeder4.getConnectedFeeders().contains(blindsFeeder1));
-//        assert(blindsFeeder1.getConnectedFeeders().contains(blindsFeeder4));
+        //********************************************************************************************//
+        //Test assigning an existing group to a feeder at default location.
+        
+        //Create a new feeder at the first location with default group name
+        BlindsFeeder blindsFeeder4 = new BlindsFeeder();
+        machine.addFeeder(blindsFeeder4);
+        
+        //Set group name with default location to existing group
+        blindsFeeder4.setFeederGroupName("BlindsFeederTestGroup1");
+        
+        //Check it is connected to the group and has the expected fiducials
+        assert(blindsFeeder4.getConnectedFeeders().contains(blindsFeeder1));
+        assert(blindsFeeder1.getConnectedFeeders().contains(blindsFeeder4));
+        assert(blindsFeeder4.getFiducial1Location().equals(blindsFeeder1.getFiducial1Location()));
+        assert(blindsFeeder4.getFiducial2Location().equals(blindsFeeder1.getFiducial2Location()));
+        assert(blindsFeeder4.getFiducial3Location().equals(blindsFeeder1.getFiducial3Location()));
+        
+        //********************************************************************************************//
+        //Test assigning an existing group to a placed feeder that has no connected feeders.
+        //Create a new feeder at the third location
+        BlindsFeeder blindsFeeder5 = new BlindsFeeder();
+        machine.addFeeder(blindsFeeder5);
+        
+        blindsFeeder5.setFiducial1Location(feederFiducals3.fiducial1);
+        blindsFeeder5.setFiducial2Location(feederFiducals3.fiducial2);
+        blindsFeeder5.setFiducial3Location(feederFiducals3.fiducial3);
+        
+        //Set group name with default location to existing group
+        blindsFeeder5.setFeederGroupName("BlindsFeederTestGroup1");
+        assert(blindsFeeder5.getConnectedFeeders().contains(blindsFeeder1));
+        assert(blindsFeeder1.getConnectedFeeders().contains(blindsFeeder5));
+        assert(blindsFeeder5.getFiducial1Location().equals(blindsFeeder1.getFiducial1Location()));
+        assert(blindsFeeder5.getFiducial2Location().equals(blindsFeeder1.getFiducial2Location()));
+        assert(blindsFeeder5.getFiducial3Location().equals(blindsFeeder1.getFiducial3Location()));
 
+        //********************************************************************************************//
+        //Test assigning an existing group to a placed feeder with a non default name that has no connected feeders.
+        //Create a new feeder at the third location
+        BlindsFeeder blindsFeeder6 = new BlindsFeeder();
+        machine.addFeeder(blindsFeeder6);
+        
+        blindsFeeder6.setFiducial1Location(feederFiducals3.fiducial1);
+        blindsFeeder6.setFiducial2Location(feederFiducals3.fiducial2);
+        blindsFeeder6.setFiducial3Location(feederFiducals3.fiducial3);
+
+        blindsFeeder6.setFeederGroupName("BlindsFeederTemporaryTestGroup");
+        assert(blindsFeeder6.getFeederGroupName().equals("BlindsFeederTemporaryTestGroup"));
+        assert(blindsFeeder6.getConnectedFeeders().size() == 1);
+        
+        //Set group name with default location to existing group
+        blindsFeeder6.setFeederGroupName("BlindsFeederTestGroup1");
+        assert(blindsFeeder6.getConnectedFeeders().contains(blindsFeeder1));
+        assert(blindsFeeder1.getConnectedFeeders().contains(blindsFeeder6));
+        assert(blindsFeeder6.getFiducial1Location().equals(blindsFeeder1.getFiducial1Location()));
+        assert(blindsFeeder6.getFiducial2Location().equals(blindsFeeder1.getFiducial2Location()));
+        assert(blindsFeeder6.getFiducial3Location().equals(blindsFeeder1.getFiducial3Location()));
+
+        //********************************************************************************************//
+        //Test that a group of more than one named feeders will not join to another group at  the same location
+        BlindsFeeder blindsFeeder7 = new BlindsFeeder();
+        machine.addFeeder(blindsFeeder7);
+        BlindsFeeder blindsFeeder8 = new BlindsFeeder();
+        machine.addFeeder(blindsFeeder8);
+
+        blindsFeeder7.setFiducial1Location(feederFiducals2.fiducial1);
+        blindsFeeder7.setFiducial2Location(feederFiducals2.fiducial2);
+        blindsFeeder7.setFiducial3Location(feederFiducals2.fiducial3);
+        
+        blindsFeeder7.setFeederGroupName("BlindsFeederTestGroup2");
+        blindsFeeder8.setFeederGroupName("BlindsFeederTestGroup2");
+        
+        assert(blindsFeeder7.getConnectedFeeders().contains(blindsFeeder8));
+        assert(blindsFeeder8.getConnectedFeeders().contains(blindsFeeder7));
+        assert(blindsFeeder7.getFeederGroupName().contentEquals("BlindsFeederTestGroup2"));
+
+        assert(blindsFeeder7.getFiducial1Location().equals(feederFiducals2.fiducial1));
+        assert(blindsFeeder7.getFiducial2Location().equals(feederFiducals2.fiducial2));
+        assert(blindsFeeder7.getFiducial3Location().equals(feederFiducals2.fiducial3));
+        
+        //Try setting this feeder group name to the name of a different group.  Check that this is blocked.
+        blindsFeeder7.setFeederGroupName("BlindsFeederTestGroup1");
+        assert(!blindsFeeder7.getFeederGroupName().contentEquals("BlindsFeederTestGroup1"));
+        assert(!blindsFeeder7.getFeederGroupName().contentEquals("BlindsFeederTestGroup1"));
+        
+
+        //********************************************************************************************//
+        ///Test that a group of more than one named feeders will not join to another group at different location
+        blindsFeeder7.setFiducial1Location(feederFiducals3.fiducial1);
+        blindsFeeder7.setFiducial2Location(feederFiducals3.fiducial2);
+        blindsFeeder7.setFiducial3Location(feederFiducals3.fiducial3);
+
+        blindsFeeder7.setFeederGroupName("BlindsFeederTestGroup1");
+        assert(!blindsFeeder7.getFeederGroupName().contentEquals("BlindsFeederTestGroup1"));
+        assert(!blindsFeeder7.getFeederGroupName().contentEquals("BlindsFeederTestGroup1"));
 
     }
     


### PR DESCRIPTION
# Description
Named group option for BlindsFeeder which acts in addition to fiducial location to determine connected feeders.

# Justification
If multiple tiles of Blindfeeders are used in the same physical location for different jobs/builds the feeders configuration will be confused.
This benefits everyone using BlindsFeeders a significant amount.  Default behavior is by location.

# Instructions for Use

- In the BlindsFeeder tape settings there is a new editable combo box. Either choose an existing group name or enter a new one to override location based grouping.
- Leave the group name as "Default" to get the normal location based behavior.
- Entering an existing group name for a feeder with default fiducial locations or a feeder with no other connected feeders will join it to that group and give it the correct fiducials.
- Each group name can only be used for a single, co-located feeder group. Entering an existing group name for a group of more than one feeders will be rejected.
- A future suggestion for arranging multiple feeder groups on a common tile is TileName:FeederGroupName.  Please do not use the colon delimiter.
- Setting fiducial1 to the same location as an existing group will not automatically join it with the group.  This protects the name group from having uncontrolled feeders join it from co-located feeder groups.
- Renaming a feeder in a group will rename all of the connected feeders.  It will not separate that feeder from the others.
- Some keywords are treated as default.  These include Location, default, none and "".  Entering any of the location keywords results in reset back to "Default"
- A single feeder can leave a group and be assigned back to "Default".  Any feeders connected to it will be disconnected.

# Implementation Details
1. How did you test the change?
Created BlindsFeederTest which performs a series of  BlindsFeeder behavior tests.  The expected fiducials, group name, feeder number and connected feeders are checked for all feeders at every step. 

Basic behavior test including:
  1. Create feeders, set fiducials and check
  2. Connect second feeders using fiducial1
  2. Create third feeder at another location and check that it does not connect to the previous group
  3. Test setting feeder pocket locations operates as expected
  4. Test moving feeder1 to check that conencted feeder2 moves with it.

and a set of group naming tests

1. Create a feeder, set fiducials and change its group name
2. Check that a second feeder set with the same fiducial1 does not join until its group name is set correctly.
3. Check that a feeder at null location can join a group and have its fiducials set correctly
4. Check that a feeder at defined location but no other connected feeders can join a group and be moved to the correct fiducials
5. Check that a group of more than one feeder can't be assigned another existing group name, either at the same or a different location.

Additional tests:
- Feeder group names are persistent through machine.xml
- Feeder group name dropdown contains all of the used feeder group names. Removing all isntances of a group name results in it being excluded from this list when the feeder configuration view is refreshed.


2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)?  Yes?
3. No changes to `org.openpnp.spi` or `org.openpnp.model` packages 
4. `mvn test` run and passed