### PR TITLE
Feature/Automatic Machine Calibration using Issues & Solutions - Round 2

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/ContactProbeNozzle.java
+++ b/src/main/java/org/openpnp/machine/reference/ContactProbeNozzle.java
@@ -858,7 +858,7 @@ public class ContactProbeNozzle extends ReferenceNozzle {
                         nozzle, 
                         "Converting the ContactProbeNozzle back to a plain ReferenceNozzle may simplify the machine setup.", 
                         "Replace with ReferenceNozzle.", 
-                        Severity.Fundamental,
+                        Severity.Suggestion,
                         "https://github.com/openpnp/openpnp/wiki/Contact-Probing-Nozzle") {
 
                     @Override

--- a/src/main/java/org/openpnp/machine/reference/ReferenceMachine.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceMachine.java
@@ -506,7 +506,7 @@ public class ReferenceMachine extends AbstractMachine {
     @Element(required = false)
     private VisionSolutions visualSolutions = new VisionSolutions();
 
-    public VisionSolutions getVisualSolutions() {
+    public VisionSolutions getVisionSolutions() {
         return visualSolutions;
     }
 
@@ -553,7 +553,7 @@ public class ReferenceMachine extends AbstractMachine {
                         this, 
                         "Advanced motion planner set. Revert to a simpler, safer planner.", 
                         "Change to NullMotionPlanner", 
-                        Solutions.Severity.Fundamental,
+                        Solutions.Severity.Suggestion,
                         "https://github.com/openpnp/openpnp/wiki/Motion-Planner#choosing-a-motion-planner") {
                     final MotionPlanner oldMotionPlanner =  ReferenceMachine.this.getMotionPlanner();
 

--- a/src/main/java/org/openpnp/machine/reference/axis/ReferenceControllerAxis.java
+++ b/src/main/java/org/openpnp/machine/reference/axis/ReferenceControllerAxis.java
@@ -198,7 +198,7 @@ public class ReferenceControllerAxis extends AbstractControllerAxis {
     }
 
     public void setFeedratePerSecond(Length feedratePerSecond) {
-        this.feedratePerSecond = convertFromSytem(feedratePerSecond);
+        this.feedratePerSecond = convertFromSystem(feedratePerSecond);
     }
 
     public Length getAccelerationPerSecond2() {
@@ -206,7 +206,7 @@ public class ReferenceControllerAxis extends AbstractControllerAxis {
     }
 
     public void setAccelerationPerSecond2(Length accelerationPerSecond2) {
-        this.accelerationPerSecond2 = convertFromSytem(accelerationPerSecond2);
+        this.accelerationPerSecond2 = convertFromSystem(accelerationPerSecond2);
     }
 
     public Length getJerkPerSecond3() {
@@ -214,7 +214,7 @@ public class ReferenceControllerAxis extends AbstractControllerAxis {
     }
 
     public void setJerkPerSecond3(Length jerkPerSecond3) {
-        this.jerkPerSecond3 = convertFromSytem(jerkPerSecond3);
+        this.jerkPerSecond3 = convertFromSystem(jerkPerSecond3);
     }
 
     public String getPreMoveCommand() {
@@ -238,7 +238,7 @@ public class ReferenceControllerAxis extends AbstractControllerAxis {
     }
 
     public void setBacklashOffset(Length backlashOffset) {
-        this.backlashOffset = convertFromSytem(backlashOffset);
+        this.backlashOffset = convertFromSystem(backlashOffset);
     }
 
     public Length getSneakUpOffset() {

--- a/src/main/java/org/openpnp/machine/reference/solutions/GcodeDriverSolutions.java
+++ b/src/main/java/org/openpnp/machine/reference/solutions/GcodeDriverSolutions.java
@@ -104,7 +104,7 @@ public class GcodeDriverSolutions implements Solutions.Subject {
                         gcodeDriver, 
                         "Use the GcodeDriver for simpler setup. Accept or Dismiss to continue.", 
                         "Convert to GcodeDriver.", 
-                        Severity.Fundamental,
+                        Severity.Suggestion,
                         "https://github.com/openpnp/openpnp/wiki/GcodeAsyncDriver") {
 
                     @Override
@@ -126,9 +126,6 @@ public class GcodeDriverSolutions implements Solutions.Subject {
                     }
                 };
                 solutions.add(issue);
-                if (!solutions.isSolutionsIssueDismissed(issue)) {
-                    return; // No further troubleshooting until this is decided.
-                }
             }
         }
         if (solutions.isTargeting(Milestone.Connect)) {
@@ -625,8 +622,9 @@ public class GcodeDriverSolutions implements Solutions.Subject {
                                                     +"G90 ; Set absolute positioning mode";
                                     if (isTinyG) {
                                         commandBuilt = 
-                                                "$ex=1\n" // XonXoff
-                                                +"$sv=0\n" // Non-verbose
+                                                // We no longer propose the $ex setting. You can't change flow-control in mid-connection reliably.
+                                                //"$ex=1\n" // XonXoff
+                                                "$sv=0\n" // Non-verbose
                                                 +commandBuilt;
                                     }
                                 }
@@ -638,10 +636,11 @@ public class GcodeDriverSolutions implements Solutions.Subject {
                                     else if (command.contains("$ex=0")) {
                                         commandBuilt = command.replace("$ex=0", "$ex=1");
                                     }
-                                    else if (!command.contains("$ex=1")){
-                                        commandBuilt = "$ex=1\n"
-                                                +command;
-                                    }
+                                    // We no longer propose the $ex setting. You can't change flow-control in mid-connection reliably.
+//                                    else if (!command.contains("$ex=1")){
+//                                        commandBuilt = "$ex=1\n"
+//                                                +command;
+//                                    }
                                 }
                                 break;
                             case COMMAND_CONFIRM_REGEX:

--- a/src/main/java/org/openpnp/model/Length.java
+++ b/src/main/java/org/openpnp/model/Length.java
@@ -332,4 +332,11 @@ public class Length {
         }
         return Double.valueOf(getValue()).compareTo(Double.valueOf(other.convertToUnits(units).getValue()));
     }
+
+    /**
+     * @return true, if non-zero, assuming no initialized value can be zero.  
+     */
+    public boolean isInitialized() {
+        return getValue() != 0.0;
+    }
 }

--- a/src/main/java/org/openpnp/spi/base/AbstractCamera.java
+++ b/src/main/java/org/openpnp/spi/base/AbstractCamera.java
@@ -32,9 +32,6 @@ import org.openpnp.model.Configuration;
 import org.openpnp.model.Length;
 import org.openpnp.model.LengthUnit;
 import org.openpnp.model.Location;
-import org.openpnp.model.Solutions;
-import org.openpnp.model.Solutions.Milestone;
-import org.openpnp.model.Solutions.Severity;
 import org.openpnp.spi.Actuator;
 import org.openpnp.spi.Camera;
 import org.openpnp.spi.Head;
@@ -1309,31 +1306,6 @@ public abstract class AbstractCamera extends AbstractHeadMountable implements Ca
         @Override
         public boolean equals(Object obj) {
             return obj.equals(listener);
-        }
-    }
-
-    @Override
-    public void findIssues(Solutions solutions) {
-        super.findIssues(solutions);
-        if (solutions.isTargeting(Milestone.Vision)) {
-
-            if ((unitsPerPixel.getX() == 0) || (unitsPerPixel.getY() == 0)) {
-                solutions.add(new Solutions.PlainIssue(
-                        this, 
-                        "Camera units per pixel has not been calibrated.", 
-                        "Calibrate the camera's units per pixel.", 
-                        Severity.Warning,
-                        "https://github.com/openpnp/openpnp/wiki/Setup-and-Calibration%3A-General-Camera-Setup#set-units-per-pixel"));
-            }
-            else if (solutions.isTargeting(Milestone.Advanced) 
-                    && !isSecondaryUnitsPerPixelCalibrated()) {
-                solutions.add(new Solutions.PlainIssue(
-                        this, 
-                        "Camera units per pixel can be calibrated for 3D scale estimation.", 
-                        "Calibrate the camera's units per pixel at two different heights.", 
-                        Severity.Suggestion,
-                        "https://github.com/openpnp/openpnp/wiki/Setup-and-Calibration%3A-General-Camera-Setup#set-units-per-pixel"));
-            }
         }
     }
 }

--- a/src/main/java/org/openpnp/spi/base/AbstractCoordinateAxis.java
+++ b/src/main/java/org/openpnp/spi/base/AbstractCoordinateAxis.java
@@ -91,7 +91,7 @@ public abstract class AbstractCoordinateAxis extends AbstractAxis implements Coo
     @Override
     public void setHomeCoordinate(Length homeCoordinate) {
         Object oldValue = this.homeCoordinate;
-        this.homeCoordinate = convertFromSytem(homeCoordinate);
+        this.homeCoordinate = convertFromSystem(homeCoordinate);
         firePropertyChange("homeCoordinate", oldValue, homeCoordinate);
     }
 
@@ -141,7 +141,7 @@ public abstract class AbstractCoordinateAxis extends AbstractAxis implements Coo
         }
     }
 
-    protected Length convertFromSytem(Length length) {
+    protected Length convertFromSystem(Length length) {
         if (type == Axis.Type.Rotation) {
             // This is actually an angle, not a length, just take it at it numerical value
             // and store as neutral mm.


### PR DESCRIPTION
# Description
Enhancement and bug-fix round based on test version feed-back

* Copy static texts to clipboard in I&S `IssuePanel` using right mouse click. This is signalled by quickly flashing the text.
* I&S conservative solutions proposed when going back to more basic milestones (such as reverting a `GcodeAsyncDriver` to a `GcodeDriver`) are now only severity `Suggestion` (and not `Fundamental`) and they do no longer (reverse-) block dependent solutions.
* When replacing an `ImageCamera` or `SimulatedUpLookingCamera` with a real `OpenPnpCaptureCamera`, the old/new camera is now properly (un)registered in the `CameraView`. No OpenPnP restart required. Furthermore, should a USB device have been assigned in the meantime, the camera device is properly closed when the solution is undone.
* Fixed typo `AbstractCoordinateAxis.convertFromSystem()` (missing "s"), also in `ReferenceControllerAxis`.
* Added missing `toHeadLocation()` transformation to the axis coordinate to camera transformation in backlash calibration.
* Added proper inter-solution dependencies for many calibration solutions. These are always tested both before proposing the solution and before setting it to solved, i.e. before doing the calibration. This ensures, nothing bad happens, should the preconditions have changed in the meantime, such as when a prerequisite solution is reopened/undone.
* `HeadSolutions` will now discover the initial Nozzle configuration of a migrated machine. If the machine has a Milestone other than Welcome (which is only assumed for machines, that still have a `NullDriver` etc.), the solution is marked as already solved, i.e. it will be hidden by default.
* Test objects can now be larger relative to the camera dimension.
* When capturing preliminary nozzle head offsets, they are not updated when very close to the offsets already set. This ensures, calibrated offsets will survive if this rather crude solution is revisited. Only the Z of the nozzle is then used to set the fiducial Z and 3D Units per Pixel information.
* Added a `Length.isInitialized()` method.
* Removed Units per Pixel calibration reminder solutions (obsolete).

# Justification
See the discussion in the testing round:
https://groups.google.com/g/openpnp/c/dBg7txMB0R0/m/5UpXsvJMBwAJ

# Instructions for Use
See #1248

# Implementation Details
1. Tested in simulation, partly with user `machine.xml`.
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. Added `org.openpnp.model.Length.isInitialized()`.
4. Successful `mvn test` before submitting the Pull Request. 
