### PR TITLE
Add rectangle detection stage.

### DIFF
--- a/src/main/java/org/openpnp/vision/pipeline/stages/DetectRectangle.java
+++ b/src/main/java/org/openpnp/vision/pipeline/stages/DetectRectangle.java
@@ -1,0 +1,311 @@
+package org.openpnp.vision.pipeline.stages;
+
+import java.awt.Color;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.ArrayList;
+
+import org.opencv.core.MatOfPoint;
+import org.opencv.core.Point;
+import org.opencv.core.Mat;
+import org.opencv.core.Scalar;
+import org.opencv.imgproc.Imgproc;
+import org.openpnp.vision.FluentCv;
+import org.openpnp.vision.pipeline.CvPipeline;
+import org.openpnp.vision.pipeline.CvStage;
+import org.openpnp.vision.pipeline.Property;
+import org.openpnp.vision.pipeline.Stage;
+import org.simpleframework.xml.Attribute;
+import org.pmw.tinylog.Logger;
+
+@Stage(description="Find expected rectangle centered on nozzle.")
+public class DetectRectangle extends CvStage {
+
+    @Attribute
+    @Property(description = "Index of rectangle to return.")
+    private int index = 0;
+
+    @Attribute
+    @Property(description = "Minimum accumulator count to be considered a line.")
+    private int threshold = 20;
+
+    @Attribute
+    @Property(description = "Weight of accumulator count that contributes to score")
+    private double accWeight = 0.1;
+
+    @Attribute
+    @Property(description = "Maximum angle deviation of lines to be considered a pair.")
+    private double deltaTheta = 0.03;
+
+    @Attribute
+    @Property(description = "Maximum angle deviation of pairs to be considered a rectangle")
+    private double deltaAlpha = 0.03;
+
+    @Attribute
+    @Property(description = "Maximum symmetry deviation of lines to be considered a pair")
+    private double deltaRho = 20;
+
+    @Attribute
+    @Property(description = "Minimum line separation to be considered a pair")
+    private double minRho = 10;
+
+    @Attribute
+    @Property(description = "Estimated pair distance A")
+    private double rhoA = 15;
+
+    @Attribute
+    @Property(description = "Estimated pair distance B")
+    private double rhoB = 15;
+
+    public int getIndex() {
+        return this.index;
+    }
+
+    public void setIndex(int v) {
+        this.index = v;
+    }
+    
+    public int getThreshold() {
+        return this.threshold;
+    }
+
+    public void setThreshold(int v) {
+        this.threshold = v;
+    }
+    
+    public double getAccWeight() {
+        return this.accWeight;
+    }
+
+    public void setAccWeight(double v) {
+        this.accWeight = v;
+    }
+    
+    public double getDeltaTheta() {
+        return this.deltaTheta;
+    }
+
+    public void setDeltaTheta(double v) {
+        this.deltaTheta = v;
+    }
+    
+    public double getDeltaAlpha() {
+        return this.deltaAlpha;
+    }
+
+    public void setDeltaAlpha(double v) {
+        this.deltaAlpha = v;
+    }
+    
+    public double getDeltaRho() {
+        return this.deltaRho;
+    }
+
+    public void setDeltaRho(double v) {
+        this.deltaRho = v;
+    }
+    
+    public double getMinRho() {
+        return this.minRho;
+    }
+
+    public void setMinRho(double v) {
+        this.minRho = v;
+    }
+    
+    public double getRhoA() {
+        return this.rhoA;
+    }
+
+    public void setRhoA(double v) {
+        this.rhoA = v;
+    }
+    
+    public double getRhoB() {
+        return this.rhoB;
+    }
+
+    public void setRhoB(double v) {
+        this.rhoB = v;
+    }
+    
+    private class HoughLine {
+        final private double rho;
+        final private double theta;
+
+        private HoughLine(double rho, double theta) {
+            this.rho = rho;
+            this.theta = theta;
+        }
+    }
+
+    private class HoughPair {
+        final private int[] lines;
+        final private double alpha;
+        final private double xi;
+
+        private HoughPair(int a, int b, double alpha, double xi) {
+            this.lines = new int[2];
+            this.lines[0] = a;
+            this.lines[1] = b;
+            this.alpha = alpha;
+            this.xi = xi;
+        }
+    }
+
+    private class HoughRect {
+        final private HoughPair[] pairs;
+        final private double score;
+
+        private HoughRect(HoughPair a, HoughPair b, double score) {
+            this.pairs = new HoughPair[2];
+            this.pairs[0] = a;
+            this.pairs[1] = b;
+            this.score = score;
+        }
+    }
+
+    private void drawLine(Mat image, Mat lines, int lineNo) {
+        double rho = lines.get(lineNo, 0)[0];
+        double theta = lines.get(lineNo, 0)[1];
+        double a = Math.cos(theta);
+        double b = Math.sin(theta);
+        double x0 = a * rho;
+        double y0 = b * rho;
+        Point pt1 = new Point(x0 + 1000.0*(-b), y0 + 1000.0*(a));
+        Point pt2 = new Point(x0 - 1000.0*(-b), y0 - 1000.0*(a));
+        Scalar c = FluentCv.colorToScalar(Color.white);
+        Imgproc.line(image, pt1, pt2, c, 1);
+    }
+    
+    private void drawRect(Mat image, Mat lines, HoughRect rect) {
+        drawLine(image, lines, rect.pairs[0].lines[0]);
+        drawLine(image, lines, rect.pairs[0].lines[1]);
+        drawLine(image, lines, rect.pairs[1].lines[0]);
+        drawLine(image, lines, rect.pairs[1].lines[1]);
+    }
+
+    private List<HoughLine> translateLines(Mat image, Mat matLines) {
+        List<HoughLine> lines = new ArrayList<>();
+
+        double halfWidth = image.width() / 2.0;
+        double halfHeight = image.height() / 2.0;
+
+        for (int i = 0; i < matLines.rows() && i < 256; i++) {
+            double rho = matLines.get(i, 0)[0];
+            double theta = matLines.get(i, 0)[1];
+            double diff = halfWidth * Math.cos(theta) + halfHeight * Math.sin(theta);
+            /* List index matches original OpenCV index */
+            lines.add(new HoughLine(rho - diff, theta));
+        }
+
+        return lines;
+    }
+
+    private List<HoughPair> findPairs(List<HoughLine> lines) {
+        /* For every line, see if there is another line that is both parallel,
+         * and approximately equidistant from the origin */
+        List<HoughPair> pairs = new ArrayList<>();
+
+        for (int i = 0; i < lines.size()-1; i++) {
+            HoughLine a = lines.get(i);
+            for (int j = i+1; j < lines.size(); j++) {
+                HoughLine b = lines.get(j);
+
+                double xi = Math.abs(a.rho - b.rho);
+                if ((Math.abs(a.theta - b.theta) < this.deltaTheta) && 
+                        (Math.abs(a.rho + b.rho) < this.deltaRho) &&
+                                             (xi > this.minRho)) {
+
+                    double alpha = (a.theta + b.theta) / 2.0;
+                    pairs.add(new HoughPair(i, j, alpha, xi));
+                }
+            }
+        }
+
+        return pairs;
+    }
+
+    private List<HoughRect> findRects(List<HoughPair> pairs) {
+        double score;
+        List<HoughRect> rects = new ArrayList<>();
+
+        for (int i = 0; i < pairs.size()-1; i++) {
+            HoughPair a = pairs.get(i);
+            for (int j = i+1; j < pairs.size(); j++) {
+                HoughPair b = pairs.get(j);
+
+                if (Math.abs(Math.abs(a.alpha - b.alpha) - Math.PI/2.0) < this.deltaAlpha) {
+                    /* FIXME: Surely there's a way to get the actual weight from opencv. Failing that,
+                     * lower line indexes have higher accumulator values */
+                    score = (a.lines[0] + a.lines[1] + b.lines[0] + b.lines[1]) * this.accWeight;
+
+                    score += Math.min(Math.abs(a.xi - this.rhoA) + Math.abs(b.xi - this.rhoB),
+                                      Math.abs(a.xi - this.rhoB) + Math.abs(b.xi - this.rhoA));
+
+                    rects.add(new HoughRect(a, b, score));
+                }
+            }
+        }
+
+        return rects;
+    }
+    
+    private Point getCorner(Mat lines, int a, int b) {
+        double rhoA = lines.get(a, 0)[0];
+        double rhoB = lines.get(b, 0)[0];
+        double thetaA = lines.get(a, 0)[1];
+        double thetaB = lines.get(b, 0)[1];
+        double det = Math.sin(thetaB - thetaA);
+        /* Determinant will never be zero as deltaAlpha guarantees they are not parallel */ 
+        double x = (rhoA*Math.sin(thetaB) - rhoB*Math.sin(thetaA)) / det;
+        double y = (rhoB*Math.cos(thetaA) - rhoA*Math.cos(thetaB)) / det;
+        return new Point(x, y);
+    }
+
+    private List<MatOfPoint> getContours(Mat lines, HoughRect rect) {
+        List<MatOfPoint> contours = new ArrayList<>();
+        List<Point> tmp = new ArrayList<>();
+        MatOfPoint mp = new MatOfPoint();
+        tmp.add(getCorner(lines, rect.pairs[0].lines[0], rect.pairs[1].lines[0]));
+        tmp.add(getCorner(lines, rect.pairs[0].lines[0], rect.pairs[1].lines[1]));
+        tmp.add(getCorner(lines, rect.pairs[0].lines[1], rect.pairs[1].lines[0]));
+        tmp.add(getCorner(lines, rect.pairs[0].lines[1], rect.pairs[1].lines[1]));
+        mp.fromList(tmp);
+        contours.add(mp);
+        return contours;
+    }
+
+    @Override
+    public Result process(CvPipeline pipeline) throws Exception {
+        Mat matImage = pipeline.getWorkingImage();
+        Mat matLines = new Mat();
+
+        /* Lines are sorted so that the first line has the highest accumulator value */
+        Imgproc.HoughLines(matImage, matLines, 1.0, 0.01, this.threshold);
+
+        List<HoughLine> lines = translateLines(matImage, matLines);
+        List<HoughPair> pairs = findPairs(lines);
+        List<HoughRect> rects = findRects(pairs);
+
+        if (rects.size() <= this.index) {
+            matLines.release();
+            return new Result(matImage, null);
+        }
+
+        /* Sort rects based on score */
+        Collections.sort(rects, new Comparator<HoughRect>() {
+            @Override
+            public int compare(HoughRect a, HoughRect b) {
+                return ((Double) a.score).compareTo(b.score);
+            }
+        });
+
+        drawRect(matImage, matLines, rects.get(this.index));
+        List<MatOfPoint> contours = getContours(matLines, rects.get(this.index));
+
+        matLines.release();
+        return new Result(matImage, contours);
+    }
+}

--- a/src/main/java/org/openpnp/vision/pipeline/ui/CvPipelineEditor.java
+++ b/src/main/java/org/openpnp/vision/pipeline/ui/CvPipelineEditor.java
@@ -34,7 +34,7 @@ import org.openpnp.vision.pipeline.stages.DetectEdgesLaplacian;
 import org.openpnp.vision.pipeline.stages.DetectEdgesRobertsCross;
 import org.openpnp.vision.pipeline.stages.DetectFixedCirclesHough;
 import org.openpnp.vision.pipeline.stages.DetectLinesHough;
-import org.openpnp.vision.pipeline.stages.DetectRectangle;
+import org.openpnp.vision.pipeline.stages.DetectRectangleHough;
 import org.openpnp.vision.pipeline.stages.DilateModel;
 import org.openpnp.vision.pipeline.stages.DrawCircles;
 import org.openpnp.vision.pipeline.stages.DrawContours;
@@ -108,7 +108,7 @@ public class CvPipelineEditor extends JPanel {
         registerStageClass(CreateShapeTemplateImage.class);
         registerStageClass(DetectCirclesHough.class);
         registerStageClass(DetectLinesHough.class);
-        registerStageClass(DetectRectangle.class);
+        registerStageClass(DetectRectangleHough.class);
         registerStageClass(DetectEdgesCanny.class);
         registerStageClass(DetectEdgesRobertsCross.class);
         registerStageClass(DetectEdgesLaplacian.class);

--- a/src/main/java/org/openpnp/vision/pipeline/ui/CvPipelineEditor.java
+++ b/src/main/java/org/openpnp/vision/pipeline/ui/CvPipelineEditor.java
@@ -34,6 +34,7 @@ import org.openpnp.vision.pipeline.stages.DetectEdgesLaplacian;
 import org.openpnp.vision.pipeline.stages.DetectEdgesRobertsCross;
 import org.openpnp.vision.pipeline.stages.DetectFixedCirclesHough;
 import org.openpnp.vision.pipeline.stages.DetectLinesHough;
+import org.openpnp.vision.pipeline.stages.DetectRectangle;
 import org.openpnp.vision.pipeline.stages.DilateModel;
 import org.openpnp.vision.pipeline.stages.DrawCircles;
 import org.openpnp.vision.pipeline.stages.DrawContours;
@@ -107,6 +108,7 @@ public class CvPipelineEditor extends JPanel {
         registerStageClass(CreateShapeTemplateImage.class);
         registerStageClass(DetectCirclesHough.class);
         registerStageClass(DetectLinesHough.class);
+        registerStageClass(DetectRectangle.class);
         registerStageClass(DetectEdgesCanny.class);
         registerStageClass(DetectEdgesRobertsCross.class);
         registerStageClass(DetectEdgesLaplacian.class);


### PR DESCRIPTION
Loosly based on the paper "Rectangle Detection based on a Windowed Hough
Transform" by Jung et al.

----------------------------------------------------------------------

# Description
This adds a new vision stage called DetectRectangle. It uses the HoughLines function of OpenCV and then does some further processing on the lines found. The first step is to organise lines into parallel pairs that are approximately symmetrical about the centre of the image. Pairs are then collected into quads that form rectangles. A score is applied to rectangles, based on the deviation from the expected size, along with a weighted score based on the strength of a line. Finally the corners are used to create a rotated rectangle, that can be used to get the part rotation and centre.


# Justification
I had quite a bit of difficulty getting the default bottom vision pipeline to recognise parts. This probably has something to do with the lighting/lens situation of my machine, however I've been getting really good results using this new model. It works very well for chip capacitors/resistors, as well as chips. Based on the idea that most electronic parts are rectangular.

# Instructions for Use
The module works well if it is preceded by the canny edge detector. Here is an example pipeline which I've been using:
```<cv-pipeline>                                                                   
   <stages>                                                                     
      <cv-stage class="org.openpnp.vision.pipeline.stages.ImageRead" name="read" enabled="true" file="/home/kmtaylor/nuvotion/vision/radmic_images_0/cap502953625777304466.png" color-space="Bgr"/>
      <cv-stage class="org.openpnp.vision.pipeline.stages.ConvertColor" name="bgr2gray" enabled="true" conversion="Bgr2Gray"/>
      <cv-stage class="org.openpnp.vision.pipeline.stages.DetectEdgesCanny" name="canny" enabled="true" threshold-1="100.0" threshold-2="200.0"/>
      <cv-stage class="org.openpnp.vision.pipeline.stages.DetectRectangle" name="hough" enabled="true" index="0" threshold="20" acc-weight="0.1" delta-theta="0.03" delta-alpha="0.03" delta-rho="20.0" min-rho="10.0" rho-a="15.0" rho-b="15.0"/>
      <cv-stage class="org.openpnp.vision.pipeline.stages.SetColor" name="black" enabled="true">
         <color r="0" g="0" b="0" a="255"/>                                     
      </cv-stage>                                                               
      <cv-stage class="org.openpnp.vision.pipeline.stages.DrawContours" name="draw" enabled="true" contours-stage-name="hough" thickness="1" index="-1">
         <color r="254" g="254" b="254" a="255"/>                               
      </cv-stage>                                                               
      <cv-stage class="org.openpnp.vision.pipeline.stages.MinAreaRect" name="min_area" enabled="true" threshold-min="100" threshold-max="255"/>
      <cv-stage class="org.openpnp.vision.pipeline.stages.ImageRecall" name="orig" enabled="true" image-stage-name="read"/>
      <cv-stage class="org.openpnp.vision.pipeline.stages.DrawRotatedRects" name="result" enabled="true" rotated-rects-stage-name="min_area" thickness="3" draw-rect-center="false" rect-center-radius="20" show-orientation="false">
         <color r="255" g="0" b="0" a="255"/>                                   
      </cv-stage>                                                               
      <cv-stage class="org.openpnp.vision.pipeline.stages.ImageWriteDebug" name="debug" enabled="true" prefix="debug" suffix=".png"/>
   </stages>                                                                    
</cv-pipeline>
```


# Implementation Details
I have tested this code on my machine through a production run. It resulted in a substantial improvement of 0603 resistor placement. It was also effective in detecting SOT-23 parts which had low contrast on my installation.
I've tried to follow the coding style used in the other vision stages as closely as possible.
The maven test stage passes (mainly since it doesn't actually call this code)
