### PR TITLE
Fix / Bug in Similarity Comparison Function

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/feeder/ReferencePushPullFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/ReferencePushPullFeeder.java
@@ -1796,7 +1796,7 @@ public class ReferencePushPullFeeder extends ReferenceFeeder {
                     return diff;
                 }
                 // same part pitch is favored
-                diff = (getPartPitch().equals(feeder1.getPartPitch())?0:1) - (getPartPitch().equals(getPartPitch())?0:1);
+                diff = (getPartPitch().equals(feeder1.getPartPitch())?0:1) - (getPartPitch().equals(feeder2.getPartPitch())?0:1);
                 if (diff != 0) {
                     return diff;
                 }


### PR DESCRIPTION
# Description
Fixes a bug in the heuristic feeder parts similarity comparison function. Instead of comparing the similarity in part pitch with feeder1 and feeder2 respectively, it compared similarity with feeder1 and similarity with itself (always equal).

Not surprisingly, this created a 
`java.lang.IllegalArgumentException: Comparison method violates its general contract!`
as soon as the more important properties (tape spec, package, template status) were all equal, but part pitch was different.

# Justification
See https://groups.google.com/g/openpnp/c/VDEKlvYKfTY/m/h3qBvl4GAwAJ

# Instructions for Use
Same as before.

# Implementation Details
1. Cognitive test (see source code change).
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. Successful `mvn test` before submitting the Pull Request. 
