### PR TITLE
Fix / Deprecated Double.NaN Substitution broken through ContactProbeNozzle

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/ContactProbeNozzle.java
+++ b/src/main/java/org/openpnp/machine/reference/ContactProbeNozzle.java
@@ -574,7 +574,7 @@ public class ContactProbeNozzle extends ReferenceNozzle {
         if (! Arrays.asList(options).contains(LocationOption.SuppressDynamicCompensation)) {
             if (zCalibratedNozzleTip != null && calibrationOffsetZ != null) {
                 location = location.subtract(new Location(calibrationOffsetZ .getUnits(), 0, 0, calibrationOffsetZ.getValue(), 0));
-                Logger.trace("{}.transformToHeadLocation({}, ...) Z offset {}", getName(), location, calibrationOffsetZ);
+                Logger.trace("{}.toHeadLocation({}, ...) Z offset {}", getName(), location, calibrationOffsetZ);
             }
         }
         return super.toHeadLocation(location, currentLocation, options);

--- a/src/main/java/org/openpnp/machine/reference/ReferenceHead.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceHead.java
@@ -82,7 +82,6 @@ public class ReferenceHead extends AbstractHead {
                 AxesLocation axesHomingLocation;
                 if (getVisualHomingMethod() == VisualHomingMethod.ResetToFiducialLocation) {
                     // Convert fiducial location to raw coordinates
-                    // TODO: are you sure the toHeadLocation() is needed?
                     axesHomingLocation = hm.toRaw(hm.toHeadLocation(getHomingFiducialLocation()));
                 }
                 else {

--- a/src/main/java/org/openpnp/machine/reference/ReferenceNozzle.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceNozzle.java
@@ -435,7 +435,7 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
             if (calibrationNozzleTip != null && calibrationNozzleTip.getCalibration().isCalibrated(this)) {
                 Location correctionOffset = calibrationNozzleTip.getCalibration().getCalibratedOffset(this, location.getRotation());
                 location = location.subtract(correctionOffset);
-                Logger.trace("{}.transformToHeadLocation({}, ...) runout compensation {}", getName(), location, correctionOffset);
+                Logger.trace("{}.toHeadLocation({}, ...) runout compensation {}", getName(), location, correctionOffset);
             }
         }
         return super.toHeadLocation(location, currentLocation, options);

--- a/src/main/java/org/openpnp/spi/base/AbstractHeadMountable.java
+++ b/src/main/java/org/openpnp/spi/base/AbstractHeadMountable.java
@@ -236,7 +236,9 @@ public abstract class AbstractHeadMountable extends AbstractModelObject implemen
     @Override
     public void moveTo(Location location, double speed, MotionOption... options) throws Exception {
         Logger.debug("{}.moveTo({}, {})", getName(), location, speed);
-        Location headLocation = toHeadLocation(location, getLocation());
+        Location currentLocation = getLocation();
+        location = substituteUnchangedCoordinates(location, currentLocation);
+        Location headLocation = toHeadLocation(location, currentLocation);
         getHead().moveTo(this, headLocation, getHead().getMaxPartSpeed() * speed, options);
     }
 
@@ -292,6 +294,12 @@ public abstract class AbstractHeadMountable extends AbstractModelObject implemen
     }
 
     public Location toHeadLocation(Location location, Location currentLocation, LocationOption... options) {
+        // Subtract the Head offset.
+        location = location.subtract(getHeadOffsets());
+        return location;
+    }
+
+    public static Location substituteUnchangedCoordinates(Location location, Location currentLocation) {
         if (currentLocation != null) {
             // Shortcut Double.NaN. Sending Double.NaN in a Location is an old API that should no
             // longer be used. It will be removed eventually:
@@ -304,8 +312,6 @@ public abstract class AbstractHeadMountable extends AbstractModelObject implemen
                     Double.isNaN(location.getZ()), 
                     Double.isNaN(location.getRotation())); 
         }
-        // Subtract the Head offset.
-        location = location.subtract(getHeadOffsets());
         return location;
     }
     @Override
@@ -314,18 +320,6 @@ public abstract class AbstractHeadMountable extends AbstractModelObject implemen
     }
 
     public Location toHeadMountableLocation(Location location, Location currentLocation, LocationOption... options) {
-        if (currentLocation != null) {
-            // Shortcut Double.NaN. Sending Double.NaN in a Location is an old API that should no
-            // longer be used. It will be removed eventually:
-            // https://github.com/openpnp/openpnp/issues/255
-            // In the mean time, since Double.NaN would cause a problem for transformations, we shortcut
-            // it here by replacing any NaN values with the current value from the axes.
-            location = location.derive(currentLocation, 
-                    Double.isNaN(location.getX()), 
-                    Double.isNaN(location.getY()), 
-                    Double.isNaN(location.getZ()), 
-                    Double.isNaN(location.getRotation()));
-        }
         // Add the Head offset.
         location = location.add(getHeadOffsets());
         return location;
@@ -385,6 +379,7 @@ public abstract class AbstractHeadMountable extends AbstractModelObject implemen
             throws Exception {
         // Inverse-transform the desired location to a raw location, applying the approximation options, which means some 
         // compensation effects are suppressed.
+        desiredLocation = substituteUnchangedCoordinates(desiredLocation, currentLocation);
         Location desiredHeadLocation = toHeadLocation(desiredLocation, options);
         Location currentHeadLocation = toHeadLocation(currentLocation);
         AxesLocation desiredRawLocation = toRaw(desiredHeadLocation);


### PR DESCRIPTION
# Description

Deprecated `Double.NaN` substitution was broken through the `ContactProbeNozzle.toHeadLocation()` override.

* This change removes the handling from `toHeadLocation()` and puts it into a separate method `substituteUnchangedCoordinates()`, to be used by all callers potentially getting `Double.NaN` infested Locations, i.e. before those are plugged into  `toHeadLocation()`.
* Also fixes some errors in (old) comments.

# Justification
See #1258 

# Instructions for Use
No change.

# Implementation Details
1. Due to the deprecated nature and special use case in the user report, no tests were conducted, instead this will be closely followed up.  
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. Successful `mvn test` before submitting the Pull Request.
