### PR TITLE
Feature/Automatic Machine Calibration using Issues & Solutions - Round 4

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/solutions/CalibrationSolutions.java
+++ b/src/main/java/org/openpnp/machine/reference/solutions/CalibrationSolutions.java
@@ -318,8 +318,9 @@ public class CalibrationSolutions implements Solutions.Subject {
                             + "<p>Jog camera " + defaultCamera.getName()
                             + " over the test object. Target it with the cross-hairs.</p><br/>"
                             + "<p>Adjust the <strong>Detected feature diameter</strong> up and down and see if it is detected right in the "
-                            + "camera view.</p><br/>"
-                            + "<p><strong color=\"red\">Caution:</strong> The nozzle "+nozzle.getName()+" will now move to the test object "
+                            + "camera view. A green circle and cross-hairs should appear and hug the test object contour. "
+                            + "Zoom the camera using the scroll-wheel.</p><br/>"
+                            + "<p><strong color=\"red\">Caution:</strong> The nozzle "+nozzle.getName()+" will move to the test object "
                             + "and perform the calibration pick & place pattern. Make sure to load the right nozzle tip and "
                             + "ready the vacuum system.</p><br/>"
                             + "<p>When ready, press Accept.</p>"

--- a/src/main/java/org/openpnp/machine/reference/solutions/VisionSolutions.java
+++ b/src/main/java/org/openpnp/machine/reference/solutions/VisionSolutions.java
@@ -86,7 +86,7 @@ public class VisionSolutions implements Solutions.Subject {
 
     // See org.openpnp.vision.pipeline.stages.DetectCircularSymmetry.findCircularSymmetry for what these mean.
     @Attribute(required = false)
-    private double minSymmetry = 1.25;
+    private double minSymmetry = 1.5;
     @Attribute(required = false)
     private int subSampling = 4;
     @Attribute(required = false)
@@ -244,7 +244,7 @@ public class VisionSolutions implements Solutions.Subject {
         public Solutions.Issue.CustomProperty[] getProperties() {
             return new Solutions.Issue.CustomProperty[] {
                     new Solutions.Issue.IntegerProperty(
-                            "Detected feature diameter",
+                            "Feature diameter",
                             "Adjust the feature diameter that should be detected.",
                             3, (int)(Math.min(camera.getWidth(), camera.getHeight())*maxCameraRelativeSubjectDiameter)) {
                         @Override
@@ -257,7 +257,7 @@ public class VisionSolutions implements Solutions.Subject {
                             try {
                                 UiUtils.submitUiMachineTask(() -> {
                                     try {
-                                        // This show a diagnostic detection image in the camera view for 2000ms.
+                                        // This show a diagnostic detection image in the camera view.
                                         getSubjectPixelLocation(camera, null, new Circle(0, 0, value), 0.05, "Diameter "+(int)value+" px");
                                     }
                                     catch (Exception e) {
@@ -310,7 +310,8 @@ public class VisionSolutions implements Solutions.Subject {
                             + "<p>Jog camera " + camera.getName()
                             + " over the privary fiducial. Target it roughly with the cross-hairs.</p><br/>"
                             + "<p>Adjust the <strong>Detected feature diameter</strong> up and down and see if it is detected right in the "
-                            + "camera view.</p><br/>"
+                            + "camera view. A green circle and cross-hairs should appear and hug the fiducial contour. "
+                            + "Zoom the camera using the scroll-wheel.</p><br/>"
                             + "<p>Then press Accept to capture the position. The camera will perform a small calibration movement "
                             + "pattern</p>"
                             + "</html>";
@@ -392,7 +393,8 @@ public class VisionSolutions implements Solutions.Subject {
                             + "<p>Jog camera " + camera.getName()
                             + " over the secondary fiducial. Target it roughly with the cross-hairs.</p><br/>"
                             + "<p>Adjust the <strong>Detected feature diameter</strong> up and down and see if it is detected right in the "
-                            + "camera view.</p><br/>"
+                            + "camera view. A green circle and cross-hairs should appear and hug the fiducial contour. "
+                            + "Zoom the camera using the scroll-wheel.</p><br/>"
                             + "<p>Then press Accept to capture the position.</p>"
                             + "</html>";
                 }
@@ -463,7 +465,8 @@ public class VisionSolutions implements Solutions.Subject {
                             + "<p>Jog camera " + camera.getName()
                             + " over the primary fiducial. Target it with the cross-hairs.</p><br/>"
                             + "<p>Adjust the <strong>Detected feature diameter</strong> up and down and see if it is detected right in the "
-                            + "camera view.</p><br/>"
+                            + "camera view. A green circle and cross-hairs should appear and hug the fiducial contour. "
+                            + "Zoom the camera using the scroll-wheel.</p><br/>"
                             + "<p>Then press Accept to capture the offsets. The camera will perform a small calibration movement "
                             + "</html>";
                 }
@@ -560,8 +563,10 @@ public class VisionSolutions implements Solutions.Subject {
                             + "<p>Jog the nozzle tip point down in Z so it is in focus. This should be more or less on the same Z level "
                             + "as the PCB surface. If not, consider adjusting the camera focus to make it so.</p><br/>"
                             + "<p>Adjust the <strong>Detected feature diameter</strong> up and down and see if it is detected right in the "
-                            + "camera view. Make sure to target a circular edge that can be detected consistently even when seen from the side. "
-                            + "This means it has to be a rather sharp-angled edge between faces. Typically, the air bore edge is targeted.</p><br/>"
+                            + "camera view. A green circle and cross-hairs should appear and hug the wanted contour. "
+                            + "Zoom the camera using the scroll-wheel.</p><br/>"
+                            + "<p>Make sure to target a circular edge that can be detected consistently even when seen from the side. "
+                            + "This means it has to be a rather sharp-angled edge. Typically, the air bore contour is targeted.</p><br/>"
                             + "<p>Then press Accept to capture the camera position.</p>"
                             + "</html>";
                 }
@@ -822,8 +827,9 @@ public class VisionSolutions implements Solutions.Subject {
                             + "<p>Home the machine by means of your controller/manually. The controller must presently work in the wanted "
                             + "coordinate system.</p><br/>"
                             + "<p>Jog camera "+defaultCamera.getName()+" over the fiducial. Target it roughly with the cross-hairs.</p><br/>"
-                            + "<p>Adjust the <strong>Detected feature diameter</strong> up and down and see if it is detected right in the " 
-                            + "camera view.</p><br/>"
+                            + "<p>Adjust the <strong>Detected feature diameter</strong> up and down and see if it is detected right in the "
+                            + "camera view. A green circle and cross-hairs should appear and hug the fiducial contour. "
+                            + "Zoom the camera using the scroll-wheel.</p><br/>"
                             + "<p>Then press Accept to detect the precise position of the fiducial and set it up for visual homing.</p><br/>"
                             + "<p>Note: This will not change your present machine coordinate system, but rather pin it down to the fiducial. "
                             + "If the mechanics were to change slightly in the future (e.g. a homing end-switch slightly moved), the "
@@ -1167,7 +1173,7 @@ public class VisionSolutions implements Solutions.Subject {
      * @param extraSearchRange Specifies an extra search range, relative to the camera view size (minimum of width, height). 
      * @param diagnostics
      * @param subjectDiameter   Provides the fiducial diameter in pixels, if known, null otherwise. 
-     * @return
+     * @return The match as a Circle.
      * @throws Exception
      */
     public Circle getSubjectPixelLocation(ReferenceCamera camera, HeadMountable movable, Circle expectedOffsetAndDiameter, double extraSearchRange, 
@@ -1233,7 +1239,7 @@ public class VisionSolutions implements Solutions.Subject {
         List<Circle> results = DetectCircularSymmetry.findCircularSymmetry(image, 
                 expectedX, expectedY, 
                 maxDiameter, minDiameter, maxDistance, maxDistance, maxDistance, 1,
-                minSymmetry, 0.0, subSampling, superSampling, diagnostics != null, scoreRange);
+                minSymmetry, 0.0, subSampling, superSampling, diagnostics != null, false, scoreRange);
         if (diagnostics != null) {
             if (LogUtils.isDebugEnabled()) {
                 File file = Configuration.get().createResourceFile(getClass(), "loc_", ".png");

--- a/src/main/resources/org/openpnp/machine/reference/vision/ReferenceFiducialLocator-CircularSymmetryPipeline.xml
+++ b/src/main/resources/org/openpnp/machine/reference/vision/ReferenceFiducialLocator-CircularSymmetryPipeline.xml
@@ -3,9 +3,9 @@
       <cv-stage class="org.openpnp.vision.pipeline.stages.ImageCapture" name="image" enabled="true" default-light="true" settle-first="true" count="1"/>
       <cv-stage class="org.openpnp.vision.pipeline.stages.ImageWriteDebug" name="deb0" enabled="false" prefix="fidloc_source_" suffix=".png"/>
       <cv-stage class="org.openpnp.vision.pipeline.stages.BlurGaussian" name="blur" enabled="false" kernel-size="3"/>
-      <cv-stage class="org.openpnp.vision.pipeline.stages.DetectCircularSymmetry" name="circular" enabled="true" min-diameter="10" max-diameter="100" max-distance="200" min-symmetry="1.2" property-name="fiducial" outer-margin="0.2" inner-margin="0.4" sub-sampling="8" diagnostics="false"/>
+      <cv-stage class="org.openpnp.vision.pipeline.stages.DetectCircularSymmetry" name="circular" enabled="true" min-diameter="10" max-diameter="100" max-distance="200" search-width="0" search-height="0" max-target-count="1" min-symmetry="1.2" corr-symmetry="0.0" property-name="fiducial" outer-margin="0.2" inner-margin="0.4" sub-sampling="8" super-sampling="8" diagnostics="true" heat-map="false"/>
       <cv-stage class="org.openpnp.vision.pipeline.stages.ConvertModelToKeyPoints" name="results" enabled="true" model-stage-name="circular"/>
-      <cv-stage class="org.openpnp.vision.pipeline.stages.DrawCircles" name="draw" enabled="true" circles-stage-name="circular" thickness="1">
+      <cv-stage class="org.openpnp.vision.pipeline.stages.DrawCircles" name="draw" enabled="false" circles-stage-name="circular" thickness="1">
          <color r="255" g="255" b="0" a="255"/>
          <center-color r="255" g="153" b="0" a="255"/>
       </cv-stage>


### PR DESCRIPTION


# Description
Just a small update to this testing round:

* Anti-aliased circle and cross-hairs diagnostics for `DetectCircularSymmetry`. If no match is found, a dashed red circle indicates the unmatched diameter.
* Separate boolean for circular symmetry heat map diagnostics. Normally switched off.
* Better description for feature diameter adjustments (see animation below). 
* Add super-sampling to the homing-fiducial pipeline that is assigned by Issues & Solutions.

![Feature Diameter](https://user-images.githubusercontent.com/9963310/130353893-9daaf41a-a3ec-4286-9b53-5f0a5c75509c.gif)

# Justification
See here:
https://groups.google.com/g/openpnp/c/-1VWW3uXOKw/m/cT-Wfct2BQAJ

# Instructions for Use
See the Wiki:
https://github.com/openpnp/openpnp/wiki/Vision-Solutions#calibration-primary-fiducial

# Implementation Details
1. Tested in simulation.
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. Successful `mvn test` before submitting the Pull Request. 
