### PR TITLE
Fix/Better GcodeDriver Configuration Error Diagnostics

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/driver/GcodeDriver.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/GcodeDriver.java
@@ -638,6 +638,9 @@ public class GcodeDriver extends AbstractReferenceDriver implements Named {
     @Override
     public void moveTo(HeadMountable hm, MoveToCommand move)
             throws Exception {
+        if (isUsingLetterVariables() && isSupportingPreMove()) {
+            throw new Exception(getName()+" configuration error: Cannot enable both Letter Variables and Allow Pre-Move Commands.");
+        }
         // Get the axes that are actually moving.
         AxesLocation movedAxesLocation = move.getMovedAxesLocation();
         AxesLocation allAxesLocation = move.getLocation1();
@@ -653,11 +656,17 @@ public class GcodeDriver extends AbstractReferenceDriver implements Named {
             if (movedAxesLocation.isEmpty()) {
                 return;
             }
-            throw new Exception(getName()+" MOVE_TO_COMMAND missing, please use Issues & Solutions to propose proper G-code commands.");
+            if (isSupportingPreMove()) {
+                throw new Exception(getName()+" MOVE_TO_COMMAND missing for "+hm.getClass().getSimpleName()+" "+hm.getName()
+                +", please set the command in the driver (no automatic support by Issues & Solutions due to driver Allow Pre-Move Commands option).");
+            }
+            else {
+                throw new Exception(getName()+" MOVE_TO_COMMAND missing, please use Issues & Solutions to propose proper G-code commands.");
+            }
         }
         if (hasVariable(command, "BacklashFeedRate")) {
             throw new Exception(getName()+" configuration upgrade needed: Please remove the extra backlash compensation move from your MOVE_TO_COMMAND. "
-                    +"Backlash compensation is now done outside of the drivers.");
+                    +"Backlash compensation is now done outside of the drivers and configured on the axes.");
         }
 
         command = substituteVariable(command, "Id", hm.getId());
@@ -1503,7 +1512,7 @@ public class GcodeDriver extends AbstractReferenceDriver implements Named {
 
         try {
             sendCommand("M115");
-            String firmware = receiveSingleResponse("^FIRMWARE.*");
+            String firmware = receiveSingleResponse("^.*FIRMWARE.*");
             if (firmware != null) {
                 setDetectedFirmware(firmware);
             }

--- a/src/main/java/org/openpnp/machine/reference/driver/GcodeDriverSolutions.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/GcodeDriverSolutions.java
@@ -379,7 +379,7 @@ public class GcodeDriverSolutions implements Solutions.Subject {
                     if (gcodeDriver.isSupportingPreMove()) {
                         solutions.add(new Solutions.Issue(
                                 gcodeDriver, 
-                                "Disallow Pre-Move Commands for advanced features. Accept or Dismiss to continue.", 
+                                "Disallow Pre-Move Commands for automatic G-code setup and other advanced features. Accept or Dismiss to continue.", 
                                 "Disable Allow Letter Pre-Move Commands.", 
                                 Severity.Fundamental,
                                 "https://github.com/openpnp/openpnp/wiki/Advanced-Motion-Control#migration-from-a-previous-version") {
@@ -394,7 +394,7 @@ public class GcodeDriverSolutions implements Solutions.Subject {
                     else if (!gcodeDriver.isUsingLetterVariables()) {
                         solutions.add(new Solutions.Issue(
                                 gcodeDriver, 
-                                "Use Axis Letter Variables for simpler use and advanced features.", 
+                                "Use Axis Letter Variables for simpler use, automatic G-code setup, and other advanced features.", 
                                 "Enable Letter Variables.", 
                                 Severity.Fundamental,
                                 "https://github.com/openpnp/openpnp/wiki/Advanced-Motion-Control#migration-from-a-previous-version") {


### PR DESCRIPTION
# Description
* Better error diagnostics for **Allow Pre-Move-Command** enabled drivers.
* More tolerant M115 firmware detection REGEX.

# Justification
See 
https://groups.google.com/g/openpnp/c/WxDSbj5KkGw/m/V-tjvT6pAQAJ

# Instructions for Use
Configurations errors will be (better) reported:

![grafik](https://user-images.githubusercontent.com/9963310/121721737-dfbd2000-cae4-11eb-8dcb-cdc40e022e11.png)

![grafik](https://user-images.githubusercontent.com/9963310/121721747-e2b81080-cae4-11eb-9173-ae14ada45d82.png)

See also the Wiki about **Allow Pre-Move-Command**:
https://github.com/openpnp/openpnp/wiki/GcodeAsyncDriver#gcodedriver-new-settings

# Implementation Details
1. Tested in simulation.
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. Successful `mvn test` before submitting the Pull Request. 
