### PR TITLE
Fix / Unload Nozzle Tips without applying Z Calibration

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/ReferenceNozzle.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceNozzle.java
@@ -370,7 +370,7 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
         Configuration.get().getScripting().on("Nozzle.AfterPlace", globals);
     }
 
-    private ReferenceNozzleTip getUnloadedNozzleTipStandin() {
+    protected ReferenceNozzleTip getUnloadedNozzleTipStandin() {
         for (NozzleTip nozzleTip : this.getCompatibleNozzleTips()) {
             if (nozzleTip instanceof ReferenceNozzleTip) {
                 ReferenceNozzleTip referenceNozzleTip = (ReferenceNozzleTip)nozzleTip;
@@ -559,7 +559,7 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
                 .getScripting()
                 .on("NozzleTip.BeforeLoad", globals);
 
-                ensureZCalibrated();
+                ensureZCalibrated(true);
 
                 Logger.debug("{}.loadNozzleTip({}): moveTo Start Location",
                         new Object[] {getName(), nozzleTip.getName()});
@@ -610,7 +610,7 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
         firePropertyChange("nozzleTip", null, getNozzleTip());
         ((ReferenceMachine) head.getMachine()).fireMachineHeadActivity(head);
 
-        ensureZCalibrated();
+        ensureZCalibrated(true);
 
         if (!nt.isUnloadedNozzleTipStandin()) {
             if (!changerEnabled) {
@@ -662,7 +662,7 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
                 .getScripting()
                 .on("NozzleTip.BeforeUnload", globals);
 
-                ensureZCalibrated();
+                ensureZCalibrated(false);
 
                 Logger.debug("{}.unloadNozzleTip(): moveTo End Location", getName());
                 MovableUtils.moveToLocationAtSafeZ(this, nt.getChangerEndLocationCalibrated(true), speed);
@@ -713,7 +713,7 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
             throw new Exception("Manual NozzleTip "+nt.getName()+" unload from Nozzle "+getName()+" required!");
         }
 
-        ensureZCalibrated();
+        ensureZCalibrated(true);
 
         // May need to calibrate the "unloaded" nozzle tip stand-in i.e. the naked nozzle tip holder. 
         ReferenceNozzleTip calibrationNozzleTip = this.getCalibrationNozzleTip();
@@ -741,7 +741,7 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
         this.changerEnabled = changerEnabled;
     }
 
-    protected void ensureZCalibrated() throws Exception {}
+    protected void ensureZCalibrated(boolean assumeNozzleTipLoaded) throws Exception {}
 
     @Override
     public Wizard getConfigurationWizard() {

--- a/src/main/java/org/openpnp/machine/reference/ReferenceNozzleTip.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceNozzleTip.java
@@ -141,7 +141,10 @@ public class ReferenceNozzleTip extends AbstractNozzleTip {
     private Location visionCalibrationOffset;
 
     public enum ZCalibrationTrigger {
-        Manual, MachineHome, NozzleTipChange
+        Manual, MachineHome, NozzleTipChange;
+        public boolean isPerNozzleTip() {
+            return this == NozzleTipChange;
+        }
     }
 
     @Attribute(required = false)


### PR DESCRIPTION
# Description
(from the Wiki, [where this is already documented](https://github.com/openpnp/openpnp/wiki/Contact-Probing-Nozzle#z-calibration-inside-the-tool-changer))

### Z Calibration inside the Tool Changer

The following does only apply, if **Auto Z Calibration** is set to **NozzleTipChange**, i.e. when Z calibration happens **per nozzle tip** and not per nozzle. For machines with uneven nozzle tips.

Z Calibration is referencing the coordinate system Z to the point of the nozzle tip (the red dashed line in the illustration below). This is obviously the most important Z reference point for a pick & place machine. However, when loading and unloading a nozzle tip, the point of the tip is not actually relevant, other features of the nozzle tip are: There are flanges etc. on the tip that come into contact with the changer slot and allow it to pressed on, or pulled off, these might be at different Z, as measured from the nozzle tip point (case B in the illustration below). And there is the coupling of the nozzle with the nozzle tip, these might be at different Z, as measured from the flange (case C in the illustration below). 

![nozzle_tip_different_Z_calibration](https://user-images.githubusercontent.com/9963310/131672327-9b7e377f-2326-4a8f-9a45-e9e0d2312d96.png)

Case A and B may actually use the same changer slot Z coordinates, because the flange is at the same (uncalibrated) nozzle Z. Case B's nozzle tip is longer, so after Z calibration, B is lifted up a bit. 

Case C however, because the nozzle is inserted less when coupling, needs a special slot configuration with higher-up (uncalibrated) Z coordinates, otherwise it would likely collide with the slot when pushed down as much as case A. After Z calibration, case C is lifted up to compensate for the lesser coupling depth.

When you initially capture the changer slot locations, the nozzle is not yet Z calibrated (or it is neutrally calibrated for the "unloaded" state i.e. the bare nozzle). These captured Z coordinates must **not** be made subject to Z calibration, as you can easily see, when you mentally try to load or unload case B or C with _calibrated_ instead of _uncalibrated_ Z. Therefore, OpenPnP voids the Z calibration immediately before unloading a nozzle tip. 

For machines with very inconsistent Z homing and/or very uneven multiple nozzles, there must be a way to calibrate Z even before we can load any nozzle tips. There is a simple trick in OpenPNP to do that: just create a nozzle tip that is named "unloaded". The calibration system will automatically use this stand-in whenever the bare nozzle needs to be calibrated and compensated. The "unloaded" stand-in can be configured for Z calibration, like regular nozzle tips. The Z calibration will then be used for unloading/loading any nozzle tip. **CAUTION**: On a machine with very inconsistent Z homing, you must unload all the nozzle tips before exiting OpenPnP, power-cycling or homing the machine. On the next startup the bare nozzle can be measured as the first thing. The "unloaded" stand-in is explained in the similar context of [nozzle tip runout calibration](https://github.com/openpnp/openpnp/wiki/Nozzle-Tip-Calibration-Setup#calibrating-the-bare-nozzle).

# Justification
See #1269 

# Instructions for Use
See the Wiki:
https://github.com/openpnp/openpnp/wiki/Contact-Probing-Nozzle#z-calibration-inside-the-tool-changer

# Implementation Details
1. The intention is to let @doppelgrau test this in his use case of #1269.
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. Successful `mvn test` before submitting the Pull Request.
