### PR TITLE
Fix / Regression in null Part handling on Dynamic Safe Z

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/ContactProbeNozzle.java
+++ b/src/main/java/org/openpnp/machine/reference/ContactProbeNozzle.java
@@ -286,7 +286,9 @@ public class ContactProbeNozzle extends ReferenceNozzle {
     @Override
     public void moveToPlacementLocation(Location placementLocation, Part part) throws Exception {
         // Calculate the probe starting location.
-        Length partHeight = getSafePartHeight(part);
+        Length partHeight = ((part == null && nozzleTip != null) ? 
+                nozzleTip.getMaxPartHeight() // for discard 
+                : getSafePartHeight(part));  // for normal part operation
         Location placementLocationPart = placementLocation.add(new Location(partHeight.getUnits(), 0, 0, partHeight.getValue(), 0));
         // null part means discarding. 
         String partId = (part != null ? part.getId() : "discard");

--- a/src/main/java/org/openpnp/machine/reference/ReferenceNozzle.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceNozzle.java
@@ -449,16 +449,15 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
 
     @Override
     public Length getSafePartHeight(Part part) {
-        if ((part == null || part.isPartHeightUnknown()) 
-                && nozzleTip != null) {
-            return nozzleTip.getMaxPartHeight();
+        if (part != null) {
+            if (part.isPartHeightUnknown() && nozzleTip != null) {
+                return nozzleTip.getMaxPartHeight();
+            }
+            else {
+                return part.getHeight();
+            }
         }
-        else if (part != null) {
-            return part.getHeight();
-        }
-        else {
-            return new Length(0, LengthUnit.Millimeters);
-        }
+        return new Length(0, LengthUnit.Millimeters);
     }
 
     @Override 


### PR DESCRIPTION
# Description
The null part must not apply dynamic Safe Z (obviously). 

This bug was brought in by #1223, mistakenly thinking the null case can be generalized inside the helper method `getSafePartHeight()`. This has been reverted. 

Instead, ContactProbeNozzle must handle the null part case (for discard probing) specifically. 

# Justification
See  
https://groups.google.com/g/openpnp/c/Y20VM7QZd9U/m/iDQLEHrfAAAJ

# Instructions for Use
No change.

# Implementation Details
1. Tested in simulation (#1223 test regime).
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. Successful `mvn test` before submitting the Pull Request. 
