### PR TITLE
Fix/Manual Nozzle Tip Change Motion

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/ReferenceNozzle.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceNozzle.java
@@ -33,6 +33,7 @@ import org.openpnp.spi.Actuator.ActuatorValueType;
 import org.openpnp.spi.Camera;
 import org.openpnp.spi.CoordinateAxis;
 import org.openpnp.spi.Feeder;
+import org.openpnp.spi.MotionPlanner.CompletionType;
 import org.openpnp.spi.Nozzle;
 import org.openpnp.spi.NozzleTip;
 import org.openpnp.spi.PropertySheetHolder;
@@ -609,6 +610,7 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
                     // can't automatically recalibrate with manual change - reset() for now
                     this.nozzleTip.getCalibration().reset(this);
                 }
+                waitForCompletion(CompletionType.WaitForStillstand);
                 throw new Exception("Manual NozzleTip "+nt.getName()+" load on Nozzle "+getName()+" required!");
             }
         }
@@ -697,6 +699,7 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
         ((ReferenceMachine) head.getMachine()).fireMachineHeadActivity(head);
 
         if (!changerEnabled) {
+            waitForCompletion(CompletionType.WaitForStillstand);
             throw new Exception("Manual NozzleTip "+nt.getName()+" unload from Nozzle "+getName()+" required!");
         }
 

--- a/src/main/java/org/openpnp/machine/reference/driver/AbstractMotionPlanner.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/AbstractMotionPlanner.java
@@ -627,6 +627,12 @@ public abstract class AbstractMotionPlanner extends AbstractModelObject implemen
     }
 
     @Override
+    public synchronized void clearQueuedMotion() {
+        // The motion commands are reset.
+        motionCommands = new LinkedList<>();
+    }
+
+    @Override
     public synchronized void clearMotionPlanOlderThan(double time) {
         while (motionPlan.isEmpty() == false && motionPlan.firstKey() < time) {
             motionPlan.remove(motionPlan.firstKey());

--- a/src/main/java/org/openpnp/spi/MotionPlanner.java
+++ b/src/main/java/org/openpnp/spi/MotionPlanner.java
@@ -23,8 +23,8 @@ package org.openpnp.spi;
 
 import org.openpnp.model.AxesLocation;
 import org.openpnp.model.Motion;
-import org.openpnp.model.Solutions;
 import org.openpnp.model.Motion.MotionOption;
+import org.openpnp.model.Solutions;
 
 /**
  * <p>
@@ -177,6 +177,11 @@ public interface MotionPlanner extends PropertySheetHolder, Solutions.Subject {
      * @throws Exception 
      */
     void waitForCompletion(HeadMountable hm, CompletionType completionType) throws Exception;
+    
+    /**
+     * Clear all queued motion. This should only be used when the machine task is aborted.
+     */
+    void clearQueuedMotion();
 
     /**
      * Get the planned motion at a certain time. Works into the future as far as planned and into the past

--- a/src/main/java/org/openpnp/spi/base/AbstractMachine.java
+++ b/src/main/java/org/openpnp/spi/base/AbstractMachine.java
@@ -558,6 +558,7 @@ public abstract class AbstractMachine extends AbstractModelObject implements Mac
 
                     // If there was an error cancel all pending tasks.
                     if (exception != null) {
+                        getMotionPlanner().clearQueuedMotion();
                         executor.shutdownNow();
                     }
 


### PR DESCRIPTION
# Description
When manual nozzle tip change is enabled, the user is prompted to load/unload a nozzle tip when needed. This is done by throwing an Exception, interrupting the current machine task and ultimately resulting in a message box being displayed: 

![Unload](https://user-images.githubusercontent.com/9963310/95016645-90207d80-0654-11eb-945c-88855120b8c6.png)

![Unload](https://user-images.githubusercontent.com/9963310/95016651-96165e80-0654-11eb-8863-cf1cc9ae24ce.png)

Bug: When the advanced motion planner is enabled, the move to the manual change location might only be queued and not yet be executed when the Exception is thrown. Instead, the motion commands remained in the queue and would unexpectedly be executed later. 

This PR fixes both problems: 

1. It waits for motion to complete, before throwing the Exception.
2. It clears queued commands from the planner, when the machine task/executor is aborted. Otherwise, these could unexpectedly be executed in the context of the next task.

Note: the second problem is more general and can happen in other exception throwing cases, if continuous planned motion is enabled and motion commands are queued up at the moment. The exception leading to the abortion of the commands happens after the `moveTo()` commands in question. So aborting these queued moves is more conservative than with the `NullPlanner`, where such motion would already have been executed. The whole motion sequence becomes _one transaction_, the pending moves are _rolled back_ on failure (a bit like in a relational database).

# Justification
See #1215 

# Instructions for Use
No change.

# Implementation Details
1. Problem number 2 was discovered earlier (in other ongoing development work), and the fix tested on the machine. Problem number 1 and 2 were also tested in simulation, both inside and outside jobs. The correct behavior was confirmed and also analyzed in the log. 
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. The `MotionPlanner` in `org.openpnp.spi` got the new method `clearQueuedMotion()` to clean up after aborting a task. 
4. Successful `mvn test` before submitting the Pull Request.
