### PR TITLE
Feature / Nozzle Vacuum Actuators by Reference, not by Name (Round 2)

### DIFF
--- a/src/main/java/org/openpnp/machine/neoden4/NeoDen4Driver.java
+++ b/src/main/java/org/openpnp/machine/neoden4/NeoDen4Driver.java
@@ -148,10 +148,8 @@ public class NeoDen4Driver extends AbstractReferenceDriver {
             n = new ReferenceNozzle("N1");
             n.setName("N1");
             head.addNozzle(n);
-            getOrCreateActuatorInHead(head, ACT_N1_VACUUM);
-            getOrCreateActuatorInHead(head, ACT_N1_BLOW);
-            n.setBlowOffActuatorName(ACT_N1_BLOW);
-            n.setVacuumActuatorName(ACT_N1_VACUUM);
+            n.setVacuumActuator(getOrCreateActuatorInHead(head, ACT_N1_VACUUM));
+            n.setBlowOffActuator(getOrCreateActuatorInHead(head, ACT_N1_BLOW));
         }
         
         n = (ReferenceNozzle) head.getNozzle("N2");
@@ -159,10 +157,8 @@ public class NeoDen4Driver extends AbstractReferenceDriver {
             n = new ReferenceNozzle("N2");
             n.setName("N2");
             head.addNozzle(n);
-            getOrCreateActuatorInHead(head, ACT_N2_VACUUM);
-            getOrCreateActuatorInHead(head, ACT_N2_BLOW);
-            n.setBlowOffActuatorName(ACT_N2_BLOW);
-            n.setVacuumActuatorName(ACT_N2_VACUUM);
+            n.setVacuumActuator(getOrCreateActuatorInHead(head, ACT_N2_VACUUM));
+            n.setBlowOffActuator(getOrCreateActuatorInHead(head, ACT_N2_BLOW));
         }
         
         n = (ReferenceNozzle) head.getNozzle("N3");
@@ -170,10 +166,8 @@ public class NeoDen4Driver extends AbstractReferenceDriver {
             n = new ReferenceNozzle("N3");
             n.setName("N3");
             head.addNozzle(n);
-            getOrCreateActuatorInHead(head, ACT_N3_VACUUM);
-            getOrCreateActuatorInHead(head, ACT_N3_BLOW);
-            n.setBlowOffActuatorName(ACT_N3_BLOW);
-            n.setVacuumActuatorName(ACT_N3_VACUUM);
+            n.setVacuumActuator(getOrCreateActuatorInHead(head, ACT_N3_VACUUM));
+            n.setBlowOffActuator(getOrCreateActuatorInHead(head, ACT_N3_BLOW));
        }
         
         n = (ReferenceNozzle) head.getNozzle("N4");
@@ -181,10 +175,8 @@ public class NeoDen4Driver extends AbstractReferenceDriver {
             n = new ReferenceNozzle("N4");
             n.setName("N4");
             head.addNozzle(n);
-            getOrCreateActuatorInHead(head, ACT_N4_VACUUM);
-            getOrCreateActuatorInHead(head, ACT_N4_BLOW);
-            n.setBlowOffActuatorName(ACT_N4_BLOW);
-            n.setVacuumActuatorName(ACT_N4_VACUUM);
+            n.setVacuumActuator(getOrCreateActuatorInHead(head, ACT_N4_VACUUM));
+            n.setBlowOffActuator(getOrCreateActuatorInHead(head, ACT_N4_BLOW));
         }
         
         a = (ReferenceActuator) machine.getActuatorByName("Lights-Down");

--- a/src/main/java/org/openpnp/machine/reference/HttpActuator.java
+++ b/src/main/java/org/openpnp/machine/reference/HttpActuator.java
@@ -68,6 +68,11 @@ public class HttpActuator extends ReferenceActuator {
     public HttpActuator() {}
 
     @Override
+    public boolean isDriverless() {
+        return true;
+    }
+
+    @Override
     protected void driveActuation(boolean on) throws Exception {
         if (on && this.onUrl.isEmpty()) {
             driveActuation("1");

--- a/src/main/java/org/openpnp/machine/reference/ScriptActuator.java
+++ b/src/main/java/org/openpnp/machine/reference/ScriptActuator.java
@@ -4,10 +4,10 @@ import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.openpnp.scripting.Scripting;
 import org.openpnp.gui.support.Wizard;
 import org.openpnp.machine.reference.wizards.ScriptActuatorConfigurationWizard;
 import org.openpnp.model.Configuration;
+import org.openpnp.scripting.Scripting;
 import org.simpleframework.xml.Element;
 
 public class ScriptActuator extends ReferenceActuator {
@@ -21,6 +21,11 @@ public class ScriptActuator extends ReferenceActuator {
         File scriptsDirectory = scripting.getScriptsDirectory();
         File script = new File(scriptsDirectory, scriptName);
         scripting.execute(script, globals);
+    }
+
+    @Override
+    public boolean isDriverless() {
+        return true;
     }
 
     @Override

--- a/src/main/java/org/openpnp/machine/reference/feeder/ReferenceHeapFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/ReferenceHeapFeeder.java
@@ -975,7 +975,7 @@ public class ReferenceHeapFeeder extends ReferenceFeeder {
             // discard the part
             nozzle.place();
             // blow off the part
-            Actuator blowOffValve = nozzle.getHead().getActuatorByName(((ReferenceNozzle) nozzle).getBlowOffActuatorName()); 
+            Actuator blowOffValve = ((ReferenceNozzle) nozzle).getBlowOffActuator(); 
             if (blowOffValve != null) {
                 blowOffValve.actuate(true);
             }

--- a/src/main/java/org/openpnp/machine/reference/wizards/ReferenceNozzleVacuumWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/wizards/ReferenceNozzleVacuumWizard.java
@@ -27,7 +27,9 @@ import javax.swing.JPanel;
 
 import org.openpnp.gui.support.AbstractConfigurationWizard;
 import org.openpnp.gui.support.ActuatorsComboBoxModel;
+import org.openpnp.gui.support.NamedConverter;
 import org.openpnp.machine.reference.ReferenceNozzle;
+import org.openpnp.spi.Actuator;
 
 import com.jgoodies.forms.layout.CellConstraints;
 import com.jgoodies.forms.layout.ColumnSpec;
@@ -96,9 +98,9 @@ public class ReferenceNozzleVacuumWizard extends AbstractConfigurationWizard {
 
     @Override
     public void createBindings() {
-
-        addWrappedBinding(nozzle, "vacuumActuatorName", vacuumComboBoxActuator, "selectedItem");
-        addWrappedBinding(nozzle, "blowOffActuatorName", blowOffComboBoxActuator, "selectedItem");
-        addWrappedBinding(nozzle, "vacuumSenseActuatorName", vacuumSenseActuator, "selectedItem");
+        NamedConverter<Actuator> actuatorConverter = (new NamedConverter<>(nozzle.getHead().getActuators()));
+        addWrappedBinding(nozzle, "vacuumActuator", vacuumComboBoxActuator, "selectedItem", actuatorConverter);
+        addWrappedBinding(nozzle, "blowOffActuator", blowOffComboBoxActuator, "selectedItem", actuatorConverter);
+        addWrappedBinding(nozzle, "vacuumSenseActuator", vacuumSenseActuator, "selectedItem", actuatorConverter);
     }
 }

--- a/src/main/java/org/openpnp/spi/Actuator.java
+++ b/src/main/java/org/openpnp/spi/Actuator.java
@@ -37,6 +37,13 @@ public interface Actuator
 
     public void setDriver(Driver driver);
 
+    /**
+     * @return true if a Driver is not required. Some actuator sub-classes use alternative means for actuation (http, scripting, etc).
+     */
+    public default boolean isDriverless() {
+        return false;
+    }
+
     public enum ActuatorValueType {
         Double,
         Boolean,

--- a/src/main/java/org/openpnp/spi/Machine.java
+++ b/src/main/java/org/openpnp/spi/Machine.java
@@ -100,6 +100,12 @@ public interface Machine extends WizardConfigurable, PropertySheetHolder, Closea
     public List<Actuator> getActuators();
 
     /**
+     * Gets a list of all Actuator attached to the Machine and to all the Heads.
+     * @return
+     */
+    public List<Actuator> getAllActuators();
+
+    /**
      * Get the Actuator attached to this Machine and not to a Head that has the specified id.
      * 
      * @param id

--- a/src/main/java/org/openpnp/spi/base/AbstractMachine.java
+++ b/src/main/java/org/openpnp/spi/base/AbstractMachine.java
@@ -112,7 +112,7 @@ public abstract class AbstractMachine extends AbstractModelObject implements Mac
             head.setMachine(this);
         }
     }
-    
+
     public void addHead(Head head) {
         head.setMachine(this);
         heads.add(head);
@@ -255,6 +255,16 @@ public abstract class AbstractMachine extends AbstractModelObject implements Mac
     @Override
     public List<Actuator> getActuators() {
         return Collections.unmodifiableList(actuators);
+    }
+
+    @Override
+    public List<Actuator> getAllActuators() {
+        Stream<Actuator> stream = Stream.of();
+        for (Head head : getHeads()) {
+            stream = Stream.concat(stream, head.getActuators().stream());
+        }
+        stream = Stream.concat(stream, getActuators().stream());
+        return stream.collect(Collectors.toList());
     }
 
     @Override

--- a/src/test/java/ReferenceJobProcessorRetryTests.java
+++ b/src/test/java/ReferenceJobProcessorRetryTests.java
@@ -1,3 +1,7 @@
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import javax.swing.Action;
 
 import org.junit.jupiter.api.Test;
@@ -29,8 +33,6 @@ import org.openpnp.spi.Nozzle;
 import org.openpnp.spi.NozzleTip;
 import org.openpnp.spi.PnpJobProcessor;
 import org.openpnp.spi.PropertySheetHolder;
-
-import static org.junit.jupiter.api.Assertions.*;
 
 public class ReferenceJobProcessorRetryTests {
     /**
@@ -328,8 +330,8 @@ public class ReferenceJobProcessorRetryTests {
             nozzle.setAxis(new ReferenceVirtualAxis(Type.Z));
             nozzle.setAxis(new ReferenceVirtualAxis(Type.Rotation));
             nozzle.setChangerEnabled(true);
-            nozzle.setVacuumActuatorName(name + "_VAC");
-            nozzle.setVacuumSenseActuatorName(name + "_VAC");
+            nozzle.setVacuumActuator(actuator);
+            nozzle.setVacuumSenseActuator(actuator);
             
             for (String ntName : compatibleNozzleTipNames) {
                 NozzleTip nt = machine.getNozzleTipByName(ntName);


### PR DESCRIPTION
# Description

## Features
* The ReferenceNozzle now stores Actuator object references internally, names are only used for persistence.
* Therefore, changing an actuator name no longer breaks the reference.
* Nozzle actuator setters/getters by name were removed. Code accessing these was refactored.
* The ReferenceNozzleVacuumWizard was reworked to use references instead of names.
* Bonus: The Nozzle adds simple reminders to Issues & Solutions, when vacuum actuators, assigned drivers, and/or their G-code command and/or regex are missing.

## Changes in SPI
* `org.openpnp.spi.Actuator.isDriverless()` was added to declare when an Actuator does not need a driver. `HttpActuator` and `ScriptActuator` are ok to be driverless even though they are derived from `ReferenceActuator` which _needs_ a driver (the distinction is required for Issues & Solutions support). Obviously, a more thorough refactoring would be to create a common abstract base class for  `HttpActuator`, `ScriptActuator`  and `ReferenceActuator`, and then only add the driver to the `ReferenceActuator`. 
* `org.openpnp.spi.Machine.getAllActuators()` was added to get all actuators from all heads and the machine (analog to `getAllCameras()`).

This builds on top of #1231. This turned out to be insufficient for the purpose (which is upcoming Issues & Solutions automatic vacuum actuator creation support). 

# Justification
Same as in #1231.

# Instructions for Use
Same as before. 

https://github.com/openpnp/openpnp/wiki/Setup-and-Calibration%3A-Vacuum-Setup

You can now change actuator names without problems. 

# Implementation Details
1. Tested in simulation. 
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. Changes in the `org.openpnp.spi` package, see "Changes in SPI " section above.
4. Successful `mvn test` before submitting the Pull Request. 
