### PR TITLE
Feature/Automatic Machine Calibration using Issues & Solutions - Round 6

### DIFF
--- a/src/main/java/org/openpnp/gui/JogControlsPanel.java
+++ b/src/main/java/org/openpnp/gui/JogControlsPanel.java
@@ -234,7 +234,7 @@ public class JogControlsPanel extends JPanel {
 
         tool.moveTo(targetLocation, MotionOption.JogMotion); 
 
-        MovableUtils.fireTargetedUserAction(tool);
+        MovableUtils.fireTargetedUserAction(tool, true);
     }
 
     private boolean nozzleLocationIsSafe(Location origin, Location dimension, Location nozzle,
@@ -607,7 +607,7 @@ public class JogControlsPanel extends JPanel {
                 Location location = hm.getLocation();
                 location = location.derive(null, null, null, 0.);
                 hm.moveTo(location);
-                MovableUtils.fireTargetedUserAction(hm);
+                MovableUtils.fireTargetedUserAction(hm, true);
             });
         }
     };

--- a/src/main/java/org/openpnp/gui/components/CameraView.java
+++ b/src/main/java/org/openpnp/gui/components/CameraView.java
@@ -669,8 +669,7 @@ public class CameraView extends JComponent implements CameraListener {
                 // safe Z.
                 if (camera.getLocation().getLengthZ().compareTo(camera.getSafeZ()) < 0) {   
                     LengthConverter lengthConverter = new LengthConverter();
-                    String text = "Z: " + lengthConverter.convertForward(camera.getLocation().getLengthZ()) 
-                    + Configuration.get().getSystemUnits().getShortName();
+                    String text = "Z: " + lengthConverter.convertForward(camera.getLocation().getLengthZ());
                     Dimension dim = measureTextOverlay(g2d, text);
                     drawTextOverlay(g2d, width - dim.width - 10, height - dim.height - 10, text);
                 }
@@ -1519,7 +1518,7 @@ public class CameraView extends JComponent implements CameraListener {
                 // move the camera to the location
                 MovableUtils.moveToLocationAtSafeZ(camera, location);
             }
-            MovableUtils.fireTargetedUserAction(camera);
+            MovableUtils.fireTargetedUserAction(camera, true);
         });
     }
     
@@ -1543,7 +1542,7 @@ public class CameraView extends JComponent implements CameraListener {
             Location location = selectedTool.getLocation();
             location = location.derive(null, null, null, targetAngle);
             MovableUtils.moveToLocationAtSafeZ(selectedTool, location);
-            MovableUtils.fireTargetedUserAction(selectedTool);
+            MovableUtils.fireTargetedUserAction(selectedTool, true);
         });
     }
 

--- a/src/main/java/org/openpnp/gui/components/CameraViewPopupMenu.java
+++ b/src/main/java/org/openpnp/gui/components/CameraViewPopupMenu.java
@@ -62,15 +62,6 @@ public class CameraViewPopupMenu extends JPopupMenu {
         // For cameras that have been calibrated at two different heights, add menu options to reset
         // the viewing plane and for estimating an object's height
         if (cameraView.isViewingPlaneChangable()) {
-            JMenuItem mntmResetReticleHeight = new JMenuItem("Reset Viewing Plane Z to Default");
-            mntmResetReticleHeight.addActionListener(new ActionListener() {
-                @Override
-                public void actionPerformed(ActionEvent e) {
-                    cameraView.resetViewingPlaneZ();
-                }
-            });
-            add(mntmResetReticleHeight);
-
             JMenuItem mntmEstimateZCoordinate = new JMenuItem("Estimate Z Coordinate of Object");
             mntmEstimateZCoordinate.addActionListener(estimateZCoordinateAction);
             add(mntmEstimateZCoordinate);

--- a/src/main/java/org/openpnp/gui/wizards/CameraConfigurationWizard.java
+++ b/src/main/java/org/openpnp/gui/wizards/CameraConfigurationWizard.java
@@ -355,13 +355,6 @@ public class CameraConfigurationWizard extends AbstractConfigurationWizard {
             }
         });
         panelUpp.add(enableUnitsPerPixel3D, "4, 2");
-        
-        lblAutoViewPlaneZ = new JLabel("Auto-Scale?");
-        lblAutoViewPlaneZ.setToolTipText("<html>Automatically set the Units Per Pixel scale in the Camera View when a<br/>\r\nuser action is related to the camera and Z is known.\r\n</html>\r\n");
-        panelUpp.add(lblAutoViewPlaneZ, "6, 2, right, default");
-        
-        autoViewPlaneZ = new JCheckBox("");
-        panelUpp.add(autoViewPlaneZ, "8, 2");
 
         lblX = new JLabel("X");
         panelUpp.add(lblX, "4, 4, center, default");
@@ -527,8 +520,6 @@ public class CameraConfigurationWizard extends AbstractConfigurationWizard {
         btnMeasure2.setVisible(enable3D);
         btnCancelMeasure2.setVisible(enable3D);
         lblZ.setVisible(enable3D);
-        lblAutoViewPlaneZ.setVisible(enable3D);
-        autoViewPlaneZ.setVisible(enable3D);
         
         boolean cameraZ = enable3D && lookingDown
                 && !(camera.getAxisZ() == null || camera.getAxisZ() instanceof ReferenceVirtualAxis);
@@ -567,7 +558,6 @@ public class CameraConfigurationWizard extends AbstractConfigurationWizard {
         addWrappedBinding(camera, "antiGlareLightOff", antiGlareLightOff, "selected");
 
         addWrappedBinding(camera, "enableUnitsPerPixel3D", enableUnitsPerPixel3D, "selected");
-        addWrappedBinding(camera, "autoViewPlaneZ", autoViewPlaneZ, "selected");
 
         addWrappedBinding(camera, "defaultZ", textFieldDefaultZ, "text", lengthConverter);
 
@@ -910,8 +900,6 @@ public class CameraConfigurationWizard extends AbstractConfigurationWizard {
     private JLabel lblCalibrationObject;
     private JLabel lbldCalibration;
     private JCheckBox enableUnitsPerPixel3D;
-    private JLabel lblAutoViewPlaneZ;
-    private JCheckBox autoViewPlaneZ;
     private JLabel lblShowMultiview;
     private JCheckBox shownInMultiCameraView;
     private JLabel lblFocusSensing;

--- a/src/main/java/org/openpnp/machine/reference/AbstractBroadcastingCamera.java
+++ b/src/main/java/org/openpnp/machine/reference/AbstractBroadcastingCamera.java
@@ -101,7 +101,7 @@ public abstract class AbstractBroadcastingCamera extends AbstractCamera implemen
                         }
 
                         @Override
-                        public void machineTargetedUserAction(Machine machine, HeadMountable hm) {
+                        public void machineTargetedUserAction(Machine machine, HeadMountable hm, boolean jogging) {
                             // Find the nearest camera.
                             Camera nearestCamera = null;
                             if (hm instanceof Camera) {

--- a/src/main/java/org/openpnp/machine/reference/AbstractBroadcastingCamera.java
+++ b/src/main/java/org/openpnp/machine/reference/AbstractBroadcastingCamera.java
@@ -30,11 +30,8 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.concurrent.atomic.AtomicReference;
 
-import javax.swing.SwingUtilities;
-
 import org.openpnp.CameraListener;
 import org.openpnp.ConfigurationListener;
-import org.openpnp.gui.MainFrame;
 import org.openpnp.model.Configuration;
 import org.openpnp.model.LengthUnit;
 import org.openpnp.model.Location;
@@ -195,15 +192,6 @@ public abstract class AbstractBroadcastingCamera extends AbstractCamera implemen
         if (isAutoVisible()) {
             ensureCameraVisible();
         }
-        if (isAutoViewPlaneZ()) {
-            setViewingPlaneZ(location);
-        }
-    }
-
-    public void setViewingPlaneZ(Location location) {
-        SwingUtilities.invokeLater(() -> {
-            MainFrame.get().getCameraViews().getCameraView(this).setViewingPlaneZ(location.getLengthZ());
-        });
     }
 
     public synchronized static BufferedImage getCaptureErrorImage() {

--- a/src/main/java/org/openpnp/machine/reference/camera/AutoFocusProvider.java
+++ b/src/main/java/org/openpnp/machine/reference/camera/AutoFocusProvider.java
@@ -88,7 +88,8 @@ public class AutoFocusProvider implements FocusProvider {
     public Location autoFocus(Camera camera, HeadMountable movable,
             Length subjectMaxSize,
             Location location0, Location location1) throws Exception {
-        // Compute the pixel diameter of the subject maximum size.
+        // Compute the pixel diameter of the subject maximum size. 
+        // As we don't know the focus [Z] plane, we take standard UnitsPerPixel.
         Location unitsPerPixel = camera.getUnitsPerPixel();
         int diameter = (int) Math.ceil(Math.max(
                 subjectMaxSize.divide(unitsPerPixel.getLengthX()),

--- a/src/main/java/org/openpnp/machine/reference/camera/BufferedImageCamera.java
+++ b/src/main/java/org/openpnp/machine/reference/camera/BufferedImageCamera.java
@@ -35,8 +35,6 @@ public class BufferedImageCamera extends ReferenceCamera {
 
     public BufferedImageCamera(Camera originalCamera) {
         this.originalCamera = originalCamera;
-
-        setUnitsPerPixel(originalCamera.getUnitsPerPixel());
     }
 
     protected void setImage(BufferedImage source) {
@@ -86,6 +84,7 @@ public class BufferedImageCamera extends ReferenceCamera {
             bufferedCamera = new BufferedImageCamera(camera); 
             bufferedCameras.put(camera, bufferedCamera);
         }
+        bufferedCamera.setUnitsPerPixel(camera.getUnitsPerPixelAtZ());
         bufferedCamera.setImage(image);
         return bufferedCamera;
     }

--- a/src/main/java/org/openpnp/machine/reference/feeder/AdvancedLoosePartFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/AdvancedLoosePartFeeder.java
@@ -60,7 +60,7 @@ public class AdvancedLoosePartFeeder extends ReferenceFeeder {
     @Override
     public void feed(Nozzle nozzle) throws Exception {
         // no part found => no pick location
-        pickLocation = location.derive(null, null, Double.NaN, 0.0);
+        pickLocation = location;
 
         // if there is a part, get a precise location
         for (int i = 0; i < 3 && pickLocation != null; i++) {
@@ -85,7 +85,7 @@ public class AdvancedLoosePartFeeder extends ReferenceFeeder {
      */
     private Location locateFeederPart(Nozzle nozzle, Location startPoint) throws Exception {
         Camera camera = nozzle.getHead().getDefaultCamera();
-        MovableUtils.moveToLocationAtSafeZ(camera, startPoint.derive(null, null, Double.NaN, 0d));
+        MovableUtils.moveToLocationAtSafeZ(camera, startPoint);
         camera.waitForCompletion(CompletionType.WaitForStillstand);
         try (CvPipeline pipeline = getPipeline()) {
             // Process the pipeline to extract RotatedRect results
@@ -139,8 +139,8 @@ public class AdvancedLoosePartFeeder extends ReferenceFeeder {
         double distanceY = Math.abs(this.location.convertToUnits(LengthUnit.Millimeters).getY() - testLocation.convertToUnits(LengthUnit.Millimeters).getY());
         
         // if moved more than the half of the camera picture size => something went wrong => return no result
-        if (distanceX > camera.getUnitsPerPixel().convertToUnits(LengthUnit.Millimeters).getX() * camera.getWidth() / 2
-                || distanceY > camera.getUnitsPerPixel().convertToUnits(LengthUnit.Millimeters).getY() * camera.getHeight() / 2) {
+        if (distanceX > camera.getUnitsPerPixelAtZ().convertToUnits(LengthUnit.Millimeters).getX() * camera.getWidth() / 2
+                || distanceY > camera.getUnitsPerPixelAtZ().convertToUnits(LengthUnit.Millimeters).getY() * camera.getHeight() / 2) {
             System.err.println("Vision outside of the initial area");
             return null;
         }        

--- a/src/main/java/org/openpnp/machine/reference/feeder/ReferenceDragFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/ReferenceDragFeeder.java
@@ -44,6 +44,7 @@ import org.openpnp.spi.Head;
 import org.openpnp.spi.Nozzle;
 import org.openpnp.spi.PropertySheetHolder;
 import org.openpnp.spi.VisionProvider;
+import org.openpnp.util.MovableUtils;
 import org.openpnp.util.Utils2D;
 import org.pmw.tinylog.Logger;
 import org.simpleframework.xml.Attribute;
@@ -276,11 +277,9 @@ public class ReferenceDragFeeder extends ReferenceFeeder {
             throw new Exception("Area of Interest is required when vision is enabled.");
         }
 
-        head.moveToSafeZ();
-
         // Position the camera over the pick location.
         Logger.debug("Move camera to pick location.");
-        camera.moveTo(pickLocation);
+        MovableUtils.moveToLocationAtSafeZ(camera, pickLocation);
 
         // Move the camera to be in focus over the pick location.
         // head.moveTo(head.getX(), head.getY(), z, head.getC());
@@ -330,7 +329,7 @@ public class ReferenceDragFeeder extends ReferenceFeeder {
         Logger.debug("negated offsetX {}, offsetY {}", offsetX, offsetY);
 
         // And convert pixels to units
-        Location unitsPerPixel = camera.getUnitsPerPixel();
+        Location unitsPerPixel = camera.getUnitsPerPixelAtZ();
         offsetX *= unitsPerPixel.getX();
         offsetY *= unitsPerPixel.getY();
 

--- a/src/main/java/org/openpnp/machine/reference/feeder/ReferenceLeverFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/ReferenceLeverFeeder.java
@@ -44,7 +44,7 @@ import org.openpnp.spi.Head;
 import org.openpnp.spi.Nozzle;
 import org.openpnp.spi.PropertySheetHolder;
 import org.openpnp.spi.VisionProvider;
-import org.openpnp.util.Utils2D;
+import org.openpnp.util.MovableUtils;
 import org.pmw.tinylog.Logger;
 import org.simpleframework.xml.Attribute;
 import org.simpleframework.xml.Element;
@@ -225,11 +225,9 @@ public class ReferenceLeverFeeder extends ReferenceFeeder {
             throw new Exception("Area of Interest is required when vision is enabled.");
         }
 
-        head.moveToSafeZ();
-
         // Position the camera over the pick location.
         Logger.debug("Move camera to pick location.");
-        camera.moveTo(pickLocation);
+        MovableUtils.moveToLocationAtSafeZ(camera, pickLocation);
 
         // Move the camera to be in focus over the pick location.
         // head.moveTo(head.getX(), head.getY(), z, head.getC());
@@ -279,7 +277,7 @@ public class ReferenceLeverFeeder extends ReferenceFeeder {
         Logger.debug("negated offsetX {}, offsetY {}", offsetX, offsetY);
 
         // And convert pixels to units
-        Location unitsPerPixel = camera.getUnitsPerPixel();
+        Location unitsPerPixel = camera.getUnitsPerPixelAtZ();
         offsetX *= unitsPerPixel.getX();
         offsetY *= unitsPerPixel.getY();
 

--- a/src/main/java/org/openpnp/machine/reference/feeder/ReferenceStripFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/ReferenceStripFeeder.java
@@ -204,6 +204,13 @@ public class ReferenceStripFeeder extends ReferenceFeeder {
         return l;
     }
 
+    public void ensureFeederZ(Camera camera) throws Exception {
+        if (camera.isUnitsPerPixelAtZCalibrated()
+                && !getReferenceHoleLocation().getLengthZ().isInitialized()) {
+            throw new Exception("Feeder "+getName()+": please set the Reference Hole Location Z coordinate first.");
+        }
+    }
+
     public Location[] getIdealLineLocations() {
         if (visionLocation == null) {
             return new Location[] {referenceHoleLocation, lastHoleLocation};
@@ -237,6 +244,7 @@ public class ReferenceStripFeeder extends ReferenceFeeder {
         }
         // go to where we expect to find the next reference hole
         Camera camera = nozzle.getHead().getDefaultCamera();
+        ensureFeederZ(camera);
         Location expectedLocation = null;
         Location[] lineLocations = getIdealLineLocations();
 

--- a/src/main/java/org/openpnp/machine/reference/feeder/wizards/BlindsFeederConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/wizards/BlindsFeederConfigurationWizard.java
@@ -23,7 +23,6 @@
 package org.openpnp.machine.reference.feeder.wizards;
 
 import java.awt.BorderLayout;
-import java.awt.Color;
 import java.awt.event.ActionEvent;
 import java.io.File;
 import java.io.PrintWriter;
@@ -950,6 +949,7 @@ public class BlindsFeederConfigurationWizard extends AbstractConfigurationWizard
 
     private void editPipeline() throws Exception {
         Camera camera = Configuration.get().getMachine().getDefaultHead().getDefaultCamera();
+        feeder.ensureCameraZ(camera);
         CvPipeline pipeline = feeder.getCvPipeline(camera, false);
         CvPipelineEditor editor = new CvPipelineEditor(pipeline);
         JDialog dialog = new JDialog(MainFrame.get(), feeder.getName() + " Pipeline");

--- a/src/main/java/org/openpnp/machine/reference/feeder/wizards/ReferencePushPullFeederConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/wizards/ReferencePushPullFeederConfigurationWizard.java
@@ -740,8 +740,8 @@ extends AbstractReferenceFeederConfigurationWizard {
                     throw new Exception("This feeder is used as a template and cannot be overwritten.");
                 }
                 int result;
-                if (feeder.getLocation().equals(ReferencePushPullFeeder.nullLocation)) {
-                    // if the feeder.location is completely null, we assume this is a freshly created feeder 
+                if (!feeder.getLocation().isInitialized()) {
+                    // if the feeder.location is completely zero, we assume this is a freshly created feeder 
                     result = JOptionPane.YES_OPTION; 
                 }
                 else {

--- a/src/main/java/org/openpnp/machine/reference/feeder/wizards/ReferenceStripFeederConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/wizards/ReferenceStripFeederConfigurationWizard.java
@@ -376,12 +376,13 @@ public class ReferenceStripFeederConfigurationWizard extends AbstractConfigurati
         panelLocations.add(textFieldFeedEndY, "6, 6");
         textFieldFeedEndY.setColumns(8);
 
-        textFieldFeedEndZ = new JTextField();
-        panelLocations.add(textFieldFeedEndZ, "8, 6");
-        textFieldFeedEndZ.setColumns(8);
+//        textFieldFeedEndZ = new JTextField();
+//        panelLocations.add(textFieldFeedEndZ, "8, 6");
+//        textFieldFeedEndZ.setColumns(8);
 
         locationButtonsPanelFeedEnd = new LocationButtonsPanel(textFieldFeedEndX, textFieldFeedEndY,
-                textFieldFeedEndZ, null);
+                null, //textFieldFeedEndZ, 
+                null);
         panelLocations.add(locationButtonsPanelFeedEnd, "10, 6");
     }
 
@@ -420,7 +421,7 @@ public class ReferenceStripFeederConfigurationWizard extends AbstractConfigurati
         bind(UpdateStrategy.READ_WRITE, feeder, "lastHoleLocation", feedEndLocation, "location");
         addWrappedBinding(feedEndLocation, "lengthX", textFieldFeedEndX, "text", lengthConverter);
         addWrappedBinding(feedEndLocation, "lengthY", textFieldFeedEndY, "text", lengthConverter);
-        addWrappedBinding(feedEndLocation, "lengthZ", textFieldFeedEndZ, "text", lengthConverter);
+//        addWrappedBinding(feedEndLocation, "lengthZ", textFieldFeedEndZ, "text", lengthConverter);
 
         addWrappedBinding(feeder, "visionEnabled", chckbxUseVision, "selected");
 
@@ -436,7 +437,7 @@ public class ReferenceStripFeederConfigurationWizard extends AbstractConfigurati
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldFeedStartZ);
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldFeedEndX);
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldFeedEndY);
-        ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldFeedEndZ);
+//        ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldFeedEndZ);
     }
 
     private void updatePartInfo(ActionEvent e)
@@ -472,6 +473,16 @@ public class ReferenceStripFeederConfigurationWizard extends AbstractConfigurati
                                                .getMachine()
                                                .getDefaultHead()
                                                .getDefaultCamera();
+                if (autoSetupCamera.isUnitsPerPixelAtZCalibrated()) {
+                    // We need 3D units per pixel, make sure the Z is set first.
+                    LengthConverter lengthConverter = new LengthConverter();
+                    Length z = lengthConverter.convertReverse(textFieldFeedStartZ.getText());
+                    if (!z.isInitialized()) {
+                        throw new Exception("Please set the Reference Hole Location Z coordinate first.");
+                    }
+                    autoSetupCamera.moveTo(autoSetupCamera.getLocation()
+                            .deriveLengths(null, null, z, null));
+                }
             }
             catch (Exception ex) {
                 MessageBoxes.errorBox(getTopLevelAncestor(), "Auto Setup Failure", ex);
@@ -788,7 +799,7 @@ public class ReferenceStripFeederConfigurationWizard extends AbstractConfigurati
                 // Checks the distance to the line *segment*, as we expect the line to have the maximum extents that
                 // encompass all points (circles) that meet the criteria.
                 Double distance = camera.getLocation().getLinearDistanceToLineSegment(aLocation, bLocation);
-                Double distancePx = VisionUtils.toPixels(new Length(distance, camera.getUnitsPerPixel().getUnits()), camera);
+                Double distancePx = VisionUtils.toPixels(new Length(distance, camera.getLocation().getUnits()), camera);
                 // Min distance is because we're centered at the part, not the hole - so we need to ignore
                 // circles found in the part
                 if ((distancePx >= minDistancePx) && (distancePx <= maxDistancePx)) {
@@ -1008,8 +1019,8 @@ public class ReferenceStripFeederConfigurationWizard extends AbstractConfigurati
             pipeline.setProperty("sprocketHole.diameter", feeder.getHoleDiameter());
             // Search Range is half camera. 
             Length range = camera.getWidth() > camera.getHeight() ? 
-                    camera.getUnitsPerPixel().getLengthY().multiply(camera.getHeight()/2)
-                    : camera.getUnitsPerPixel().getLengthX().multiply(camera.getWidth()/2);
+                    camera.getUnitsPerPixelAtZ().getLengthY().multiply(camera.getHeight()/2)
+                    : camera.getUnitsPerPixelAtZ().getLengthX().multiply(camera.getWidth()/2);
             pipeline.setProperty("sprocketHole.maxDistance", range);
             return pipeline;
         }

--- a/src/main/java/org/openpnp/machine/reference/solutions/CalibrationSolutions.java
+++ b/src/main/java/org/openpnp/machine/reference/solutions/CalibrationSolutions.java
@@ -357,8 +357,7 @@ public class CalibrationSolutions implements Solutions.Subject {
                                     Circle testObject = visualSolutions
                                             .getSubjectPixelLocation(defaultCamera, null, new Circle(0, 0, featureDiameter), 0, null, null);
                                     head.setCalibrationTestObjectDiameter(
-                                            new Length(testObject.getDiameter()*defaultCamera.getUnitsPerPixel().getX(), 
-                                                    defaultCamera.getUnitsPerPixel().getUnits()));
+                                            defaultCamera.getUnitsPerPixelPrimary().getLengthX().multiply(testObject.getDiameter()));
                                     calibrateNozzleOffsets(head, defaultCamera, nozzle);
                                     return true;
                                 },
@@ -393,7 +392,7 @@ public class CalibrationSolutions implements Solutions.Subject {
 
     public void calibrateAxisBacklash(ReferenceHead head, ReferenceCamera camera,
             HeadMountable movable, ReferenceControllerAxis axis, Length acceptableTolerance) throws Exception {
-        // Check pre-conditions (this method can be called from outside Issues & Solutioins).
+        // Check pre-conditions (this method can be called from outside Issues & Solutions).
         if (!(axis.isSoftLimitLowEnabled() && axis.isSoftLimitHighEnabled())) {
             throw new Exception("Axis "+axis.getName()+" must have soft limits enabled for backlash calibration.");
         }
@@ -782,8 +781,8 @@ public class CalibrationSolutions implements Solutions.Subject {
         resolution = resolution.multiply(Math.ceil(finestResolution.divide(resolution)));
         // Get the sub-pixel resolution of the detection capability. 
         Length subPixelUnit = (axis.getType() == Type.X  
-                ? camera.getUnitsPerPixel().getLengthX() 
-                        : camera.getUnitsPerPixel().getLengthY())
+                ? camera.getUnitsPerPixelPrimary().getLengthX() 
+                        : camera.getUnitsPerPixelPrimary().getLengthY())
                 .multiply(1.0/machine.getVisionSolutions().getSuperSampling());
         if (tolerance) {
             // Round up to the next full sub-pixel (Note, this also covers the case where the axis resolution is not yet set).
@@ -829,7 +828,8 @@ public class CalibrationSolutions implements Solutions.Subject {
             testPart.setPackage(packag);
             ReferenceTubeFeeder feeder = new ReferenceTubeFeeder();
             feeder.setPart(testPart);
-            // Get the initial precise test object location.
+            // Get the initial precise test object location. It must lay on the primary fiducial. 
+            MovableUtils.moveToLocationAtSafeZ(defaultCamera, head.getCalibrationPrimaryFiducialLocation());
             Location location = machine.getVisionSolutions()
                     .centerInOnSubjectLocation(defaultCamera, defaultCamera,
                             head.getCalibrationTestObjectDiameter(), "Nozzle Offset Calibration", false);

--- a/src/main/java/org/openpnp/machine/reference/solutions/CalibrationSolutions.java
+++ b/src/main/java/org/openpnp/machine/reference/solutions/CalibrationSolutions.java
@@ -820,6 +820,7 @@ public class CalibrationSolutions implements Solutions.Subject {
 
     private void calibrateNozzleOffsets(ReferenceHead head, ReferenceCamera defaultCamera, ReferenceNozzle nozzle)
             throws Exception {
+        Location restoreLocation = nozzle.getLocation();
         try {
             // Create a pseudo part, package and feeder to enable pick and place.
             Part testPart = new Part("TEST-OBJECT");
@@ -832,6 +833,7 @@ public class CalibrationSolutions implements Solutions.Subject {
             Location location = machine.getVisionSolutions()
                     .centerInOnSubjectLocation(defaultCamera, defaultCamera,
                             head.getCalibrationTestObjectDiameter(), "Nozzle Offset Calibration", false);
+            restoreLocation = location;
             // We accumulate all the detected differences and only calculate the centroid in the end. 
             int accumulated = 0;
             Location offsetsDiff = new Location(LengthUnit.Millimeters);
@@ -882,6 +884,9 @@ public class CalibrationSolutions implements Solutions.Subject {
             if (nozzle.getPart() != null) {
                 nozzle.place();
             }
+            // Move nozzle over restore location at safe Z and with zero rotation.
+            MovableUtils.moveToLocationAtSafeZ(nozzle, restoreLocation
+                    .derive(null, null, nozzle.getSafeZ().convertToUnits(restoreLocation.getUnits()).getValue(), 0.0));
         }
     }
 }

--- a/src/main/java/org/openpnp/machine/reference/solutions/VisionSolutions.java
+++ b/src/main/java/org/openpnp/machine/reference/solutions/VisionSolutions.java
@@ -227,7 +227,7 @@ public class VisionSolutions implements Solutions.Subject {
             super(subject, issue, solution, severity, uri);
             this.camera = camera;
             featureDiameter = 20;
-            if (camera.getUnitsPerPixel().getX() != 0
+            if (camera.getUnitsPerPixelPrimary().getX() != 0
                     && featureDiameterIfKnown != null
                     && featureDiameterIfKnown.getValue() != 0) {
                 // Existing diameter setting.
@@ -680,7 +680,6 @@ public class VisionSolutions implements Solutions.Subject {
             final Length oldPrimaryZ = defaultCamera.getCameraPrimaryZ();
             final Length oldSecondaryZ = defaultCamera.getCameraSecondaryZ();
             final boolean oldEnabled3D = defaultCamera.isEnableUnitsPerPixel3D();
-            final boolean oldAutoViewPlaneZ = defaultCamera.isAutoViewPlaneZ();
             for (boolean primary : (nozzle == defaultNozzle && isSolvedSecondaryXY(head)) ? new boolean [] {true, false} : new boolean [] {true} ) {
                 String qualifier = primary ? "primary" : "secondary";
                 solutions.add(new Solutions.Issue(
@@ -754,7 +753,6 @@ public class VisionSolutions implements Solutions.Subject {
                                                         .derive(nozzleLocation, false, false, true, false);
                                                 defaultCamera.setUnitsPerPixelSecondary(upp);
                                                 defaultCamera.setEnableUnitsPerPixel3D(true);
-                                                defaultCamera.setAutoViewPlaneZ(true);
                                             }
                                         }
                                         if (primary) {
@@ -825,7 +823,6 @@ public class VisionSolutions implements Solutions.Subject {
                                 defaultCamera.setUnitsPerPixelSecondary(upp);
                                 defaultCamera.setCameraSecondaryZ(oldSecondaryZ);
                                 defaultCamera.setEnableUnitsPerPixel3D(oldEnabled3D);
-                                defaultCamera.setAutoViewPlaneZ(oldAutoViewPlaneZ);
                             }
                         }
                     }
@@ -836,7 +833,7 @@ public class VisionSolutions implements Solutions.Subject {
 
     private void perHeadSolutions(Solutions solutions, ReferenceHead head, ReferenceCamera defaultCamera) {
         // Visual Homing
-        if (defaultCamera.getUnitsPerPixel().isInitialized()
+        if (defaultCamera.getUnitsPerPixelPrimary().isInitialized()
                 && head.getVisualHomingMethod() == VisualHomingMethod.None) {
             final Location oldFiducialLocation = head.getHomingFiducialLocation();
             final Length oldFiducialDiameter = getHomingFiducialDiameter();
@@ -883,7 +880,7 @@ public class VisionSolutions implements Solutions.Subject {
                 @Override
                 public void setState(Solutions.State state) throws Exception {
                     if (state == State.Solved) {
-                        if (! defaultCamera.getUnitsPerPixel().isInitialized()) {
+                        if (! defaultCamera.getUnitsPerPixelPrimary().isInitialized()) {
                             throw new Exception("The camera "+defaultCamera.getName()+" has no initial calibration. "
                                     + "Use the \"Primary calibration fiducial position and initial camera calibration\".");
                         }
@@ -928,14 +925,14 @@ public class VisionSolutions implements Solutions.Subject {
             flipX = camera.isFlipX();
             flipY = camera.isFlipY();
             rotation = camera.getRotation();
-            unitsPerPixel = camera.getUnitsPerPixel();
+            unitsPerPixel = camera.getUnitsPerPixelPrimary();
         }
 
         void restoreTo(ReferenceCamera camera) {
             camera.setFlipX(flipX);
             camera.setFlipY(flipY);
             camera.setRotation(rotation);
-            camera.setUnitsPerPixel(camera.getUnitsPerPixel()
+            camera.setUnitsPerPixel(camera.getUnitsPerPixelPrimary()
                     .derive(unitsPerPixel, true, true, false, false));
         }
     }

--- a/src/main/java/org/openpnp/machine/reference/vision/ReferenceFiducialLocator.java
+++ b/src/main/java/org/openpnp/machine/reference/vision/ReferenceFiducialLocator.java
@@ -295,6 +295,10 @@ public class ReferenceFiducialLocator implements FiducialLocator {
      * @throws Exception
      */
     public Location getHomeFiducialLocation(Location location, Part part) throws Exception {
+        // Because the homing fiducial must by definition be at default Z, we supply it here,
+        // so the 3D units per pixel scaling will be correct. 
+        Camera camera = Configuration.get().getMachine().getDefaultHead().getDefaultCamera();
+        location = location.deriveLengths(null, null, camera.getDefaultZ(), null);
         return getFiducialLocation(location, part);
     }
 

--- a/src/main/java/org/openpnp/machine/reference/wizards/ReferenceNozzleTipCalibrationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/wizards/ReferenceNozzleTipCalibrationWizard.java
@@ -390,8 +390,8 @@ public class ReferenceNozzleTipCalibrationWizard extends AbstractConfigurationWi
         ReferenceNozzle nozzle = getUiCalibrationNozzle(nozzleTip);
         Location location = nozzle.getLocation();
         Location distance = location.subtract(camera.getLocation());
-        if (Math.abs(distance.getLengthX().divide(camera.getUnitsPerPixel().getLengthX())) >= camera.getWidth()/2
-            || Math.abs(distance.getLengthY().divide(camera.getUnitsPerPixel().getLengthY())) >= camera.getHeight()/2) {
+        if (Math.abs(distance.getLengthX().divide(camera.getUnitsPerPixelAtZ().getLengthX())) >= camera.getWidth()/2
+            || Math.abs(distance.getLengthY().divide(camera.getUnitsPerPixelAtZ().getLengthY())) >= camera.getHeight()/2) {
             // Outside the camera view, need to move to the center.
             location = calibration.getCalibrationLocation(camera, nozzle);
         }

--- a/src/main/java/org/openpnp/model/Location.java
+++ b/src/main/java/org/openpnp/model/Location.java
@@ -334,6 +334,29 @@ public class Location {
     }
 
     /**
+     * Returns a new Location with the same units as this one but with values updated to the passed
+     * in Lengths. A caveat is that if a specified value is null, the new Location will contain the
+     * value from this object instead of the new value. The Lengths will automatically be converted 
+     * to this locations's units.
+     * 
+     * This is intended as a utility method, useful for creating new Locations based on existing
+     * ones with one or more values changed.
+     * 
+     * @param x
+     * @param y
+     * @param z
+     * @param rotation
+     * @return
+     */
+    public Location deriveLengths(Length x, Length y, Length z, Double rotation) {
+        return new Location(units, 
+                (x == null ? this.x : x.convertToUnits(units).getValue()), 
+                (y == null ? this.y : y.convertToUnits(units).getValue()),
+                (z == null ? this.z : z.convertToUnits(units).getValue()), 
+                (rotation == null ? this.rotation : rotation));
+    }
+
+    /**
      * Returns a new Location with the same units as this one but with values updated from 
      * a second Location. If a specified boolean is false, the new Location will contain the
      * value from this object instead of the second location.

--- a/src/main/java/org/openpnp/model/Motion.java
+++ b/src/main/java/org/openpnp/model/Motion.java
@@ -1039,7 +1039,7 @@ public class Motion {
             // When the candidate segment is added, we need to repeat the analysis, with the new origin.
             while(true) {
                 AxesLocation segment = location0.motionSegmentTo(location2).drivenBy(driver);
-                boolean isTooSmall = segment.multiply(1.0/distStep).matches(AxesLocation.zero);  
+                boolean isTooSmall = segment.isEmpty() || segment.multiply(1.0/distStep).matches(AxesLocation.zero);  
                 if (special && isTooSmall) {
                     // Last step distance lower than distStep resolution ticks, merge with previous segment.
                     if (command1 != null) {
@@ -1057,8 +1057,9 @@ public class Motion {
                         t0 = tS;
                         command0 = commandS;
                         segment = location0.motionSegmentTo(location2).drivenBy(driver);
+                        // It may still be too small.
+                        isTooSmall = segment.isEmpty() || segment.multiply(1.0/distStep).matches(AxesLocation.zero);
                     }
-                    isTooSmall = false;
                 }
                 if (isTooSmall) {
                     break;

--- a/src/main/java/org/openpnp/spi/Camera.java
+++ b/src/main/java/org/openpnp/spi/Camera.java
@@ -79,6 +79,20 @@ public interface Camera extends HeadMountable, WizardConfigurable,
      */
     public Location getUnitsPerPixel(Length z);
 
+
+    /**
+     * Gets units per pixel for determining the physical size of an object in an image given
+     * its Z is at the (virtual) Z axis of the camera location. If the camera Z is at or above 
+     * Safe Z, meaning the Z is actually not set, it will fall back to the standard units per pixel.
+     * 
+     * This is also the default for cameras that do not have a concept of a location or Z axis.   
+     * 
+     * @return
+     */
+    public default Location getUnitsPerPixelAtZ() {
+        return getUnitsPerPixel();
+    }
+
     /**
      * Gets the Z  height of the default working plane for this camera.  This is the height
      * at which objects are assumed to be if no other information is available.
@@ -86,6 +100,13 @@ public interface Camera extends HeadMountable, WizardConfigurable,
      * @return the Z height of the default working plane
      */
     public Length getDefaultZ();
+
+    /**
+     * @return true, if Z-dependent units per pixel are available and configured. 
+     */
+    default boolean isUnitsPerPixelAtZCalibrated() {
+        return false;
+    }
 
     /**
      * Immediately captures an image from the camera and returns it in it's native format. Fires

--- a/src/main/java/org/openpnp/spi/MachineListener.java
+++ b/src/main/java/org/openpnp/spi/MachineListener.java
@@ -28,7 +28,7 @@ package org.openpnp.spi;
 public interface MachineListener {
     void machineHeadActivity(Machine machine, Head head);
 
-    void machineTargetedUserAction(Machine abstractMachine, HeadMountable hm);
+    void machineTargetedUserAction(Machine abstractMachine, HeadMountable hm, boolean jogging);
 
     void machineActuatorActivity(Machine machine, Actuator actuator);
 
@@ -52,7 +52,7 @@ public interface MachineListener {
         public void machineHeadActivity(Machine machine, Head head) {}
 
         @Override
-        public void machineTargetedUserAction(Machine machine, HeadMountable hm) {}
+        public void machineTargetedUserAction(Machine machine, HeadMountable hm, boolean jogging) {}
 
         @Override
         public void machineActuatorActivity(Machine machine, Actuator actuator) {}

--- a/src/main/java/org/openpnp/spi/base/AbstractMachine.java
+++ b/src/main/java/org/openpnp/spi/base/AbstractMachine.java
@@ -465,9 +465,9 @@ public abstract class AbstractMachine extends AbstractModelObject implements Mac
         }
     }
 
-    public void fireMachineTargetedUserAction(HeadMountable hm) {
+    public void fireMachineTargetedUserAction(HeadMountable hm, boolean jogging) {
         for (MachineListener listener : listeners) {
-            listener.machineTargetedUserAction(this, hm);
+            listener.machineTargetedUserAction(this, hm, jogging);
         }
     }
 

--- a/src/main/java/org/openpnp/util/MovableUtils.java
+++ b/src/main/java/org/openpnp/util/MovableUtils.java
@@ -53,11 +53,15 @@ public class MovableUtils {
         hm.moveTo(location);
     }
 
-    public static void fireTargetedUserAction(HeadMountable hm) {
+    public static void fireTargetedUserAction(HeadMountable hm, boolean jogging) {
         Machine machine = Configuration.get().getMachine();
         if (machine instanceof AbstractMachine) {
-            ((AbstractMachine)machine).fireMachineTargetedUserAction(hm);
+            ((AbstractMachine)machine).fireMachineTargetedUserAction(hm, jogging);
         }
+    }
+
+    public static void fireTargetedUserAction(HeadMountable hm) {
+        fireTargetedUserAction(hm, false);
     }
 
     public static boolean isInSafeZZone(HeadMountable hm) {

--- a/src/main/java/org/openpnp/util/OpenCvUtils.java
+++ b/src/main/java/org/openpnp/util/OpenCvUtils.java
@@ -110,7 +110,7 @@ public class OpenCvUtils {
                 new Object[] {camera.getName(), minDiameter, maxDiameter, minDistance});
 
         // convert inputs to the same units
-        Location unitsPerPixel = camera.getUnitsPerPixel();
+        Location unitsPerPixel = camera.getUnitsPerPixelAtZ();
         minDiameter = minDiameter.convertToUnits(unitsPerPixel.getUnits());
         maxDiameter = maxDiameter.convertToUnits(unitsPerPixel.getUnits());
         minDistance = minDistance.convertToUnits(unitsPerPixel.getUnits());
@@ -278,7 +278,7 @@ public class OpenCvUtils {
     public static BufferedImage createFootprintTemplate(Camera camera, Footprint footprint, double rotation,
             boolean topView, Color padsColor, Color bodyColor, Color backgroundColor, double marginFactor, int minimumMarginSize)
                     throws Exception {
-        Location unitsPerPixel = camera.getUnitsPerPixel();
+        Location unitsPerPixel = camera.getUnitsPerPixelAtZ();
 
         Shape shape = footprint.getShape();
         Shape bodyShape = footprint.getBodyShape();

--- a/src/main/java/org/openpnp/util/VisionUtils.java
+++ b/src/main/java/org/openpnp/util/VisionUtils.java
@@ -56,11 +56,11 @@ public class VisionUtils {
         double offsetY = (imageHeight / 2) - y;
 
         // And convert pixels to units
-        Location unitsPerPixel = camera.getUnitsPerPixel();
+        Location unitsPerPixel = camera.getUnitsPerPixelAtZ();
         offsetX *= unitsPerPixel.getX();
         offsetY *= unitsPerPixel.getY();
 
-        return new Location(camera.getUnitsPerPixel().getUnits(), offsetX, offsetY, 0, 0);
+        return new Location(unitsPerPixel.getUnits(), offsetX, offsetY, 0, 0);
     }
 
     /**
@@ -132,7 +132,7 @@ public class VisionUtils {
     
     public static double toPixels(Length length, Camera camera) {
         // convert inputs to the same units
-        Location unitsPerPixel = camera.getUnitsPerPixel();
+        Location unitsPerPixel = camera.getUnitsPerPixelAtZ();
         length = length.convertToUnits(unitsPerPixel.getUnits());
 
         // we average the units per pixel because circles can't be ovals
@@ -189,7 +189,7 @@ public class VisionUtils {
      */
     public static Point getLocationPixelCenterOffsets(Camera camera, HeadMountable tool, Location location) {
         // get the units per pixel scale 
-        Location unitsPerPixel = camera.getUnitsPerPixel();
+        Location unitsPerPixel = camera.getUnitsPerPixelAtZ();
         // convert inputs to the same units, center on camera and scale
         location = location.convertToUnits(unitsPerPixel.getUnits())
                 .subtract(camera.getLocation(tool))

--- a/src/main/java/org/openpnp/vision/FluentCv.java
+++ b/src/main/java/org/openpnp/vision/FluentCv.java
@@ -277,7 +277,7 @@ public class FluentCv {
     public FluentCv convertCirclesToLocations(List<Location> locations) {
         checkCamera();
         Location unitsPerPixel =
-                camera.getUnitsPerPixel().convertToUnits(camera.getLocation().getUnits());
+                camera.getUnitsPerPixelAtZ().convertToUnits(camera.getLocation().getUnits());
         double avgUnitsPerPixel = (unitsPerPixel.getX() + unitsPerPixel.getY()) / 2;
 
         for (int i = 0; i < mat.cols(); i++) {

--- a/src/main/java/org/openpnp/vision/pipeline/stages/AffineWarp.java
+++ b/src/main/java/org/openpnp/vision/pipeline/stages/AffineWarp.java
@@ -174,7 +174,7 @@ public class AffineWarp extends CvStage {
         if (camera == null) {
             throw new Exception("Property \"camera\" is required.");
         }
-        Location unitsPerPixel = camera.getUnitsPerPixel()
+        Location unitsPerPixel = camera.getUnitsPerPixelAtZ()
                 .convertToUnits(lengthUnit);
 
         double x0 = this.x0;

--- a/src/main/java/org/openpnp/vision/pipeline/stages/CreateShapeTemplateImage.java
+++ b/src/main/java/org/openpnp/vision/pipeline/stages/CreateShapeTemplateImage.java
@@ -9,7 +9,6 @@ import java.awt.geom.AffineTransform;
 import java.awt.geom.Rectangle2D;
 import java.awt.image.BufferedImage;
 
-import org.openpnp.model.Footprint;
 import org.openpnp.model.Length;
 import org.openpnp.model.LengthUnit;
 import org.openpnp.model.Location;
@@ -65,7 +64,7 @@ public class CreateShapeTemplateImage extends CvStage {
             throw new Exception("Property named after templateShapeName is required.");
         }
 
-        Location unitsPerPixel = camera.getUnitsPerPixel();
+        Location unitsPerPixel = camera.getUnitsPerPixelAtZ();
 
         // Determine the scaling factor to go from Outline units to
         // Camera units.

--- a/src/main/java/org/openpnp/vision/pipeline/stages/ReadPartTemplateImage.java
+++ b/src/main/java/org/openpnp/vision/pipeline/stages/ReadPartTemplateImage.java
@@ -29,6 +29,8 @@ import org.opencv.core.Scalar;
 import org.opencv.core.Size;
 import org.opencv.imgcodecs.Imgcodecs;
 import org.openpnp.model.Configuration;
+import org.openpnp.model.Footprint;
+import org.openpnp.model.Location;
 import org.openpnp.model.Part;
 import org.openpnp.spi.Camera;
 import org.openpnp.spi.Feeder;
@@ -180,13 +182,12 @@ public class ReadPartTemplateImage extends CvStage {
                     // TODO: it would be best if we could define a package outline, e.g. as a
                     // polygon
                     // and use that to draw the part and match templates
-                    if (part.getPackage()
-                              .getFootprint() != null) {
-                        width = part.getPackage()
-                                      .getFootprint()
+                    Footprint footprint = part.getPackage()
+                                  .getFootprint();
+                    if (footprint != null) {
+                        width = footprint
                                       .getBodyWidth();
-                        height = part.getPackage()
-                                       .getFootprint()
+                        height = footprint
                                        .getBodyHeight();
                         if (width == 0 || height == 0) {
                             if (log) {
@@ -203,10 +204,9 @@ public class ReadPartTemplateImage extends CvStage {
                         }
                         // get length conversion value from camera
                         Camera camera = (Camera) pipeline.getProperty("camera");
-                        width /= camera.getUnitsPerPixel()
-                                       .getX();
-                        height /= camera.getUnitsPerPixel()
-                                        .getY();
+                        Location upp = camera.getUnitsPerPixelAtZ().convertToUnits(footprint.getUnits());
+                        width /= upp.getX();
+                        height /= upp.getY();
                         // create a white rect image as the template
                         Mat templateImage = new Mat((int) height, (int) width, CvType.CV_8UC3);
                         templateImage.setTo(new Scalar(255, 255, 255));

--- a/src/main/java/org/openpnp/vision/pipeline/stages/SimpleOcr.java
+++ b/src/main/java/org/openpnp/vision/pipeline/stages/SimpleOcr.java
@@ -326,7 +326,7 @@ public class SimpleOcr extends CvStage {
 
         // Determine the scaling factor to go from given LengthUnit/pt units to
         // Camera units and pixels.
-        Location unitsPerPixel = camera.getUnitsPerPixel().convertToUnits(LengthUnit.Millimeters);
+        Location unitsPerPixel = camera.getUnitsPerPixelAtZ().convertToUnits(LengthUnit.Millimeters);
         Length l = new Length(1.0/72.0, LengthUnit.Inches);
         l = l.convertToUnits(unitsPerPixel.getUnits());
         double scalePt = l.getValue()/unitsPerPixel.getY();

--- a/src/main/java/org/openpnp/vision/pipeline/ui/ResultsPanel.java
+++ b/src/main/java/org/openpnp/vision/pipeline/ui/ResultsPanel.java
@@ -18,6 +18,7 @@ import javax.swing.JButton;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
+import javax.swing.JSeparator;
 import javax.swing.JSplitPane;
 import javax.swing.JTextPane;
 import javax.swing.JToolBar;
@@ -38,8 +39,6 @@ import org.openpnp.vision.pipeline.CvStage;
 import org.openpnp.vision.pipeline.CvStage.Result;
 import org.openpnp.vision.pipeline.CvStage.Result.Circle;
 import org.pmw.tinylog.Logger;
-
-import javax.swing.JSeparator;
 
 public class ResultsPanel extends JPanel {
     private final CvPipelineEditor editor;
@@ -152,7 +151,7 @@ public class ResultsPanel extends JPanel {
                             Camera camera = (Camera) editor.getPipeline().getProperty("camera");
                             if (camera != null) {
                                 // convert camera (pixels) to stage units 
-                                Location unitsPerPixel = camera.getUnitsPerPixel()
+                                Location unitsPerPixel = camera.getUnitsPerPixelAtZ()
                                         .convertToUnits(lengthUnit);
                                 Location mouseLocation = unitsPerPixel.multiply(p.x-image.getWidth()/2, -p.y+image.getHeight()/2, 0, 0);
                                 auxCoords = String.format(" (%f, %f %s)", mouseLocation.getX(), mouseLocation.getY(), lengthUnit.getShortName()); 

--- a/src/test/java/BlindsFeederTest.java
+++ b/src/test/java/BlindsFeederTest.java
@@ -1,22 +1,17 @@
 import java.io.File;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 import org.apache.commons.io.FileUtils;
-import org.junit.jupiter.api.Test;
-import org.opencv.core.RotatedRect;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.openpnp.machine.reference.feeder.BlindsFeeder;
 import org.openpnp.model.Configuration;
 import org.openpnp.model.Length;
-import org.openpnp.spi.Machine;
-import org.openpnp.vision.Ransac.Line;
-import org.openpnp.spi.Camera;
-import org.openpnp.spi.Feeder;
-import org.openpnp.machine.reference.feeder.BlindsFeeder;
-import org.openpnp.machine.reference.feeder.BlindsFeeder.FindFeatures;
-import org.openpnp.model.Location;
 import org.openpnp.model.LengthUnit;
+import org.openpnp.model.Location;
+import org.openpnp.spi.Feeder;
+import org.openpnp.spi.Machine;
 
 import com.google.common.io.Files;
 
@@ -33,9 +28,9 @@ public class BlindsFeederTest {
         }
         
         BlindsFeederTestFiducials(){
-            fiducial1 = BlindsFeeder.nullLocation;
-            fiducial2 = BlindsFeeder.nullLocation;
-            fiducial3 = BlindsFeeder.nullLocation;
+            fiducial1 = Location.origin;
+            fiducial2 = Location.origin;
+            fiducial3 = Location.origin;
         }
     }
     


### PR DESCRIPTION
# Description
Another round of bug-fixes and improvements in the Automatic Machine Calibration using Issues & Solutions.

## Automatic 3D Calibration deployed to Vision Operations
After having established automatic calibration, the 3D Units per Pixel can now be deployed to vision operations of all kinds:

![Camera View 3D Z](https://user-images.githubusercontent.com/9963310/131219680-fa0a4dc5-9800-49a8-ac0d-119e098e6c5c.png)

* Introduced 3D Units per Pixel into vision operations according to camera (virtual) Z axis coordinate.
* All code using vision operations must now properly move the camera to the right Z axis coordinate.
* `Camera.getUnitsPerPixelAtZ()` was introduced to get UPP on the camera Z axis plane.
* `Camera.isUnitsPerPixelAtZCalibrated()` was introduced to determine if a camera has 3D UPP.
* `openCvUtils`, `VisionUtils`, `FluentCv` now use `getUnitsPerPixelAtZ()` throughout.
* Separate scroll-wheel controlled Z working plane in `CameraView` has been removed, all is now done with the camera (virtual) Z axis. 
* This precludes the bottom camera from using 3D UPP at the moment. On most machines, you can always bring the subject into the focal plane by moving the nozzle in Z. Note: For pneumatic nozzle machines, this restriction might one day have to be removed. The Z axis of the subject movable (e.g. nozzle) would have to somehow be "registered" with the camera, as the subject Z. A part height or other offset might also be needed.  
* `AbstractCamera.autoViewPlaneZ` was deprecated. 3D UPP will now either be completely off, or always active.
* The `AdvancedLoosePartFeeder`, `BlindsFeeder`, `ReferenceDragFeeder`, `ReferenceLeverFeeder`, `ReferencePushPullFeeder`, `ReferenceStripFeeder` and respective Wizards have specifically been reworked to support setting the camera Z axis right in setup (Pipeline Editing) and routine vision operations.
* When 3D UPP is active and Z information is missing, the feeders will report an error. Users will have to probe the Z coordinate first, before vision based Auto-Setup etc. is possible. `BlindsFeeder` and `ReferencePushPullFeeder` will automatically propose Z from a related _array_ or _template_ feeder.
* The `FiducialLocator` has been checked, and its visual homing support amended to assume the default Z working plane coordinate.
* `VisionSolutions` and `CalibrationSolutions` have been reworked to make sure specific primary/secondary UPP are used and camera Z axis always set.
* Nozzle tip changer vision was complemented with an **Adjust Z** setting to shift the focal plane away from the corresponding changer (nozzle) location. To make sure the changer slot surface will properly scaled in the camera view.
* Pipeline Stages have been reworked to use 3D UPP.
* The Pipeline Editor results panel has been reworked to use 3D UPP.
* Auto Safe Z of the camera virtual axes must be restricted to jogging (arrows and mouse-drag). Other targeted user action must **not** trigger it. Otherwise, setting the 3D units per pixel would be lost. The allowed "unsafe Z" roaming area was extended to 10mm around the original below-safe-Z user action location. 

![3D Units per Pixel](https://user-images.githubusercontent.com/9963310/131219497-938464d2-697e-4ec2-90c0-dc706fbca421.png)

## Other Changes

* `BlindsFeeder`'s and `ReferencePushPullFeeder`'s proprietary nullLocation hacks have been replaced with Location.origin and Location.isInitialized().
* `Location.deriveLengths()` method was introduced to encapsulate units conversion.
* Restore the nozzle location Z and C after offset calibration to prevent confusion about resulting offsets/machine state. 
* Made `AbstractMotionPath` motion planning more conservative: co-linear segments with different feed-rate, acceleration and jerk limits will now always be broken up.
* Fixed a bug in dependent head offset propagation.
* Fixed bug in move interpolation. If two (or more) probed special segments were too small, the feed-rate-limit was not correctly calculated, resulting in random (slow) speeds.
* No units in CameraView Z indicator (like all the other length indicators).
* After a direction change, the DirectionalSneakUp backlash compensation method must backtrack, if the sneak-up distance is too small.
* Automatic calibration of backlash compensation will now select DirectionalSneakUp, if backlash is inconsistent over a sneak-up distance that is larger than the backlash itself.
* Logarithmic distribution of random moves in automatic calibration of backlash compensation.

# Justification
Ongoing testing round and feed-backs from the group.

# Instructions for Use
Where usage changes, new instructions were added to the Wiki:

-  [Changes in Backlash Compensation (Sneak-up offset handling)](https://github.com/openpnp/openpnp/wiki/Backlash-Compensation#axis-configuration) 
- [3D Units per Pixel usage](https://github.com/openpnp/openpnp/wiki/3D-Units-per-Pixel)

# Implementation Details
1. Tested both in simulation as well as on the machine. 
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. Changes in the `org.openpnp.spi` or `org.openpnp.model` packages: see Description.
4. Successful `mvn test` before submitting the Pull Request. 
