### PR TITLE
Cleanup / Setting and Getting Nozzle Vacuum Actuators

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/feeder/ReferenceHeapFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/ReferenceHeapFeeder.java
@@ -282,8 +282,7 @@ public class ReferenceHeapFeeder extends ReferenceFeeder {
      * @throws Exception Something went wrong.
      */
     double readVacuum(Nozzle nozzle) throws Exception {
-        Actuator vacuumActuator = nozzle.getHead().getActuatorByName(((ReferenceNozzle)nozzle).getVacuumActuatorName());
-        return Double.parseDouble(vacuumActuator.read());
+        return ((ReferenceNozzle)nozzle).readVacuumLevel();
     }
 
     /**
@@ -317,7 +316,7 @@ public class ReferenceHeapFeeder extends ReferenceFeeder {
         }
         // prepare
         nozzle.moveToSafeZ();
-        nozzle.getHead().getActuatorByName(((ReferenceNozzle)nozzle).getVacuumActuatorName()).actuate(true);
+        ((ReferenceNozzle)nozzle).getExpectedVacuumActuator().actuate(true);
         long vacuumOn = System.currentTimeMillis();
         // move to heap
         nozzle.moveTo(location.derive(null, null, Double.NaN, null), Motion.MotionOption.SpeedOverPrecision);


### PR DESCRIPTION
# Description
* Make setting and getting vacuum actuators a public interface of ReferenceNozzle.
* In return, setting, getting, resolving actuators by name should be avoided outside the Nozzle (fixed in ReferenceHeapFeeder.java)
* This also improves diagnostics (Exceptions) when the actuator is not found (by name) vs. when it simply is not set. The nozzle is named in the second error message, so users know where to fix it.

![grafik](https://user-images.githubusercontent.com/9963310/127739164-f9cfe343-971a-41dd-a706-95b27551eee0.png)

![grafik](https://user-images.githubusercontent.com/9963310/127739169-b800b19d-b32d-4e5a-a24a-a5fe3524a529.png)

### Bug-fixes
* A minor migration error was fixed (Valve actuator was suggested to be of Double type when in fact it is Boolean).
* PartOff/PartOn enabling was mistakenly depending on the presence of the _valve_ actuator instead of the _sensing_ actuator. 

# Justification
This is a general move towards encapsulating the actuators' referencing by name. More specifically, it is in preparation for some actuator setting/getting in upcoming Issues & Solutions, where the vacuum actuators should also be created and wired by the automatic nozzle solution setup process (see #1188 section "Welcome Milestone").

# Instructions for Use
Same use as before.

# Implementation Details
1. Tested vacuum switching and sensing in GcodeServer simuation. 
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. Successful `mvn test` before submitting the Pull Request. 
