### PR TITLE
Fix / Ensure Nozzle at Safe Z when sensing PartOff before Pick

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/ReferencePnpJobProcessor.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferencePnpJobProcessor.java
@@ -664,6 +664,9 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
                 return;
             }
             try {
+                // Part-off check can only be done at safe Z. An explicit move to safe Z is needed, because some feeder classes 
+                // may move the nozzle to (near) the pick location i.e. down in Z in feed().
+                nozzle.moveToSafeZ();
                 if (!nozzle.isPartOff()) {
                     throw new JobProcessorException(nozzle, "Part vacuum-detected on nozzle before pick.");
                 }
@@ -893,6 +896,7 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
                 return;
             }
             try {
+                // Note, we 're already at safe Z, see place().
                 if (!nozzle.isPartOff()) {
                     throw new JobProcessorException(nozzle, "Part vacuum-detected on nozzle after place.");
                 }


### PR DESCRIPTION
# Description
Ensure the nozzle is at Safe Z when a Part-Off test is made before picking.

# Justification
See #1281.

# Instructions for Use
No change. See
https://github.com/openpnp/openpnp/wiki/Setup-and-Calibration%3A-Vacuum-Sensing

# Implementation Details
1. Tested in simulation.
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. Successful `mvn test` before submitting the Pull Request.
