### PR TITLE
Fix / Pending Motion must be executed even after Exception

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/driver/AbstractMotionPlanner.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/AbstractMotionPlanner.java
@@ -627,12 +627,6 @@ public abstract class AbstractMotionPlanner extends AbstractModelObject implemen
     }
 
     @Override
-    public synchronized void clearQueuedMotion() {
-        // The motion commands are reset.
-        motionCommands = new LinkedList<>();
-    }
-
-    @Override
     public synchronized void clearMotionPlanOlderThan(double time) {
         while (motionPlan.isEmpty() == false && motionPlan.firstKey() < time) {
             motionPlan.remove(motionPlan.firstKey());

--- a/src/main/java/org/openpnp/spi/MotionPlanner.java
+++ b/src/main/java/org/openpnp/spi/MotionPlanner.java
@@ -148,7 +148,7 @@ public interface MotionPlanner extends PropertySheetHolder, Solutions.Subject {
          */
         WaitForUnconditionalCoordination,
         /**
-         * Like WaitForFullCoordination but wait "forever" i.e. with very long timeout. Used e.g. for homing.
+         * Like WaitForUnconditionalCoordination but wait "forever" i.e. with very long timeout. Used e.g. for homing.
          */
         WaitForStillstandIndefinitely;
 
@@ -177,11 +177,6 @@ public interface MotionPlanner extends PropertySheetHolder, Solutions.Subject {
      * @throws Exception 
      */
     void waitForCompletion(HeadMountable hm, CompletionType completionType) throws Exception;
-    
-    /**
-     * Clear all queued motion. This should only be used when the machine task is aborted.
-     */
-    void clearQueuedMotion();
 
     /**
      * Get the planned motion at a certain time. Works into the future as far as planned and into the past

--- a/src/main/java/org/openpnp/spi/base/AbstractMachine.java
+++ b/src/main/java/org/openpnp/spi/base/AbstractMachine.java
@@ -556,9 +556,26 @@ public abstract class AbstractMachine extends AbstractModelObject implements Mac
                         exception = e;
                     }
 
+                    if (exception != null) {
+                        try {
+                            // If there was an exception, we still need to execute the moves that were already in the queue
+                            // when it happened. When full asynchronous operation is configured (location confirmation flow control)
+                            // OpenPnP will not necessarily know which commands were executed successfully. We therefore issue a 
+                            // WaitForStillstand, which will result in a position report and sync OpenPnP's internal position 
+                            // with that of the machine.  
+                            Logger.trace(exception, "Exception caught, executing pending motion");
+                            getMotionPlanner().waitForCompletion(null, CompletionType.WaitForStillstand);
+                        }
+                        catch (Exception e) {
+                            // If there is a second exception, there is likely something fundamentally wrong with the driver or communications. 
+                            // We rely on user diagnosis to re-home the machine when necessary, there is really nothing we can do, except log this 
+                            // secondary exception and hope the first one is conclusive for the user. 
+                            Logger.error(e, "Secondary exception when executing pending motion planner commands");
+                        }
+                    }
+
                     // If there was an error cancel all pending tasks.
                     if (exception != null) {
-                        getMotionPlanner().clearQueuedMotion();
                         executor.shutdownNow();
                     }
 


### PR DESCRIPTION
# Description
In #1216 I introduced a new exception behavior that turns out faulty:

In case of an exception, the pending moves were cleared, but OpenPnP's advanced planner then still thought it is (planned to be) at the target position of these queued moves. So if it for instance thinks it is already at Safe Z, it will later not issue new move commands to go there, even if the machine is still down in Z. 

Before this latest change, the pending moves were retained in the queue _through_ any exception and then (unexpectedly!) executed when the next move (such as a jog by the user) was executed.

This PR changes it to the behavior that is present with the NullPlanner (older OpenPnP) i.e. before continuous/asynchronous execution of motion was introduced: Even in case of an exception the pending moves should still be executed (which felt wrong to me, but turns out to be the right thing). After all, these commands were already committed to the planner queue before the cause of the Exception was encountered, so it should still be OK to execute those in general. 

## Test case
Try to move to the bottom camera but the lower Z soft limit is set too high (deliberately for the purpose of this test).

This shows the fixed behavior: 

As you see  in the log, the continuous moves are commanded in the form `"N.moveTo(...)" `etc. No G-code is yet sent to the controllers, motion commands are only queued. But the last leg down to the camera violates the soft limit. The exception interrupts the task, is caught, and reports `"Exception caught, executing pending motion"`. The pending motion is then sent to the driver, counter-intuitively, _after the exception_. Finally, the Exception is reported to the user with a MessageBox (in the last line).

```
2021-06-18 23:04:46.954 ReferenceHead DEBUG: H1.moveToSafeZ(1.0)
2021-06-18 23:04:46.954 AbstractHeadMountable DEBUG: N.moveToSafeZ(1.0)
2021-06-18 23:04:46.954 ReferenceNozzle TRACE: N.transformToHeadLocation((0.000000, 0.000000, -1.420000, 0.000000 mm), ...) runout compensation (0.000000, 0.000000, 0.000000, 0.000000 mm)
2021-06-18 23:04:46.955 ReferenceNozzle TRACE: N.transformToHeadLocation((0.000000, 0.000000, -1.420000, 0.000000 mm), ...) runout compensation (0.000000, 0.000000, 0.000000, 0.000000 mm)
2021-06-18 23:04:46.955 AbstractHeadMountable DEBUG: Top.moveToSafeZ(1.0)
2021-06-18 23:04:46.955 AbstractHeadMountable DEBUG: N.moveTo((118.805719, 7.123719, -1.420000, 0.000000 mm), 1.0)
2021-06-18 23:04:46.955 ReferenceNozzle TRACE: N.transformToHeadLocation((118.805719, 7.123719, -1.420000, 0.000000 mm), ...) runout compensation (0.000000, 0.000000, 0.000000, 0.000000 mm)
2021-06-18 23:04:46.956 AbstractHeadMountable DEBUG: N.moveTo((118.805719, 7.123719, -15.000000, 0.000000 mm), 1.0)
2021-06-18 23:04:46.956 ReferenceNozzle TRACE: N.transformToHeadLocation((118.805719, 7.123719, -15.000000, 0.000000 mm), ...) runout compensation (0.000000, 0.000000, 0.000000, 0.000000 mm)
2021-06-18 23:04:46.959 AbstractMachine TRACE: Exception caught, executing pending motion: java.lang.Exception: Can't move Z to -15.000mm, lower than soft limit -10.000mm.
	at org.openpnp.machine.reference.driver.AbstractMotionPlanner.limitAxesLocation(AbstractMotionPlanner.java:480)
	at org.openpnp.machine.reference.driver.AbstractMotionPlanner.moveTo(AbstractMotionPlanner.java:136)
	at org.openpnp.machine.reference.driver.ReferenceAdvancedMotionPlanner.moveTo(ReferenceAdvancedMotionPlanner.java:317)
	at org.openpnp.machine.reference.ReferenceHead.moveTo(ReferenceHead.java:152)
	at org.openpnp.spi.base.AbstractHeadMountable.moveTo(AbstractHeadMountable.java:240)
	at org.openpnp.util.MovableUtils.moveToLocationAtSafeZ(MovableUtils.java:41)
	at org.openpnp.util.MovableUtils.moveToLocationAtSafeZ(MovableUtils.java:45)
	at org.openpnp.machine.reference.wizards.ReferenceNozzleTipCalibrationWizard$1.lambda$0(ReferenceNozzleTipCalibrationWizard.java:311)
	at org.openpnp.util.UiUtils.lambda$0(UiUtils.java:33)
	at org.openpnp.spi.base.AbstractMachine$1.call(AbstractMachine.java:549)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
2021-06-18 23:04:46.959 GcodeAsyncDriver DEBUG: simulated: port 62376 commandQueue.offer(M204 S2003.59 G1 X118.8057 Y7.1237   F27994.47 ; move to target, 15000)...
2021-06-18 23:04:46.960 GcodeAsyncDriver$WriterThread TRACE: [simulated: port 62376] >> M204S2003.59G1X118.8057Y7.1237F27994.47
2021-06-18 23:04:46.960 GcodeServer$Worker DEBUG: Parsed Gcode: M204 S2003.59 G1 X118.8057 Y7.1237 F27994.47 
2021-06-18 23:04:46.960 GcodeAsyncDriver DEBUG: simulated: port 62376 commandQueue.offer(M400 ; Wait for moves to complete before returning, 15000)...
2021-06-18 23:04:46.960 GcodeAsyncDriver DEBUG: simulated: port 62376 commandQueue.offer(M114 ; get position, -1)...
2021-06-18 23:04:46.960 GcodeAsyncDriver$WriterThread TRACE: [simulated: port 62376] >> M400
2021-06-18 23:04:46.960 GcodeServer$Worker TRACE: Move takes 510.18272375353155 ms
2021-06-18 23:04:46.960 GcodeAsyncDriver$WriterThread TRACE: [simulated: port 62376] >> M114
2021-06-18 23:04:46.960 GcodeServer$Worker TRACE: New location: (x:118.805700, y:7.123700, Z:-1.420000, C:0.000000)
2021-06-18 23:04:46.960 GcodeServer$Worker DEBUG: Parsed Gcode: M400 
2021-06-18 23:04:46.960 GcodeDriver$ReaderThread TRACE: [simulated: port 62376] << ok
2021-06-18 23:04:46.960 GcodeServer$Worker TRACE: Waiting 509ms
2021-06-18 23:04:47.470 GcodeServer$Worker DEBUG: Parsed Gcode: M114 
2021-06-18 23:04:47.470 GcodeDriver$ReaderThread TRACE: [simulated: port 62376] << ok
2021-06-18 23:04:47.470 GcodeDriver$ReaderThread TRACE: [simulated: port 62376] << ok C: X:118.8057 Y:7.1237 Z:-1.4200 C:0.0000
2021-06-18 23:04:47.470 GcodeDriver TRACE: Position report: ok C: X:118.8057 Y:7.1237 Z:-1.4200 C:0.0000
2021-06-18 23:04:47.470 GcodeDriver TRACE: GcodeDriver got lastReportedLocation (x:118.805700, y:7.123700, Z:-1.420000, C:0.000000)
2021-06-18 23:04:47.470 GcodeAsyncDriver TRACE: GcodeDriver confirmation complete.
2021-06-18 23:04:47.470 MessageBoxes DEBUG: Error: java.lang.Exception: Can't move Z to -15.000mm, lower than soft limit -10.000mm.
```

# Justification
See here:
https://groups.google.com/g/openpnp/c/yYJmmnvJRLA/m/aeVSj9hQBAAJ

# Instructions for Use
No change in usage. 

# Implementation Details
1. Tested in simulation.
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. Changes in the `org.openpnp.spi` reverted those of #1216.
4. Successful `mvn test` before submitting the Pull Request. 
