### PR TITLE
Fix/Part Recycling Feature should use Nozzle.moveToPickLocation()

### DIFF
--- a/src/main/java/org/openpnp/gui/JogControlsPanel.java
+++ b/src/main/java/org/openpnp/gui/JogControlsPanel.java
@@ -443,7 +443,7 @@ public class JogControlsPanel extends JPanel {
         panelSpecial.add(btnDiscard);
 
         JButton btnRecycle = new JButton(recycleAction);
-        btnRecycle.setEnabled(false);
+        recycleAction.setEnabled(false);
         btnRecycle.setToolTipText(Translations.getString("JogControlsPanel.btnRecycle.toolTipText")); //$NON-NLS-1$
         btnRecycle.setText(Translations.getString("JogControlsPanel.btnRecycle.text")); //$NON-NLS-1$
         panelSpecial.add(btnRecycle);

--- a/src/main/java/org/openpnp/machine/reference/camera/SimulatedUpCamera.java
+++ b/src/main/java/org/openpnp/machine/reference/camera/SimulatedUpCamera.java
@@ -9,10 +9,9 @@ import java.awt.geom.AffineTransform;
 import java.awt.geom.Ellipse2D;
 import java.awt.geom.Rectangle2D;
 import java.awt.image.BufferedImage;
-import java.util.ConcurrentModificationException;
 import java.awt.image.ConvolveOp;
 import java.awt.image.Kernel;
-import java.util.List;
+import java.util.ConcurrentModificationException;
 
 import org.openpnp.gui.support.Wizard;
 import org.openpnp.machine.reference.ReferenceCamera;
@@ -84,19 +83,21 @@ public class SimulatedUpCamera extends ReferenceCamera {
         // determine if there are any nozzles within our bounds and if so render them
         Machine machine = Configuration.get()
                 .getMachine();
-        try {
-            for (Head head :  machine.getHeads()) {
-                for (Nozzle nozzle : head.getNozzles()) {
-                    Location l = SimulationModeMachine.getSimulatedPhysicalLocation(nozzle, getLooking());
-                    if (phyBounds.contains(l.getX(), l.getY())) {
-                        drawNozzle(g, nozzle, l);
+        if (machine != null) {
+            try {
+                for (Head head :  machine.getHeads()) {
+                    for (Nozzle nozzle : head.getNozzles()) {
+                        Location l = SimulationModeMachine.getSimulatedPhysicalLocation(nozzle, getLooking());
+                        if (phyBounds.contains(l.getX(), l.getY())) {
+                            drawNozzle(g, nozzle, l);
+                        }
                     }
                 }
             }
-        }
-        catch (ConcurrentModificationException e) {
-            // If nozzles are added/removed while enumerating them here, a ConcurrentModificationExceptions 
-            // is thrown. This is not so unlikely when this camera has high fps. 
+            catch (ConcurrentModificationException e) {
+                // If nozzles are added/removed while enumerating them here, a ConcurrentModificationExceptions 
+                // is thrown. This is not so unlikely when this camera has high fps. 
+            }
         }
 
         g.setTransform(tx);

--- a/src/main/java/org/openpnp/machine/reference/feeder/AdvancedLoosePartFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/AdvancedLoosePartFeeder.java
@@ -175,8 +175,7 @@ public class AdvancedLoosePartFeeder extends ReferenceFeeder {
         }
 
         // ok, now put the part back on the location of the last pick
-        Location putLocation = getPickLocation();
-        MovableUtils.moveToLocationAtSafeZ(nozzle, putLocation);
+        nozzle.moveToPickLocation(this);
         nozzle.place();
         nozzle.moveToSafeZ();
         if (nozzle.isPartOffEnabled(Nozzle.PartOffStep.AfterPlace) && !nozzle.isPartOff()) {

--- a/src/main/java/org/openpnp/machine/reference/feeder/BlindsFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/BlindsFeeder.java
@@ -370,15 +370,16 @@ public class BlindsFeeder extends ReferenceFeeder {
             throw new UnsupportedOperationException("Feeder: " + getName() + " - Currently no free slot. Can not take back the part.");
         }
 
-        // if not yet open, open it
-        if (isCoverClosed()) {
+        // if not yet open, open it (this should rarely be necessary as we likely just picked the part from this feeder;
+        // however if cover opening is needed, it will only work if the machine has multiple nozzles and one is free, 
+        // as cover opening is forbidden, when a part is on he nozzle). 
+        if (!isCoverOpen()) {
             // repeat last feed operation, so that the pickLocation is the last free spot 
             setFeedCount(getFeedCount() - 1); // is immediately increased during feed
             feed(nozzle);
         }
         // ok, now put the part back on the location of the last pick
-        Location putLocation = getPickLocation();
-        MovableUtils.moveToLocationAtSafeZ(nozzle, putLocation);
+        nozzle.moveToPickLocation(this);
         // put the part back
         nozzle.place();
         nozzle.moveToSafeZ();

--- a/src/main/java/org/openpnp/machine/reference/feeder/ReferenceLoosePartFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/ReferenceLoosePartFeeder.java
@@ -134,8 +134,7 @@ public class ReferenceLoosePartFeeder extends ReferenceFeeder {
         }
 
         // ok, now put the part back on the location of the last pick
-        Location putLocation = getPickLocation();
-        MovableUtils.moveToLocationAtSafeZ(nozzle, putLocation);
+        nozzle.moveToPickLocation(this);
         nozzle.place();
         nozzle.moveToSafeZ();
         if (nozzle.isPartOffEnabled(Nozzle.PartOffStep.AfterPlace) && !nozzle.isPartOff()) {

--- a/src/main/java/org/openpnp/machine/reference/feeder/ReferenceRotatedTrayFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/ReferenceRotatedTrayFeeder.java
@@ -29,7 +29,6 @@ import org.openpnp.model.LengthUnit;
 import org.openpnp.model.Location;
 import org.openpnp.spi.Nozzle;
 import org.openpnp.spi.PropertySheetHolder;
-import org.openpnp.util.MovableUtils;
 import org.pmw.tinylog.Logger;
 import org.simpleframework.xml.Attribute;
 import org.simpleframework.xml.Element;
@@ -158,8 +157,7 @@ public class ReferenceRotatedTrayFeeder extends ReferenceFeeder {
         }
 
         // ok, now put the part back on the location of the last pick
-        Location putLocation = getPickLocation();
-        MovableUtils.moveToLocationAtSafeZ(nozzle, putLocation);
+        nozzle.moveToPickLocation(this);
         nozzle.place();
         nozzle.moveToSafeZ();
         if (nozzle.isPartOffEnabled(Nozzle.PartOffStep.AfterPlace) && !nozzle.isPartOff()) {

--- a/src/main/java/org/openpnp/machine/reference/feeder/ReferenceStripFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/ReferenceStripFeeder.java
@@ -342,8 +342,7 @@ public class ReferenceStripFeeder extends ReferenceFeeder {
         }
         
         // ok, now put the part back on the location of the last pick
-        Location putLocation = getPickLocation();
-        MovableUtils.moveToLocationAtSafeZ(nozzle, putLocation);
+        nozzle.moveToPickLocation(this);
         // put the part back
         nozzle.place();
         nozzle.moveToSafeZ();

--- a/src/main/java/org/openpnp/machine/reference/feeder/ReferenceTrayFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/ReferenceTrayFeeder.java
@@ -30,7 +30,6 @@ import org.openpnp.model.LengthUnit;
 import org.openpnp.model.Location;
 import org.openpnp.spi.Nozzle;
 import org.openpnp.spi.PropertySheetHolder;
-import org.openpnp.util.MovableUtils;
 import org.pmw.tinylog.Logger;
 import org.simpleframework.xml.Attribute;
 import org.simpleframework.xml.Element;
@@ -128,8 +127,7 @@ public class ReferenceTrayFeeder extends ReferenceFeeder {
             feed(nozzle);
         }
         // ok, now put the part back on the location of the last pick
-        Location putLocation = getPickLocation();
-        MovableUtils.moveToLocationAtSafeZ(nozzle, putLocation);
+        nozzle.moveToPickLocation(this);
         nozzle.place();
         nozzle.moveToSafeZ();
         if (nozzle.isPartOffEnabled(Nozzle.PartOffStep.AfterPlace) && !nozzle.isPartOff()) {


### PR DESCRIPTION
# Description
* For the part on nozzle recycling feature, use the `Nozzle.moveToPickLocation()` method instead of `MovableUtils.moveToLocationAtSafeZ()`
* Fixed button/action enabling inconsistency bug.
* Fixed `BlindsFeeder` recycling logic error. 
* Fixed a `SimulatedUpCamera` race condition.

## Recycling Positioning Bug

This bug is due to @doppelgrau and myself having developed two features #1143/#1174 in parallel, i.e. my refactoring did not cover @doppelgrau's work that was not yet merged at the time. 

I was introducing the `Nozzle.moveToPickLocation(Feeder)` and `Nozzle.moveToPlacementLocation(Location, Part)` methods that should now always be used instead of the generic `MovableUtils.moveToLocationAtSafeZ()`. 

Why? This is done to support on-the-fly contact probing when you have a `ContactProbeNozzle`. So if the feeder and/or PCB Z is unknown or only set roughly, it will automatically probe it the first time it wants to pick or place. Similarly, it will also probe the part height where it is unknown (which is possible for the loose part feeders).

The two loose part feeder classes are special in that their components' height is above the stored Z of the feeder. I believe it has to be that way because they can have different parts with different heights in one feeder and the height is only determined once the vision has identified the part.

There is the method `Feeder.isPartHeightAbovePickLocation()` that tells the difference, and it is intended to be supported in more feeders in the future. 

The new `Nozzle.moveToPickLocation(Feeder)` and `Nozzle.moveToPlacementLocation(Location, Part)` methods know all about that and will account for the part height where needed and do the probing where necessary/possible.

So the main fix here is replacing the `MovableUtils.moveToLocationAtSafeZ(nozzle, putLocation)` with a `nozzle.moveToPickLocation(this)` in all the `takeBackPart()` overrides (where applicable).

## Recycling Button Enabling Bug

The original code disabled the _button_ after creation, then enabled the _action_ in the part-on-nozzle listener. This resulted in the button never being enabled on Windows. 

## BlindsFeeder Cover Actuation Logic Error

The recycling feature opens the cover when needed. It used `isCoverClosed()` instead of `!isCoverOpen()`. These are not logically the same: both methods return true only if the state is _positively_ known to be true, false otherwise. If the state is unknown, both methods return false. So the right question is to ask is "if not positively open". 

## SimulatedUpCamera Race Condition

Fixed a race condition that sometimes happens in unit testing. It occasionally seemed to pop up in Github action, I finally caught it on my machine. It seems the camera thread is sometimes faster than the configuration loading thread, so access to `Configuration.get().getMachine()` must be null-checked.

# Justification
See
https://groups.google.com/g/openpnp/c/izVmMvZJkTY/m/rXJDnB_qAQAJ

# Instructions for Use
No change. See #1143 for the original feature description.

# Implementation Details
1. Tested in simulation, analyzed the log.
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. Ran `mvn test` before submitting the Pull Request, that's where the (unrelated) `SimulatedUpCamera` bug popped up.
