### PR TITLE
Feature/blinds feeder qrc - QR code part ID check - WIP/Concept/Review

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/feeder/wizards/BlindsFeederConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/wizards/BlindsFeederConfigurationWizard.java
@@ -108,6 +108,7 @@ public class BlindsFeederConfigurationWizard extends AbstractConfigurationWizard
     private JTextField textFieldLocationRotation;
     private JButton btnAutoSetup;
     private JButton btnIDPart;
+    private JButton btnExportQrc;
     private JCheckBox chckbxUseVision;
     private JCheckBox chckbxUsePartIdentifier;
     private JLabel lblUseVision;
@@ -267,6 +268,10 @@ public class BlindsFeederConfigurationWizard extends AbstractConfigurationWizard
         btnIDPart.setToolTipText("Capture QRC or text ID for the feeder part.");
         panelTapeSettings.add(btnIDPart, "14, 8, 1, 2");
 
+        btnExportQrc = new JButton(exportQRCCodeImage);
+        btnExportQrc.setToolTipText("Export QR code image for feeder parts.");
+        panelTapeSettings.add(btnExportQrc, "14, 10, 1, 2");
+        
         lblPocketPitch = new JLabel("Pocket Pitch");
         lblPocketPitch.setToolTipText("Picth of the part pockets in the tape.");
         panelTapeSettings.add(lblPocketPitch, "2, 4, right, default");
@@ -865,6 +870,22 @@ public class BlindsFeederConfigurationWizard extends AbstractConfigurationWizard
             });
         }
     };
+    
+    private Action exportQRCCodeImage = new AbstractAction("Export QRC Code", Icons.export) {
+        {
+            putValue(Action.SHORT_DESCRIPTION,
+                    "Export QRC code image for all of the connected feeders");
+        }
+
+        @Override
+        public void actionPerformed(ActionEvent e) {
+            applyAction.actionPerformed(e);
+            UiUtils.submitUiMachineTask(() -> {
+                feeder.generatePartNumberQRCodeImage();
+            });
+        }
+    };
+    
 
     private Action openCover = new AbstractAction("Open Cover", Icons.lockOpenOutline) {
         {

--- a/src/main/java/org/openpnp/machine/reference/feeder/wizards/BlindsFeederConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/wizards/BlindsFeederConfigurationWizard.java
@@ -107,8 +107,11 @@ public class BlindsFeederConfigurationWizard extends AbstractConfigurationWizard
     private JLabel lblRotationInTape;
     private JTextField textFieldLocationRotation;
     private JButton btnAutoSetup;
+    private JButton btnIDPart;
     private JCheckBox chckbxUseVision;
+    private JCheckBox chckbxUsePartIdentifier;
     private JLabel lblUseVision;
+    private JLabel lblUsePartIdentifer;
     private JLabel lblPart;
     private JLabel lblRetryCount;
     private JTextField retryCountTf;
@@ -259,6 +262,10 @@ public class BlindsFeederConfigurationWizard extends AbstractConfigurationWizard
         btnAutoSetup = new JButton(autoSetup);
         btnAutoSetup.setToolTipText("Capture the pocket pitch, size and centerline from the current camera position.");
         panelTapeSettings.add(btnAutoSetup, "14, 4, 1, 3");
+
+        btnIDPart = new JButton(identifyPart);
+        btnIDPart.setToolTipText("Capture QRC or text ID for the feeder part.");
+        panelTapeSettings.add(btnIDPart, "14, 8, 1, 2");
 
         lblPocketPitch = new JLabel("Pocket Pitch");
         lblPocketPitch.setToolTipText("Picth of the part pockets in the tape.");
@@ -555,6 +562,13 @@ public class BlindsFeederConfigurationWizard extends AbstractConfigurationWizard
         panelVision.add(chckbxUseVision, "4, 2");
         panelVision.add(btnEditPipeline, "2, 4");
 
+//        lblUsePartIdentifer = new JLabel("Use part identifier?");
+//        lblUsePartIdentifer.setToolTipText("<html><p>Use vision to check qrcode identifying part.</p><html>");
+//        panelVision.add(lblUsePartIdentifer, "6, 2");
+//
+//        chckbxUsePartIdentifier = new JCheckBox("");
+//        panelVision.add(chckbxUsePartIdentifier, "8, 2");
+
         JButton btnResetPipeline = new JButton(resetPipelineAction);
 
         btnPipelineToAllFeeders = new JButton(setPipelineToAllAction);
@@ -833,6 +847,21 @@ public class BlindsFeederConfigurationWizard extends AbstractConfigurationWizard
                         .getDefaultCamera();
 
                 feeder.findPocketsAndCenterline(camera);
+            });
+        }
+    };
+
+    private Action identifyPart = new AbstractAction("Identify Part", Icons.captureCamera) {
+        {
+            putValue(Action.SHORT_DESCRIPTION,
+                    "Capture the part identifier for a feeder.");
+        }
+
+        @Override
+        public void actionPerformed(ActionEvent e) {
+            applyAction.actionPerformed(e);
+            UiUtils.submitUiMachineTask(() -> {
+                feeder.showPartIdentifiers();
             });
         }
     };

--- a/src/main/java/org/openpnp/machine/reference/feeder/wizards/BlindsFeederConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/wizards/BlindsFeederConfigurationWizard.java
@@ -118,6 +118,8 @@ public class BlindsFeederConfigurationWizard extends AbstractConfigurationWizard
     private JLabel lblPart;
     private JLabel lblRetryCount;
     private JTextField retryCountTf;
+    private JLabel lblEnablePartIdCheck;
+    private JCheckBox chckbxPartIdCheck;
     private JLabel lblFiducial3Location;
     private JLabel lblTapeLength;
     private JTextField textFieldTapeLength;
@@ -205,6 +207,13 @@ public class BlindsFeederConfigurationWizard extends AbstractConfigurationWizard
         panelPart.add(retryCountTf, "4, 6, fill, default");
         retryCountTf.setColumns(4);
 
+        lblEnablePartIdCheck = new JLabel("Part Id Check");
+        panelPart.add(lblEnablePartIdCheck, "8, 6, right, default");
+
+        chckbxPartIdCheck = new JCheckBox("");
+        chckbxPartIdCheck.setToolTipText("");
+        panelPart.add(chckbxPartIdCheck, "10, 6");
+        
         panelTapeSettings = new JPanel();
         contentPanel.add(panelTapeSettings);
         panelTapeSettings.setBorder(new TitledBorder(
@@ -603,7 +612,7 @@ public class BlindsFeederConfigurationWizard extends AbstractConfigurationWizard
         bind(UpdateStrategy.READ_WRITE, feeder, "location", location, "location");
         addWrappedBinding(location, "rotation", textFieldLocationRotation, "text", doubleConverter);
         addWrappedBinding(location, "lengthZ", textFieldPartZ, "text", lengthConverter);
-
+        
         addWrappedBinding(feeder, "part", comboBoxPart, "selectedItem");
         addWrappedBinding(feeder, "feedRetryCount", retryCountTf, "text", intConverter);
 
@@ -641,6 +650,8 @@ public class BlindsFeederConfigurationWizard extends AbstractConfigurationWizard
 
         addWrappedBinding(feeder, "visionEnabled", chckbxUseVision, "selected");
         addWrappedBinding(feeder, "normalize", chckbxNormalize, "selected");
+        
+        addWrappedBinding(feeder, "identifierCheckEnabled", chckbxPartIdCheck, "selected");
         addWrappedBinding(feeder, "identifierLeftSide", chckbxIdentifierLeft, "selected");
 
         addWrappedBinding(feeder, "feederNo", textFieldFeederNo, "text", intConverter);

--- a/src/main/java/org/openpnp/machine/reference/feeder/wizards/BlindsFeederConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/wizards/BlindsFeederConfigurationWizard.java
@@ -94,6 +94,8 @@ public class BlindsFeederConfigurationWizard extends AbstractConfigurationWizard
     private JTextField textFieldFeedersTotal;
     private JLabel lblNormalize;
     private JCheckBox chckbxNormalize;
+    private JLabel lblIdentifierLeft;
+    private JCheckBox chckbxIdentifierLeft;
     private JLabel lblPocketPitch;
     private JTextField textFieldPocketPitch;
     private JPanel panelTapeSettings;
@@ -536,6 +538,14 @@ public class BlindsFeederConfigurationWizard extends AbstractConfigurationWizard
         chckbxNormalize = new JCheckBox("");
         chckbxNormalize.setToolTipText("");
         panelLocations.add(chckbxNormalize, "4, 10");
+        
+        lblIdentifierLeft = new JLabel("Id on feeder left");
+        lblIdentifierLeft.setToolTipText("<html>Feeder part identifier is on the left side, otherwise to the right\r\n</html>");
+        panelLocations.add(lblIdentifierLeft, "6, 10, right, default");
+        
+        chckbxIdentifierLeft = new JCheckBox("");
+        chckbxIdentifierLeft.setToolTipText("");
+        panelLocations.add(chckbxIdentifierLeft, "8, 10");
 
         btnCalibrateFiducials = new JButton(calibrateFiducialsAction);
         panelLocations.add(btnCalibrateFiducials, "12, 10");
@@ -631,6 +641,7 @@ public class BlindsFeederConfigurationWizard extends AbstractConfigurationWizard
 
         addWrappedBinding(feeder, "visionEnabled", chckbxUseVision, "selected");
         addWrappedBinding(feeder, "normalize", chckbxNormalize, "selected");
+        addWrappedBinding(feeder, "identifierLeftSide", chckbxIdentifierLeft, "selected");
 
         addWrappedBinding(feeder, "feederNo", textFieldFeederNo, "text", intConverter);
         addWrappedBinding(feeder, "feedersTotal", textFieldFeedersTotal, "text", intConverter);
@@ -866,7 +877,7 @@ public class BlindsFeederConfigurationWizard extends AbstractConfigurationWizard
         public void actionPerformed(ActionEvent e) {
             applyAction.actionPerformed(e);
             UiUtils.submitUiMachineTask(() -> {
-                feeder.showPartIdentifiers();
+                feeder.checkPartIdentifier();
             });
         }
     };


### PR DESCRIPTION
# Description
Optional check of blinds feeder part ID against QR code placed next to the feeder.
Can generate a png image of QR codes arranged and scaled to be in the correct position for each connected feeder.

# Justification
Prevents bad part or feeder group identification by cross checking expected part numbers expected marked on the feeder and the value set.
Feeder part ID can be read with a phone camera for assist correct component installation.

# Instructions for Use
1. Home the machine
2. Select a BlindsFeeder and calibrate fiducials
2. If the QR code is placed on the left side of the feeder select "ID on feeder left" from the locations section.
3. From the "Tape Settings" section select "Identify part".  The camera will move to the expected QR code location.

If a QRcode image is required select Export QR Code from the "Tape Settings" section.  The image can be found in the folder .openpnp/org.openpnp.machine.reference.feeder.BlindsFeeder

# Implementation Details
1. Only basic testing so far.  More to do after review.
2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)? Needs tidyup. 
3. No changes to `org.openpnp.spi` or `org.openpnp.model` 
4. `mvn test` ok
