### PR TITLE
Fix/Discard Contact Probing

### DIFF
--- a/src/main/java/org/openpnp/gui/JogControlsPanel.java
+++ b/src/main/java/org/openpnp/gui/JogControlsPanel.java
@@ -63,6 +63,7 @@ import org.openpnp.spi.HeadMountable;
 import org.openpnp.spi.Machine;
 import org.openpnp.spi.Nozzle;
 import org.openpnp.spi.base.AbstractNozzle;
+import org.openpnp.spi.base.AbstractPnpJobProcessor;
 import org.openpnp.util.BeanUtils;
 import org.openpnp.util.MovableUtils;
 import org.openpnp.util.UiUtils;
@@ -630,19 +631,7 @@ public class JogControlsPanel extends JPanel {
         public void actionPerformed(ActionEvent arg0) {
             UiUtils.submitUiMachineTask(() -> {
                 Nozzle nozzle = machineControlsPanel.getSelectedNozzle();
-                // move to the discard location
-                Map<String, Object> globals = new HashMap<>();
-                globals.put("nozzle", nozzle);
-                Configuration.get().getScripting().on("Job.BeforeDiscard", globals);
-
-                MovableUtils.moveToLocationAtSafeZ(nozzle, Configuration.get()
-                        .getMachine()
-                        .getDiscardLocation());
-                // discard the part
-                nozzle.place();
-                nozzle.moveToSafeZ();
-
-                Configuration.get().getScripting().on("Job.AfterDiscard", globals);
+                AbstractPnpJobProcessor.discard(nozzle);
             });
         }
     };

--- a/src/main/java/org/openpnp/gui/JogControlsPanel.java
+++ b/src/main/java/org/openpnp/gui/JogControlsPanel.java
@@ -63,8 +63,8 @@ import org.openpnp.spi.HeadMountable;
 import org.openpnp.spi.Machine;
 import org.openpnp.spi.Nozzle;
 import org.openpnp.spi.base.AbstractNozzle;
-import org.openpnp.spi.base.AbstractPnpJobProcessor;
 import org.openpnp.util.BeanUtils;
+import org.openpnp.util.Cycles;
 import org.openpnp.util.MovableUtils;
 import org.openpnp.util.UiUtils;
 
@@ -631,7 +631,7 @@ public class JogControlsPanel extends JPanel {
         public void actionPerformed(ActionEvent arg0) {
             UiUtils.submitUiMachineTask(() -> {
                 Nozzle nozzle = machineControlsPanel.getSelectedNozzle();
-                AbstractPnpJobProcessor.discard(nozzle);
+                Cycles.discard(nozzle);
             });
         }
     };

--- a/src/main/java/org/openpnp/machine/reference/ContactProbeNozzle.java
+++ b/src/main/java/org/openpnp/machine/reference/ContactProbeNozzle.java
@@ -282,13 +282,13 @@ public class ContactProbeNozzle extends ReferenceNozzle {
 
     @Override
     public void moveToPlacementLocation(Location placementLocation, Part part) throws Exception {
+        // Calculate the probe starting location.
         Length partHeight = getSafePartHeight(part);
         Location placementLocationPart = placementLocation.add(new Location(partHeight.getUnits(), 0, 0, partHeight.getValue(), 0));
         // null part means discarding. 
         String partId = (part != null ? part.getId() : "discard");
         if (isPartHeightProbingNeeded(part)) {
             boolean partHeightProbing = (part != null && part.isPartHeightUnknown());
-            // Calculate the probe starting location.
             moveAboveProbingLocation(placementLocationPart);
 
             Map<String, Object> globals = new HashMap<>();

--- a/src/main/java/org/openpnp/machine/reference/ContactProbeNozzle.java
+++ b/src/main/java/org/openpnp/machine/reference/ContactProbeNozzle.java
@@ -298,8 +298,8 @@ public class ContactProbeNozzle extends ReferenceNozzle {
 
             Length depthZ;
             if (part == null || partHeightProbing) {
-                // We're probing for the part height.
-                depthZ = nozzleTip.getMaxPartHeight();
+                // We're probing for the part height, plus probe depth.
+                depthZ = nozzleTip.getMaxPartHeight().add(contactProbeDepthZ);
             }
             else {
                 depthZ = contactProbeDepthZ;
@@ -441,7 +441,8 @@ public class ContactProbeNozzle extends ReferenceNozzle {
      * @throws Exception
      */
     public void moveAboveProbingLocation(Location nominalLocation) throws Exception {
-        nominalLocation = nominalLocation.add(new Location(contactProbeStartOffsetZ .getUnits(), 0, 0, contactProbeStartOffsetZ.getValue(), 0));
+        nominalLocation = nominalLocation.add(
+                new Location(contactProbeStartOffsetZ.getUnits(), 0, 0, contactProbeStartOffsetZ.getValue(), 0));
         MovableUtils.moveToLocationAtSafeZ(this, nominalLocation);
     }
 

--- a/src/main/java/org/openpnp/machine/reference/ContactProbeNozzle.java
+++ b/src/main/java/org/openpnp/machine/reference/ContactProbeNozzle.java
@@ -118,6 +118,9 @@ public class ContactProbeNozzle extends ReferenceNozzle {
     @Attribute(required=false)
     private ContactProbeTrigger partHeightProbing = ContactProbeTrigger.EachTime;
 
+    @Attribute(required=false)
+    private boolean discardProbing = false; 
+
     @Element(required=false)
     private Length calibrationOffsetZ = null;
 
@@ -202,7 +205,7 @@ public class ContactProbeNozzle extends ReferenceNozzle {
         }
         if (part == null) {
             // null part means discard, i.e. we probe each time. 
-            return true;
+            return isDiscardProbing();
         }
         if (feederHeightProbing == ContactProbeTrigger.EachTime) {
             return true;
@@ -341,7 +344,7 @@ public class ContactProbeNozzle extends ReferenceNozzle {
                 MovableUtils.moveToLocationAtSafeZ(this, placementLocationPart);
             }
             else {
-                super.moveToPlacementLocation(placementLocationPart, part);
+                super.moveToPlacementLocation(placementLocation, part);
             }
         }
     }
@@ -432,6 +435,14 @@ public class ContactProbeNozzle extends ReferenceNozzle {
 
     public void setPartHeightProbing(ContactProbeTrigger partHeightProbing) {
         this.partHeightProbing = partHeightProbing;
+    }
+
+    public boolean isDiscardProbing() {
+        return discardProbing;
+    }
+
+    public void setDiscardProbing(boolean discardProbing) {
+        this.discardProbing = discardProbing;
     }
 
     /**
@@ -794,12 +805,15 @@ public class ContactProbeNozzle extends ReferenceNozzle {
                                     GcodeDriver.CommandType.ACTUATE_BOOLEAN_COMMAND, suggestedCommand, false, false);
                         }
                         else {
-                            solutions.add(new Solutions.PlainIssue(
-                                    this, 
-                                    "Missing ACTUATE_BOOLEAN_COMMAND for actuator "+contactProbeActuator.getName()+" on driver "+gcodeDriver.getName()+" (no suggestion available for detected firmware).", 
-                                    "Please add the command manually.",
-                                    Severity.Error,
-                                    "https://github.com/openpnp/openpnp/wiki/Contact-Probing-Nozzle#setting-up-the-g-code"));
+                            String currentCommand = gcodeDriver.getCommand(contactProbeActuator, GcodeDriver.CommandType.ACTUATE_BOOLEAN_COMMAND);
+                            if (currentCommand == null || currentCommand.isEmpty()) {
+                                solutions.add(new Solutions.PlainIssue(
+                                        this, 
+                                        "Missing ACTUATE_BOOLEAN_COMMAND for actuator "+contactProbeActuator.getName()+" on driver "+gcodeDriver.getName()+" (no suggestion available for detected firmware).", 
+                                        "Please add the command manually.",
+                                        Severity.Error,
+                                        "https://github.com/openpnp/openpnp/wiki/Contact-Probing-Nozzle#setting-up-the-g-code"));
+                            }
                         }
                     }
                 }

--- a/src/main/java/org/openpnp/machine/reference/ReferenceNozzle.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceNozzle.java
@@ -449,15 +449,16 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
 
     @Override
     public Length getSafePartHeight(Part part) {
-        if (part != null) {
-            if (part.isPartHeightUnknown() && nozzleTip != null) {
-                return nozzleTip.getMaxPartHeight();
-            }
-            else {
-                return part.getHeight();
-            }
+        if ((part == null || part.isPartHeightUnknown()) 
+                && nozzleTip != null) {
+            return nozzleTip.getMaxPartHeight();
         }
-        return new Length(0, LengthUnit.Millimeters);
+        else if (part != null) {
+            return part.getHeight();
+        }
+        else {
+            return new Length(0, LengthUnit.Millimeters);
+        }
     }
 
     @Override 

--- a/src/main/java/org/openpnp/machine/reference/wizards/ContactProbeNozzleWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/wizards/ContactProbeNozzleWizard.java
@@ -28,6 +28,7 @@ import java.awt.event.ItemListener;
 import javax.swing.AbstractAction;
 import javax.swing.Action;
 import javax.swing.JButton;
+import javax.swing.JCheckBox;
 import javax.swing.JComboBox;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
@@ -54,26 +55,6 @@ import com.jgoodies.forms.layout.RowSpec;
 @SuppressWarnings("serial")
 public class ContactProbeNozzleWizard extends AbstractConfigurationWizard {
     private final ReferenceNozzle nozzle;
-    private JPanel panel;
-    private JLabel lblContactProbeActuator;
-    private JComboBox comboBoxContactProbeActuator;
-    private JLabel lblStartOffset;
-    private JTextField contactProbeStartOffsetZ;
-    private JLabel lblProbeDepth;
-    private JTextField contactProbeDepthZ;
-    private JLabel lblSniffleIncrement;
-    private JTextField sniffleIncrementZ;
-    private JLabel lblFinalAdjustment;
-    private JTextField contactProbeAdjustZ;
-    private JLabel lblMethod;
-    private JComboBox contactProbeMethod;
-    private JLabel lblFeederHeightProbing;
-    private JComboBox feederHeightProbing;
-    private JLabel lblPartHeightProbing;
-    private JComboBox partHeightProbing;
-    private JLabel lblZCalibration;
-    private JTextField calibrationOffsetZ;
-    private JButton btnCalibrateNow;
 
     public ContactProbeNozzleWizard(ContactProbeNozzle nozzle) {
         this.nozzle = nozzle;
@@ -95,6 +76,8 @@ public class ContactProbeNozzleWizard extends AbstractConfigurationWizard {
                 FormSpecs.RELATED_GAP_COLSPEC,
                 FormSpecs.DEFAULT_COLSPEC,},
             new RowSpec[] {
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
                 FormSpecs.RELATED_GAP_ROWSPEC,
                 FormSpecs.DEFAULT_ROWSPEC,
                 FormSpecs.RELATED_GAP_ROWSPEC,
@@ -190,16 +173,23 @@ public class ContactProbeNozzleWizard extends AbstractConfigurationWizard {
         partHeightProbing = new JComboBox(ContactProbeTrigger.values());
         panel.add(partHeightProbing, "4, 20, fill, default");
         
+        lblDiscardProbing = new JLabel("Discard Probing");
+        lblDiscardProbing.setToolTipText("<html>Enable contact probing for discard. There must be a surface that the nozzle<br/>\r\ncan probe into that is likely to brush/tilt off a part from the nozzle, like a (ESD safe) soft<br/>\r\nmaterial or a slanted surface. \r\n</html>");
+        panel.add(lblDiscardProbing, "2, 22, right, default");
+
+        discardProbing = new JCheckBox("");
+        panel.add(discardProbing, "4, 22");
+
         lblZCalibration = new JLabel("Calibration Z Offset");
-        panel.add(lblZCalibration, "2, 24, right, default");
+        panel.add(lblZCalibration, "2, 26, right, default");
         
         calibrationOffsetZ = new JTextField();
         calibrationOffsetZ.setEditable(false);
-        panel.add(calibrationOffsetZ, "4, 24, fill, default");
+        panel.add(calibrationOffsetZ, "4, 26, fill, default");
         calibrationOffsetZ.setColumns(10);
         
         btnCalibrateNow = new JButton(calibrateZAction);
-        panel.add(btnCalibrateNow, "6, 24");
+        panel.add(btnCalibrateNow, "6, 26");
     }
 
     protected void adaptDialog() {
@@ -225,6 +215,8 @@ public class ContactProbeNozzleWizard extends AbstractConfigurationWizard {
         feederHeightProbing.setVisible(isActuator);
         lblPartHeightProbing.setVisible(isActuator);
         partHeightProbing.setVisible(isActuator);
+        lblDiscardProbing.setVisible(isActuator);
+        discardProbing.setVisible(isActuator);
 
         lblZCalibration.setVisible(isProbing);
         calibrationOffsetZ.setVisible(isProbing);
@@ -247,6 +239,7 @@ public class ContactProbeNozzleWizard extends AbstractConfigurationWizard {
 
         addWrappedBinding(nozzle, "feederHeightProbing", feederHeightProbing, "selectedItem");
         addWrappedBinding(nozzle, "partHeightProbing", partHeightProbing, "selectedItem");
+        addWrappedBinding(nozzle, "discardProbing", discardProbing, "selected");
 
         addWrappedBinding(nozzle, "calibrationOffsetZ", calibrationOffsetZ, "text", lengthConverter);
 
@@ -273,7 +266,30 @@ public class ContactProbeNozzleWizard extends AbstractConfigurationWizard {
             });
         }
     };
+
+    private JPanel panel;
+    private JLabel lblContactProbeActuator;
+    private JComboBox comboBoxContactProbeActuator;
+    private JLabel lblStartOffset;
+    private JTextField contactProbeStartOffsetZ;
+    private JLabel lblProbeDepth;
+    private JTextField contactProbeDepthZ;
+    private JLabel lblSniffleIncrement;
+    private JTextField sniffleIncrementZ;
+    private JLabel lblFinalAdjustment;
+    private JTextField contactProbeAdjustZ;
+    private JLabel lblMethod;
+    private JComboBox contactProbeMethod;
+    private JLabel lblFeederHeightProbing;
+    private JComboBox feederHeightProbing;
+    private JLabel lblPartHeightProbing;
+    private JComboBox partHeightProbing;
+    private JLabel lblZCalibration;
+    private JTextField calibrationOffsetZ;
+    private JButton btnCalibrateNow;
     private JLabel lblSniffleDwellTime;
     private JTextField sniffleDwellTime;
+    private JLabel lblDiscardProbing;
+    private JCheckBox discardProbing;
 
 }

--- a/src/main/java/org/openpnp/spi/JobProcessor.java
+++ b/src/main/java/org/openpnp/spi/JobProcessor.java
@@ -1,5 +1,8 @@
 package org.openpnp.spi;
 
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
 import org.openpnp.model.Job;
 
 public interface JobProcessor extends PropertySheetHolder, WizardConfigurable {
@@ -21,12 +24,24 @@ public interface JobProcessor extends PropertySheetHolder, WizardConfigurable {
         private static final long serialVersionUID = 1L;
         
         private final Object source;
-        
+
+        private static String getThrowableMessage(Throwable throwable) {
+            if (throwable.getMessage() != null) {
+                return throwable.getMessage();
+            }
+            // If a message is missing, use the stack trace as the message
+            // (same behavior as MessageBoxes.errorBox() when given an exception directly).
+            StringWriter sw = new StringWriter();
+            PrintWriter pw = new PrintWriter(sw);
+            throwable.printStackTrace(pw);
+            return sw.toString();
+        }
+
         public JobProcessorException(Object source, Throwable throwable) {
-            super(throwable.getMessage(), throwable);
+            super(getThrowableMessage(throwable), throwable);
             this.source = source;
         }
-        
+
         public JobProcessorException(Object source, String message) {
             super(message);
             this.source = source;

--- a/src/main/java/org/openpnp/spi/base/AbstractPnpJobProcessor.java
+++ b/src/main/java/org/openpnp/spi/base/AbstractPnpJobProcessor.java
@@ -1,9 +1,5 @@
 package org.openpnp.spi.base;
 
-import java.util.HashMap;
-import java.util.Map;
-
-import org.openpnp.model.Configuration;
 import org.openpnp.model.Part;
 import org.openpnp.spi.Feeder;
 import org.openpnp.spi.Head;
@@ -11,6 +7,7 @@ import org.openpnp.spi.Machine;
 import org.openpnp.spi.Nozzle;
 import org.openpnp.spi.PartAlignment;
 import org.openpnp.spi.PnpJobProcessor;
+import org.openpnp.util.Cycles;
 
 public abstract class AbstractPnpJobProcessor extends AbstractJobProcessor
         implements PnpJobProcessor {
@@ -23,29 +20,14 @@ public abstract class AbstractPnpJobProcessor extends AbstractJobProcessor
 
 
     /**
-     * Discard the Part, if any, on the given Nozzle. the Nozzle is returned to Safe Z at the end of
-     * the operation.
+     * Discard the Part, if any, on the given Nozzle.
      * 
      * @param nozzle
      * @throws Exception
      */
     public static void discard(Nozzle nozzle) throws JobProcessorException {
-        if (nozzle.getPart() == null) {
-            return;
-        }
-
         try {
-            Map<String, Object> globals = new HashMap<>();
-            globals.put("nozzle", nozzle);
-            Configuration.get().getScripting().on("Job.BeforeDiscard", globals);
-
-            // move to the discard location
-            nozzle.moveToPlacementLocation(Configuration.get().getMachine().getDiscardLocation(), null);
-            // discard the part
-            nozzle.place();
-            nozzle.moveToSafeZ();
-
-            Configuration.get().getScripting().on("Job.AfterDiscard", globals);
+            Cycles.discard(nozzle);
         }
         catch (Exception e) {
             throw new JobProcessorException(nozzle, e);


### PR DESCRIPTION
# Description
Fixed null pointer bug for discard placement. Discarding is signalled by passing `part` as `null`. 

- The `NullPointerException` was brought in by #1205 (by accessing the null part id). Fixed.
- Added new option for the ContactProbeNozzle to probe on discard. The part can be brushed/tilted away from the nozzle. Probing will make sure there is no undue pressure even with an unknown part-on-nozzle state (i.e. including when picked badly, tomb-stoned, shifted etc.). On my machine, I'm using soft material to brush parts away from the nozzle (just switching off the valve does not reliably drop 0402 parts). 
- The empty MessageBox on exceptions that have no message is fixed. 
- A ContactProbeNozzle Issues&Solutions bug was fixed: when the firmware was unknown (neither Smoothieware, nor TinyG, where probing G-code can be automatically suggested), it would constantly moan about missing G-code, when in fact it was present.

![Discard Probing Option](https://user-images.githubusercontent.com/9963310/123115037-13326f80-d440-11eb-96ae-d7ded9069c63.png)

Exceptions with no message (such as `NullPointerException`s) before and after:

![Error message before](https://user-images.githubusercontent.com/9963310/123115114-22192200-d440-11eb-9121-2ce1d2ff066d.png)
![Error message after](https://user-images.githubusercontent.com/9963310/123115269-42e17780-d440-11eb-9e6b-f047c8b8fe9f.png)

# Justification
User error report, see:
https://groups.google.com/g/openpnp/c/yea1C90iNlE/m/hFf3QR4BBAAJ

# Instructions for Use
Use the **Discard Probing** function with a ContactProbeNozzle. 

![Discard Probing Option](https://user-images.githubusercontent.com/9963310/123115662-8c31c700-d440-11eb-9fbc-72e70a9b2120.png)

- If **Discard Probing** is enabled, it should now unconditionally probe for the height, as it is not known if the part is on/off/tomb-stoned. But it should never store that probed height as the part height. 
- If **Discard Probing** is not enabled, it should just behave like a normal Nozzle (calls the super class method). 

# Implementation Details
1. Tested in simulation only (machine not functional at the moment). Used "random" relative motion G-code to simulate probing using the GcodeServer. 
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. Successful `mvn test` before submitting the Pull Request.

Sorry about the many afterthoughts/commits after the initial push. 
