### PR TITLE
Feature/Automatic Machine Calibration using Issues & Solutions - Round 3

### DIFF
--- a/src/main/java/org/openpnp/gui/components/CameraView.java
+++ b/src/main/java/org/openpnp/gui/components/CameraView.java
@@ -707,7 +707,7 @@ public class CameraView extends JComponent implements CameraListener {
                 paintLightToggle(g2d);
             }
 
-            if (viewingPlaneZ != null) {
+            if (viewingPlaneZ != null && camera.getDefaultZ() != null) {
                 // Display the height of the reticle in the lower left corner if it is different than
                 // the default
                 Length viewingPlaneDiff = viewingPlaneZ.subtract(camera.getDefaultZ());

--- a/src/main/java/org/openpnp/gui/components/IssuePanel.java
+++ b/src/main/java/org/openpnp/gui/components/IssuePanel.java
@@ -16,22 +16,28 @@ import javax.swing.JScrollPane;
 import javax.swing.JSlider;
 import javax.swing.JSpinner;
 import javax.swing.JTextArea;
+import javax.swing.JTextField;
 import javax.swing.SpinnerNumberModel;
 import javax.swing.SwingUtilities;
 import javax.swing.UIManager;
 import javax.swing.border.TitledBorder;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
+import javax.swing.event.DocumentEvent;
+import javax.swing.event.DocumentListener;
 
 import org.jdesktop.beansbinding.AutoBinding;
 import org.jdesktop.beansbinding.AutoBinding.UpdateStrategy;
 import org.jdesktop.beansbinding.BeanProperty;
 import org.jdesktop.beansbinding.Bindings;
+import org.openpnp.gui.support.LengthConverter;
 import org.openpnp.machine.reference.ReferenceMachine;
+import org.openpnp.model.Length;
 import org.openpnp.model.Solutions;
 import org.openpnp.model.Solutions.Issue;
 import org.openpnp.model.Solutions.Issue.DoubleProperty;
 import org.openpnp.model.Solutions.Issue.IntegerProperty;
+import org.openpnp.model.Solutions.Issue.LengthProperty;
 import org.openpnp.util.UiUtils;
 
 import com.jgoodies.forms.layout.ColumnSpec;
@@ -227,6 +233,36 @@ public class IssuePanel extends JPanel {
                 slider.setToolTipText(property.getToolTip());
                 slider.setEnabled(issue.getState() == Solutions.State.Open);
                 panel.add(slider, "4, "+(formRow*2)+", left, default");
+            }
+            else if (property instanceof LengthProperty) {
+                LengthProperty lengthProperty = (LengthProperty) property;
+                JLabel lbl = new JLabel(lengthProperty.getLabel());
+                lbl.setToolTipText(lengthProperty.getToolTip());
+                panel.add(lbl, "2, "+(formRow*2)+", right, default");
+                JTextField textField = new JTextField();
+                textField.setToolTipText(lengthProperty.getToolTip());
+                textField.setEnabled(issue.getState() == Solutions.State.Open);
+                textField.setColumns(10);
+                LengthConverter lengthConverter = new LengthConverter();
+                textField.setText(lengthConverter.convertForward(lengthProperty.get()));
+                textField.getDocument().addDocumentListener(new DocumentListener() {
+                    public void changedUpdate(DocumentEvent e) {
+                        changedText();
+                    }
+                    public void removeUpdate(DocumentEvent e) {
+                        changedText();
+                    }
+                    public void insertUpdate(DocumentEvent e) {
+                        changedText();
+                    }
+
+                    public void changedText() {
+                        String text = textField.getText();
+                        Length length = lengthConverter.convertReverse(text);
+                        lengthProperty.set(length);
+                    }
+                });
+                panel.add(textField, "4, "+(formRow*2)+", left, default");
             }
             // Consume the row
             formRow++;

--- a/src/main/java/org/openpnp/gui/components/SimpleGraphView.java
+++ b/src/main/java/org/openpnp/gui/components/SimpleGraphView.java
@@ -136,6 +136,23 @@ public class SimpleGraphView extends JComponent implements MouseMotionListener, 
                         min.y = Math.min(-max.y, min.y);
                     }
                 }
+                if (dataScale.isSquareAspectRatio()) {
+                    if (min != null && max != null) {
+                        if (dataScale.isSymmetricIfSigned()) {
+                            if (min.x < 0.0 && max.x > 0) {
+                                max.x = Math.max(max.x, -min.x);
+                                min.x = Math.min(-max.x, min.x);
+                            }
+                        }
+                        double maxDiffOver2 = Math.max(max.x - min.x, max.y - min.y)/2;
+                        double midX = (max.x + min.x)/2;
+                        double midY = (max.y + min.y)/2;
+                        max.x = midX + maxDiffOver2;
+                        min.x = midX - maxDiffOver2;
+                        max.y = midY + maxDiffOver2;
+                        min.y = midY - maxDiffOver2;
+                    }
+                }
                 if (min != null && max != null && (max.y-min.y) > 0.0 && (max.x-min.x) > 0.0) {
                     double xOrigin = (w-1)*graph.getRelativePaddingLeft();
                     double xScale = (w-1)*(1.0-graph.getRelativePaddingLeft()-graph.getRelativePaddingRight())/(max.x-min.x);
@@ -247,6 +264,9 @@ public class SimpleGraphView extends JComponent implements MouseMotionListener, 
                             if (xAxis != null) {
                                 // Convert to pixel coordinates
                                 int size = dataRow.size();
+                                boolean showLine = dataRow.isLineShown();
+                                boolean showMarker = dataRow.isMarkerShown();
+                                boolean showMarkerOnly = showMarker && !showLine;
                                 if (size >= 2) {
                                     double [] xfPlot = new double [size]; 
                                     double [] yfPlot = new double [size];
@@ -273,7 +293,7 @@ public class SimpleGraphView extends JComponent implements MouseMotionListener, 
                                         double n0 = Math.sqrt(dx0*dx0+dy0*dy0); 
                                         double n1 = Math.sqrt(dx1*dx1+dy1*dy1); 
                                         double cosine = ((dx0*dx1) + (dy0*dy1))/n0/n1;
-                                        if (cosine < 0.99 
+                                        if (showMarkerOnly || cosine < 0.99 
                                                 || Math.abs(xfPlot[i]-xPlot[s-1]) > 12 || Math.abs(yfPlot[i]-yPlot[s-1]) > 1.5) {
                                             // Corner point or relevant change.
                                             xPlot[s] = (int) xfPlot[i];
@@ -285,9 +305,17 @@ public class SimpleGraphView extends JComponent implements MouseMotionListener, 
                                     xPlot[s] = (int) xfPlot[size-1];
                                     yPlot[s] = (int) yfPlot[size-1];
                                     s++;
-                                    // Draw as polyline.
                                     g2d.setColor(dataRow.getColor());
-                                    g2d.drawPolyline(xPlot, yPlot, s);
+                                    if (showLine) {
+                                        // Draw as polyline.
+                                        g2d.drawPolyline(xPlot, yPlot, s);
+                                    }
+                                    if (showMarker) {
+                                        int dia = 4;
+                                        for (int p=0; p<s; p++) {
+                                            g2d.fillOval(xPlot[p]-dia/2, yPlot[p]-dia/2, dia, dia);
+                                        }
+                                    }
                                     if (selectedX != null) {
                                         drawYIndicator(g2d, dfm, fontAscent, w, min, max, yOrigin, yScale, yUnit, 
                                                 dataRow.getInterpolated(selectedX), dataRow.getColor());

--- a/src/main/java/org/openpnp/machine/reference/ReferenceActuator.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceActuator.java
@@ -378,7 +378,7 @@ public class ReferenceActuator extends AbstractActuator implements ReferenceHead
 
     @Override
     public Action[] getPropertySheetHolderActions() {
-        return new Action[] { deleteAction };
+        return new Action[] { deleteAction, permutateUpAction, permutateDownAction };
     }
     
     public Action deleteAction = new AbstractAction("Delete Actuator") {
@@ -400,6 +400,44 @@ public class ReferenceActuator extends AbstractActuator implements ReferenceHead
                 else {
                     Configuration.get().getMachine().removeActuator(ReferenceActuator.this);
                 }
+            }
+        }
+    };
+
+    @SuppressWarnings("serial")
+    public Action permutateUpAction = new AbstractAction() {
+        {
+            putValue(SMALL_ICON, Icons.arrowUp);
+            putValue(NAME, "Permutate Up");
+            putValue(SHORT_DESCRIPTION, "Move the currently selected actuator one position up.");
+        }
+
+        @Override
+        public void actionPerformed(ActionEvent arg0) {
+            if (getHead() == null) {
+                Configuration.get().getMachine().permutateActuator(ReferenceActuator.this, -1);
+            }
+            else {
+                getHead().permutateActuator(ReferenceActuator.this, -1);
+            }
+        }
+    };
+
+    @SuppressWarnings("serial")
+    public Action permutateDownAction = new AbstractAction() {
+        {
+            putValue(SMALL_ICON, Icons.arrowDown);
+            putValue(NAME, "Permutate Down");
+            putValue(SHORT_DESCRIPTION, "Move the currently selected actuator one position down.");
+        }
+
+        @Override
+        public void actionPerformed(ActionEvent arg0) {
+            if (getHead() == null) {
+                Configuration.get().getMachine().permutateActuator(ReferenceActuator.this, +1);
+            }
+            else {
+                getHead().permutateActuator(ReferenceActuator.this, +1);
             }
         }
     };

--- a/src/main/java/org/openpnp/machine/reference/ReferenceHead.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceHead.java
@@ -40,7 +40,6 @@ import org.openpnp.spi.Axis;
 import org.openpnp.spi.HeadMountable;
 import org.openpnp.spi.PropertySheetHolder;
 import org.openpnp.spi.base.AbstractHead;
-import org.openpnp.spi.base.AbstractHeadMountable;
 import org.pmw.tinylog.Logger;
 import org.simpleframework.xml.Attribute;
 
@@ -132,16 +131,6 @@ public class ReferenceHead extends AbstractHead {
     public void moveToSafeZ(double speed) throws Exception {
         Logger.debug("{}.moveToSafeZ({})", getName(), speed);
         super.moveToSafeZ(speed);
-    }
-
-    @Override 
-    public boolean isInsideSoftLimits(HeadMountable hm, Location location)  throws Exception {
-        if (hm instanceof ReferenceHeadMountable) {
-            Location headLocation = ((AbstractHeadMountable) hm).toHeadLocation(location);
-            AxesLocation axesLocation = ((AbstractHeadMountable) hm).toRaw(headLocation);
-            return (getMachine().getMotionPlanner().isValidLocation(axesLocation));
-        }
-        return true;
     }
 
     @Override 

--- a/src/main/java/org/openpnp/machine/reference/ReferenceNozzle.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceNozzle.java
@@ -1349,7 +1349,7 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
                     this, 
                     "Nozzle is missing a "+qualifier+" actuator.", 
                     "Create and assign a "+qualifier+" actuator as described in the Wiki.", 
-                    Severity.Suggestion,
+                    Severity.Warning,
                     "https://github.com/openpnp/openpnp/wiki/Setup-and-Calibration%3A-Vacuum-Setup"));
         }
         else if (actuator.getDriver() == null) {
@@ -1357,7 +1357,7 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
                     actuator, 
                     "The "+qualifier+" actuator "+actuator.getName()+" has no driver assigned.", 
                     "Assign a driver as described in the Wiki.", 
-                    Severity.Suggestion,
+                    Severity.Warning,
                     "https://github.com/openpnp/openpnp/wiki/Setup-and-Calibration%3A-Actuators#driver-assignment"));
             }
         }
@@ -1369,7 +1369,7 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
                             driver, 
                             "The "+qualifier+" actuator "+actuator.getName()+" has no "+commandType+" assigned.", 
                             "Assign the command to driver "+driver.getName()+" as described in the Wiki.", 
-                            Severity.Suggestion,
+                            Severity.Warning,
                             "https://github.com/openpnp/openpnp/wiki/Setup-and-Calibration%3A-Actuators#assigning-commands"));
                 }
             }

--- a/src/main/java/org/openpnp/machine/reference/ReferenceNozzleTipCalibration.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceNozzleTipCalibration.java
@@ -20,6 +20,7 @@ import org.openpnp.model.LengthUnit;
 import org.openpnp.model.Location;
 import org.openpnp.model.Point;
 import org.openpnp.spi.Camera;
+import org.openpnp.spi.HeadMountable;
 import org.openpnp.spi.NozzleTip;
 import org.openpnp.util.MovableUtils;
 import org.openpnp.util.OpenCvUtils;
@@ -583,7 +584,9 @@ public class ReferenceNozzleTipCalibration extends AbstractModelObject {
             referenceCamera = (ReferenceCamera)camera;
         }
 
-        Location measureBaseLocation = getCalibrationLocation(camera);
+        // Note: we do not apply the tool specific calibration offset here
+        // as this would defy the very purpose of finding a new one here. Pass null.  
+        Location measureBaseLocation = getCalibrationLocation(camera, null);
 
         try {
             calibrating = true;
@@ -748,10 +751,9 @@ public class ReferenceNozzleTipCalibration extends AbstractModelObject {
         }
     }
 
-    public Location getCalibrationLocation(Camera camera) {
-        // This is our baseline location. Note: we do not apply the tool specific calibration offset here
-        // as this would defy the very purpose of finding a new one here.  
-        Location cameraLocation = camera.getLocation();
+    public Location getCalibrationLocation(Camera camera, HeadMountable nozzle) {
+        // This is our baseline location. 
+        Location cameraLocation = camera.getLocation(nozzle);
         Location measureBaseLocation = cameraLocation.derive(null, null, null, 0d)
                 .add(new Location(this.calibrationZOffset.getUnits(), 0, 0, this.calibrationZOffset.getValue(), 0));
         return measureBaseLocation;

--- a/src/main/java/org/openpnp/machine/reference/SimulationModeMachine.java
+++ b/src/main/java/org/openpnp/machine/reference/SimulationModeMachine.java
@@ -399,7 +399,11 @@ public class SimulationModeMachine extends ReferenceMachine {
      */
     public static Location getSimulatedPhysicalLocation(HeadMountable hm, Looking looking) {
         // Use ideal location as a default, used in case this fails (not a place to throw).
-        Location location = hm.getLocation().convertToUnits(AxesLocation.getUnits()); 
+        Location location = hm.getLocation().convertToUnits(AxesLocation.getUnits());
+        if (Configuration.get().getMachine() == null) {
+            // Uninitialized (Unit Test). 
+            return location;
+        }
         // Try to get a simulated physical location.
         SimulationModeMachine machine = getSimulationModeMachine();
         if (machine == null || machine.getSimulationMode() == SimulationMode.Off) {

--- a/src/main/java/org/openpnp/machine/reference/axis/ReferenceControllerAxis.java
+++ b/src/main/java/org/openpnp/machine/reference/axis/ReferenceControllerAxis.java
@@ -96,6 +96,9 @@ public class ReferenceControllerAxis extends AbstractControllerAxis {
     private BacklashCompensationMethod backlashCompensationMethod = BacklashCompensationMethod.None;
 
     @Element(required = false)
+    private Length acceptableTolerance = new Length(0.025, LengthUnit.Millimeters);
+
+    @Element(required = false)
     private Length backlashOffset = new Length(0.0, LengthUnit.Millimeters);
 
     @Element(required = false)
@@ -231,6 +234,14 @@ public class ReferenceControllerAxis extends AbstractControllerAxis {
 
     public void setBacklashCompensationMethod(BacklashCompensationMethod backlashCompensationMethod) {
         this.backlashCompensationMethod = backlashCompensationMethod;
+    }
+
+    public Length getAcceptableTolerance() {
+        return acceptableTolerance;
+    }
+
+    public void setAcceptableTolerance(Length acceptableTolerance) {
+        this.acceptableTolerance = acceptableTolerance;
     }
 
     public Length getBacklashOffset() {

--- a/src/main/java/org/openpnp/machine/reference/camera/AutoFocusProvider.java
+++ b/src/main/java/org/openpnp/machine/reference/camera/AutoFocusProvider.java
@@ -97,8 +97,15 @@ public class AutoFocusProvider implements FocusProvider {
         diameter &= ~1; // Must be an even number.
 
         double speed = Configuration.get().getMachine().getSpeed();
-        // Move the movable to the start location at safe Z.
-        MovableUtils.moveToLocationAtSafeZ(movable, location0);
+        // Try to start from a 1mm retract location to get rid of any backlash that may not be compensated (typical in Z axes).
+        Location retract = location1.convertToUnits(LengthUnit.Millimeters).unitVectorTo(location0).multiply(1.0);
+        Location retractedLocation = location0.add(retract);
+        if (! movable.isReachable(retractedLocation)) {
+            // OK, then not.
+            retractedLocation = location0;
+        }
+        // Move the movable to the retracted location at safe Z.
+        MovableUtils.moveToLocationAtSafeZ(movable, retractedLocation);
         // Switch on the light.
         camera.actuateLightBeforeCapture();
         CameraView cameraView = MainFrame.get().getCameraViews().getCameraView(camera);
@@ -145,10 +152,16 @@ public class AutoFocusProvider implements FocusProvider {
                 }
 
                 // Find the next iteration sub-range. 
-                // Note, we swap location0/location1 so the search direction changes.
                 double nextFocus = Math.max(1.0, Math.min(curveSteps-1-1.0, bestFocus));
-                location1 = location0.add(focalStep.multiply(nextFocus-1.0));
-                location0 = location0.add(focalStep.multiply(nextFocus+1.0));
+                Location oldLocation0 = location0; 
+                location0 = oldLocation0.add(focalStep.multiply(nextFocus-1.0));
+                location1 = oldLocation0.add(focalStep.multiply(nextFocus+1.0));
+                // Retract, same as at the start.
+                retractedLocation = location0.add(retract);
+                if (! movable.isReachable(retractedLocation)) {
+                    retractedLocation = location0;
+                }
+                movable.moveTo(retractedLocation);
             }
         }
         finally {

--- a/src/main/java/org/openpnp/machine/reference/feeder/BlindsFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/BlindsFeeder.java
@@ -1037,8 +1037,7 @@ public class BlindsFeeder extends ReferenceFeeder {
                         .getDefaultCamera();
                 setFiducial1Location(locateFiducial(camera, getFiducial1Location()));
                 setFiducial3Location(locateFiducial(camera, getFiducial3Location()));
-                Head head = Configuration.get().getMachine().getDefaultHead();
-                if (head.isInsideSoftLimits(camera, getFiducial2Location())) {
+                if (camera.isReachable(getFiducial2Location())) {
                     setFiducial2Location(locateFiducial(camera, getFiducial2Location()));
                 }
                 else {

--- a/src/main/java/org/openpnp/machine/reference/feeder/wizards/ReferencePushPullFeederConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/wizards/ReferencePushPullFeederConfigurationWizard.java
@@ -67,7 +67,6 @@ import org.openpnp.model.Configuration;
 import org.openpnp.model.RegionOfInterest;
 import org.openpnp.spi.Camera;
 import org.openpnp.spi.Head;
-import org.openpnp.spi.MotionPlanner.CompletionType;
 import org.openpnp.util.MovableUtils;
 import org.openpnp.util.UiUtils;
 import org.openpnp.vision.pipeline.CvPipeline;
@@ -629,29 +628,16 @@ extends AbstractReferenceFeederConfigurationWizard {
 
         @Override
         public void actionPerformed(ActionEvent e) {
-            if (Configuration.get().getMachine().isEnabled()) {
-                UiUtils.submitUiMachineTask(() -> {
-                    MovableUtils.moveToLocationAtSafeZ(feeder.getCamera(), feeder.getNominalVisionLocation());
-                    MovableUtils.fireTargetedUserAction(feeder.getCamera());
-                    feeder.getCamera().waitForCompletion(CompletionType.WaitForStillstand);
-                    SwingUtilities.invokeLater(() -> {
-                        UiUtils.messageBoxOnException(() -> {
+            UiUtils.messageBoxOnException(() -> {
+                UiUtils.confirmMoveToLocationAndAct(
+                        getTopLevelAncestor(), 
+                        "move the camera to the proper feeder vision location before editing the pipeline", 
+                        feeder.getCamera(), 
+                        feeder.getNominalVisionLocation(), 
+                        true, () -> {
                             editPipeline();
                         });
-                    });
-                });
-            }
-            else {
-                int result = JOptionPane.showConfirmDialog(getTopLevelAncestor(),
-                        "Machine not enabled, unable to move the camera to the right location to edit the pipeline.\n"
-                                +"Do you want to proceed anyway?",
-                                null, JOptionPane.YES_NO_OPTION, JOptionPane.WARNING_MESSAGE);
-                if (result == JOptionPane.YES_OPTION) {
-                    UiUtils.messageBoxOnException(() -> {
-                        editPipeline();
-                    });                    
-                }
-            }
+            });
         }
     };
 

--- a/src/main/java/org/openpnp/machine/reference/solutions/HeadSolutions.java
+++ b/src/main/java/org/openpnp/machine/reference/solutions/HeadSolutions.java
@@ -412,6 +412,14 @@ public class HeadSolutions implements Solutions.Subject {
         for (AbstractNozzle unusedNozzle : nozzles) {
             head.removeNozzle(unusedNozzle);
         }
+        // Cleanup unused Actuators
+        ArrayList<Actuator> unusedActuators = new ArrayList<>();
+        unusedActuators.addAll(valveActuators);
+        unusedActuators.addAll(senseActuators);
+        for (Actuator unusedActuator : unusedActuators) {
+            head.removeActuator(unusedActuator);
+        }
+        // Store the solution.
         head.setNozzleSolution(nozzleSolution);
         head.setNozzleSolutionsMultiplier(nozzleSolutionsMultiplier);
     }

--- a/src/main/java/org/openpnp/machine/reference/solutions/VisionSolutions.java
+++ b/src/main/java/org/openpnp/machine/reference/solutions/VisionSolutions.java
@@ -308,6 +308,12 @@ public class VisionSolutions implements Solutions.Subject {
                 }
 
                 @Override
+                public boolean isForcedUnsolved() {
+                    // When the camera is not at all calibrated. Always show this as unsolved.
+                    return camera.getUnitsPerPixelPrimary().getX() <= 0.0 || camera.getUnitsPerPixelPrimary().getY() <= 0.0;
+                }
+
+                @Override
                 public void setState(Solutions.State state) throws Exception {
                     if (state == State.Solved) {
                         final State oldState = getState();
@@ -454,6 +460,12 @@ public class VisionSolutions implements Solutions.Subject {
                 }
 
                 @Override
+                public boolean isForcedUnsolved() {
+                    // When the camera is not at all calibrated. Always show this as unsolved.
+                    return camera.getUnitsPerPixelPrimary().getX() <= 0.0 || camera.getUnitsPerPixelPrimary().getY() <= 0.0;
+                }
+
+                @Override
                 public void setState(Solutions.State state) throws Exception {
                     if (state == State.Solved) {
                         if (! isSolvedPrimaryXY(head)) {
@@ -541,6 +553,12 @@ public class VisionSolutions implements Solutions.Subject {
                             + "This means it has to be a rather sharp-angled edge between faces. Typically, the air bore edge is targeted.</p><br/>"
                             + "<p>Then press Accept to capture the camera position.</p>"
                             + "</html>";
+                }
+
+                @Override
+                public boolean isForcedUnsolved() {
+                    // When the camera is not at all calibrated. Always show this as unsolved.
+                    return camera.getUnitsPerPixelPrimary().getX() <= 0.0 || camera.getUnitsPerPixelPrimary().getY() <= 0.0;
                 }
 
                 @Override

--- a/src/main/java/org/openpnp/machine/reference/solutions/VisionSolutions.java
+++ b/src/main/java/org/openpnp/machine/reference/solutions/VisionSolutions.java
@@ -90,7 +90,7 @@ public class VisionSolutions implements Solutions.Subject {
     @Attribute(required = false)
     private int subSampling = 4;
     @Attribute(required = false)
-    private int superSampling = 12;
+    private int superSampling = 8;
 
     @Attribute(required = false)
     protected long diagnosticsMilliseconds = 2000;
@@ -245,7 +245,7 @@ public class VisionSolutions implements Solutions.Subject {
             return new Solutions.Issue.CustomProperty[] {
                     new Solutions.Issue.IntegerProperty(
                             "Detected feature diameter",
-                            "Adjust the nozzle tip feature diameter that should be detected.",
+                            "Adjust the feature diameter that should be detected.",
                             3, (int)(Math.min(camera.getWidth(), camera.getHeight())*maxCameraRelativeSubjectDiameter)) {
                         @Override
                         public int get() {

--- a/src/main/java/org/openpnp/machine/reference/solutions/VisionSolutions.java
+++ b/src/main/java/org/openpnp/machine/reference/solutions/VisionSolutions.java
@@ -1031,8 +1031,8 @@ public class VisionSolutions implements Solutions.Subject {
 
                 if (pass == 0 && movable != camera && zeroKnowledgeAutoFocusDepthMm != 0) {
                     // Auto-focus and set Z of camera.
-                    Location location0 = initialLocation.add(new Location(LengthUnit.Millimeters, 0, 0, 0.5*zeroKnowledgeAutoFocusDepthMm, 0));
-                    Location location1 = initialLocation.add(new Location(LengthUnit.Millimeters, 0, 0, -0.5*zeroKnowledgeAutoFocusDepthMm, 0));
+                    Location location0 = initialLocation.add(new Location(LengthUnit.Millimeters, 0, 0, zeroKnowledgeAutoFocusDepthMm, 0));
+                    Location location1 = initialLocation.add(new Location(LengthUnit.Millimeters, 0, 0, -zeroKnowledgeAutoFocusDepthMm, 0));
                     initialLocation = new AutoFocusProvider().autoFocus(camera, movable, featureDiameter.multiply(4), location0, location1);
                     Location cameraHeadOffsetsNew = camera.getHeadOffsets().derive(initialLocation, false, false, true, false);
                     Logger.info("Setting camera "+camera.getName()+" Z to "+cameraHeadOffsetsNew.getLengthZ()+" (previously "+camera.getHeadOffsets().getLengthZ());

--- a/src/main/java/org/openpnp/model/Location.java
+++ b/src/main/java/org/openpnp/model/Location.java
@@ -292,13 +292,13 @@ public class Location {
     }
 
     /**
-     * Returns the unit vector of the vector between this and l. 
+     * Returns the unit vector of the vector between this and location l in units of this. 
      * 
      * @param l
      * @return
      */
     public Location unitVectorTo(Location l) {
-        Location vector = l.subtract(this);
+        Location vector = l.convertToUnits(units).subtract(this);
         double norm = 1/this.getXyzDistanceTo(l);
         return vector.multiply(norm, norm, norm, 0.0);
     }

--- a/src/main/java/org/openpnp/model/Solutions.java
+++ b/src/main/java/org/openpnp/model/Solutions.java
@@ -382,6 +382,13 @@ public class Solutions extends AbstractTableModel {
             public abstract double get();
             public abstract void set(double value);
         }
+        public abstract class LengthProperty extends CustomProperty {
+            public LengthProperty(String label, String toolTip) {
+                super(label, toolTip);
+            }
+            public abstract Length get();
+            public abstract void set(Length value);
+        }
 
         public CustomProperty [] getProperties() {
             return new CustomProperty[] {};

--- a/src/main/java/org/openpnp/model/Solutions.java
+++ b/src/main/java/org/openpnp/model/Solutions.java
@@ -304,6 +304,14 @@ public class Solutions extends AbstractTableModel {
             this.choice = choice;
         }
 
+        /**
+         * @return true if this solution is triggered by a machine condition that absolutely needs to be 
+         * addressed. This will force a solution to be unsolved, even is marked as "solved". Note, it will not
+         * force open a solution that is marked as "dismissed".
+         */
+        public boolean isForcedUnsolved() {
+            return false;
+        }
         void setInitialState(State state) {
             this.state = state;
         }
@@ -588,7 +596,10 @@ public class Solutions extends AbstractTableModel {
                 }
             }
             else if (isSolutionsIssueSolved(issue)) {
-                if (isShowSolved()) {
+                if (issue.isForcedUnsolved()) {
+                    setSolutionsIssueSolved(issue, false);
+                }
+                else if (isShowSolved()) {
                     issue.setInitialState(State.Solved);
                 }
                 else {

--- a/src/main/java/org/openpnp/spi/Head.java
+++ b/src/main/java/org/openpnp/spi/Head.java
@@ -120,6 +120,8 @@ public interface Head extends Identifiable, Named, WizardConfigurable, PropertyS
 
     public void removeActuator(Actuator actuator);
 
+    public void permutateActuator(Actuator actuator, int direction);
+
     public void moveToSafeZ(double speed) throws Exception;
 
     public void moveToSafeZ() throws Exception;

--- a/src/main/java/org/openpnp/spi/Head.java
+++ b/src/main/java/org/openpnp/spi/Head.java
@@ -168,12 +168,4 @@ public interface Head extends Identifiable, Named, WizardConfigurable, PropertyS
     public Actuator getZProbe(); 
     
     public Actuator getPump(); 
-
-    /**
-     * Returns true if the given HeadMountable can go to the specified location within soft-limits.
-     * @param hm
-     * @param location
-     * @return
-     */
-    public boolean isInsideSoftLimits(HeadMountable hm, Location location) throws Exception;
 }

--- a/src/main/java/org/openpnp/spi/Machine.java
+++ b/src/main/java/org/openpnp/spi/Machine.java
@@ -217,6 +217,8 @@ public interface Machine extends WizardConfigurable, PropertySheetHolder, Closea
 
     public void removeActuator(Actuator actuator);
 
+    public void permutateActuator(Actuator actuator, int direction);
+
     public PnpJobProcessor getPnpJobProcessor();
     
     public Future<Object> submit(Runnable runnable);

--- a/src/main/java/org/openpnp/spi/Movable.java
+++ b/src/main/java/org/openpnp/spi/Movable.java
@@ -20,6 +20,12 @@ public interface Movable extends Locatable {
 
     void moveTo(Location location, MotionOption... options) throws Exception;
 
+    /**
+     * @param location
+     * @return true if the location can be moved to with this Movable (soft limits etc.)
+     * @throws Exception 
+     */
+    boolean isReachable(Location location) throws Exception;
 
     /**
      * @return The lower and upper limits of the Safe Zone as defined on the Z axis. The array elements may be null 

--- a/src/main/java/org/openpnp/spi/base/AbstractHead.java
+++ b/src/main/java/org/openpnp/spi/base/AbstractHead.java
@@ -216,6 +216,18 @@ public abstract class AbstractHead extends AbstractModelObject implements Head {
         }
     }
 
+    @Override 
+    public void permutateActuator(Actuator actuator, int direction) {
+        int index0 = actuators.indexOf(actuator);
+        int index1 = direction > 0 ? index0+1 : index0-1;
+        if (0 <= index1 && actuators.size() > index1) {
+            actuators.remove(actuator);
+            actuators.add(index1, actuator);
+            fireIndexedPropertyChange("actuators", index0, actuator, actuators.get(index0));
+            fireIndexedPropertyChange("actuators", index1, actuators.get(index0), actuator);
+        }
+    }
+
     @Override
     public void addNozzle(Nozzle nozzle) throws Exception {
         nozzle.setHead(this);

--- a/src/main/java/org/openpnp/spi/base/AbstractHeadMountable.java
+++ b/src/main/java/org/openpnp/spi/base/AbstractHeadMountable.java
@@ -414,4 +414,12 @@ public abstract class AbstractHeadMountable extends AbstractModelObject implemen
         Location approximativeLocation = toHeadMountableLocation(headApproximativeLocation);
         return approximativeLocation;
     }
+
+    @Override 
+    public boolean isReachable(Location location) throws Exception {
+            Location headLocation = toHeadLocation(location);
+            AxesLocation axesLocation = toRaw(headLocation);
+            return (Configuration.get().getMachine().getMotionPlanner().isValidLocation(axesLocation));
+    }
+
 }

--- a/src/main/java/org/openpnp/spi/base/AbstractMachine.java
+++ b/src/main/java/org/openpnp/spi/base/AbstractMachine.java
@@ -407,6 +407,18 @@ public abstract class AbstractMachine extends AbstractModelObject implements Mac
         }
     }
 
+    @Override 
+    public void permutateActuator(Actuator actuator, int direction) {
+        int index0 = actuators.indexOf(actuator);
+        int index1 = direction > 0 ? index0+1 : index0-1;
+        if (0 <= index1 && actuators.size() > index1) {
+            actuators.remove(actuator);
+            actuators.add(index1, actuator);
+            fireIndexedPropertyChange("actuators", index0, actuator, actuators.get(index0));
+            fireIndexedPropertyChange("actuators", index1, actuators.get(index0), actuator);
+        }
+    }
+
     @Override
     public void addDriver(Driver driver) throws Exception {
         drivers.add(driver);

--- a/src/main/java/org/openpnp/util/SimpleGraph.java
+++ b/src/main/java/org/openpnp/util/SimpleGraph.java
@@ -240,7 +240,15 @@ public class SimpleGraph {
                 double x1 = entry1.getKey();
                 double y0 = data.get(x0);
                 double y1 = data.get(x1);
-                double r = (x-x0)/(x1-x0);
+                double r;
+                if (isLineShown()) {
+                    // interpolate
+                    r = (x-x0)/(x1-x0);
+                }
+                else {
+                    // step to nearest
+                    r = x - x0 < x1 - x ? 0 : 1;
+                }
                 return y0+r*(y1-y0);
             }
             return null;

--- a/src/main/java/org/openpnp/util/SimpleGraph.java
+++ b/src/main/java/org/openpnp/util/SimpleGraph.java
@@ -48,6 +48,7 @@ public class SimpleGraph {
         private double relativePaddingTop;
         private double relativePaddingBottom;
         private boolean symmetricIfSigned;
+        private boolean squareAspectRatio;
 
         public void addDataRow(DataRow dataRow) {
             dataRows.add(dataRow);
@@ -96,6 +97,14 @@ public class SimpleGraph {
             this.symmetricIfSigned = symmetricIfSigned;
         }
 
+        public boolean isSquareAspectRatio() {
+            return squareAspectRatio;
+        }
+        
+        public void setSquareAspectRatio(boolean squareAspectRatio) {
+            this.squareAspectRatio = squareAspectRatio;
+        }
+        
         public Point2D.Double getMinimum() {
             Point2D.Double minimum = null;
             for (DataRow dataRow : dataRows) {
@@ -198,6 +207,8 @@ public class SimpleGraph {
     public static class DataRow {
         private String label;
         private Color color;
+        private boolean markerShown = false;
+        private boolean lineShown = true;
         private int displayCycleMask = 1; // Displayed on mask 1
         private TreeMap<Double, Double> data = new TreeMap<>();
 
@@ -298,6 +309,22 @@ public class SimpleGraph {
         }
         public void setColor(Color color) {
             this.color = color;
+        }
+
+        public boolean isMarkerShown() {
+            return markerShown;
+        }
+
+        public void setMarkerShown(boolean markerShown) {
+            this.markerShown = markerShown;
+        }
+
+        public boolean isLineShown() {
+            return lineShown;
+        }
+
+        public void setLineShown(boolean lineShown) {
+            this.lineShown = lineShown;
         }
 
         public int getDisplayCycleMask() {

--- a/src/main/java/org/openpnp/util/UiUtils.java
+++ b/src/main/java/org/openpnp/util/UiUtils.java
@@ -1,14 +1,19 @@
 package org.openpnp.util;
 
+import java.awt.Component;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Future;
 import java.util.function.Consumer;
 
+import javax.swing.JOptionPane;
 import javax.swing.SwingUtilities;
 
 import org.openpnp.gui.MainFrame;
 import org.openpnp.gui.support.MessageBoxes;
 import org.openpnp.model.Configuration;
+import org.openpnp.model.Location;
+import org.openpnp.spi.HeadMountable;
+import org.openpnp.spi.MotionPlanner.CompletionType;
 
 import com.google.common.util.concurrent.FutureCallback;
 
@@ -109,8 +114,85 @@ public class UiUtils {
         }
     }
 
+    /**
+     * Functional wrapper for actions that may throw an Exception. Presents an error box to the user
+     * with the Exception contents if one is thrown. The action is performed later on the GUI thread.
+     * 
+     * @param thrunnable
+     */
     public static void messageBoxOnExceptionLater(Thrunnable thrunnable) {
         SwingUtilities.invokeLater(() -> messageBoxOnException(thrunnable));
     }
 
+    /**
+     * Some UI actions require the machine to move to a certain location as a prerequisite (e.g. editing a pipeline). 
+     * For some actions this might be unexpected for the user. This wrapper asks the user to confirm the move, if not 
+     * already at the location. 
+     * It also handles a disabled machine and lets the user proceed, if this is an option.
+     * It then moves to the location at safe Z, and executes the action thrunnable.
+     * The wrapper also handles all the proper GUI/machine task dispatching and shows message boxes on Exceptions.
+     * 
+     * @param parentComponent 
+     * @param moveBeforeActionDescription
+     * @param movable
+     * @param location
+     * @param allowWithoutMove
+     * @param actionThrunnable
+     */
+    public static void confirmMoveToLocationAndAct(Component parentComponent, 
+            String moveBeforeActionDescription, HeadMountable movable, 
+            Location location, boolean allowWithoutMove,
+            final Thrunnable actionThrunnable) {
+        messageBoxOnException(() -> {
+            if (location.equals(movable.getLocation())) {
+                // Already there, just act.
+                actionThrunnable.thrun();
+            }
+            else if (Configuration.get().getMachine().isEnabled()) {
+                // We need to move there, ask the user to confirm.
+                int result;
+                if (allowWithoutMove) {
+                    result = JOptionPane.showConfirmDialog(parentComponent,
+                            "Do you want to "+moveBeforeActionDescription+"?\n",
+                                    null, JOptionPane.YES_NO_CANCEL_OPTION, JOptionPane.QUESTION_MESSAGE);
+                }
+                else {
+                    result = JOptionPane.showConfirmDialog(parentComponent,
+                            "About to "+moveBeforeActionDescription+".\n"
+                                    +"Do you want to proceed?",
+                                    null, JOptionPane.YES_NO_OPTION, JOptionPane.WARNING_MESSAGE);
+                }
+                if (result == JOptionPane.YES_OPTION) {
+                    // Move wanted.
+                    UiUtils.submitUiMachineTask(() -> {
+                        MovableUtils.moveToLocationAtSafeZ(movable, location);
+                        MovableUtils.fireTargetedUserAction(movable);
+                        movable.waitForCompletion(CompletionType.WaitForStillstand);
+                        UiUtils.messageBoxOnExceptionLater(actionThrunnable);
+                    });
+                }
+                else if (result == JOptionPane.NO_OPTION && allowWithoutMove) {
+                    // No move wanted.
+                    actionThrunnable.thrun();
+                }
+            }
+            else {
+                // We can't move but should.
+                if (!allowWithoutMove) {
+                    // Just say we can't. 
+                    throw new Exception("Machine not enabled, unable to "+moveBeforeActionDescription+".");
+                }
+                else {
+                    // Ask the user if it is OK to proceed without moving. 
+                    int result = JOptionPane.showConfirmDialog(parentComponent,
+                            "Machine not enabled, unable to "+moveBeforeActionDescription+".\n"
+                                    +"Do you want to proceed anyway?",
+                                    null, JOptionPane.YES_NO_OPTION, JOptionPane.WARNING_MESSAGE);
+                    if (result == JOptionPane.YES_OPTION) {
+                        actionThrunnable.thrun();
+                    }
+                }
+            }
+        });
+    }
 }

--- a/src/main/resources/org/openpnp/machine/reference/vision/ReferenceFiducialLocator-CircularSymmetryPipeline.xml
+++ b/src/main/resources/org/openpnp/machine/reference/vision/ReferenceFiducialLocator-CircularSymmetryPipeline.xml
@@ -1,0 +1,14 @@
+<cv-pipeline>
+   <stages>
+      <cv-stage class="org.openpnp.vision.pipeline.stages.ImageCapture" name="image" enabled="true" default-light="true" settle-first="true" count="1"/>
+      <cv-stage class="org.openpnp.vision.pipeline.stages.ImageWriteDebug" name="deb0" enabled="false" prefix="fidloc_source_" suffix=".png"/>
+      <cv-stage class="org.openpnp.vision.pipeline.stages.BlurGaussian" name="blur" enabled="false" kernel-size="3"/>
+      <cv-stage class="org.openpnp.vision.pipeline.stages.DetectCircularSymmetry" name="circular" enabled="true" min-diameter="10" max-diameter="100" max-distance="200" min-symmetry="1.2" property-name="fiducial" outer-margin="0.2" inner-margin="0.4" sub-sampling="8" diagnostics="false"/>
+      <cv-stage class="org.openpnp.vision.pipeline.stages.ConvertModelToKeyPoints" name="results" enabled="true" model-stage-name="circular"/>
+      <cv-stage class="org.openpnp.vision.pipeline.stages.DrawCircles" name="draw" enabled="true" circles-stage-name="circular" thickness="1">
+         <color r="255" g="255" b="0" a="255"/>
+         <center-color r="255" g="153" b="0" a="255"/>
+      </cv-stage>
+      <cv-stage class="org.openpnp.vision.pipeline.stages.ImageWriteDebug" name="deb1" enabled="false" prefix="fidloc_results_" suffix=".png"/>
+   </stages>
+</cv-pipeline>


### PR DESCRIPTION
# Description
This roundup of enhancements include the following:

- Merged develop into test
- Used @tonyluken 's new SimpleGraph improvements to better visualize backlash error data.
    
    ![New Backlash Calibration Graphs](https://user-images.githubusercontent.com/9963310/130335118-e0eaf9dc-5786-4803-8ed4-f59e73bf21fc.png)

- Introduces `UiUtils.confirmMoveToLocationAndAct()` for UI actions that need to perform moves by the machine, that are possibly unexpected by the user. So this wrapper asks for confirmation and handles a disabled machine, threading issues and exception message boxes. Refactored `ReferencePushPullFeederConfigurationWizard` pre pipeline editing move (where this was extracted). Added a `ReferenceNozzleTipCalibrationWizard` pre pipeline editing move.
- Fix null pointer exception due to 3D UPP configuration error in `CameraView`.
- Move the `Head.isInsideSoftLimits()` to `Movable.isReachable()`, as it is actually not Head business.
- When setting head offsets on a `ReferenceNozzle`, update other, dependent head offsets, including bottom camera locations (which are head offsets internally). This allows recalibration of nozzle head offsets without invalidating other calibrations.
- Improve the Auto-Focus to always use the same servo direction. Add a small retract distance before each iteration. This gets rid of any uncompensated backlash in the axis (which is typically the case with Z axes that are used to auto-focus).
- Increase the auto-calibration Auto-Focus focal depth.
- Fix a bug/ambiguity in unit vector LengthUnits handling.
- When Issues & Solutions nozzle solutions are applied that have fewer nozzles than before, delete surplus actuators (as it already did with nozzles and axes).
- Allow for actuators on Head or Machine to be permutated with Up/Down arrow buttons in the Machine Setup tree, same as Drivers, Axes.
- Make sure solutions are presented, when absolutely needed, even when marked as "solved".
- Added this to camera preliminary calibrations in case Units per Pixels are missing.
- Issues & Solutions Visual Homing calibration will now also create the "FIDUCIAL-HOME" package and part, and set its diameter based on interactive diameter setting. A `DetectCircularSymmetry` stage based vision pipeline is automatically assigned, providing tuning free fiducial vision.
- Add `LengthProperty` to `Solution.Issue` and `IssuePanel`
- Add `acceptableTolerance` to `ReferenceControllerAxis` and `ReferenceControllerAxisConfigurationWizard`.
- Use` acceptableTolerance` in `CalibrationSolutions` backlash compensation.
- Improve `calibrateAxisBacklash` to consider both directed and reversed moves. Add random move test.
- `SimpleGraph` should not interpolate between points that have no line shown (scatter plot). Instead, snap to the nearest data point.

- Bug-fix (unit tests only): Prevent `Configuration.getMachine()` not yet ready race condition in `SimulationModeMachine`.

# Justification
Ongoing testing in the testing version.

# Instructions for Use
Updated the Wiki:
https://github.com/openpnp/openpnp/wiki/Issues-and-Solutions#kinematics-milestone

# Implementation Details
1. Tested both in simulation and on the machine.
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. Small changes in the `org.openpnp.spi` or `org.openpnp.model` packages. `Head.isInsideSoftLimits()` to `Movable.isReachable()`.
4. Successful `mvn test` before submitting the Pull Request. 
