### PR TITLE
HeapFeeder Maintenance

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/feeder/ReferenceHeapFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/ReferenceHeapFeeder.java
@@ -356,12 +356,13 @@ public class ReferenceHeapFeeder extends ReferenceFeeder {
     private double pokeForParts(Nozzle nozzle, double vacuumLevel) throws Exception {
         // while vacuum difference is not reached, slowly stir in the heap
         double currentDepth = lastFeedDepth ; // start at the same height, finish that "level"
-        for (int i = 1; ! stableVacuumDifferenceReached(nozzle, vacuumLevel, requiredVacuumDifference)                // part found
-                && currentDepth > (boxDepth + part.getHeight().getValue()/2)                                          // on the bottom
-                && !(currentDepth <= (lastFeedDepth - 2 * part.getHeight().getValue()) && lastFeedDepth != 0); i++) { // avoid going to deep into parts. Risk of damaging parts and low chance of picking something up. 
-            // searched a whole layer, go down a bit
-            if (i % 15 == 0 || i % 15 == 10) {
-                currentDepth -= Math.max(0.05, (part.getHeight().getValue() / 4.0));                                     // move a bit down, larger steps compared to stir, since we can utilize the spring
+        currentDepth += Math.max(0.05, (part.getHeight().getValue() / 4.0));                                            // add what will be subtracted in the loop
+        for (int i = 0; ! stableVacuumDifferenceReached(nozzle, vacuumLevel, requiredVacuumDifference)                  // part found
+                && currentDepth > (boxDepth + part.getHeight().getValue()/2)                                            // on the bottom
+                && !(currentDepth <= (lastFeedDepth - 2 * part.getHeight().getValue()) && lastFeedDepth != 0); i=i+2) { // avoid going to deep into parts. Risk of damaging parts and low chance of picking something up. 
+            // searched half a  layer, go down a bit
+            if (i % 25 == 0 || i % 25 == 1) {
+                currentDepth -= Math.max(0.05, (part.getHeight().getValue() / 4.0));                                    // move a bit down, larger steps compared to stir, since we can utilize the spring
             }                                                                                                           // (but only if not after reset = 0. First time let it find the start of the heap)
             moveToPokeLocation(nozzle, currentDepth, part.getHeight().getValue(), i % 15);
             // wait a bit for the vacuum-levels to stabilize
@@ -380,63 +381,9 @@ public class ReferenceHeapFeeder extends ReferenceFeeder {
 
     
     private void moveToPokeLocation(Nozzle nozzle, double currentDepth, double partHeight, int step) throws Exception {
-        Location destination = location.add(new Location(LengthUnit.Millimeters, 0, 0, currentDepth, 0));
-        switch (step) {
-            case 1: {
-                destination = destination.add(new Location(LengthUnit.Millimeters,  0.00,  0.00, 0, 0));    // center
-                break;
-            }
-            case 2: {
-                destination = destination.add(new Location(LengthUnit.Millimeters,  1.25,  0, 0, 0));    // right middle
-                break;
-            }
-            case 3: {
-                destination = destination.add(new Location(LengthUnit.Millimeters,  1.25,  1.25, 0, 0));  // and now counter clockwise
-                break;
-            }
-            case 4: {
-                destination = destination.add(new Location(LengthUnit.Millimeters,  0.00,  1.25, 0, 0)); 
-                break;
-            }
-            case 5: {
-                destination = destination.add(new Location(LengthUnit.Millimeters, -1.25,  1.25, 0, 0)); 
-                break;
-            }
-            case 6: {
-                destination = destination.add(new Location(LengthUnit.Millimeters, -1.25,  0.00, 0, 0)); 
-                break;
-            }
-            case 7: {
-                destination = destination.add(new Location(LengthUnit.Millimeters, -1.25, -1.25, 0, 0)); 
-                break;
-            }
-            case 8: {
-                destination = destination.add(new Location(LengthUnit.Millimeters,  0.00, -1.25, 0, 0)); 
-                break;
-            }
-            case 9: {
-                destination = destination.add(new Location(LengthUnit.Millimeters,  1.25, -1.25, 0, 0)); 
-                break;
-            }
-            case 11: {
-                destination = destination.add(new Location(LengthUnit.Millimeters,  0.65, -0.65, 0, 0));    // middle between center and corner
-                break;
-            }
-            case 12: {
-                destination = destination.add(new Location(LengthUnit.Millimeters,  0.65,  0.65, 0, 0)); 
-                break;
-            }
-            case 13: {
-                destination = destination.add(new Location(LengthUnit.Millimeters, -0.65,  0.65, 0, 0)); 
-                break;
-            }
-            case 14: {
-                destination = destination.add(new Location(LengthUnit.Millimeters, -0.65, -0.65, 0, 0)); 
-                break;
-            }
-
-
-        }
+        int row = step / 5;
+        int coloum = step % 5;
+        Location destination = location.add(new Location(LengthUnit.Millimeters, -1.25 + coloum * 0.625, -1.25 + row * 0.625, currentDepth, 0));
         nozzle.moveTo(destination.add(new Location(LengthUnit.Millimeters, 0,0, 2.25 * partHeight, 0)), 1, Motion.MotionOption.SpeedOverPrecision);        
         nozzle.waitForCompletion(CompletionType.WaitForStillstand);
         nozzle.moveTo(destination, 0.33, Motion.MotionOption.SpeedOverPrecision);        

--- a/src/main/java/org/openpnp/machine/reference/feeder/ReferenceHeapFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/ReferenceHeapFeeder.java
@@ -397,7 +397,7 @@ public class ReferenceHeapFeeder extends ReferenceFeeder {
         int row = step / 5;
         int coloum = step % 5;
         Location destination = location.add(new Location(LengthUnit.Millimeters, -1.25 + coloum * 0.625, -1.25 + row * 0.625, currentDepth, 0));
-        nozzle.moveTo(destination.add(new Location(LengthUnit.Millimeters, 0,0, 2.25 * partHeight, 0)), 1, Motion.MotionOption.SpeedOverPrecision);        
+        nozzle.moveTo(destination.add(new Location(LengthUnit.Millimeters, 0,0, Math.max(1, 2.25 * partHeight), 0)), 1, Motion.MotionOption.SpeedOverPrecision);        
         nozzle.waitForCompletion(CompletionType.WaitForStillstand);
         nozzle.moveTo(destination, 0.33, Motion.MotionOption.SpeedOverPrecision);        
     }

--- a/src/main/java/org/openpnp/machine/reference/feeder/ReferenceHeapFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/ReferenceHeapFeeder.java
@@ -374,7 +374,8 @@ public class ReferenceHeapFeeder extends ReferenceFeeder {
             }                                                                                                           // (but only if not after reset = 0. First time let it find the start of the heap)
             moveToPokeLocation(nozzle, currentDepth, part.getHeight().getValue(), i % 25);
             // wait a bit for the vacuum-levels to stabilize
-            Thread.sleep(((ReferenceNozzle)nozzle).getPlaceDwellMilliseconds());                                 
+            Thread.sleep(((ReferenceNozzle)nozzle).getPlaceDwellMilliseconds());
+        }
         // if at the bottom => failed
         if (currentDepth <= (boxDepth + part.getHeight().getValue())) {
             throw new Exception("HeapFeeder " + getName() + ": Can not grab parts. Heap Empty or VacuumDifference wrong.");

--- a/src/main/java/org/openpnp/machine/reference/feeder/ReferenceHeapFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/ReferenceHeapFeeder.java
@@ -107,7 +107,7 @@ public class ReferenceHeapFeeder extends ReferenceFeeder {
      * partOn() not used, since the chance is high, that there are larger leakages.
      */
     @Attribute(required = false)
-    private int requiredVacuumDifference = 300;
+    private int requiredVacuumDifference = 150;
 
     /**
      * Pipeline to detect parts (correct laying).

--- a/src/main/java/org/openpnp/machine/reference/feeder/ReferenceHeapFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/ReferenceHeapFeeder.java
@@ -364,7 +364,7 @@ public class ReferenceHeapFeeder extends ReferenceFeeder {
             if (i % 25 == 0 || i % 25 == 1) {
                 currentDepth -= Math.max(0.05, (part.getHeight().getValue() / 4.0));                                    // move a bit down, larger steps compared to stir, since we can utilize the spring
             }                                                                                                           // (but only if not after reset = 0. First time let it find the start of the heap)
-            moveToPokeLocation(nozzle, currentDepth, part.getHeight().getValue(), i % 15);
+            moveToPokeLocation(nozzle, currentDepth, part.getHeight().getValue(), i % 25);
             // wait a bit for the vacuum-levels to stabilize
             Thread.sleep(((ReferenceNozzle)nozzle).getPlaceDwellMilliseconds() / 3);                                    // divided by three a rough guess
         }

--- a/src/main/java/org/openpnp/machine/reference/feeder/ReferenceHeapFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/ReferenceHeapFeeder.java
@@ -272,9 +272,10 @@ public class ReferenceHeapFeeder extends ReferenceFeeder {
      */
     public void moveToHeap(Nozzle nozzle) throws Exception {
         nozzle.moveToSafeZ();
-        nozzle.moveTo(way3.derive(null, null, Double.NaN, Double.NaN), Motion.MotionOption.SpeedOverPrecision);
-        nozzle.moveTo(way2.derive(null, null, Double.NaN, Double.NaN), Motion.MotionOption.SpeedOverPrecision);
-        nozzle.moveTo(way1.derive(null, null, Double.NaN, Double.NaN), Motion.MotionOption.SpeedOverPrecision);
+        Location nozzleLocation = nozzle.getLocation();
+        nozzle.moveTo(nozzleLocation.derive(way3, true, true, false, false), Motion.MotionOption.SpeedOverPrecision);
+        nozzle.moveTo(nozzleLocation.derive(way2, true, true, false, false), Motion.MotionOption.SpeedOverPrecision);
+        nozzle.moveTo(nozzleLocation.derive(way1, true, true, false, false), Motion.MotionOption.SpeedOverPrecision);
         nozzle.moveTo(location);
     }
 
@@ -286,9 +287,10 @@ public class ReferenceHeapFeeder extends ReferenceFeeder {
      */
     public void moveFromHeap(Nozzle nozzle) throws Exception {
         nozzle.moveToSafeZ();
-        nozzle.moveTo(way1.derive(null, null, Double.NaN, Double.NaN), Motion.MotionOption.SpeedOverPrecision);
-        nozzle.moveTo(way2.derive(null, null, Double.NaN, Double.NaN), Motion.MotionOption.SpeedOverPrecision);
-        nozzle.moveTo(way3.derive(null, null, Double.NaN, Double.NaN), Motion.MotionOption.SpeedOverPrecision);
+        Location nozzleLocation = nozzle.getLocation();
+        nozzle.moveTo(nozzleLocation.derive(way1, true, true, false, false), Motion.MotionOption.SpeedOverPrecision);
+        nozzle.moveTo(nozzleLocation.derive(way2, true, true, false, false), Motion.MotionOption.SpeedOverPrecision);
+        nozzle.moveTo(nozzleLocation.derive(way3, true, true, false, false), Motion.MotionOption.SpeedOverPrecision);
     }
 
     /**
@@ -335,7 +337,9 @@ public class ReferenceHeapFeeder extends ReferenceFeeder {
         ((ReferenceNozzle)nozzle).getExpectedVacuumActuator().actuate(true);
         long vacuumOn = System.currentTimeMillis();
         // move to heap
-        nozzle.moveTo(location.derive(null, null, Double.NaN, null), Motion.MotionOption.SpeedOverPrecision);
+        Location nozzleLocation = nozzle.getLocation();
+        nozzle.moveTo(nozzleLocation.derive(location, true, true, false, true), Motion.MotionOption.SpeedOverPrecision);
+
         // if that didn't take long enough, wait
         ((ReferenceNozzle)nozzle).getPlaceDwellMilliseconds();
         vacuumOn = vacuumOn - (System.currentTimeMillis() + 
@@ -493,7 +497,7 @@ public class ReferenceHeapFeeder extends ReferenceFeeder {
      * @throws Exception something went wrong.
      */
     private Location getFeederPart(Nozzle nozzle) throws Exception {
-        Location location = dropBox.centerBottomLocation.derive(null, null, Double.NaN, 0.0);
+        Location location = dropBox.centerBottomLocation.derive(new Location(LengthUnit.Millimeters, 0, 0, 0, 0), false, false, false, true);
         CvPipeline pipeline = getFeederPipeline();
         Camera camera = nozzle.getHead().getDefaultCamera();
         // if there is a part, get a precise location
@@ -502,8 +506,8 @@ public class ReferenceHeapFeeder extends ReferenceFeeder {
             location = HeapFeederHelper.getNearestPart(pipeline, camera, nozzle, this, getDropBox());
             if (location != null) {
                 // adjust Z
-                location = location.derive(null, null, dropBox.centerBottomLocation.convertToUnits(location.getUnits()).getZ()
-                        + part.getHeight().convertToUnits(location.getUnits()).getValue(), null);
+                location = location.derive(new Location(LengthUnit.Millimeters, 0, 0, dropBox.centerBottomLocation.convertToUnits(location.getUnits()).getZ()
+                        + part.getHeight().convertToUnits(location.getUnits()).getValue(), 0), false, false, true, false);
             }
         }
         MainFrame.get()

--- a/src/main/java/org/openpnp/machine/reference/feeder/ReferenceHeapFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/ReferenceHeapFeeder.java
@@ -32,6 +32,7 @@ import org.openpnp.util.MovableUtils;
 import org.openpnp.util.OpenCvUtils;
 import org.openpnp.util.VisionUtils;
 import org.openpnp.vision.pipeline.CvPipeline;
+import org.openpnp.vision.pipeline.CvStage.Result;
 import org.simpleframework.xml.Attribute;
 import org.simpleframework.xml.Element;
 import org.simpleframework.xml.ElementList;
@@ -975,9 +976,12 @@ public class ReferenceHeapFeeder extends ReferenceFeeder {
             pipeline.setProperty("nozzle", nozzle);
             pipeline.setProperty("feeder", feeder);
             pipeline.process();
-            // Grab the results
-            List<RotatedRect> results =
-                    (List<RotatedRect>) pipeline.getResult(VisionUtils.PIPELINE_RESULTS_NAME).model;
+            // make sure we have a result
+            Result visionResult = pipeline.getResult(VisionUtils.PIPELINE_RESULTS_NAME);
+            if ( visionResult == null) {
+                return null;
+            }
+            List<RotatedRect> results = (List<RotatedRect>) visionResult.model;
             if (results == null || results.isEmpty()) {
                 return null;
             }

--- a/src/main/java/org/openpnp/machine/reference/feeder/ReferenceHeapFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/ReferenceHeapFeeder.java
@@ -216,7 +216,7 @@ public class ReferenceHeapFeeder extends ReferenceFeeder {
             // no part found, try to flip a part by throwing it in the dropBox again
             if (!dropBox.tryToFlipSomePart(nozzle)) {
                 if (lastRoundPartsFetched == true) {
-                    throw new Exception("Feeder " + getName() + ": Fetching parts failedd => feed failed.");
+                    throw new Exception("Feeder " + getName() + ": Fetching parts failed => feed failed.");
                 } else {
                     // nothing there, get new parts
                     fetchParts(nozzle);

--- a/src/main/java/org/openpnp/machine/reference/feeder/ReferenceHeapFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/ReferenceHeapFeeder.java
@@ -349,8 +349,6 @@ public class ReferenceHeapFeeder extends ReferenceFeeder {
         }
         // save current value as reference value
         double vacuumLevel = (readVacuum(nozzle) + readVacuum(nozzle) + readVacuum(nozzle)) / 3.0; // average over three reads to reduce the influence of noise
-        // last pick location
-        nozzle.moveTo(location.add(new Location(LengthUnit.Millimeters, 0, 0, lastFeedDepth, 0)), Motion.MotionOption.SpeedOverPrecision);
 
         // locate parts (or throw exception), return the depth where it was found
         if (pokeForParts == true) {
@@ -396,10 +394,15 @@ public class ReferenceHeapFeeder extends ReferenceFeeder {
     private void moveToPokeLocation(Nozzle nozzle, double currentDepth, double partHeight, int step) throws Exception {
         int row = step / 5;
         int coloum = step % 5;
-        Location destination = location.add(new Location(LengthUnit.Millimeters, -1.25 + coloum * 0.625, -1.25 + row * 0.625, currentDepth, 0));
-        nozzle.moveTo(destination.add(new Location(LengthUnit.Millimeters, 0,0, Math.max(1, 2.25 * partHeight), 0)), 1, Motion.MotionOption.SpeedOverPrecision);        
-        nozzle.waitForCompletion(CompletionType.WaitForStillstand);
-        nozzle.moveTo(destination, 0.33, Motion.MotionOption.SpeedOverPrecision);        
+        Location pokeLocation = location.add(new Location(LengthUnit.Millimeters, -1.25 + coloum * 0.625, -1.25 + row * 0.625, currentDepth, 0));
+        row = (step + 1) / 5;
+        coloum = (step + 1) % 5;
+        Location nextLocation = location.add(new Location(LengthUnit.Millimeters, -1.25 + coloum * 0.625, -1.25 + row * 0.625, currentDepth + Math.max(1, 2.25 * partHeight), 0));
+        
+        // move
+        nozzle.moveTo(pokeLocation, 0.33, Motion.MotionOption.SpeedOverPrecision);    
+        nozzle.waitForCompletion(CompletionType.WaitForStillstand);   
+        nozzle.moveTo(nextLocation, 1, Motion.MotionOption.SpeedOverPrecision);        
     }
 
     private double stirParts(Nozzle nozzle, double vacuumLevel) throws Exception {

--- a/src/main/java/org/openpnp/machine/reference/feeder/ReferenceHeapFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/ReferenceHeapFeeder.java
@@ -439,6 +439,7 @@ public class ReferenceHeapFeeder extends ReferenceFeeder {
                     break;
                 }
             }
+            Thread.sleep(((ReferenceNozzle)nozzle).getPlaceDwellMilliseconds() / 3);
         }
         // if at the bottom => failed
         if (currentDepth <= (boxDepth + part.getHeight().getValue())) {
@@ -479,7 +480,7 @@ public class ReferenceHeapFeeder extends ReferenceFeeder {
                 break;
             }
         }
-        nozzle.moveTo(destination, 0.33, Motion.MotionOption.SpeedOverPrecision);
+        nozzle.moveTo(destination, 0.25, Motion.MotionOption.SpeedOverPrecision);
     }
 
     /**

--- a/src/main/java/org/openpnp/machine/reference/feeder/wizards/ReferenceHeapFeederConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/wizards/ReferenceHeapFeederConfigurationWizard.java
@@ -72,6 +72,8 @@ import com.jgoodies.forms.layout.ColumnSpec;
 import com.jgoodies.forms.layout.FormLayout;
 import com.jgoodies.forms.layout.FormSpecs;
 import com.jgoodies.forms.layout.RowSpec;
+import javax.swing.SwingConstants;
+import javax.swing.JCheckBox;
 
 @SuppressWarnings("serial")
 public class ReferenceHeapFeederConfigurationWizard
@@ -415,6 +417,10 @@ public class ReferenceHeapFeederConfigurationWizard
         partCb.setRenderer(new IdentifiableListCellRenderer<Part>());
         whateverPanel.add(partCb, "4, 20");
         
+        chckbxPokeForParts = new JCheckBox("Poke for Parts");
+        chckbxPokeForParts.setToolTipText("If enabled the nozzle is lifted for each move inside the heap. Reduces the risk to damage (large) parts, but slower.");
+        whateverPanel.add(chckbxPokeForParts, "8, 20");
+        
         lblDetectionPipeline = new JLabel("Detection Pipeline");
         whateverPanel.add(lblDetectionPipeline, "2, 22");
         
@@ -451,6 +457,8 @@ public class ReferenceHeapFeederConfigurationWizard
         addWrappedBinding(feeder, "lastFeedDepth", lastFeedDepthTf, "text", doubleConverter);
         addWrappedBinding(feeder, "requiredVacuumDifference", vacuumDifferenceTf, "text", intConverter);
         addWrappedBinding(feeder, "part", partCb, "selectedItem");
+        addWrappedBinding(feeder, "pokeForParts", chckbxPokeForParts, "selected");
+
 
         ComponentDecorators.decorateWithAutoSelect(retryCountTf);
         ComponentDecorators.decorateWithAutoSelect(pickRetryCount);
@@ -746,4 +754,5 @@ public class ReferenceHeapFeederConfigurationWizard
     private JTextField tfDropLocation_z;
     private JLabel lblDropLocation;
     private LocationButtonsPanel dropBoxDropLocButtons;
+    private JCheckBox chckbxPokeForParts;
 }


### PR DESCRIPTION
# Description
Some maintenance on the HeapFeeder.

- Adresses bug #1268 
- Removes an exception if the template match pipeline throws an exception (template larger than are marked in the camera picture)
- Failing to get parts from the Heap now counts as a feed failure. Avoids that in some circumstances (e.g. camera failures) dozens of fetch operations are executed.
- Minor maintenance

# Justification
Improves the quality and usability of the HeapFeeder

# Instructions for Use
If a parts are stored in a Heap that tend to clog/build rigid structures where the nozzle can not move easily (e.g. 1206 capacitors), you can now enable in the settings the "Poke for Parts" option. That means that during each move Z is lifted 2 1/4 times part size (but at least one mm) before moving back down. So the nozzle tip should never apply large forces to the parts in the Heap.

# Implementation Details
1. How did you test the change? Simmulator and my machine
2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)? yes
3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing.
4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted.
