### PR TITLE
Fix / GcodeServer should ignore $ Commands

### DIFF
--- a/src/main/java/org/openpnp/util/GcodeServer.java
+++ b/src/main/java/org/openpnp/util/GcodeServer.java
@@ -346,11 +346,21 @@ public class GcodeServer extends Thread {
                 else if (Character.toUpperCase(ch) >= 'A' && Character.toUpperCase(ch) <= 'Z') {
                     // Finalize the running word.
                     commandWords = finalizeGcodeWord(currentWord, commandWords);
-                    // And start a new one.
+                    if (isDollar) {
+                        // we just support $H, the rest we ignore
+                        if (Character.toUpperCase(ch) == 'H') {
+                            currentWord = new GcodeWord(Character.toUpperCase(ch), isDollar);
+                        }
+                        break;
+                    }
+                    // And start a new word.
                     currentWord = new GcodeWord(Character.toUpperCase(ch), isDollar);
-                    isDollar = false;
                 }
                 else if (currentWord == null) {
+                    if (isDollar) {
+                        // custom command, probably TinyG setting, ignore
+                        break;
+                    }
                     // the remaining character are only allowed inside a word 
                     throw new Exception("Syntax error at col "+col+" '"+ch+"' unexpected: "+input);
                 }

--- a/src/main/java/org/openpnp/util/GcodeServer.java
+++ b/src/main/java/org/openpnp/util/GcodeServer.java
@@ -308,7 +308,7 @@ public class GcodeServer extends Thread {
             GcodeWord currentWord = null;
             int col = 0;
             boolean insideComment = false;
-            boolean isDollar = true;
+            boolean isDollar = false;
             List<GcodeWord> commandWords = new ArrayList<>();
             for (char ch : input.toCharArray()) {
                 col++;
@@ -344,21 +344,21 @@ public class GcodeServer extends Thread {
                     break;
                 }
                 else if (Character.toUpperCase(ch) >= 'A' && Character.toUpperCase(ch) <= 'Z') {
+                    if (isDollar) {
+                        // we just support $H, the rest we ignore.
+                        if (Character.toUpperCase(ch) != 'H') {
+                            break;
+                        }
+                    }
                     // Finalize the running word.
                     commandWords = finalizeGcodeWord(currentWord, commandWords);
-                    if (isDollar) {
-                        // we just support $H, the rest we ignore
-                        if (Character.toUpperCase(ch) == 'H') {
-                            currentWord = new GcodeWord(Character.toUpperCase(ch), isDollar);
-                        }
-                        break;
-                    }
-                    // And start a new word.
+                    // And start a new one.
                     currentWord = new GcodeWord(Character.toUpperCase(ch), isDollar);
+                    isDollar = false;
                 }
                 else if (currentWord == null) {
                     if (isDollar) {
-                        // custom command, probably TinyG setting, ignore
+                        // custom command, probably TinyG setting, ignore.
                         break;
                     }
                     // the remaining character are only allowed inside a word 
@@ -448,6 +448,9 @@ public class GcodeServer extends Thread {
         public String toString(List<GcodeWord> commandWords) {
             StringBuilder regurg = new StringBuilder();
             for (GcodeWord word : commandWords) {
+                if (word.isDollar()) {
+                    regurg.append('$');
+                }
                 regurg.append(word.letter);
                 if (word.signum < 0) {
                     regurg.append('-');
@@ -659,7 +662,7 @@ public class GcodeServer extends Thread {
                 GcodeWord g1Word = getCodeWord(Gcode.G1, commandWords);
                 GcodeWord hWord = getLetterWord('H', commandWords);
                 GcodeWord g28Word = getCodeWord(Gcode.G28, commandWords);
-                if (g0Word != null || g1Word != null || g28Word != null) {
+                if (g0Word != null || g1Word != null || g28Word != null || (hWord != null && hWord.isDollar())) {
                     double speed = 1.0;
                     if (g28Word != null || hWord != null && hWord.isDollar()) {
                         // Homing command.


### PR DESCRIPTION
# Description
Let the GcodeServer ignore `$` commands (except `$H`), so the typical TinyG setup chatter is ignored. 

# Justification
So I can test a TinyG user `machine.xml` against the GcodeServer controller simulator.

# Instructions for Use
Like always, set **Communications Type** to **tcp** and assign `GcodeServer` as the IP Address:

![grafik](https://user-images.githubusercontent.com/9963310/124000550-fd8af000-d9d3-11eb-8409-8905f88be12e.png)

You likely need to change the `COMMAND_CONFIRM_REGEX` to the standard, as the TinyG has a quirky one: 

![grafik](https://user-images.githubusercontent.com/9963310/124000778-388d2380-d9d4-11eb-8e40-ec050548007f.png)

Then you are ready to test with a TinyG `machine.xml`.

# Implementation Details
1. Tested as described in the Instruction for Use (above). Also tested if `$H` still works as a homing command. 
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. Successful `mvn test` before submitting the Pull Request. 
