### PR TITLE
Fix / Avoid Degradation of Motion when limiting Axis is absent

### DIFF
--- a/src/main/java/org/openpnp/model/Motion.java
+++ b/src/main/java/org/openpnp/model/Motion.java
@@ -456,11 +456,12 @@ public class Motion {
             // Also include the given speed factor.
             effectiveSpeed = (time > 0 ? euclideanTime/time : 1.0) * Math.max(0.01, nominalSpeed);
             euclideanDistance = overallLimits[0];
-            double effectiveSpeedDerivatives = nominalSpeed;
 
             for (Entry<ControllerAxis, Integer> entry : axisIndex.entrySet()) {
+                double effectiveSpeedDerivatives = nominalSpeed;
                 ControllerAxis axis = entry.getKey();
-                double axisFraction = Math.abs(distance.getCoordinate(axis)) // fractional axis distance
+                double d = distance.getCoordinate(axis);
+                double axisFraction = Math.abs(d) // fractional axis distance
                         /euclideanDistance;
                 double sMin = Double.NEGATIVE_INFINITY;
                 double sMax = Double.POSITIVE_INFINITY;
@@ -482,7 +483,8 @@ public class Motion {
                 }
 
                 int options = profileOptions();
-                if (axis.getDriver() != null) {
+                if (d != 0.0 && axis.getDriver() != null) {
+                    // Axis is present in the motion and the driver is set, apply driver restrictions. 
                     if (simpleSCurve) {
                         options |= ProfileOption.SimplifiedSCurve.flag();
                     }
@@ -508,7 +510,7 @@ public class Motion {
 
                 // Compute s0 by distance rather than taking location0, because some axes may have been omitted in location. 
                 double s1 = location1.getCoordinate(axis); 
-                double s0 = s1 - distance.getCoordinate(axis);
+                double s0 = s1 - d;
 
 
                 axesProfiles[entry.getValue()] = new MotionProfile(


### PR DESCRIPTION
# Description
Fixes a small bug where an axis linked to a driver with limited capabilities would degrade the whole motion, even if that axis (and therefore the driver) was not part of the motion.

The driver may for instance have the **ToolpathFeedRate** Motion Control Type, which will degrade motion control, as only the feed-rate limit is set. The minimum "useful" Motion Control Type is **EuclideanAxisLimits**. 

![Driver](https://user-images.githubusercontent.com/9963310/122819321-96d24c00-d2da-11eb-8b23-4a96295ff325.png)

See also:
https://github.com/openpnp/openpnp/wiki/GcodeAsyncDriver#gcodedriver-new-settings

# Justification
See bug report and discussion here:
https://groups.google.com/g/openpnp/c/uueGw-eweYM/m/X1xgDeRbBQAJ

# Instructions for Use
No change.

# Implementation Details
1. Tested with user's machine.xml in simulation. Reproduced the bug and then confirmed the fix was working. 
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. Successful `mvn test` before submitting the Pull Request.
