### PR TITLE
pom: Add an assembly to generate tarball during maven package

### DIFF
--- a/assembly_bin.xml
+++ b/assembly_bin.xml
@@ -1,0 +1,30 @@
+<assembly xmlns="http://maven.apache.org/ASSEMBLY/2.1.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.1.0 http://maven.apache.org/xsd/assembly-2.1.0.xsd">
+	<id>bin</id>
+	<formats>
+		<format>tar.gz</format>
+	</formats>
+	<fileSets>
+		<fileSet>
+			<directory>${project.basedir}</directory>
+			<outputDirectory></outputDirectory>
+			<includes>
+				<include>openpnp.sh</include>
+				<include>CHANGES.md</include>
+				<include>SPONSORS.md</include>
+				<include>LICENSE.txt</include>
+				<include>OPENPNP_2_0.md</include>
+				<include>samples/**</include>
+			</includes>
+		</fileSet>
+		<fileSet>
+			<directory>${project.build.directory}</directory>
+			<outputDirectory>target</outputDirectory>
+			<includes>
+				<include>*.jar</include>
+				<include>lib/**</include>
+			</includes>
+		</fileSet>
+	</fileSets>
+</assembly>

--- a/pom.xml
+++ b/pom.xml
@@ -388,6 +388,24 @@
 				</configuration>
 			</plugin>
 
+			<!-- Generate a tarball as part of the package phase -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-assembly-plugin</artifactId>
+				<configuration>
+					<descriptor>assembly_bin.xml</descriptor>
+					<finalName>openpnp-gui-${pom.version}</finalName>
+				</configuration>
+				<executions>
+					<execution>
+						<phase>package</phase>
+						<goals>
+							<goal>single</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+
 		</plugins>
 		<pluginManagement>
 			<plugins>


### PR DESCRIPTION
# Description
Use maven assembly plugin to generate a tarball at the package phase. Add assembly xml to specify contents.

The contents are similar to the Install4j contents.

# Justification
When using a yocto recipe to install openpnp into an image it's convenient to have a tar file as a build artefact. This avoids the recipe needing detailed knowledge of the build files produced.

NB - Anti-justification: This change results in an additional 180MB-ish file being generated which isn't of any use to most people.

# Instructions for Use
Not relevant for end users. For developers the mvn package phase now generates a tar.gz file with the same prefix as the jar file.

# Implementation Details
1. How did you test the change? Be descriptive. Untested code will not be accepted.
2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)?
3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing.
4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted.

``
1. Just tested mvn package. Original output unaffected. Tar is also created.
2. N/A
3. No changes to source code
4. Maven tests unaffected as they run before package phase. They still pass.
