### PR TITLE
Feature/Enhanced DetectCircularSymmetry Stage

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/ReferenceNozzleTipCalibration.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceNozzleTipCalibration.java
@@ -1049,7 +1049,7 @@ public class ReferenceNozzleTipCalibration extends AbstractModelObject {
         pipeline.setProperty("camera", camera);
         pipeline.setProperty("nozzleTip.diameter", getCalibrationTipDiameter());
         // Set the search tolerance to be somewhat larger than the threshold.
-        pipeline.setProperty("nozzleTip.tolerance", getOffsetThresholdLength().multiply(1 + detectionThresholdMargin));
+        pipeline.setProperty("nozzleTip.maxDistance", getOffsetThresholdLength().multiply(1 + detectionThresholdMargin));
         pipeline.setProperty("nozzleTip.center", measureLocation);
         Point maskCenter = VisionUtils.getLocationPixels(camera, measureLocation);
         pipeline.setProperty("MaskCircle.center", new org.opencv.core.Point(maskCenter.getX(), maskCenter.getY()));

--- a/src/main/java/org/openpnp/machine/reference/feeder/ReferencePushPullFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/ReferencePushPullFeeder.java
@@ -216,7 +216,7 @@ public class ReferencePushPullFeeder extends ReferenceFeeder {
     private double calibrationToleranceMm = 1.95;
     // vision and comparison sprocket hole tolerance (in size, position)
     @Attribute(required = false)
-    private double sprocketHoleToleranceMm = 0.3;
+    private double sprocketHoleToleranceMm = 0.4;
     // for rows of feeders, the tolerance in X, Y
     @Attribute(required = false)
     private double rowLocationToleranceMm = 4.0; 

--- a/src/main/java/org/openpnp/machine/reference/feeder/ReferencePushPullFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/ReferencePushPullFeeder.java
@@ -232,6 +232,10 @@ public class ReferencePushPullFeeder extends ReferenceFeeder {
     @Attribute(required = false)
     private int calibrateMinStatistic = 2; 
 
+    // Some EIA 481 standard constants.
+    static final double sprocketHoleDiameterMm = 1.5;
+    static final double sprocketHolePitchMm = 4;
+
     /*
      * visionOffset contains the difference between where the part was expected to be and where it
      * is. Subtracting these offsets from the pickLocation produces the correct pick location.
@@ -444,7 +448,7 @@ public class ReferencePushPullFeeder extends ReferenceFeeder {
 
     private void obtainCalibratedVisionOffset() throws Exception {
         Camera camera = getCamera();
-        try (CvPipeline pipeline = getCvPipeline(camera, true, false)) {
+        try (CvPipeline pipeline = getCvPipeline(camera, true, false, false)) {
             OcrWrongPartAction ocrAction = OcrWrongPartAction.None;
             boolean ocrStop = false;
             if (visionOffset == null) {
@@ -1128,7 +1132,7 @@ public class ReferencePushPullFeeder extends ReferenceFeeder {
         pipeline.setProperty("alphabet", ""); // empty alphabet switches OCR off
     }
 
-    public CvPipeline getCvPipeline(Camera camera, boolean clone, boolean performOcr) {
+    public CvPipeline getCvPipeline(Camera camera, boolean clone, boolean performOcr, boolean autoSetup) {
         try {
             CvPipeline pipeline = getPipeline();
             if (clone) {
@@ -1136,6 +1140,21 @@ public class ReferencePushPullFeeder extends ReferenceFeeder {
             }
             pipeline.setProperty("camera", camera);
             pipeline.setProperty("feeder", this);
+            pipeline.setProperty("sprocketHole.diameter", new Length(sprocketHoleDiameterMm, LengthUnit.Millimeters));
+            Length range;
+            if (autoSetup) { 
+                // Auto-Setup: search Range is half camera. 
+                range = camera.getWidth() > camera.getHeight() ? 
+                        camera.getUnitsPerPixel().getLengthY().multiply(camera.getHeight()/2)
+                        : camera.getUnitsPerPixel().getLengthX().multiply(camera.getWidth()/2);
+            }
+            else {
+                // Normal mode: search range is half the distance between the holes plus one pitch. 
+                range = getHole1Location().getLinearLengthTo(getHole2Location())
+                        .multiply(0.5)
+                        .add(new Length(sprocketHolePitchMm, LengthUnit.Millimeters));
+            }
+            pipeline.setProperty("sprocketHole.maxDistance", range);
             if (performOcr && getOcrRegion() != null) {
                 setupOcr(camera, pipeline);
             }
@@ -1359,8 +1378,6 @@ public class ReferencePushPullFeeder extends ReferenceFeeder {
                     calibratedPickLocation  = getLocation();
                 }
                 else {
-                    final double sprocketHoleDiameterMm = 1.5;
-                    final double sprocketHolePitchMm = 4;
                     final double partPitchMinMm = 2;
                     final double sprocketHoleToPartMinMm = 3.5; // sprocket hole to part @ 8mm
                     final double sprocketHoleToPartGridMm = 2;  // +multiples of 2mm for wider tapes 
@@ -1615,7 +1632,7 @@ public class ReferencePushPullFeeder extends ReferenceFeeder {
 
     public void showFeatures() throws Exception {
         Camera camera = getCamera();
-        try (CvPipeline pipeline = getCvPipeline(camera, true, true)) {
+        try (CvPipeline pipeline = getCvPipeline(camera, true, true, true)) {
 
             // Process vision and show feature without applying anything
             pipeline.process();
@@ -1634,7 +1651,7 @@ public class ReferencePushPullFeeder extends ReferenceFeeder {
             setCalibrationTrigger(CalibrationTrigger.UntilConfident);
         }
 
-        try (CvPipeline pipeline = getCvPipeline(camera, true, true)) {
+        try (CvPipeline pipeline = getCvPipeline(camera, true, true, true)) {
             // Process vision and get some features 
             pipeline.process();
             FindFeatures feature = new FindFeatures(camera, pipeline, 2000, FindFeaturesMode.FromPickLocationGetHoles)
@@ -2261,7 +2278,7 @@ public class ReferencePushPullFeeder extends ReferenceFeeder {
             throw new Exception("Feeder "+getName()+" has no OCR region defined.");
         }
         Camera camera = getCamera();
-        try (CvPipeline pipeline = getCvPipeline(camera, true, true)) {
+        try (CvPipeline pipeline = getCvPipeline(camera, true, true, false)) {
             // run a sprocket hole calibration, including OCR
             performVisionOperations(camera, pipeline, false, false, true, ocrAction, ocrStop, report); 
         }

--- a/src/main/java/org/openpnp/machine/reference/feeder/ReferenceStripFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/ReferenceStripFeeder.java
@@ -282,6 +282,9 @@ public class ReferenceStripFeeder extends ReferenceFeeder {
             pipeline.setProperty("DetectFixedCirclesHough.minDistance", pxMinDistance);
             pipeline.setProperty("DetectFixedCirclesHough.minDiameter", pxMinDiameter);
             pipeline.setProperty("DetectFixedCirclesHough.maxDiameter", pxMaxDiameter);
+            pipeline.setProperty("sprocketHole.diameter", getHoleDiameter());
+            // Search range is half-way to the next hole. 
+            pipeline.setProperty("sprocketHole.maxDistance", getHolePitch().multiply(0.5));
             pipeline.process();
     
             if (MainFrame.get() != null) {

--- a/src/main/java/org/openpnp/machine/reference/feeder/wizards/ReferencePushPullFeederConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/wizards/ReferencePushPullFeederConfigurationWizard.java
@@ -1032,7 +1032,7 @@ extends AbstractReferenceFeederConfigurationWizard {
 
     private void editPipeline() throws Exception {
         Camera camera = feeder.getCamera();
-        CvPipeline pipeline = feeder.getCvPipeline(camera, false, true, false);
+        CvPipeline pipeline = feeder.getCvPipeline(camera, false, true, true);
         CvPipelineEditor editor = new CvPipelineEditor(pipeline);
         JDialog dialog = new JDialog(MainFrame.get(), feeder.getName() + " Pipeline");
         dialog.getContentPane().setLayout(new BorderLayout());

--- a/src/main/java/org/openpnp/machine/reference/feeder/wizards/ReferencePushPullFeederConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/wizards/ReferencePushPullFeederConfigurationWizard.java
@@ -1032,7 +1032,7 @@ extends AbstractReferenceFeederConfigurationWizard {
 
     private void editPipeline() throws Exception {
         Camera camera = feeder.getCamera();
-        CvPipeline pipeline = feeder.getCvPipeline(camera, false, true);
+        CvPipeline pipeline = feeder.getCvPipeline(camera, false, true, false);
         CvPipelineEditor editor = new CvPipelineEditor(pipeline);
         JDialog dialog = new JDialog(MainFrame.get(), feeder.getName() + " Pipeline");
         dialog.getContentPane().setLayout(new BorderLayout());

--- a/src/main/java/org/openpnp/machine/reference/feeder/wizards/ReferenceStripFeederConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/wizards/ReferenceStripFeederConfigurationWizard.java
@@ -1005,6 +1005,12 @@ public class ReferenceStripFeederConfigurationWizard extends AbstractConfigurati
             pipeline.setProperty("DetectFixedCirclesHough.minDistance", pxMinDistance);
             pipeline.setProperty("DetectFixedCirclesHough.minDiameter", pxMinDiameter);
             pipeline.setProperty("DetectFixedCirclesHough.maxDiameter", pxMaxDiameter);
+            pipeline.setProperty("sprocketHole.diameter", feeder.getHoleDiameter());
+            // Search Range is half camera. 
+            Length range = camera.getWidth() > camera.getHeight() ? 
+                    camera.getUnitsPerPixel().getLengthY().multiply(camera.getHeight()/2)
+                    : camera.getUnitsPerPixel().getLengthX().multiply(camera.getWidth()/2);
+            pipeline.setProperty("sprocketHole.maxDistance", range);
             return pipeline;
         }
         catch (CloneNotSupportedException e) {

--- a/src/main/java/org/openpnp/vision/pipeline/stages/DetectCircularSymmetry.java
+++ b/src/main/java/org/openpnp/vision/pipeline/stages/DetectCircularSymmetry.java
@@ -20,6 +20,9 @@
 package org.openpnp.vision.pipeline.stages;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 
 import org.opencv.core.Mat;
@@ -32,6 +35,7 @@ import org.openpnp.vision.pipeline.CvPipeline;
 import org.openpnp.vision.pipeline.CvStage;
 import org.openpnp.vision.pipeline.Property;
 import org.openpnp.vision.pipeline.Stage;
+import org.pmw.tinylog.Logger;
 import org.simpleframework.xml.Attribute;
 
 /**
@@ -53,8 +57,17 @@ public class DetectCircularSymmetry extends CvStage {
     private int maxDistance = 100;
 
     @Attribute(required = false)
+    @Property(description = "Maximum number of targets to be found.")
+    private int maxTargetCount = 1;
+
+    @Attribute(required = false)
     @Property(description = "Minimum relative circular symmetry (overall pixel variance vs. circular pixel variance).")
     private double minSymmetry = 1.2;
+
+    @Attribute(required = false)
+    @Property(description = "Correlated minimum circular symmetry for multiple matches, i.e. other matches must have "
+            + "at least this relative symmetry. Must be in the interval [0,1]. ")
+    private double corrSymmetry = 0.0;
 
     @Attribute(required = false)
     @Property(description = "Property name as controlled by the vision operation using this pipeline.<br/>"
@@ -76,6 +89,11 @@ public class DetectCircularSymmetry extends CvStage {
             + "The subSampling value will automatically be reduced for small diameters. "
             + "Use BlurGaussian before this stage if subSampling suffers from moiré effects.")
     private int subSampling = 8;
+
+    @Attribute(required = false)
+    @Property(description = "The superSampling value can be used to achieve sub-pixel final precision: "
+            + "1 means no supersampling, 2 means half sub-pixel precision etc.")
+    private int superSampling = 1;
 
     @Attribute(required = false)
     @Property(description = "Overlay match map.")
@@ -121,6 +139,14 @@ public class DetectCircularSymmetry extends CvStage {
         this.subSampling = subSampling;
     }
 
+    public int getSuperSampling() {
+        return superSampling;
+    }
+
+    public void setSuperSampling(int superSampling) {
+        this.superSampling = superSampling;
+    }
+
     public boolean isDiagnostics() {
         return diagnostics;
     }
@@ -153,11 +179,27 @@ public class DetectCircularSymmetry extends CvStage {
         this.innerMargin = innerMargin;
     }
 
+    public int getMaxTargetCount() {
+        return maxTargetCount;
+    }
+
+    public void setMaxTargetCount(int maxTargetCount) {
+        this.maxTargetCount = maxTargetCount;
+    }
+
+    public double getCorrSymmetry() {
+        return corrSymmetry;
+    }
+
+    public void setCorrSymmetry(double corrSymmetry) {
+        this.corrSymmetry = corrSymmetry;
+    }
+
     @Override
     public Result process(CvPipeline pipeline) throws Exception {
         Camera camera = (Camera) pipeline.getProperty("camera");
         Mat mat = pipeline.getWorkingImage();
-        // Get overrinding properties, if any and convert to pixels.
+        // Get overriding properties, if any and convert to pixels.
         Length diameterByProperty = (Length) pipeline.getProperty(propertyName+".diameter");
         int minDiameter = this.minDiameter;
         int maxDiameter = this.maxDiameter;
@@ -177,248 +219,493 @@ public class DetectCircularSymmetry extends CvStage {
             center = VisionUtils.getLocationPixels(camera, centerByProperty);
         }
 
-        int effectiveSubSampling = Math.max(1, Math.min(subSampling, Math.min((maxDiameter-minDiameter)/4, minDiameter/3)));
         List<Result.Circle> circles = findCircularSymmetry(mat, (int)center.x, (int)center.y, 
-                maxDiameter, minDiameter, maxDistance*2, minSymmetry, effectiveSubSampling, diagnostics, new ScoreRange());
+                maxDiameter, minDiameter, maxDistance*2, maxTargetCount, minSymmetry, corrSymmetry, subSampling, superSampling, diagnostics, new ScoreRange());
         return new Result(null, circles);
     }
 
     public static class ScoreRange {
         public double minScore = Double.POSITIVE_INFINITY;
         public double maxScore = Double.NEGATIVE_INFINITY;
+        public double finalScore = Double.NEGATIVE_INFINITY;
         void add(double score) {
-            if (Double.isFinite(score)) {
+            if (score > 1) {
                 minScore = Math.min(minScore, score); 
                 maxScore = Math.max(maxScore, score);
+                finalScore = Math.max(finalScore, score);
             }
         }
     }
+
+    public static class SymmetryCircle extends CvStage.Result.Circle {
+        public SymmetryCircle(double x, double y, double diameter, double score) {
+            super(x, y, diameter);
+            this.score = score;
+        }
+
+        public double score;
+
+        public double getScore() {
+            return score;
+        }
+
+        public void setScore(double score) {
+            this.score = score;
+        }
+
+        @Override
+        public String toString() {
+            return "Circle [x=" + x + ", y=" + y + ", diameter=" + diameter + ", score="+ score + "]";
+        }
+    }
+
+    /**
+     * The detection will recurse into a local search with finer subSampling. A range of iterationRadius*subSampling 
+     * pixels around the preliminary best location will be searched.  
+     */
+    static final private int iterationRadius = 2;
+    /**
+     * The subSampling block size will be divided by iterationDivision when recursing into a local search. 
+     */
+    static final private int iterationDivision = 4;
+    /**
+     * Some extra debugging stuff used for development, that might be useful again in the future.  
+     */
+    static final boolean DEBUG = false;
 
     /**
      * Find the circle that has its center at the greatest circular symmetry in the given image,
      * indicating the largest contrast edge as its diameter.
      * 
-     * @param image
-     * @param xCenter
-     * @param yCenter
-     * @param maxDiameter
-     * @param diagnostics TODO
-     * @param tolerance
-     * @return
-     * @throws Exception 
+     * @param image             Image to be searched. If diagnostics are enabled, this image will be modified. 
+     * @param xCenter           Nominal X center of the search area inside the given image, in pixels.
+     * @param yCenter           Nominal Y center of the search area inside the given image, in pixels.
+     * @param maxDiameter       Maximum diameter of the examined circular symmetry area (pixels outside it are ignored).
+     * @param minDiameter       Minimum diameter of the examined circular symmetry area (pixels inside it are ignored).
+     * @param searchRange       Search range around the given center.
+     * @param maxTargetCount    Maximum number of wanted targets detected.
+     * @param minSymmetry       The minimum circular symmetry required to detect a match. This is the ratio of overall pixel
+     *                          variance divided by the circular pixel variance (sum of ring pixel variances). 
+     * @param corrSymmetry      Correlated minimum circular symmetry for multiple matches, i.e. other matches must have 
+     *                          at least this relative symmetry. Must be in the interval [0,1].
+     * @param subSampling       Sub-sampling pixel distance, i.e. only one pixel out of a square of size subSampling will be 
+     *                          examined on the first pass. 
+     * @param superSampling     Super-sampling pixel fraction, i.e. the result will have 1/superSampling sub-pixel accuracy.   
+     * @param diagnostics       If true, draws a diagnostic heat map, circle and cross hairs into the image. 
+     * @param scoreRange        Outputs the score range of all the sampled center candidates.
+     * @return                  A list of the the detected circles (currently only the best).
+     * @throws Exception
      */
     public static  List<Result.Circle> findCircularSymmetry(Mat image, int xCenter, int yCenter,
-            int maxDiameter, int minDiameter, int maxDistance, double minSymmetry, int subSampling, boolean diagnostics,
-            ScoreRange scoreRange) throws Exception {
+            int maxDiameter, int minDiameter, int searchRange, int maxTargetCount, 
+            double minSymmetry, double corrSymmetry, int subSampling,
+            int superSampling, boolean diagnostics, ScoreRange scoreRange) throws Exception {
+        // Image properties.
         final int channels = image.channels();
         final int width = image.cols();
         final int height = image.rows();
+        // Some sanity checks on the diameters.
         maxDiameter |= 1; // make it odd
         minDiameter = Math.max(3, minDiameter | 1);
-        final int tolerance = Math.min((xCenter-maxDiameter/2)-2, Math.min((width-xCenter-maxDiameter/2)-2,
+        // Effective subSampling may have to be finer if the searched circular edge is finer. 
+        final int subSamplingEff = Math.max(1, 
+                Math.min(subSampling, Math.min((maxDiameter-minDiameter)/4, minDiameter/2)));
+        // Constrain the search range to the image.
+        final int searchRangeEff = (Math.min((xCenter-maxDiameter/2)-2, Math.min((width-xCenter-maxDiameter/2)-2,
                 Math.min((yCenter-maxDiameter/2)-2, Math.min((height-yCenter-maxDiameter/2)-2, 
-                        maxDistance/2))))*2;
-        if (tolerance < maxDistance/5) {
+                        (searchRange+1)/2))))*2)
+                /subSamplingEff*subSamplingEff; // round to multiple of subSamplingEff
+        if (searchRangeEff < searchRange/5) {
             throw new Exception("Image too small for given parameters.");
         }
-        final int diameter = maxDiameter + tolerance;
-        final int xCrop = xCenter - diameter/2;
-        final int yCrop = yCenter - diameter/2;
-        // Get the pixels out of the Mat.
-        byte[] pixelSamples = new byte[diameter*width*channels]; 
-        image.get(yCrop, 0, pixelSamples);
+        // Derive some working variables. 
+        final int rSearch = searchRangeEff/2+1;
+        final int rSearchSq = rSearch*rSearch;
         int r = maxDiameter / 2;
         int r0 = minDiameter / 2 - 1;
-        final int ringSubSampling = Math.max(1, Math.min(subSampling, (maxDiameter-minDiameter)/8));
-        // Create the rings of circular symmetry as lists of indices into the flat array of pixels.
-        // The indices are relative to the origin but they can be offset to any x, y (within
-        // tolerance) and still remain valid, thanks to modulo properties.
-        Object[] ringsA = new Object[r + 1];
-        for (int ri = r0; ri < ringsA.length; ri += ringSubSampling) {
-            ringsA[ri] = new ArrayList<Integer>();
-        }
-        for (int y = -r, yi = 0; y <= r; y += ringSubSampling, yi += ringSubSampling) {
-            for (int x = -r, xi = 0, idx = yi * width * channels; 
-                    x <= r; 
-                    x += ringSubSampling, xi += ringSubSampling, idx += channels*ringSubSampling) {
-                int distanceSquare = x * x + y * y;
-                int distance = r0 + (-r0 + (int) Math.round(Math.sqrt(distanceSquare)))/ringSubSampling*ringSubSampling;
-                if (r0 <= distance && distance <= r) {
-                    ((ArrayList<Integer>) ringsA[distance]).add(idx);
-                }
-            }
-        }
-        // Convert indices to arrays (hopefully faster).
-        int[][] rings = new int[ringsA.length][];
-        for (int ri = r0; ri < ringsA.length; ri += ringSubSampling) {
-            rings[ri] = ((ArrayList<Integer>) ringsA[ri]).stream()
-                    .mapToInt(i -> i)
-                    .toArray();
-        }
-        // Now iterate through all the offsets and find the maximum circular symmetry
-        // which is the one with the largest ratio between radial and circular variances.
-        double scoreBest = Double.NEGATIVE_INFINITY;
-        int xBest = 0;
-        int yBest = 0;
-        int rContrastBest = 0;
-        double [] scoreMap = null;
-        if (diagnostics) {
-            scoreMap = new double[tolerance*tolerance];
-        }
-        int rTol = tolerance/2;
-        int rTolSq = rTol*rTol;
-        for (int yi = 0; yi < tolerance; yi += subSampling) {
-            for (int xi = 0, idxOffset = (yi*width + xCrop) * channels; 
-                    xi < tolerance; 
-                    xi += subSampling, idxOffset += channels*subSampling) {
-                int distSq = (xi - rTol)*(xi - rTol) + (yi - rTol)*(yi - rTol);
-                if (distSq <= rTolSq) {
-                    double varianceSum = 0.01; // Prevent div by zero.
-                    double lastAvgChannels = 0;
-                    double contrastBest = Double.NEGATIVE_INFINITY;
-                    int riContrastBest = 0;
-                    double[] sumOverall = new double[channels];
-                    double[] sumSqOverall = new double[channels];
-                    double[] nOverall = new double[channels];
-                    // Examine each ring.
-                    for (int ri = r0; ri < rings.length; ri += ringSubSampling) {
-                        int[] ring = rings[ri];
-                        double n = ring.length;
-                        if (n > 0) {
-                            long sumChannels = 0;
-                            for (int ch = 0; ch < channels; ch++) {
-                                // Calculate the variance along the ring.
-                                long sum = 0;
-                                long sumSq = 0;
-                                for (int idx : ring) {
-                                    int pixel = Byte.toUnsignedInt(pixelSamples[idxOffset + idx + ch]);
-                                    sum += pixel;
-                                    sumSq += pixel * pixel;
-                                }
-                                sumChannels += sum;
-                                sumOverall[ch] += sum;
-                                sumSqOverall[ch] += sumSq;
-                                nOverall[ch] += n;
-                                double variance = (sumSq - (sum * sum) / n);// / Math.log(ri+4);
-                                varianceSum += variance;
-                            }
-                            double avgChannels = sumChannels / n;
-                            if (ri*2 >= minDiameter) {
-                                double contrast = Math.abs(avgChannels - lastAvgChannels);
-                                if (contrastBest < contrast) {
-                                    contrastBest = contrast;
-                                    riContrastBest = ri;
-                                }
-                            }
-                            lastAvgChannels = avgChannels;
-                        }
-                    }
-                    double varianceOverall = 0.0;
-                    for (int ch = 0; ch < channels; ch++) {
-                        varianceOverall += (sumSqOverall[ch] - (sumOverall[ch] * sumOverall[ch]) / nOverall[ch]);
-                    }
-                    double score = varianceOverall/varianceSum; 
-                    if (scoreBest < score) {
-                        scoreBest = score;
-                        xBest = xi + xCrop;
-                        yBest = yi + yCrop;
-                        rContrastBest = riContrastBest;
-                    }
-                    if (scoreMap != null) {
-                        score = Math.log(Math.log(score));
-                        scoreMap[yi*tolerance + xi] = score;
-                        scoreRange.add(score);
-                    }
-                }
-            }
-        }
-        final int iterationRadius = 2;
-        CvStage.Result.Circle bestResult = new CvStage.Result.Circle(r + xBest, r + yBest, rContrastBest * 2);
-        List<CvStage.Result.Circle> ret;
-        if (subSampling == 1) {
-            ret = new ArrayList<>();
-            if (scoreBest > minSymmetry) {
-                ret.add(bestResult);
+        final int diameter = maxDiameter + searchRangeEff + subSamplingEff/2 + 1;
+        final int xCrop = xCenter - diameter/2;
+        final int yCrop = yCenter - diameter/2;
+        // Create super sampling offsets if needed.
+        double [] superSamplingOffsets;
+        final boolean finalSamplingPass = (subSamplingEff == 1 && (searchRange <= iterationRadius || superSampling <= 1));
+        if (finalSamplingPass && superSampling > 1) {
+            superSamplingOffsets = new double[superSampling];
+            for (int s = 0; s < superSampling; s++) {
+                superSamplingOffsets[s] = ((double)s)/superSampling - 0.5;
             }
         }
         else {
-            ret = findCircularSymmetry(image, r + xBest, r + yBest, maxDiameter, minDiameter, 
-                    subSampling*iterationRadius, minSymmetry, Math.max(subSampling/4, 1), diagnostics, scoreRange);
-            if (ret.size() > 0) {
-                bestResult = ret.get(0);
+            superSamplingOffsets = new double[] { 0.0 };
+        }
+
+        // Get the pixels out of the Mat.
+        byte[] pixelSamples = new byte[diameter*width*channels]; 
+        image.get(yCrop, 0, pixelSamples);
+
+        // Running best results.
+        double scoreBest = Double.NEGATIVE_INFINITY;
+        double xBest = 0;
+        double yBest = 0;
+        int rContrastBest = 0;
+        double [] scoreMap = null;
+        int[] radiusMap = null;
+        boolean showDiagnostics = (diagnostics && superSamplingOffsets.length == 1); 
+        int searchRangeMap = searchRangeEff/subSamplingEff;
+        if (showDiagnostics || maxTargetCount > 1) {
+            scoreMap = new double[searchRangeMap*searchRangeMap];
+            radiusMap = new int[searchRangeMap*searchRangeMap];
+            // The final score is reset her so it will reflect the last pass' maximum score. 
+            scoreRange.finalScore = 0;
+        }
+        // Outer super-sampling loop. 
+        for (double xOffset : superSamplingOffsets) {
+            for (double yOffset : superSamplingOffsets) {
+                double scoreBestSampling = Double.NEGATIVE_INFINITY;
+                double xBestSampling = 0;
+                double yBestSampling = 0;
+                // Create the concentric rings of circular symmetry as lists of indices into the flat array of pixels.
+                // The indices are relative to the origin but they can be offset to any x, y (within
+                // range) and still remain valid, thanks to modulo behavior.
+                Object[] ringsA = new Object[r + 1];
+                int nRingSamples = 0;
+                for (int ri = r0; ri < ringsA.length; ri += subSamplingEff) {
+                    ringsA[ri] = new ArrayList<Integer>();
+                }
+                for (int y = -r, yi = 0; y <= r; y += subSamplingEff, yi += subSamplingEff) {
+                    for (int x = -r, idx = yi*width*channels; 
+                            x <= r; 
+                            x += subSamplingEff, idx += channels*subSamplingEff) {
+                        double dx = x - xOffset;
+                        double dy = y - yOffset;
+                        double distanceSquare = dx*dx + dy*dy;
+                        double d = Math.sqrt(distanceSquare);
+                        int distance = r0 + (-r0 + (int) Math.round(d))/subSamplingEff*subSamplingEff;
+                        if (r0 <= distance && distance <= r) {
+                            ((ArrayList<Integer>) ringsA[distance]).add(idx);
+                            nRingSamples++;
+                        }
+                    }
+                }
+                // Convert indices to arrays (hopefully faster).
+                int[][] rings = new int[ringsA.length][];
+                for (int ri = r0; ri < ringsA.length; ri += subSamplingEff) {
+                    rings[ri] = ((ArrayList<Integer>) ringsA[ri]).stream()
+                            .mapToInt(i -> i)
+                            .toArray();
+                }
+                // Now iterate through all the offsets and find the maximum circular symmetry
+                // which is the one with the largest ratio between radial and circular variances.
+                for (int yi = 0, yis = 0; yi < searchRangeEff; yi += subSamplingEff, yis++) {
+                    for (int xi = 0, xis = 0, idxOffset = (yi*width + xCrop) * channels; 
+                            xi < searchRangeEff; 
+                            xi += subSamplingEff, xis++, idxOffset += channels*subSamplingEff) {
+                        int distSq = (xi - rSearch)*(xi - rSearch) + (yi - rSearch)*(yi - rSearch);
+                        if (distSq <= rSearchSq) {
+                            double varianceSum = 0.01; // Prevent div by zero.
+                            double lastAvgChannels = 0;
+                            double contrastBest = Double.NEGATIVE_INFINITY;
+                            int riContrastBest = 0;
+                            double[] sumOverall = new double[channels];
+                            double[] sumSqOverall = new double[channels];
+                            double[] nOverall = new double[channels];
+                            // Examine each ring.
+                            for (int ri = r0; ri < rings.length; ri += subSamplingEff) {
+                                int[] ring = rings[ri];
+                                double n = ring.length;
+                                if (n > 0) {
+                                    long sumChannels = 0;
+                                    for (int ch = 0; ch < channels; ch++) {
+                                        // Calculate the variance along the ring.
+                                        long sum = 0;
+                                        long sumSq = 0;
+                                        for (int idx : ring) {
+
+                                            if (DEBUG) {
+                                                int idxDebug = idxOffset + idx;
+                                                int yDebug = (idxDebug/channels)/width;
+                                                int xDebug = (idxDebug/channels)%width;
+                                                if (xDebug < xi || xDebug > xCrop + xi + r*2 + 1
+                                                        || yDebug < yi || yDebug > yi + r*2 + 1) {
+                                                    throw new Exception("unexpected idx offset calculation");
+                                                }
+                                                if (finalSamplingPass 
+                                                        && xi == searchRangeEff/2 && yi == searchRangeEff/2 
+                                                        && ri == rings.length-1
+                                                        && yOffset == xOffset) {
+                                                    byte [] pixelData = new byte[channels];
+                                                    image.get(yDebug+yCrop, xDebug, pixelData);
+                                                    int dc = Arrays.binarySearch(superSamplingOffsets, xOffset) % channels;
+                                                    pixelData[2-dc] = (byte)255;
+                                                    image.put(yDebug+yCrop, xDebug, pixelData);
+                                                }
+                                            }
+
+                                            int pixel = Byte.toUnsignedInt(pixelSamples[idxOffset + idx + ch]);
+                                            sum += pixel;
+                                            sumSq += pixel * pixel;
+                                        }
+                                        sumChannels += sum;
+                                        sumOverall[ch] += sum;
+                                        sumSqOverall[ch] += sumSq;
+                                        nOverall[ch] += n;
+                                        double variance = (sumSq - (sum * sum) / n);// / Math.log(ri+4);
+                                        varianceSum += variance;
+                                    }
+                                    double avgChannels = sumChannels / n;
+                                    if (ri*2 >= minDiameter) {
+                                        double contrast = Math.abs(avgChannels - lastAvgChannels);
+                                        if (contrastBest < contrast) {
+                                            contrastBest = contrast;
+                                            riContrastBest = ri;
+                                        }
+                                    }
+                                    lastAvgChannels = avgChannels;
+                                }
+                            }
+                            double varianceOverall = 0.01; // Prevent zero.
+                            for (int ch = 0; ch < channels; ch++) {
+                                varianceOverall += (sumSqOverall[ch] - (sumOverall[ch] * sumOverall[ch]) / nOverall[ch]);
+                            }
+                            double score = varianceOverall/varianceSum; 
+                            if (scoreBestSampling < score) {
+                                scoreBestSampling = score;
+                                xBestSampling = xi + xCrop + r + 0.5 + xOffset;
+                                yBestSampling = yi + yCrop + r + 0.5 + yOffset;
+                                if (scoreBest < score) {
+                                    scoreBest = score;
+                                    xBest = xBestSampling;
+                                    yBest = yBestSampling;
+                                    rContrastBest = riContrastBest;
+                                }
+                            }
+                            if (scoreMap != null) {
+                                scoreMap[yis*searchRangeMap + xis] = score;
+                                radiusMap[yis*searchRangeMap + xis] = riContrastBest;
+                                scoreRange.add(score);
+                            }
+                        }
+                    }
+                }
+                if (DEBUG) {
+                    Logger.trace("best circular symmetry at subSampling "+subSamplingEff+", range "+searchRangeEff
+                            +(finalSamplingPass ? ", superSampling "+superSampling+" offsets Y"+xOffset+" Y"+yOffset : "")
+                            +": "+scoreBestSampling+" X"+xBestSampling+" Y"+yBestSampling
+                            + " ring samples "+nRingSamples);
+                }
             }
         }
-        if (scoreMap != null) {
-            double rscale = 1/(scoreRange.maxScore - scoreRange.minScore);
+
+        // Process the search results.
+        List<CvStage.Result.Circle> ret;
+        if (maxTargetCount > 1) {
+            // Need to find multiple targets. Process the score map.
+            List<SymmetryCircle> maxima = new ArrayList<SymmetryCircle>();
+            if (scoreBest > minSymmetry) {
+                // Find the local maxima.
+                for (int yis = 1, yim0 = 0, yim1 = searchRangeMap, yim2 = searchRangeMap*2;  
+                        yis < searchRangeMap-1; yis++, yim0 += searchRangeMap, yim1 += searchRangeMap, yim2 += searchRangeMap) {
+                    for (int xis = 1; xis < searchRangeMap-1; xis++) {
+                        //      x0 x1 x2
+                        //    -----------
+                        // y0 ¦  0  1  2
+                        // y1 ¦  3  4  5
+                        // y2 ¦  6  7  8
+                        double score = scoreMap[yim1 + xis];
+                        // This will only find true peaks, no plateaus, but plateaus will never happen in real life. 
+                        if (score > minSymmetry
+                                && scoreMap[yim1 + xis - 1] < score 
+                                && scoreMap[yim1 + xis + 1] < score 
+                                && scoreMap[yim0 + xis - 1] < score 
+                                && scoreMap[yim0 + xis] < score 
+                                && scoreMap[yim0 + xis + 1] < score
+                                && scoreMap[yim2 + xis - 1] < score 
+                                && scoreMap[yim2 + xis] < score 
+                                && scoreMap[yim2 + xis + 1] < score) {
+                            SymmetryCircle circle = new SymmetryCircle(
+                                    xis*subSamplingEff + xCrop + r + 0.5, 
+                                    yis*subSamplingEff + yCrop + r + 0.5, 
+                                    radiusMap[yim1 + xis],
+                                    score);
+                            maxima.add(circle);
+                        }
+                    }
+                }
+                // Take only those with no better-scoring overlaps.
+                List<SymmetryCircle> maximaFiltered = new ArrayList<SymmetryCircle>();
+                int sqMinDistance = maxDiameter*maxDiameter;
+                for (SymmetryCircle cand : maxima) {
+                    boolean noBetterOverlap = true;
+                    for (SymmetryCircle other : maxima) {
+                        if (other.score > cand.score) {
+                            double dx = cand.x - other.x;
+                            double dy = cand.y - other.y;
+                            double dSq = dx*dx + dy*dy;
+                            if (dSq < sqMinDistance) {
+                                // Better-scoring overlap.
+                                noBetterOverlap = false;
+                                break;
+                            }
+                        }
+                    }
+                    if (noBetterOverlap) {
+                        maximaFiltered.add(cand);
+                    }
+                }
+
+                List<SymmetryCircle> samplingFiltered = new ArrayList<SymmetryCircle>();
+                if (finalSamplingPass) {
+                    samplingFiltered.addAll(maximaFiltered);
+                }
+                else {
+                    // For each local maxima...
+                    for (SymmetryCircle localBest : maximaFiltered) {
+                        // ... recursion into finer subSampling and local search.
+                        List<CvStage.Result.Circle> localRet = findCircularSymmetry(image, (int)localBest.x, (int)localBest.y, maxDiameter, minDiameter, 
+                                subSamplingEff*iterationRadius, 1, minSymmetry, corrSymmetry, 
+                                subSamplingEff/iterationDivision, superSampling, diagnostics, scoreRange);
+                        if (localRet.size() > 0) { 
+                            samplingFiltered.add((SymmetryCircle) localRet.get(0));
+                        }
+                    }
+                }
+
+                // Sort best results first.
+                Collections.sort(samplingFiltered, new Comparator<SymmetryCircle>() {
+                    @Override
+                    public int compare(SymmetryCircle o1, SymmetryCircle o2) {
+                        return ((Double) o2.score).compareTo(o1.score);
+                    }
+                });
+
+                // Limit the result count and correlated minimum symmetry.
+                ret = new ArrayList<>();
+                if (samplingFiltered.size() > 0) {
+                    int n = 0;
+                    double minScore = samplingFiltered.get(0).score*corrSymmetry;
+                    for (SymmetryCircle circle : samplingFiltered) {
+                        if (circle.score < minScore) {
+                            break;
+                        }
+                        ret.add(circle);
+                        if (++n >= maxTargetCount) {
+                            break;
+                        }
+                    }
+                }
+            }
+            else {
+                // Empty.
+                ret = new ArrayList<>();
+            }
+        }
+        else {  
+            // Just one result to process (maxTargetCount == 1).
+            if (finalSamplingPass) {
+                // Got the final result.
+                ret = new ArrayList<>();
+                if (scoreBest > minSymmetry) {
+                    ret.add(new SymmetryCircle(xBest, yBest, rContrastBest * 2, scoreBest));
+                }
+            }
+            else {
+                // Recursion into finer subSampling and local search.
+                ret = findCircularSymmetry(image, (int)(xBest), (int)(yBest), maxDiameter, minDiameter, 
+                        subSamplingEff*iterationRadius, 1, minSymmetry, corrSymmetry, 
+                        subSamplingEff/iterationDivision, superSampling, diagnostics, scoreRange);
+            }
+        }
+
+        if (showDiagnostics) {
+            // Paint diagnostics.
+            double rscale = 1/(scoreHeat(scoreRange.maxScore) - scoreHeat(scoreRange.minScore));
             double scale = 255*channels*rscale;
-            for (int yi = 0; yi < tolerance; yi++) {
-                for (int xi = 0; xi < tolerance; xi++) {
-                    int yis = yi/subSampling*subSampling;
-                    int xis = xi/subSampling*subSampling;
-                    int distSq = (xis - rTol)*(xis - rTol) + (yis - rTol)*(yis - rTol);
-                    if (distSq <= rTolSq) {
-                        double s = scoreMap[yis*tolerance + xis];
-                        if (!Double.isFinite(s)) {
-                            s = scoreRange.minScore;
-                        }
-                        s -= scoreRange.minScore;
-                        double score = s*scale;
-                        boolean indicate = false;
-                        if (bestResult != null) {
-                            int dx = xi + xCrop - (int) (bestResult.x) + r;
-                            int dy = yi + yCrop  - (int) (bestResult.y) + r;
-                            int distance = (int)Math.round(Math.sqrt(dx*dx + dy*dy));
-                            indicate = (distance*2 == (int)(bestResult.diameter) || dx == 0 || dy == 0);
-                        }
-                        int dx2 = (xi + xCrop - xBest);
-                        int dy2 = (yi + yCrop - yBest);
+            for (int yi = 0; yi < searchRangeEff-subSamplingEff/2; yi++) {
+                for (int xi = 0; xi < searchRangeEff-subSamplingEff/2; xi++) {
+                    // Coordinates into scoreMap (must be multiples of subSamplingEff). 
+                    int xis = (xi+subSamplingEff/2)/subSamplingEff;
+                    int yis = (yi+subSamplingEff/2)/subSamplingEff;
+                    // Mask to search Radius.
+                    double s = scoreMap[yis*searchRangeMap + xis];
+                    if (s > 1.0) {
+                        /// Pixel coordinates.
+                        int col = xi + xCrop + r;
+                        int row = yi + yCrop + r;
+                        double dx2 = (col - xBest);
+                        double  dy2 = (row - yBest);
                         int distance2 = (int)Math.round(Math.sqrt(dx2*dx2 + dy2*dy2));
-                        double alpha = Math.pow(s*rscale, 3);
-                        double alphaCompl = 1-alpha;
-                        byte [] pixelData = new byte[channels];
-                        image.get(yi + yCrop + r, xi + xCrop + r, pixelData);
-                        if (channels == 3) {
-                            int red = 0;
-                            int green = 0;
-                            int blue = 0;
-                            if (indicate) {
-                                red = 0;
-                                green = 255;
-                                blue = 0;
-                                alpha = 0.5;
-                                alphaCompl = 1 - alpha;
+                        // Put the heat-map/indicator pixel back, but only if outside the local search range. 
+                        if (subSamplingEff == 1 
+                                || distance2 >= subSamplingEff*iterationRadius/2)  {
+                            // Get the score.
+                            double heat = scoreHeat(s);
+                            if (!Double.isFinite(heat)) {
+                                heat = scoreHeat(scoreRange.minScore);
                             }
-                            else if (score <= 255) {
-                                blue = (int) score;
+                            heat -= scoreHeat(scoreRange.minScore);
+                            double score = heat*scale;
+                            // Determine if this pixel coordinate is part of the indicator (cross-hairs and diameter).
+                            boolean indicate = false;
+                            for (CvStage.Result.Circle circle : ret) {
+                                double dx = xi + xCrop - circle.x + r + 0.01;
+                                double dy = yi + yCrop - circle.y + r + 0.01;
+                                int distance = (int)Math.round(Math.sqrt(dx*dx + dy*dy));
+                                indicate = (distance == (int)(circle.diameter/2) 
+                                        || ((Math.round(dx) == 0 || Math.round(dy) == 0) 
+                                                && distance < circle.diameter));
+                                if (indicate) {
+                                    break;
+                                }
                             }
-                            else if (score <= 255+255) {
-                                blue = (int) (255+255-score);
-                                red = (int) (score-255);
+                            // Overlay the score as a heat-map, alpha-blended with the image.
+                            double alpha = Math.pow(heat*rscale, 3);
+                            double alphaCompl = 1-alpha;
+                            byte [] pixelData = new byte[channels];
+                            image.get(row, col, pixelData);
+                            if (channels == 3) {
+                                int red = 0;
+                                int green = 0;
+                                int blue = 0;
+                                if (indicate) {
+                                    red = 0;
+                                    green = 255;
+                                    blue = 0;
+                                    alpha = 0.5;
+                                    alphaCompl = 1 - alpha;
+                                }
+                                else if (score <= 255) {
+                                    blue = (int) score;
+                                }
+                                else if (score <= 255+255) {
+                                    blue = (int) (255+255-score);
+                                    red = (int) (score-255);
+                                }
+                                else {
+                                    red = (int) 255;
+                                    green = (int) (score - 255-255);
+                                }
+                                pixelData[2] = (byte) (alpha*red + alphaCompl*Byte.toUnsignedInt(pixelData[2]));
+                                pixelData[1] = (byte) (alpha*green + alphaCompl*Byte.toUnsignedInt(pixelData[1]));
+                                pixelData[0] = (byte) (alpha*blue + alphaCompl*Byte.toUnsignedInt(pixelData[0]));
                             }
                             else {
-                                red = (int) 255;
-                                green = (int) (score - 255-255);
+                                if (indicate) {
+                                    pixelData[0] = (byte) 255; 
+                                }
+                                else {
+                                    pixelData[0] = (byte) (alpha*score + alphaCompl*Byte.toUnsignedInt(pixelData[0]));
+                                }
                             }
-                            pixelData[2] = (byte) (alpha*red + alphaCompl*Byte.toUnsignedInt(pixelData[2]));
-                            pixelData[1] = (byte) (alpha*green + alphaCompl*Byte.toUnsignedInt(pixelData[1]));
-                            pixelData[0] = (byte) (alpha*blue + alphaCompl*Byte.toUnsignedInt(pixelData[0]));
-                        }
-                        else {
-                            if (indicate) {
-                                pixelData[0] = (byte) 255; 
-                            }
-                            else {
-                                pixelData[0] = (byte) (alpha*score + alphaCompl*Byte.toUnsignedInt(pixelData[0]));
-                            }
-                        }
-                        if (subSampling == 1 
-                                || distance2 >= subSampling*iterationRadius/2)  {
-                            image.put(yi + yCrop + r, xi + xCrop + r, pixelData);
+                            image.put(row, col, pixelData);
                         } 
                     }
                 }
             }
         }
         return ret;
+    }
+
+    private static double scoreHeat(double score) {
+        return Math.log(Math.log(score));
     }
 }

--- a/src/main/java/org/openpnp/vision/pipeline/stages/DetectCircularSymmetry.java
+++ b/src/main/java/org/openpnp/vision/pipeline/stages/DetectCircularSymmetry.java
@@ -305,15 +305,19 @@ public class DetectCircularSymmetry extends CvStage {
         final int width = image.cols();
         final int height = image.rows();
         // Some sanity checks on the diameters.
-        maxDiameter |= 1; // make it odd
-        minDiameter = Math.max(3, minDiameter | 1);
+        minDiameter = Math.max(3, minDiameter | 1); // make it odd
+        maxDiameter = Math.max(minDiameter+4, maxDiameter | 1); // make it odd
+        superSampling = Math.min(16, superSampling);
         // Effective subSampling may have to be finer if the searched circular edge is finer. 
         final int subSamplingEff = Math.max(1, 
                 Math.min(subSampling, Math.min((maxDiameter-minDiameter)/4, minDiameter/2)));
         // Constrain the search range to the image.
-        final int searchRangeEff = (Math.min((xCenter-maxDiameter/2)-2, Math.min((width-xCenter-maxDiameter/2)-2,
-                Math.min((yCenter-maxDiameter/2)-2, Math.min((height-yCenter-maxDiameter/2)-2, 
-                        (searchRange+1)/2))))*2)
+        final int searchRangeEff = (
+                Math.min((xCenter-maxDiameter/2)-2-subSamplingEff, 
+                        Math.min((width-xCenter-maxDiameter/2)-2-subSamplingEff,
+                                Math.min((yCenter-maxDiameter/2)-2-subSamplingEff, 
+                                        Math.min((height-yCenter-maxDiameter/2)-2-subSamplingEff, 
+                                                (searchRange+1)/2))))*2)
                 /subSamplingEff*subSamplingEff; // round to multiple of subSamplingEff
         if (searchRangeEff < searchRange/5) {
             throw new Exception("Image too small for given parameters.");


### PR DESCRIPTION
# Description
The DetectCircularSymmetry vision stage has been enhanced:

* Now supports sub-pixel accuracy detection.
* Added optional multi-target support.
* Added support for ReferenceStripFeeder 
* Added support for ReferencePushPullFeeder
* Fixed bug in ReferenceNozzleTipCalibration pipeline property.

# Justification
The sub-pixel accuracy is needed for upcoming automatic [Backlash Compensation](https://github.com/openpnp/openpnp/wiki/Backlash-Compensation) offset calibration.

Multi-target support allows the use of the stage where multiple sprocket holes etc. need to be detected. Now supports ReferenceStripFeeder and ReferencePushPullFeeder.

# Instructions for Use
For basic operation see the [Wiki page](https://github.com/openpnp/openpnp/wiki/DetectCircularSymmetry).

## New Properties
The stage has these new properties:

- **maxTargetCount**: Maximum number of targets (e.g. sprocket holes) to be found. The targets with best symmetry score are returned. Overlap is automatically eliminated. 
- **corrSymmetry**: correlated minimum circular symmetry for multiple matches, i.e. other matches must have at least this relative symmetry. Note that the symmetry score is very dynamic, so setting a robust correlation is difficult. 
- **superSampling**: can be used to achieve sub-pixel final precision: 1 means no super-sampling, 2 means half sub-pixel precision etc. Practical up to ~8.

### New Feeder Support

The ReferenceStripFeeder and ReferencePushPullFeeder set the required dynamic stage properties, i.e. the sprocket holes are detected according to their real EIA 481 standardized diameter. Relatively accurate camera units per pixel calibration is required. 

The feeders also control the search range: full camera for Auto Setup and minimized to the expected location plus tolerance for routine detection.  

### Sample Images

Deliberately difficult contrast and reflective background. The inner margin is set to only 0.05, forcing the stage to detect the outer edge, i.e. perspective and shadow bias is effectively minimized: 

![Strip Feeder](https://user-images.githubusercontent.com/9963310/122117060-afe48400-ce26-11eb-8317-e5020655427b.png)

Deliberately bent strip was perfectly followed. Zero mis-detects ever:

![Bent Strip](https://user-images.githubusercontent.com/9963310/122117195-daced800-ce26-11eb-9a58-c42cd848de2e.jpg)

Difficult transparent tape, as always zero tuning required:

![Push Pull Feeder](https://user-images.githubusercontent.com/9963310/122117329-08b41c80-ce27-11eb-8398-73b6b5d39b19.png)

The exact same pipeline also works with a paper tape:

![Paper tape](https://user-images.githubusercontent.com/9963310/122117831-a0b20600-ce27-11eb-826d-f80f2365714b.png)
 
Note, the pipeline no longer requires a saturated "green-screen" color, it just uses whatever contrast/color difference there is. But it _does_ account for all color channels in the symmetry computation. 

## Proposed Pipeline for the ReferenceStripFeeder 

Edit the pipeline and paste this using the ![Paste](https://user-images.githubusercontent.com/9963310/122116892-74e25080-ce26-11eb-9f49-3a50c4359d7b.png) button:

```
<cv-pipeline>
   <stages>
      <cv-stage class="org.openpnp.vision.pipeline.stages.ImageCapture" name="original" enabled="true" default-light="true" settle-first="true" count="1"/>
      <cv-stage class="org.openpnp.vision.pipeline.stages.BlurGaussian" name="predetect-1" enabled="false" kernel-size="5"/>
      <cv-stage class="org.openpnp.vision.pipeline.stages.DetectCircularSymmetry" name="results" enabled="true" min-diameter="10" max-diameter="100" max-distance="100" max-target-count="6" min-symmetry="1.2" corr-symmetry="0.4" property-name="sprocketHole" outer-margin="0.4" inner-margin="0.05" sub-sampling="8" super-sampling="2" diagnostics="false"/>
      <cv-stage class="org.openpnp.vision.pipeline.stages.ImageRecall" name="recalled" enabled="false" image-stage-name="original"/>
      <cv-stage class="org.openpnp.vision.pipeline.stages.DrawCircles" name="display" enabled="true" circles-stage-name="results" thickness="1">
         <color r="255" g="0" b="0" a="255"/>
      </cv-stage>
      <cv-stage class="org.openpnp.vision.pipeline.stages.ImageWriteDebug" name="0" enabled="false" prefix="debug" suffix=".png"/>
   </stages>
</cv-pipeline>

```
## Proposed Pipeline for the ReferencePushPullFeeder

Edit the pipeline and paste this using the ![Paste](https://user-images.githubusercontent.com/9963310/122116892-74e25080-ce26-11eb-9f49-3a50c4359d7b.png) button:

```
<cv-pipeline>
   <stages>
      <cv-stage class="org.openpnp.vision.pipeline.stages.ImageCapture" name="0" enabled="true" default-light="true" settle-first="true" count="1"/>
      <cv-stage class="org.openpnp.vision.pipeline.stages.BlurGaussian" name="1" enabled="true" kernel-size="5"/>
      <cv-stage class="org.openpnp.vision.pipeline.stages.AffineWarp" name="11" enabled="true" length-unit="Millimeters" x-0="0.0" y-0="0.0" x-1="0.0" y-1="0.0" x-2="0.0" y-2="0.0" scale="1.0" rectify="true" region-of-interest-property="regionOfInterest"/>
      <cv-stage class="org.openpnp.vision.pipeline.stages.ConvertColor" name="12" enabled="true" conversion="Bgr2Gray"/>
      <cv-stage class="org.openpnp.vision.pipeline.stages.SimpleOcr" name="OCR" enabled="true" alphabet="0123456789.-+_RCLDQYXJIVAFH%GMKkmuµnp" font-name="Liberation Mono" font-size-pt="7.0" font-max-pixel-size="20" auto-detect-size="false" threshold="0.75" draw-style="OverOriginalImage" debug="false"/>
      <cv-stage class="org.openpnp.vision.pipeline.stages.ImageRecall" name="20" enabled="true" image-stage-name="0"/>
      <cv-stage class="org.openpnp.vision.pipeline.stages.DetectCircularSymmetry" name="results" enabled="true" min-diameter="10" max-diameter="100" max-distance="100" max-target-count="10" min-symmetry="1.2" corr-symmetry="0.2" property-name="sprocketHole" outer-margin="0.2" inner-margin="0.2" sub-sampling="8" super-sampling="1" diagnostics="false"/>
      <cv-stage class="org.openpnp.vision.pipeline.stages.ImageRecall" name="30" enabled="false" image-stage-name="0"/>
      <cv-stage class="org.openpnp.vision.pipeline.stages.DrawCircles" name="2" enabled="false" circles-stage-name="results" thickness="1">
         <color r="255" g="0" b="0" a="255"/>
      </cv-stage>
   </stages>
</cv-pipeline>
```

# Implementation Details
1. Tested both in simulation and on machine. See images.
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. Successful `mvn test` before submitting the Pull Request. 
