### PR TITLE
Fix / FeedersPanel Move to Pick Location should not require compatible Nozzle Tip

### DIFF
--- a/src/main/java/org/openpnp/gui/FeedersPanel.java
+++ b/src/main/java/org/openpnp/gui/FeedersPanel.java
@@ -681,7 +681,13 @@ public class FeedersPanel extends JPanel implements WizardContainer {
                 Feeder feeder = getSelection();
                 Camera camera = MainFrame.get().getMachineControls().getSelectedTool().getHead()
                         .getDefaultCamera();
-                Nozzle nozzle = getCompatibleNozzleAndTip(feeder, false);
+                Nozzle nozzle;
+                try {
+                    nozzle = getCompatibleNozzleAndTip(feeder, false);
+                }
+                catch (Exception e) {
+                    nozzle = MainFrame.get().getMachineControls().getSelectedNozzle();
+                }
                 Location pickLocation = preliminaryPickLocation(feeder, nozzle);
                 MovableUtils.moveToLocationAtSafeZ(camera, pickLocation);
                 MovableUtils.fireTargetedUserAction(camera);
@@ -701,7 +707,7 @@ public class FeedersPanel extends JPanel implements WizardContainer {
         public void actionPerformed(ActionEvent arg0) {
             UiUtils.submitUiMachineTask(() -> {
                 Feeder feeder = getSelection();
-                Nozzle nozzle = getCompatibleNozzleAndTip(feeder, false);
+                Nozzle nozzle = getCompatibleNozzleAndTip(feeder, true);
 
                 Location pickLocation = preliminaryPickLocation(feeder, nozzle);
                 MovableUtils.moveToLocationAtSafeZ(nozzle, pickLocation);


### PR DESCRIPTION
# Description
Bugfix: FeedersPanel should not refuse moving the camera to the pick location if the wrong nozzle tip is loaded. 

The bug was brought in by #1174.

# Justification
See also 
https://groups.google.com/g/openpnp/c/-aEEO821wGo/m/N0lOog87AAAJ

# Instructions for Use
No change.

# Implementation Details
1. Tested on machine, inside #1220.
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. Successfully ran `mvn test`.
