### PR TITLE
Fix / Issues & Solutions Tab Title Snafu

### DIFF
--- a/src/main/java/org/openpnp/gui/IssuesAndSolutionsPanel.java
+++ b/src/main/java/org/openpnp/gui/IssuesAndSolutionsPanel.java
@@ -308,8 +308,6 @@ public class IssuesAndSolutionsPanel extends JPanel {
     }
 
     public void updateIssueIndicator() {
-        JTabbedPane tabs = frame.getTabs();
-        int index = tabs.indexOfComponent(frame.getIssuesAndSolutionsTab());
         Solutions.Severity maxSeverity = Solutions.Severity.None;
         for (Solutions.Issue issue : machine.getSolutions().getIssues()) {
             if (issue.getSeverity().ordinal() >= maxSeverity.ordinal() 
@@ -317,16 +315,24 @@ public class IssuesAndSolutionsPanel extends JPanel {
                 maxSeverity = issue.getSeverity();
             }
         }
-        if (maxSeverity.ordinal() > Solutions.Severity.Information.ordinal()) {
-            int indicatorUnicode = 0x2B24;
-            Color color = maxSeverity.color;
-            color = saturate(color);
-            tabs.setTitleAt(index, "<html>Issues &amp; Solutions <span style=\"color:#"
-                    +String.format("%02x%02x%02x", color.getRed(), color.getGreen(), color.getBlue())
-                    +";\">&#"+(indicatorUnicode)+";</span></html>");
-        }
-        else {
-            tabs.setTitleAt(index, "Issues & Solutions");
+        JTabbedPane tabs = frame.getTabs();
+        // Note this strange way to find the right tab is due to some inexplicable instability with 
+        // tabs.indexOfComponent(). See https://github.com/openpnp/openpnp/issues/1199
+        for (int index = 0; index < tabs.getTabCount(); index++) {
+            if (tabs.getTitleAt(index).contains("Issues")) {
+                if (maxSeverity.ordinal() > Solutions.Severity.Information.ordinal()) {
+                    int indicatorUnicode = 0x2B24;
+                    Color color = maxSeverity.color;
+                    color = saturate(color);
+                    tabs.setTitleAt(index, "<html>Issues &amp; Solutions <span style=\"color:#"
+                            +String.format("%02x%02x%02x", color.getRed(), color.getGreen(), color.getBlue())
+                            +";\">&#"+(indicatorUnicode)+";</span></html>");
+                }
+                else {
+                    tabs.setTitleAt(index, "Issues & Solutions");
+                }
+                break;
+            }
         }
     }
 


### PR DESCRIPTION
# Description
Apparently, on some systems, the components to tab index mapping is unreliable. This round-two-fix tries to circumvent that by comparing the tab title text (idea by @vonnieda).

# Justification
See #1199

# Instructions for Use
No change

# Implementation Details
1. Tested in simulation.
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. No sense running `mvn test` before submitting the Pull Request.
