### PR TITLE
Add a grid reticle

### DIFF
--- a/src/main/java/org/openpnp/gui/components/CameraViewPopupMenu.java
+++ b/src/main/java/org/openpnp/gui/components/CameraViewPopupMenu.java
@@ -37,6 +37,7 @@ import org.openpnp.gui.MainFrame;
 import org.openpnp.gui.components.CameraView.RenderingQuality;
 import org.openpnp.gui.components.reticle.CrosshairReticle;
 import org.openpnp.gui.components.reticle.FiducialReticle;
+import org.openpnp.gui.components.reticle.GridReticle;
 import org.openpnp.gui.components.reticle.Reticle;
 import org.openpnp.gui.components.reticle.RulerReticle;
 import org.openpnp.gui.processes.EstimateObjectZCoordinateProcess;
@@ -95,6 +96,10 @@ public class CameraViewPopupMenu extends JPopupMenu {
             if (cameraView.getDefaultReticle() instanceof RulerReticle) {
                 setReticleOptionsMenu(createRulerReticleOptionsMenu(
                         (RulerReticle) cameraView.getDefaultReticle()));
+            }
+            else if (cameraView.getDefaultReticle() instanceof GridReticle) {
+                setReticleOptionsMenu(createRulerReticleOptionsMenu(
+                        (GridReticle) cameraView.getDefaultReticle()));
             }
             else if (cameraView.getDefaultReticle() instanceof FiducialReticle) {
                 setReticleOptionsMenu(createFiducialReticleOptionsMenu(
@@ -239,6 +244,13 @@ public class CameraViewPopupMenu extends JPopupMenu {
 
         menuItem = new JRadioButtonMenuItem(crosshairReticleAction);
         if (reticle != null && reticle.getClass() == CrosshairReticle.class) {
+            menuItem.setSelected(true);
+        }
+        buttonGroup.add(menuItem);
+        menu.add(menuItem);
+
+        menuItem = new JRadioButtonMenuItem(gridReticleAction);
+        if (reticle != null && reticle.getClass() == GridReticle.class) {
             menuItem.setSelected(true);
         }
         buttonGroup.add(menuItem);
@@ -577,6 +589,16 @@ public class CameraViewPopupMenu extends JPopupMenu {
         public void actionPerformed(ActionEvent arg0) {
             CrosshairReticle reticle = new CrosshairReticle();
             JMenu optionsMenu = createCrosshairReticleOptionsMenu(reticle);
+            setReticleOptionsMenu(optionsMenu);
+            cameraView.setDefaultReticle(reticle);
+        }
+    };
+
+    private Action gridReticleAction = new AbstractAction("Grid") {
+        @Override
+        public void actionPerformed(ActionEvent arg0) {
+            GridReticle reticle = new GridReticle();
+            JMenu optionsMenu = createRulerReticleOptionsMenu(reticle);
             setReticleOptionsMenu(optionsMenu);
             cameraView.setDefaultReticle(reticle);
         }

--- a/src/main/java/org/openpnp/gui/components/reticle/GridReticle.java
+++ b/src/main/java/org/openpnp/gui/components/reticle/GridReticle.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2021 Tony Luken <tonyluken62+openpnp@gmail.com>
+ * 
+ * This file is part of OpenPnP.
+ * 
+ * OpenPnP is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * OpenPnP is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License along with OpenPnP. If not, see
+ * <http://www.gnu.org/licenses/>.
+ * 
+ * For more information about OpenPnP visit http://openpnp.org
+ */
+
+package org.openpnp.gui.components.reticle;
+
+public class GridReticle extends RulerReticle {
+
+    public GridReticle() {
+        super(false);
+    }
+
+}

--- a/src/main/java/org/openpnp/gui/components/reticle/RulerReticle.java
+++ b/src/main/java/org/openpnp/gui/components/reticle/RulerReticle.java
@@ -31,6 +31,12 @@ import org.openpnp.model.LengthUnit;
 public class RulerReticle extends CrosshairReticle {
     private LengthUnit units;
     private double unitsPerTick;
+    private boolean drawRulerOnly = true;
+
+    public RulerReticle(boolean drawRulerOnly) {
+        this();
+        this.drawRulerOnly = drawRulerOnly;
+    }
 
     public RulerReticle() {
         super();
@@ -82,9 +88,11 @@ public class RulerReticle extends CrosshairReticle {
                 .convertToUnits(this.units).getValue();
         double pixelsPerTickX = unitsPerTick / uppX;
         double pixelsPerTickY = unitsPerTick / uppY;
-        int tickLength = 3;
-        int fivetickLength = 6;
-        int tentickLength = 12;
+        
+        //If only drawing rulers, use short tick marks; otherwise, make them long to form a grid
+        int tickLength = drawRulerOnly ? 3 : halfDiagonal;
+        int fivetickLength = drawRulerOnly ? 6 : halfDiagonal;
+        int tentickLength = drawRulerOnly ? 12 : halfDiagonal;
 
         g2d.setColor(color);
         for (int i = 1; i < (halfDiagonal / pixelsPerTickX); i++) {


### PR DESCRIPTION
# Description
Adds an option to display a grid reticle in the camera views.  This is similar to the ruler reticle except the tick marks fill the entire width and height of the camera view. 

# Justification
This is just an additional option for the operator.  A grid reticle is useful when evaluating camera lens distortion and may be useful for other measurement tasks as well.

# Instructions for Use
From the camera view pop-up menu, select the Reticle->Grid option.  Just as with the ruler reticle, further options to change the Color, Units (inches/millimeters), and Units Per Tick are available under the pop-up menu Reticle->Options. 

# Implementation Details
**1. How did you test the change?** Selected the reticle grid option as detailed above and observed a full grid covering the image.  Selected various different options for Color, Units, and Units Per Tick and verified the grid appeared as expected.
**2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)?** Yes.
**3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing.** No changes were made to these.
**4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted.** The Maven tests were run and passed.
