### PR TITLE
Fix/Feeder Panel Feed compatible Nozzle and Tip, BlindsFeeder restore changed Nozzle Tip

### DIFF
--- a/src/main/java/org/openpnp/gui/FeedersPanel.java
+++ b/src/main/java/org/openpnp/gui/FeedersPanel.java
@@ -563,12 +563,11 @@ public class FeedersPanel extends JPanel implements WizardContainer {
         public void actionPerformed(ActionEvent arg0) {
             UiUtils.submitUiMachineTask(() -> {
                 Feeder feeder = getSelection();
-                Nozzle nozzle = MainFrame.get().getMachineControls().getSelectedNozzle();
+                // Do the feed and get the nozzle that would be used for the subsequent pick. 
+                Nozzle nozzle = feedFeeder(feeder);
 
-                nozzle.moveToSafeZ();
-                feeder.feed(nozzle);
                 // Note, we do not use nozzle.moveToPickLocation(feeder) as this might involve 
-                // probing, which we don't want to happen here. Instead we need to use a preliminary 
+                // probing, which we don't want to happen here. Instead we need to simulate a preliminary 
                 // pick location. 
                 Location pickLocation = preliminaryPickLocation(feeder, nozzle);
                 MovableUtils.moveToLocationAtSafeZ(nozzle, pickLocation);
@@ -594,7 +593,14 @@ public class FeedersPanel extends JPanel implements WizardContainer {
         }
     };
 
-    public static void pickFeeder(Feeder feeder) throws Exception, JobProcessorException {
+    /**
+     * Perform a job-like feed operations sequence. 
+     * 
+     * @param feeder
+     * @return the nozzle to be used for a subsequent pick.
+     * @throws Exception
+     */
+    public static Nozzle feedFeeder(Feeder feeder) throws Exception {
         if (feeder.getPart() == null) {
             throw new Exception("Feeder "+feeder.getName()+" has no part.");
         }
@@ -614,6 +620,19 @@ public class FeedersPanel extends JPanel implements WizardContainer {
         // Perform the feed.
         nozzle.moveToSafeZ();
         feeder.feed(nozzle);
+        return nozzle;
+    }
+
+    /**
+     * Perform a job-like feed and pick operations sequence. 
+     * 
+     * @param feeder
+     * @throws Exception
+     * @throws JobProcessorException
+     */
+    public static void pickFeeder(Feeder feeder) throws Exception, JobProcessorException {
+        // Do the feed an get the nozzle for the pick.
+        Nozzle nozzle = feedFeeder(feeder);
 
         // Go to the pick location and pick.
         nozzle.moveToPickLocation(feeder);

--- a/src/main/java/org/openpnp/machine/reference/feeder/BlindsFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/BlindsFeeder.java
@@ -344,7 +344,7 @@ public class BlindsFeeder extends ReferenceFeeder {
             }
         }
         else if (coverType == CoverType.PushCover) {
-            actuateCover(nozzle, true);
+            actuateCover(nozzle, true, true, true);
         }
         // increase the feed count 
         setFeedCount(getFeedCount() + 1);


### PR DESCRIPTION
# Description
* In the FeederPanel, do the feed action with a compatible nozzle and nozzle tip, even though the pick does not actually happen.
* Refactored the feed action to be more job-like, with feeder preparation and nozzle tip change and calibration as needed, analogous to the pick action (which now uses the common code).
* Fix BlindsFeeder `feed()` for push cover: restore previous nozzle tip, if changed for cover opening.

# Justification
See #1267

# Instructions for Use
See #1267.

# Implementation Details
1. Tested FeederPanel in Simulation. Hoping for short-term confirmation via #1267 on BlindsFeeder fix.
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. Successful `mvn test` before submitting the Pull Request. 
