### PR TITLE
Add enhancements to SimpleGraph

### DIFF
--- a/src/main/java/org/openpnp/gui/components/SimpleGraphView.java
+++ b/src/main/java/org/openpnp/gui/components/SimpleGraphView.java
@@ -141,6 +141,23 @@ public class SimpleGraphView extends JComponent implements MouseMotionListener, 
                         min.y = Math.min(-max.y, min.y);
                     }
                 }
+                if (dataScale.isSquareAspectRatio()) {
+                    if (min != null && max != null) {
+                        if (dataScale.isSymmetricIfSigned()) {
+                            if (min.x < 0.0 && max.x > 0) {
+                                max.x = Math.max(max.x, -min.x);
+                                min.x = Math.min(-max.x, min.x);
+                            }
+                        }
+                        double maxDiffOver2 = Math.max(max.x - min.x, max.y - min.y)/2;
+                        double midX = (max.x + min.x)/2;
+                        double midY = (max.y + min.y)/2;
+                        max.x = midX + maxDiffOver2;
+                        min.x = midX - maxDiffOver2;
+                        max.y = midY + maxDiffOver2;
+                        min.y = midY - maxDiffOver2;
+                    }
+                }
                 if (min != null && max != null && (max.y-min.y) > 0.0 && (max.x-min.x) > 0.0) {
                     double xOrigin = (w-1)*graph.getRelativePaddingLeft();
                     double xScale = (w-1)*(1.0-graph.getRelativePaddingLeft()-graph.getRelativePaddingRight())/(max.x-min.x);
@@ -252,6 +269,9 @@ public class SimpleGraphView extends JComponent implements MouseMotionListener, 
                             if (xAxis != null) {
                                 // Convert to pixel coordinates
                                 int size = dataRow.size();
+                                boolean showLine = dataRow.isLineShown();
+                                boolean showMarker = dataRow.isMarkerShown();
+                                boolean showMarkerOnly = showMarker && !showLine;
                                 if (size >= 2) {
                                     double [] xfPlot = new double [size]; 
                                     double [] yfPlot = new double [size];
@@ -278,7 +298,7 @@ public class SimpleGraphView extends JComponent implements MouseMotionListener, 
                                         double n0 = Math.sqrt(dx0*dx0+dy0*dy0); 
                                         double n1 = Math.sqrt(dx1*dx1+dy1*dy1); 
                                         double cosine = ((dx0*dx1) + (dy0*dy1))/n0/n1;
-                                        if (cosine < 0.99 
+                                        if (showMarkerOnly || cosine < 0.99 
                                                 || Math.abs(xfPlot[i]-xPlot[s-1]) > 12 || Math.abs(yfPlot[i]-yPlot[s-1]) > 1.5) {
                                             // Corner point or relevant change.
                                             xPlot[s] = (int) xfPlot[i];
@@ -290,9 +310,17 @@ public class SimpleGraphView extends JComponent implements MouseMotionListener, 
                                     xPlot[s] = (int) xfPlot[size-1];
                                     yPlot[s] = (int) yfPlot[size-1];
                                     s++;
-                                    // Draw as polyline.
                                     g2d.setColor(dataRow.getColor());
-                                    g2d.drawPolyline(xPlot, yPlot, s);
+                                    if (showLine) {
+                                        // Draw as polyline.
+                                        g2d.drawPolyline(xPlot, yPlot, s);
+                                    }
+                                    if (showMarker) {
+                                        int dia = 4;
+                                        for (int p=0; p<s; p++) {
+                                            g2d.fillOval(xPlot[p]-dia/2, yPlot[p]-dia/2, dia, dia);
+                                        }
+                                    }
                                     if (selectedX != null) {
                                         drawYIndicator(g2d, dfm, fontAscent, w, min, max, yOrigin, yScale, yUnit, 
                                                 dataRow.getInterpolated(selectedX), dataRow.getColor());

--- a/src/main/java/org/openpnp/util/SimpleGraph.java
+++ b/src/main/java/org/openpnp/util/SimpleGraph.java
@@ -46,6 +46,7 @@ public class SimpleGraph {
         private double relativePaddingTop;
         private double relativePaddingBottom;
         private boolean symmetricIfSigned;
+        private boolean squareAspectRatio;
 
         public void addDataRow(DataRow dataRow) {
             dataRows.add(dataRow);
@@ -94,6 +95,14 @@ public class SimpleGraph {
             this.symmetricIfSigned = symmetricIfSigned;
         }
 
+        public boolean isSquareAspectRatio() {
+            return squareAspectRatio;
+        }
+        
+        public void setSquareAspectRatio(boolean squareAspectRatio) {
+            this.squareAspectRatio = squareAspectRatio;
+        }
+        
         public Point2D.Double getMinimum() {
             Point2D.Double minimum = null;
             for (DataRow dataRow : dataRows) {
@@ -196,6 +205,8 @@ public class SimpleGraph {
     public static class DataRow {
         private String label;
         private Color color;
+        private boolean markerShown = false;
+        private boolean lineShown = true;
         private int displayCycleMask = 1; // Displayed on mask 1
         private TreeMap<Double, Double> data = new TreeMap<>();
 
@@ -291,6 +302,22 @@ public class SimpleGraph {
         }
         public void setColor(Color color) {
             this.color = color;
+        }
+
+        public boolean isMarkerShown() {
+            return markerShown;
+        }
+
+        public void setMarkerShown(boolean markerShown) {
+            this.markerShown = markerShown;
+        }
+
+        public boolean isLineShown() {
+            return lineShown;
+        }
+
+        public void setLineShown(boolean lineShown) {
+            this.lineShown = lineShown;
         }
 
         public int getDisplayCycleMask() {


### PR DESCRIPTION
# Description
Adds the following enhancements to SimpleGraph and SimpleGraphView:

- Adds a setting to force the X-Y aspect ratio to be 1:1 which is useful for graphs whose x axis may have the same units as the y axis
- Adds a setting to enable/disable showing of the line which can be used to de-clutter graphs where only the data points are important
- Adds a setting to enable/disable showing of a data marker at each data point which can be used to highlight the data points rather than the connections between the data points

# Justification
This change do not affect how OpenPnP currently operates but rather serves as a stepping stone to future enhancements.

# Instructions for Use
No special instructions for the operator is required as this change in not currently visible to the operator.

# Implementation Details
**1. How did you test the change?** Ran Vision tests with diagnostics enable to verify the existing graphs still work as usual.  Ran additional tests using the new settings to verify they work as intended.
**2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)?** Yes.
**3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing.** No changes were made to these packages.
**4. Be sure to run `mvn test` before submitting the Pull Request.** The Maven tests were run and all passed.
