### PR TITLE
Feature / Round-up of UI and Utils Improvements

### DIFF
--- a/src/main/java/org/openpnp/gui/components/CameraView.java
+++ b/src/main/java/org/openpnp/gui/components/CameraView.java
@@ -664,7 +664,7 @@ public class CameraView extends JComponent implements CameraListener {
                 g2d.drawImage(lastFrame, imageX, imageY, scaledWidth, scaledHeight, null);
             }
             else {
-                g2d.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_BILINEAR);
+                g2d.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_BICUBIC);
                 g2d.setRenderingHint(RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_QUALITY);
                 g2d.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
                 AffineTransform t = new AffineTransform();

--- a/src/main/java/org/openpnp/gui/components/SimpleGraphView.java
+++ b/src/main/java/org/openpnp/gui/components/SimpleGraphView.java
@@ -121,12 +121,7 @@ public class SimpleGraphView extends JComponent implements MouseMotionListener, 
         FontMetrics dfm = g2d.getFontMetrics(font);
         int fontLineHeight = dfm.getAscent()+1; // numbers are all ascent
         int fontAscent = dfm.getAscent();
-        Color gridColor = UIManager.getColor ( "PasswordField.capsLockIconColor" );
-        if (gridColor == null) {
-            gridColor = new Color(0, 0, 0, 64);
-        } else {
-            gridColor = new Color(gridColor.getRed(), gridColor.getGreen(), gridColor.getBlue(), 64);
-        }
+        Color gridColor = SimpleGraph.getDefaultGridColor();
         g2d.setFont(font);
         int w = getWidth();
         int h = getHeight();

--- a/src/main/java/org/openpnp/gui/components/TemplateImageControl.java
+++ b/src/main/java/org/openpnp/gui/components/TemplateImageControl.java
@@ -104,16 +104,16 @@ public class TemplateImageControl extends JComponent implements MouseMotionListe
         g2d.setRenderingHint(RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_QUALITY);
         g2d.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
         Color gridColor = UIManager.getColor ( "PasswordField.capsLockIconColor" );
-        Font font = getFont();
-        FontMetrics dfm = g2d.getFontMetrics(font);
-        g2d.setFont(font);
-        int w = getWidth();
-        int h = getHeight();
         if (gridColor == null) {
             gridColor = new Color(0, 0, 0, 64);
         } else {
             gridColor = new Color(gridColor.getRed(), gridColor.getGreen(), gridColor.getBlue(), 64);
         }
+        Font font = getFont();
+        FontMetrics dfm = g2d.getFontMetrics(font);
+        g2d.setFont(font);
+        int w = getWidth();
+        int h = getHeight();
         BufferedImage image = getImage();
         if (image != null) {
             g2d.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_BILINEAR);

--- a/src/main/java/org/openpnp/machine/reference/ReferenceNozzleTip.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceNozzleTip.java
@@ -9,7 +9,6 @@ import javax.imageio.ImageIO;
 import javax.swing.AbstractAction;
 import javax.swing.Action;
 import javax.swing.JOptionPane;
-import javax.swing.UIManager;
 
 import org.opencv.core.Core;
 import org.opencv.core.Core.MinMaxLocResult;
@@ -951,12 +950,6 @@ public class ReferenceNozzleTip extends AbstractNozzleTip {
     public static final String VALVE_ON = "ON"; 
 
     protected final SimpleGraph startNewVacuumGraph(double vacuumLevel, boolean valveSwitchingOn) {
-        Color gridColor = UIManager.getColor ( "PasswordField.capsLockIconColor" );
-        if (gridColor == null) {
-            gridColor = new Color(0, 0, 0, 64);
-        } else {
-            gridColor = new Color(gridColor.getRed(), gridColor.getGreen(), gridColor.getBlue(), 64);
-        }
         // start a new graph 
         SimpleGraph vacuumGraph = new SimpleGraph();
         vacuumGraph.setRelativePaddingLeft(0.05);
@@ -964,7 +957,7 @@ public class ReferenceNozzleTip extends AbstractNozzleTip {
         // init pressure scale
         SimpleGraph.DataScale vacuumScale =  vacuumGraph.getScale(PRESSURE);
         vacuumScale.setRelativePaddingBottom(0.3);
-        vacuumScale.setColor(gridColor);
+        vacuumScale.setColor(SimpleGraph.getDefaultGridColor());
         // init valve scale
         SimpleGraph.DataScale valveScale =  vacuumGraph.getScale(BOOLEAN);
         valveScale.setRelativePaddingTop(0.75);

--- a/src/main/java/org/openpnp/machine/reference/axis/wizards/AbstractAxisConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/axis/wizards/AbstractAxisConfigurationWizard.java
@@ -54,7 +54,7 @@ public abstract class AbstractAxisConfigurationWizard extends AbstractConfigurat
         contentPanel.add(panelProperties);
         panelProperties.setLayout(new FormLayout(new ColumnSpec[] {
                 FormSpecs.RELATED_GAP_COLSPEC,
-                FormSpecs.DEFAULT_COLSPEC,
+                ColumnSpec.decode("max(70dlu;default)"),
                 FormSpecs.RELATED_GAP_COLSPEC,
                 FormSpecs.DEFAULT_COLSPEC,},
             new RowSpec[] {

--- a/src/main/java/org/openpnp/machine/reference/camera/AutoFocusProvider.java
+++ b/src/main/java/org/openpnp/machine/reference/camera/AutoFocusProvider.java
@@ -169,7 +169,7 @@ public class AutoFocusProvider implements FocusProvider {
      * @param filteredImage
      * @return
      */
-    public static double focusScore(BufferedImage image, int diameter, BufferedImage filteredImage) {
+    protected double focusScore(BufferedImage image, int diameter, BufferedImage filteredImage) {
         diameter &= ~1; // Must be an even number.
         final int bands = image.getRaster().getNumBands();
         final int width = image.getWidth();

--- a/src/main/java/org/openpnp/machine/reference/camera/wizards/AutoFocusProviderConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/camera/wizards/AutoFocusProviderConfigurationWizard.java
@@ -183,11 +183,15 @@ public class AutoFocusProviderConfigurationWizard extends AbstractConfigurationW
                 if (!(nozzle instanceof ReferenceNozzle)) {
                     throw new Exception("Expected "+nozzle.getName()+" to be a ReferenceNozzle");
                 }
-                ReferenceNozzleTip nt = (ReferenceNozzleTip) nozzle.getNozzleTip(); 
+                ReferenceNozzleTip nt = ((ReferenceNozzle) nozzle).getCalibrationNozzleTip(); 
+                if (nt == null) {
+                    throw new Exception("A nozzle tip must be loaded, or the \"unloaded\" nozzle tip stand-in must be defined.");
+                }
                 Location location1 = camera.getLocation(nozzle)
                         .derive(nozzle.getLocation(), false, false, false, true); // Keep rotation
-                Location location0 = location1.add(new Location(nt.getMaxPartHeight().getUnits(), 
-                        0, 0, nt.getMaxPartHeight().getValue(), 0));
+                Length maxPartHeight = nt.getMaxPartHeight();
+                Location location0 = location1.add(new Location(maxPartHeight.getUnits(), 
+                        0, 0, maxPartHeight.getValue(), 0));
                 Location focus = focusProvider.autoFocus(camera, nozzle, nt.getMaxPartDiameter(), location0, location1);
                 setLastFocusDistance(focus.getXyzLengthTo(location1));
                 MovableUtils.fireTargetedUserAction(camera);

--- a/src/main/java/org/openpnp/machine/reference/feeder/BlindsFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/BlindsFeeder.java
@@ -64,6 +64,7 @@ import org.openpnp.util.HslColor;
 import org.openpnp.util.MovableUtils;
 import org.openpnp.util.OpenCvUtils;
 import org.openpnp.util.TravellingSalesman;
+import org.openpnp.util.Utils2D;
 import org.openpnp.util.VisionUtils;
 import org.openpnp.vision.FluentCv;
 import org.openpnp.vision.Ransac.Line;
@@ -554,16 +555,6 @@ public class BlindsFeeder extends ReferenceFeeder {
 
         }
 
-        private double angleNorm(double angle) {
-            while (angle > 45) {
-                angle -= 90;
-            }
-            while (angle < -45) {
-                angle += 90;
-            }
-            return angle;
-        }
-
         @SuppressWarnings("unchecked")
         public FindFeatures invoke() throws Exception {
             List<RotatedRect> results = null;
@@ -639,7 +630,7 @@ public class BlindsFeeder extends ReferenceFeeder {
                         double angle = transformPixelToFeederAngle(result.angle);
                         Location mmSize = mmScale.multiply(result.size.width, result.size.height, 0, 0);
                         if (positionTolerant || cameraFeederLocation.getLinearDistanceTo(center) < positionTolerance) {
-                            if (angleTolerant || Math.abs(angleNorm(angle - 45)) < angleTolerance) {
+                            if (angleTolerant || Math.abs(Utils2D.angleNorm(angle - 45)) < angleTolerance) {
                                 if (mmSize.getX() > fidMin && mmSize.getX() < fidMax 
                                         && mmSize.getY() > fidMin && mmSize.getY() < fidMax
                                         && mmSize.getX()/mmSize.getY() < fidAspect 
@@ -664,7 +655,7 @@ public class BlindsFeeder extends ReferenceFeeder {
                         }
                         if (positionTolerant || Math.abs(cameraFeederY - center.getY()) < positionTolerance) {
                             if (positionTolerant || Math.abs(cameraFeederX - center.getX()) < pocketRange) {
-                                    if (angleTolerant || Math.abs(angleNorm(angle - 0)) < angleTolerance) {
+                                    if (angleTolerant || Math.abs(Utils2D.angleNorm(angle - 0)) < angleTolerance) {
                                     if (mmSize.getX() > blindMin && mmSize.getX() < blindMax && mmSize.getY() > blindMin && mmSize.getY() < blindMax
                                             && mmSize.getX()/mmSize.getY() < blindAspect 
                                             && mmSize.getY()/mmSize.getX() < blindAspect) {

--- a/src/main/java/org/openpnp/machine/reference/feeder/ReferencePushPullFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/ReferencePushPullFeeder.java
@@ -65,6 +65,7 @@ import org.openpnp.spi.PropertySheetHolder;
 import org.openpnp.util.MovableUtils;
 import org.openpnp.util.OpenCvUtils;
 import org.openpnp.util.TravellingSalesman;
+import org.openpnp.util.Utils2D;
 import org.openpnp.util.VisionUtils;
 import org.openpnp.vision.FluentCv;
 import org.openpnp.vision.Ransac;
@@ -1479,7 +1480,7 @@ public class ReferencePushPullFeeder extends ReferenceFeeder {
                             Location partLocation = camera.getLocation().convertToUnits(LengthUnit.Millimeters);
                             double angle1 = Math.atan2(calibratedHole1Location.getY()-partLocation.getY(), calibratedHole1Location.getX()-partLocation.getX());
                             double angle2 = Math.atan2(calibratedHole2Location.getY()-partLocation.getY(), calibratedHole2Location.getX()-partLocation.getX());
-                            double angleDiff = angleNorm180((angle2-angle1)*180/Math.PI);
+                            double angleDiff = Utils2D.angleNorm(Math.toDegrees(angle2-angle1), 180);
                             if (angleDiff > 0) {
                                 // The holes 1 and 2 must appear counter-clockwise from the part location, swap them! 
                                 Location swap = calibratedHole2Location;
@@ -1617,16 +1618,6 @@ public class ReferencePushPullFeeder extends ReferenceFeeder {
                 throw new Exception("Unrecognized result type (should be Result.Circle, RotatedRect, KeyPoint): " + resultsList);
             }
             return this;
-        }
-
-        private double angleNorm180(double angle) {
-            while (angle > 180) {
-                angle -= 360;
-            }
-            while (angle < -180) {
-                angle += 360;
-            }
-            return angle;
         }
     }
 

--- a/src/main/java/org/openpnp/machine/reference/vision/ReferenceBottomVision.java
+++ b/src/main/java/org/openpnp/machine/reference/vision/ReferenceBottomVision.java
@@ -130,7 +130,7 @@ public class ReferenceBottomVision implements PartAlignment {
             wantedAngle = Utils2D.calculateBoardPlacementLocation(boardLocation, placementLocation)
                            .getRotation();
         }
-        wantedAngle = angleNorm(wantedAngle, 180.);
+        wantedAngle = Utils2D.angleNorm(wantedAngle, 180.);
         // Wanted location.
         Location wantedLocation = getCameraLocationAtPartHeight(part, camera, nozzle, wantedAngle);
                 
@@ -159,10 +159,10 @@ public class ReferenceBottomVision implements PartAlignment {
                 // is which. We can assume that the part is never picked more than +/-45º rotated.
                 // So we change the range wrapping-around to -45° .. +45°. See angleNorm():
                 if (partSettings.getMaxRotation() == MaxRotation.Adjust ) {
-                    angleOffset = angleNorm(angleOffset);
+                    angleOffset = Utils2D.angleNorm(angleOffset);
                 } else {
                     // turning more than 180° in one direction makes no sense
-                    angleOffset = angleNorm(angleOffset, 180);
+                    angleOffset = Utils2D.angleNorm(angleOffset, 180);
                 }
 
                 // When we rotate the nozzle later to compensate for the angle offset, the X, Y offsets 
@@ -248,10 +248,10 @@ public class ReferenceBottomVision implements PartAlignment {
             // is which. We can assume that the part is never picked more than +/-45º rotated.
             // So we change the range wrapping-around to -45° .. +45°. See angleNorm():
             if (partSettings.getMaxRotation() == MaxRotation.Adjust ) {
-                angleOffset = angleNorm(angleOffset);
+                angleOffset = Utils2D.angleNorm(angleOffset);
             } else {
                 // turning more than 180° in one direction makes no sense
-                angleOffset = angleNorm(angleOffset, 180);
+                angleOffset = Utils2D.angleNorm(angleOffset, 180);
             }
             
             if (!partSizeCheck(part, partSettings, rect, camera) ) {
@@ -420,18 +420,6 @@ public class ReferenceBottomVision implements PartAlignment {
         catch (Exception e) {
             throw new Error(e);
         }
-    }
-
-    private static double angleNorm(double val, double lim) {
-        double clip = lim * 2;
-        while (Math.abs(val) > lim) {
-            val += (val < 0.) ? clip : -clip;
-        }
-        return val;
-    }
-
-    private static double angleNorm(double val) {
-        return angleNorm(val, 45.);
     }
 
     @Override

--- a/src/main/java/org/openpnp/machine/reference/wizards/ReferenceNozzleTipCalibrationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/wizards/ReferenceNozzleTipCalibrationWizard.java
@@ -474,5 +474,12 @@ public class ReferenceNozzleTipCalibrationWizard extends AbstractConfigurationWi
         BeanProperty<JComboBox, Boolean> jComboBoxBeanProperty = BeanProperty.create("enabled");
         AutoBinding<JCheckBox, Boolean, JComboBox, Boolean> autoBinding_9 = Bindings.createAutoBinding(UpdateStrategy.READ, calibrationEnabledCheckbox, jCheckBoxBeanProperty, recalibrationCb, jComboBoxBeanProperty);
         autoBinding_9.bind();
+        //
+        AutoBinding<JCheckBox, Boolean, JTextField, Boolean> autoBinding_2 = Bindings.createAutoBinding(UpdateStrategy.READ, calibrationEnabledCheckbox, jCheckBoxBeanProperty, calibrationTipDiameter, jTextFieldBeanProperty);
+        autoBinding_2.bind();
+        //
+        BeanProperty<JCheckBox, Boolean> jCheckBoxBeanProperty_1 = BeanProperty.create("enabled");
+        AutoBinding<JCheckBox, Boolean, JCheckBox, Boolean> autoBinding_11 = Bindings.createAutoBinding(UpdateStrategy.READ, calibrationEnabledCheckbox, jCheckBoxBeanProperty, failHoming, jCheckBoxBeanProperty_1);
+        autoBinding_11.bind();
     }
 }

--- a/src/main/java/org/openpnp/machine/reference/wizards/SimulationModeMachineConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/wizards/SimulationModeMachineConfigurationWizard.java
@@ -21,6 +21,11 @@
 
 package org.openpnp.machine.reference.wizards;
 
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+
+import javax.swing.JButton;
+import javax.swing.JCheckBox;
 import javax.swing.JComboBox;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
@@ -44,10 +49,6 @@ import com.jgoodies.forms.layout.ColumnSpec;
 import com.jgoodies.forms.layout.FormLayout;
 import com.jgoodies.forms.layout.FormSpecs;
 import com.jgoodies.forms.layout.RowSpec;
-import javax.swing.JCheckBox;
-import javax.swing.JButton;
-import java.awt.event.ActionListener;
-import java.awt.event.ActionEvent;
 
 public class SimulationModeMachineConfigurationWizard extends AbstractConfigurationWizard {
 
@@ -170,37 +171,37 @@ public class SimulationModeMachineConfigurationWizard extends AbstractConfigurat
         
         pickAndPlaceChecking = new JCheckBox("");
         panelLocations.add(pickAndPlaceChecking, "4, 12");
+        
+        JLabel lblCameraLags = new JLabel("Camera Lag [s]");
+        panelLocations.add(lblCameraLags, "2, 16, right, default");
+        
+        simulatedCameraLag = new JTextField();
+        panelLocations.add(simulatedCameraLag, "4, 16, fill, default");
+        simulatedCameraLag.setColumns(10);
+        
+                JLabel lblCameraNoise = new JLabel("Camera Noise");
+                lblCameraNoise.setToolTipText("<html>\r\nCreates simulated noise in the camera image (number of sparks) <br/>\r\nto satisfy Camera Settling that the frame has changed. \r\n</html>");
+                panelLocations.add(lblCameraNoise, "2, 18, right, default");
+        
+                simulatedCameraNoise = new JTextField();
+                panelLocations.add(simulatedCameraNoise, "4, 18");
+                simulatedCameraNoise.setColumns(10);
 
         JLabel lblVibrationAmplitude = new JLabel("Vibration Amplitude");
         lblVibrationAmplitude.setToolTipText("Simulates Vibration, the amplitude is given in relation to the past acceleration at Eigenfrequency (try 0.1 for a strong vibration).");
-        panelLocations.add(lblVibrationAmplitude, "2, 16, right, default");
+        panelLocations.add(lblVibrationAmplitude, "2, 20, right, default");
 
         simulatedVibrationAmplitude = new JTextField();
-        panelLocations.add(simulatedVibrationAmplitude, "4, 16, fill, default");
+        panelLocations.add(simulatedVibrationAmplitude, "4, 20, fill, default");
         simulatedVibrationAmplitude.setColumns(10);
         
         JLabel lblDuration = new JLabel("Vibration Duration [s]");
         lblDuration.setToolTipText("Vibration duration in seconds (exponential decay to ~1%).");
-        panelLocations.add(lblDuration, "2, 18, right, default");
+        panelLocations.add(lblDuration, "2, 22, right, default");
         
         simulatedVibrationDuration = new JTextField();
-        panelLocations.add(simulatedVibrationDuration, "4, 18, left, default");
+        panelLocations.add(simulatedVibrationDuration, "4, 22, left, default");
         simulatedVibrationDuration.setColumns(10);
-
-        JLabel lblCameraNoise = new JLabel("Camera Noise");
-        lblCameraNoise.setToolTipText("<html>\r\nCreates simulated noise in the camera image (number of sparks) <br/>\r\nto satisfy Camera Settling that the frame has changed. \r\n</html>");
-        panelLocations.add(lblCameraNoise, "2, 20, right, default");
-
-        simulatedCameraNoise = new JTextField();
-        panelLocations.add(simulatedCameraNoise, "4, 20");
-        simulatedCameraNoise.setColumns(10);
-        
-        JLabel lblCameraLags = new JLabel("Camera Lag [s]");
-        panelLocations.add(lblCameraLags, "2, 22, right, default");
-        
-        simulatedCameraLag = new JTextField();
-        panelLocations.add(simulatedCameraLag, "4, 22, fill, default");
-        simulatedCameraLag.setColumns(10);
 
         JLabel lblX = new JLabel("X");
         panelLocations.add(lblX, "4, 26");
@@ -268,6 +269,7 @@ public class SimulationModeMachineConfigurationWizard extends AbstractConfigurat
         addWrappedBinding(machine, "simulatedRunout", simulatedRunout, "text", lengthConverter);
         addWrappedBinding(machine, "simulatedRunoutPhase", simulatedRunoutPhase, "text", degreeConverter);
         addWrappedBinding(machine, "pickAndPlaceChecking", pickAndPlaceChecking, "selected");
+
         addWrappedBinding(machine, "simulatedVibrationAmplitude", simulatedVibrationAmplitude, "text", doubleConverter);
         addWrappedBinding(machine, "simulatedVibrationDuration", simulatedVibrationDuration, "text", doubleConverter);
         addWrappedBinding(machine, "simulatedCameraNoise", simulatedCameraNoise, "text", integerConverter);

--- a/src/main/java/org/openpnp/model/Location.java
+++ b/src/main/java/org/openpnp/model/Location.java
@@ -455,4 +455,11 @@ public class Location {
         result = 31 * result + (int) (temp ^ temp >>> 32);
         return result;
     }
+
+    /**
+     * @return true if at least one of the coordinates are non-zero, assuming the location is therefore initialized.
+     */
+    public boolean isInitialized() {
+        return !this.equals(origin);
+    }
 }

--- a/src/main/java/org/openpnp/util/SimpleGraph.java
+++ b/src/main/java/org/openpnp/util/SimpleGraph.java
@@ -30,6 +30,8 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.TreeMap;
 
+import javax.swing.UIManager;
+
 public class SimpleGraph {
 
     private double relativePaddingLeft;
@@ -258,6 +260,11 @@ public class SimpleGraph {
                         maximum.y = Math.max(y, maximum.y);
                     }
                 }
+                if (minimum.x != maximum.x && minimum.y == maximum.y) {
+                    // Flatline detected, just add a pseudo min/max.
+                    minimum.y -= 0.0001;
+                    maximum.y += 0.0001;
+                }
                 dirty = false;
             }
         }
@@ -338,5 +345,15 @@ public class SimpleGraph {
 
     public List<DataScale> getScales() {
         return Collections.unmodifiableList(dataScales);
+    }
+
+    public static Color getDefaultGridColor() {
+        Color gridColor = UIManager.getColor ( "PasswordField.capsLockIconColor" );
+        if (gridColor == null) {
+            gridColor = new Color(0, 0, 0, 64);
+        } else {
+            gridColor = new Color(gridColor.getRed(), gridColor.getGreen(), gridColor.getBlue(), 64);
+        }
+        return gridColor;
     }
 }

--- a/src/main/java/org/openpnp/util/UiUtils.java
+++ b/src/main/java/org/openpnp/util/UiUtils.java
@@ -47,8 +47,16 @@ public class UiUtils {
     public static <T> Future<T> submitUiMachineTask(final Callable<T> callable) {
         return submitUiMachineTask(callable, (result) -> {
         } , (t) -> {
-            MessageBoxes.errorBox(MainFrame.get(), "Error", t);
+            showError(t);
         });
+    }
+
+    /**
+     * Show an error using a message box.
+     * @param t
+     */
+    public static void showError(Throwable t) {
+        MessageBoxes.errorBox(MainFrame.get(), "Error", t);
     }
 
     /**
@@ -97,7 +105,7 @@ public class UiUtils {
             thrunnable.thrun();
         }
         catch (Exception e) {
-            MessageBoxes.errorBox(MainFrame.get(), "Error", e);
+            showError(e);
         }
     }
 

--- a/src/main/java/org/openpnp/util/Utils2D.java
+++ b/src/main/java/org/openpnp/util/Utils2D.java
@@ -652,4 +652,16 @@ public class Utils2D {
         results.add(maxB);
         return results;
     }
+
+    public static double angleNorm(double val, double lim) {
+        double clip = lim * 2;
+        while (Math.abs(val) > lim) {
+            val += (val < 0.) ? clip : -clip;
+        }
+        return val;
+    }
+
+    public static double angleNorm(double val) {
+        return angleNorm(val, 45.);
+    }
 }


### PR DESCRIPTION
# Description
Round-up of UI and Utils improvements and some minor bug-fixes:

* `CameraView` now uses bi-cubic instead of only bi-linear interpolation in High Quality mode. 
* `SimpleGraph` now supports "flatlines", i.e. graphs where y<sub>min</sub> = y<sub>max</sub> (height of scale = 0).
* `SimpleGraphView` and `TemplateImageControl` use themed color in an improved/encapsulated way. Refactored in `ReferenceNozzleTip`.
* In `ReferenceNozzleTipCalibrationWizard` some new fields were not disabled when the calibration is disabled. 
* Minor improvements in UI layout of `AbstractAxisConfigurationWizard` and `SimulationModeMachineConfigurationWizard`.
* Interface cleanup in `AutoFocusProvider`.
* Catch empty nozzle in `AutoFocusProviderConfigurationWizard` with error message.
* Centralized angle norming in `Utils2D.angleNorm()`. Refactored `ReferenceBottomVision`, `BlindsFeeder` and `ReferencePushPullFeeder`. 
* New `Location.isInitialized()` returns true if at least one of the coordinates are non-zero, assuming the location is therefore initialized.
* Unified and made publicly available a `UiUtils.showError(Throwable t)` method to encapsulate the showing of `Throwable` message boxes. 

# Justification
All this will be used (or has popped up) in the upcoming Issues & Solutions Calibration PR. 

See also:
https://groups.google.com/g/openpnp/c/dBg7txMB0R0/m/OIUaQAS0BgAJ

# Instructions for Use
No change.

# Implementation Details
1. It was tested extensively in the testing of the upcoming PR. Tested using mvn test in the break-out. 
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. Small change in the `org.openpnp.model` package (`Location.isInitialized()`).
4. Successful run `mvn test` before submitting the Pull Request.
