### PR TITLE
Feature / Added True White Balance to Cameras

### DIFF
--- a/src/main/java/org/openpnp/gui/components/CameraView.java
+++ b/src/main/java/org/openpnp/gui/components/CameraView.java
@@ -47,10 +47,13 @@ import java.io.File;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map.Entry;
+import java.util.TreeMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
@@ -1227,19 +1230,43 @@ public class CameraView extends JComponent implements CameraListener {
         // find the highest value in the histogram
         long maxVal = 0;
         for (int channel = 0; channel < 3; channel++) {
-            for (int bucket = 0; bucket < 256; bucket++) {
-                maxVal = Math.max(maxVal, histogram[channel][bucket]);
+            // Smooth it 
+            for (int bucket = 254; bucket > 0; bucket--) {
+                histogram[channel][bucket] = 
+                        histogram[channel][bucket] 
+                                + histogram[channel][bucket-1]/2
+                                        + histogram[channel][bucket+1]/2;
             }
+            long [] sorted = histogram[channel].clone();
+            Arrays.sort(sorted);
+            // Exclude the largest extremes, typically saturation values. 
+            maxVal = Math.max(maxVal, sorted[sorted.length-3]);
         }
         // and scale it to 50 pixels tall
         double scale = 50.0 / maxVal;
-        Color[] colors = new Color[] {Color.red, Color.green, Color.blue};
-        for (int channel = 0; channel < 3; channel++) {
-            g2d.setColor(colors[channel]);
-            for (int bucket = 0; bucket < 256; bucket++) {
-                int value = (int) (histogram[channel][bucket] * scale);
-                g2d.drawLine(topLeftX + insets.left + 1 + bucket, yPen + 1 + 50 - value,
-                        topLeftX + insets.left + 1 + bucket, yPen + 1 + 50 - value);
+        Color[] colors = new Color[] {new Color(255, 0, 0), new Color(0, 255, 0), new Color(0, 0, 255)};
+        for (int bucket = 0; bucket < 256; bucket++) {
+            // Rank the three colors, we want to draw overlapping histogram bars with mixed colors.
+            TreeMap<Double, Integer> map = new TreeMap<>();
+            map.put(histogram[0][bucket]+0.1, 0);
+            map.put(histogram[1][bucket]+0.2, 1);
+            map.put(histogram[2][bucket]+0.3, 2);
+            // Start with white, where all three colors overlap.
+            Color color = new Color(255, 255, 255);
+            int value0 = 0;
+            for (Entry<Double, Integer> entry : map.entrySet()) {
+                g2d.setColor(color);
+                int value1 = (int) Math.min(50, (entry.getKey() * scale) + 0.5);
+                if (value1 > value0) {
+                    g2d.drawLine(topLeftX + insets.left + 1 + bucket, yPen + 1 + 50 - value0 - 1,
+                        topLeftX + insets.left + 1 + bucket, yPen + 1 + 50 - value1);
+                }
+                value0 = value1;
+                // Subtract the color that is out.
+                color = new Color(
+                        color.getRed() - colors[entry.getValue()].getRed(), 
+                        color.getGreen() - colors[entry.getValue()].getGreen(),
+                        color.getBlue() - colors[entry.getValue()].getBlue());
             }
         }
     }

--- a/src/main/java/org/openpnp/machine/reference/wizards/ReferenceCameraTransformsConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/wizards/ReferenceCameraTransformsConfigurationWizard.java
@@ -1,21 +1,32 @@
 package org.openpnp.machine.reference.wizards;
 
-import java.awt.Color;
+import java.awt.event.ActionEvent;
 
+import javax.swing.AbstractAction;
+import javax.swing.Action;
+import javax.swing.JButton;
 import javax.swing.JCheckBox;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
+import javax.swing.JSlider;
 import javax.swing.JTextField;
 import javax.swing.border.EtchedBorder;
 import javax.swing.border.TitledBorder;
 
+import org.jdesktop.beansbinding.AutoBinding;
+import org.jdesktop.beansbinding.AutoBinding.UpdateStrategy;
+import org.jdesktop.beansbinding.BeanProperty;
+import org.jdesktop.beansbinding.Bindings;
+import org.openpnp.gui.MainFrame;
+import org.openpnp.gui.components.CameraView;
 import org.openpnp.gui.components.ComponentDecorators;
 import org.openpnp.gui.support.AbstractConfigurationWizard;
 import org.openpnp.gui.support.DoubleConverter;
 import org.openpnp.gui.support.IntegerConverter;
-import org.openpnp.gui.support.LengthConverter;
 import org.openpnp.machine.reference.ReferenceCamera;
 import org.openpnp.model.Configuration;
+import org.openpnp.util.MovableUtils;
+import org.openpnp.util.UiUtils;
 
 import com.jgoodies.forms.layout.ColumnSpec;
 import com.jgoodies.forms.layout.FormLayout;
@@ -48,11 +59,23 @@ public class ReferenceCameraTransformsConfigurationWizard extends AbstractConfig
         contentPanel.add(panelTransforms);
         panelTransforms.setLayout(new FormLayout(new ColumnSpec[] {
                 FormSpecs.RELATED_GAP_COLSPEC,
+                ColumnSpec.decode("max(70dlu;default)"),
+                FormSpecs.RELATED_GAP_COLSPEC,
+                FormSpecs.DEFAULT_COLSPEC,
                 FormSpecs.DEFAULT_COLSPEC,
                 FormSpecs.RELATED_GAP_COLSPEC,
                 FormSpecs.DEFAULT_COLSPEC,
-                ColumnSpec.decode("default:grow"),},
+                FormSpecs.RELATED_GAP_COLSPEC,
+                FormSpecs.DEFAULT_COLSPEC,},
             new RowSpec[] {
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
                 FormSpecs.RELATED_GAP_ROWSPEC,
                 FormSpecs.DEFAULT_ROWSPEC,
                 FormSpecs.RELATED_GAP_ROWSPEC,
@@ -155,6 +178,46 @@ public class ReferenceCameraTransformsConfigurationWizard extends AbstractConfig
         
         lblremovesInterlacingFrom = new JLabel("(Removes interlacing from stacked frames)");
         panelTransforms.add(lblremovesInterlacingFrom, "5, 20");
+        
+        lblRedBalance = new JLabel("Red Balance");
+        panelTransforms.add(lblRedBalance, "2, 24, right, default");
+        
+        redBalance = new JSlider();
+        redBalance.setMajorTickSpacing(100);
+        redBalance.setMaximum(200);
+        redBalance.setPaintTicks(true);
+        redBalance.setValue(100);
+        panelTransforms.add(redBalance, "4, 24, 2, 1");
+        
+        btnAutowhitebalance = new JButton(autoWhiteBalanceAction);
+        panelTransforms.add(btnAutowhitebalance, "7, 24, fill, fill");
+        
+        lblGreenBalance = new JLabel("Green Balance");
+        panelTransforms.add(lblGreenBalance, "2, 26, right, default");
+        
+        greenBalance = new JSlider();
+        greenBalance.setPaintTicks(true);
+        greenBalance.setValue(100);
+        greenBalance.setMaximum(200);
+        greenBalance.setMajorTickSpacing(100);
+        panelTransforms.add(greenBalance, "4, 26, 2, 1");
+        
+        btnAutowhitebalance_1 = new JButton(autoWhiteBalanceBrightAction);
+        panelTransforms.add(btnAutowhitebalance_1, "7, 26, default, fill");
+        
+        lblBlueBalance = new JLabel("Blue Balance");
+        panelTransforms.add(lblBlueBalance, "2, 28, right, default");
+        
+        blueBalance = new JSlider();
+        blueBalance.setValue(100);
+        blueBalance.setMajorTickSpacing(100);
+        blueBalance.setMaximum(200);
+        blueBalance.setPaintTicks(true);
+        panelTransforms.add(blueBalance, "4, 28, 2, 1");
+        
+        btnReset = new JButton(resetAction);
+        panelTransforms.add(btnReset, "7, 28");
+        initDataBindings();
     }
 
     @Override
@@ -162,7 +225,6 @@ public class ReferenceCameraTransformsConfigurationWizard extends AbstractConfig
         IntegerConverter intConverter = new IntegerConverter();
         DoubleConverter doubleConverter =
                 new DoubleConverter(Configuration.get().getLengthDisplayFormat());
-        LengthConverter lengthConverter = new LengthConverter();
 
         addWrappedBinding(referenceCamera, "rotation", textFieldRotation, "text", doubleConverter);
         addWrappedBinding(referenceCamera, "offsetX", textFieldOffsetX, "text", intConverter);
@@ -186,6 +248,79 @@ public class ReferenceCameraTransformsConfigurationWizard extends AbstractConfig
         ComponentDecorators.decorateWithAutoSelect(scaleHeightTf);
     }
 
+    protected void initDataBindings() {
+        // These are directly bound to the camera, to see results immediately.
+        BeanProperty<ReferenceCamera, Integer> referenceCameraBeanProperty = BeanProperty.create("redBalancePercent");
+        BeanProperty<JSlider, Integer> jSliderBeanProperty = BeanProperty.create("value");
+        AutoBinding<ReferenceCamera, Integer, JSlider, Integer> autoBinding = Bindings.createAutoBinding(UpdateStrategy.READ_WRITE, referenceCamera, referenceCameraBeanProperty, redBalance, jSliderBeanProperty);
+        autoBinding.bind();
+        //
+        BeanProperty<ReferenceCamera, Integer> referenceCameraBeanProperty_1 = BeanProperty.create("greenBalancePercent");
+        BeanProperty<JSlider, Integer> jSliderBeanProperty_1 = BeanProperty.create("value");
+        AutoBinding<ReferenceCamera, Integer, JSlider, Integer> autoBinding_1 = Bindings.createAutoBinding(UpdateStrategy.READ_WRITE, referenceCamera, referenceCameraBeanProperty_1, greenBalance, jSliderBeanProperty_1);
+        autoBinding_1.bind();
+        //
+        BeanProperty<ReferenceCamera, Integer> referenceCameraBeanProperty_2 = BeanProperty.create("blueBalancePercent");
+        BeanProperty<JSlider, Integer> jSliderBeanProperty_2 = BeanProperty.create("value");
+        AutoBinding<ReferenceCamera, Integer, JSlider, Integer> autoBinding_2 = Bindings.createAutoBinding(UpdateStrategy.READ_WRITE, referenceCamera, referenceCameraBeanProperty_2, blueBalance, jSliderBeanProperty_2);
+        autoBinding_2.bind();
+    }
+
+    private final Action autoWhiteBalanceAction = new AbstractAction() {
+        {
+            putValue(NAME, "Auto White-Balance, Overall");
+            putValue(SHORT_DESCRIPTION, 
+                    "<html>Hold a neutral bright object in front of the camera and<br/>"
+                    + "press this button to automatically calibrate the white-balance.<br/><br/>"
+                    + "This method looks at where the bulk of the color is distributed,<br/>"
+                    + "overall.</html>");
+        }
+
+        public void actionPerformed(ActionEvent e) {
+            UiUtils.messageBoxOnException(() -> {
+                referenceCamera.autoAdjustWhiteBalance(false);
+                CameraView cameraView = MainFrame.get().getCameraViews().getCameraView(referenceCamera);
+                cameraView.setShowImageInfo(true);
+                MovableUtils.fireTargetedUserAction(referenceCamera);
+            });
+        }
+    };
+
+    private final Action autoWhiteBalanceBrightAction = new AbstractAction() {
+        {
+            putValue(NAME, "Auto White-Balance, Brightest");
+            putValue(SHORT_DESCRIPTION, 
+                    "<html>Hold a neutral bright object in front of the camera and<br/>"
+                    + "press this button to automatically calibrate the white-balance.<br/><br/>"
+                    + "This method looks at the brightest parts and averages the color<br/>"
+                    + "in those parts.</html>");
+        }
+
+        public void actionPerformed(ActionEvent e) {
+            UiUtils.messageBoxOnException(() -> {
+                referenceCamera.autoAdjustWhiteBalance(true);
+                CameraView cameraView = MainFrame.get().getCameraViews().getCameraView(referenceCamera);
+                cameraView.setShowImageInfo(true);
+                MovableUtils.fireTargetedUserAction(referenceCamera);
+            });
+        }
+    };
+
+    private final Action resetAction = new AbstractAction() {
+        {
+            putValue(NAME, "Reset");
+            putValue(SHORT_DESCRIPTION, "Switch off the white-balance / Reset to neutral.");
+        }
+
+        public void actionPerformed(ActionEvent e) {
+            UiUtils.messageBoxOnException(() -> {
+                referenceCamera.resetWhiteBalance();
+                CameraView cameraView = MainFrame.get().getCameraViews().getCameraView(referenceCamera);
+                cameraView.setShowImageInfo(true);
+            });
+        }
+    };
+
     private JLabel lblCropX;
     private JLabel lblCropHeight;
     private JTextField cropWidthTextField;
@@ -201,4 +336,13 @@ public class ReferenceCameraTransformsConfigurationWizard extends AbstractConfig
     private JCheckBox deinterlaceChk;
     private JLabel lblDeinterlace;
     private JLabel lblremovesInterlacingFrom;
+    private JLabel lblRedBalance;
+    private JLabel lblGreenBalance;
+    private JLabel lblBlueBalance;
+    private JSlider redBalance;
+    private JSlider greenBalance;
+    private JSlider blueBalance;
+    private JButton btnAutowhitebalance;
+    private JButton btnReset;
+    private JButton btnAutowhitebalance_1;
 }


### PR DESCRIPTION
# Description
This pull request adds true (RGB) white-balance in software. Once set to stable values, it is applied in the camera Image Transforms. When set to neutral (Reset), it incurs no additional image processing overhead, i.e. the operation is skipped. 

The white-balance can be set manually or by using automatic buttons. There is an "Overall" and a "Brightest" method:

![White Balance](https://user-images.githubusercontent.com/9963310/131741540-b2b0758b-a0bb-4d14-a236-e4da5c73a801.png)

The Histogram in the CameraView was improved to better scale to the relevant data (excluding singular extremes) and to show RGB-blended bar graphs, to better judge the overlap: 

![CameraView Histogram](https://user-images.githubusercontent.com/9963310/131741667-a9cc55e9-bd39-47eb-8c2e-7f4f5f0ad806.png)

# Justification
Cheap LED rings have bad blueish-greenisch color casts, that needs to be corrected in order to work with color based vision operations such as HSV masking a.k.a. "Green-Screening", as used for Juki nozzles, BlindsFeeder, ReferencePushPullFeeder. 

USB device based "white balance" does only really work in automatic mode. When switching to manual mode, it degrades to one-dimensional "hue shifting" with unusable results (at least on the ELP cameras that I own). Using the automatic mode requires large camera settling times for it to adapt. When large areas of the image are cast in one color, the automatic mode will overcompensate. Vision failures due to these effects keep popping up occasionally. 

# Instructions for Use

Use a bright color-neutral camera subject in order to perform the white-balance. E.g. put a white paper, brushed metal or similar in front of the camera and the LEDs. Then use the **Exposure** slider in the **Device Settings** tab to set the proper camera exposure and wanted image brightness. There should be no overexposed (clipped) parts in the image (apart from tiny highlights perhaps). A well exposed image might even look slightly dark to humans. 

Set the **Red, Green, Blue Balance** sliders manually in a range of 0% to 200%. 

Use the **Auto White-Balance, Overall** button to get a neutral look for the overall image. If you look at the Histogram in the camera view (which is automatically enabled by the button), the "mountains" of the color channels should mostly overlap nicely. 

Use the **Auto White-Balance, Brightest** button to adapt to the brightest areas in the image. As this will likely capture the lit areas and reflections of the LEDs, it is probably the better option for most machines.  

![white-balance](https://user-images.githubusercontent.com/9963310/131747016-a8189a1e-fa9a-4c27-8154-99a40f0c312b.gif)

Notes: 

* The Auto buttons are **one-time** automatic, i.e. the calibrated balance will then be fixed for repeatable Computer Vision when using color operations such as MaskHSV in bottom vision with Juki nozzles, the BlindsFeeder, ReferencePushPullFeeder, etc. 

* To avoid image noise and posterization effects, the Auto buttons will never increase the whole image brightness, even when the view is dark. You should also not try to do this manually. For good quality, use the **Exposure** slider in the **Device Settings** tab to set the proper camera exposure for the wanted image brightness. 

Use the **Reset** button to set the color balance to the neutral position (which is also the default). The white-balance is then effectively switched off, the computation skipped. 

Use the context menu (right mouse button) in the CameraView to switch on/off the **Image Info**, which includes the Histogram:

![Image Info](https://user-images.githubusercontent.com/9963310/131744015-e92a9b8d-6f69-4182-b7b4-83c5449b6314.png)


# Implementation Details
1. Tested with webcams.
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. Successful `mvn test` before submitting the Pull Request. 
