### PR TITLE
Update Install4J to 9.0.4 to make Fedora compatible

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -46,14 +46,14 @@ jobs:
 
       - name: Build Installers
         run: |
-          wget https://openpnp.s3-us-west-2.amazonaws.com/install4j_unix_8_0_6.tar.gz
-          tar -xzf install4j_unix_8_0_6.tar.gz
-          ./install4j8.0.6/bin/install4jc -L ${{secrets.INSTALL4J_LICENSE_KEY }}
+          wget https://download-gcdn.ej-technologies.com/install4j/install4j_unix_9_0_4.tar.gz
+          tar -xzf install4j_unix_9_0_4.tar.gz
+          ./install4j9.0.4/bin/install4jc -L ${{secrets.INSTALL4J_LICENSE_KEY }}
           wget https://s3-us-west-2.amazonaws.com/openpnp/macosx-amd64-1.8.0_131.tar.gz
           wget https://s3-us-west-2.amazonaws.com/openpnp/windows-amd64-1.8.0_131.tar.gz
           wget https://s3-us-west-2.amazonaws.com/openpnp/windows-x86-1.8.0_131.tar.gz
           VERSION=`java -jar target/openpnp-gui-0.0.1-alpha-SNAPSHOT.jar --version`
-          ./install4j8.0.6/bin/install4jc -r $VERSION -d installers -D mediaFileVersion=$BRANCH_NAME OpenPnP.install4j
+          ./install4j9.0.4/bin/install4jc -r $VERSION -d installers -D mediaFileVersion=$BRANCH_NAME OpenPnP.install4j
           mv installers/updates.xml installers/updates-$BRANCH_NAME.xml
           mkdir -p installers/$BRANCH_NAME/$VERSION
           cp installers/OpenPnP* installers/$BRANCH_NAME/$VERSION


### PR DESCRIPTION
# Description
Update Install4J version to fix RPM package, fixes #1229 

# Justification
Due to a regression, Install4J version 8 doesn't work on Fedora 33 and 34. This PR makes it work, making it possible for Fedora users to use the RPM package.

# Instructions for Use
No changes to the workflow or installation procedure.

# Implementation Details
1. How did you test the change? 

I've made the change and allowed the scripts to run on my fork and created a Install4J trial license key to test and I have confirmed it works by installing it on my machine (Fedora 34).

2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)?

The only thing which my edit diverts from what was done is that it is using Install4J servers and not the privately owned AWS service that @vonnieda seems to have.

3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing.

N/A

4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted.

N/A