### PR TITLE
Fix / Nozzle Tip Changer Vision Calibration, Y-Inversion 

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/ReferenceNozzleTip.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceNozzleTip.java
@@ -1174,13 +1174,13 @@ public class ReferenceNozzleTip extends AbstractNozzleTip {
                         Imgproc.matchTemplate(cameraCropMat, templateMatEmpty, resultEmptyMat,
                                 Imgproc.TM_CCOEFF_NORMED);
                         MinMaxLocResult emptyMatch = Core.minMaxLoc(resultEmptyMat);
-                        emptyMatch.maxLoc.x -= resultEmptyMat.cols()/2;
-                        emptyMatch.maxLoc.y -= resultEmptyMat.rows()/2;
+                        emptyMatch.maxLoc.x = emptyMatch.maxLoc.x - resultEmptyMat.cols()/2;
+                        emptyMatch.maxLoc.y = resultEmptyMat.rows()/2 - emptyMatch.maxLoc.y;
                         Imgproc.matchTemplate(cameraCropMat, templateMatOccupied, resultOccupiedMat,
                                 Imgproc.TM_CCOEFF_NORMED);
                         MinMaxLocResult occupiedMatch = Core.minMaxLoc(resultOccupiedMat);
-                        occupiedMatch.maxLoc.x -= resultOccupiedMat.cols()/2.;
-                        occupiedMatch.maxLoc.y -= resultOccupiedMat.rows()/2.;
+                        occupiedMatch.maxLoc.x = occupiedMatch.maxLoc.x - resultOccupiedMat.cols()/2.;
+                        occupiedMatch.maxLoc.y = resultOccupiedMat.rows()/2. - occupiedMatch.maxLoc.y;
                         if (LogUtils.isDebugEnabled()) {
                             File file;
                             file = Configuration.get().createResourceFile(getClass(), "match-empty", ".png");


### PR DESCRIPTION
# Description
Fixes a bug in the nozzle tip tool changer vision calibration. When pixel coordinates are transformed to machine coordinates, the Y axis was not inverted, resulting in Y-mirrored template match offsets:

![Vision Calibration](https://user-images.githubusercontent.com/9963310/131263170-f86f9099-639a-472b-b345-ea6236a256f4.png)

# Justification
If a nozzle tip changer slot was offset in Y, it would actually compensate in the wrong direction. 

# Instructions for Use
See
https://github.com/openpnp/openpnp/wiki/Nozzle-Tip-Changer
and more specifically
https://github.com/openpnp/openpnp/wiki/Nozzle-Tip-Changer#vision-calibration

# Implementation Details
1. The bug was detected during tests for another feature. Bug-fix was tested on machine.
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. Successful `mvn test` before submitting the Pull Request. 
