### PR TITLE
Feature/Better White Balance

### DIFF
--- a/src/main/java/org/openpnp/gui/support/PercentIntegerConverter.java
+++ b/src/main/java/org/openpnp/gui/support/PercentIntegerConverter.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2021 <mark@makr.zone>
+ * 
+ * This file is part of OpenPnP.
+ * 
+ * OpenPnP is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * OpenPnP is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License along with OpenPnP. If not, see
+ * <http://www.gnu.org/licenses/>.
+ * 
+ * For more information about OpenPnP visit http://openpnp.org
+ */
+
+package org.openpnp.gui.support;
+
+import org.jdesktop.beansbinding.Converter;
+
+public class PercentIntegerConverter extends Converter<Double, Integer> {
+    public PercentIntegerConverter() {
+    }
+
+    @Override
+    public Integer convertForward(Double arg0) {
+        return (int)Math.round(arg0*100);
+    }
+
+    @Override
+    public Double convertReverse(Integer arg0) {
+        return arg0*0.01;
+    }
+}

--- a/src/main/java/org/openpnp/machine/reference/ReferenceCamera.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceCamera.java
@@ -19,6 +19,7 @@
 
 package org.openpnp.machine.reference;
 
+import java.awt.Color;
 import java.awt.event.ActionEvent;
 import java.awt.image.BufferedImage;
 import java.io.IOException;
@@ -69,6 +70,7 @@ import org.openpnp.spi.Head;
 import org.openpnp.spi.Machine;
 import org.openpnp.util.Collect;
 import org.openpnp.util.OpenCvUtils;
+import org.openpnp.util.SimpleGraph;
 import org.openpnp.util.UiUtils;
 import org.openpnp.vision.LensCalibration;
 import org.openpnp.vision.LensCalibration.LensModel;
@@ -164,13 +166,22 @@ public abstract class ReferenceCamera extends AbstractBroadcastingCamera impleme
 
     @Attribute(required = false)
     private double whiteBalanceClipFractile = 0.99;
-    
+
+    @Element(required = false)
+    private double[] redColorMap;
+    @Element(required = false)
+    private double[] greenColorMap;
+    @Element(required = false)
+    private double[] blueColorMap;
+
+
     private boolean calibrating;
     private CalibrationCallback calibrationCallback;
     private int calibrationCountGoal = 25;
 
     private Mat undistortionMap1;
     private Mat undistortionMap2;
+    private Mat lut;
 
     private LensCalibration lensCalibration;
 
@@ -418,7 +429,9 @@ public abstract class ReferenceCamera extends AbstractBroadcastingCamera impleme
     public void setRedBalance(double redBalance) {
         Object oldValue = this.redBalance;
         this.redBalance = redBalance;
+        resetColorMaps();
         firePropertyChange("redBalance", oldValue, redBalance);
+        firePropertyChange("colorBalanceGraph", null, getColorBalanceGraph());
         cameraViewHasChanged(null);
     }
 
@@ -429,7 +442,9 @@ public abstract class ReferenceCamera extends AbstractBroadcastingCamera impleme
     public void setGreenBalance(double greenBalance) {
         Object oldValue = this.greenBalance;
         this.greenBalance = greenBalance;
+        resetColorMaps();
         firePropertyChange("greenBalance", oldValue, greenBalance);
+        firePropertyChange("colorBalanceGraph", null, getColorBalanceGraph());
         cameraViewHasChanged(null);
     }
 
@@ -440,7 +455,9 @@ public abstract class ReferenceCamera extends AbstractBroadcastingCamera impleme
     public void setBlueBalance(double blueBalance) {
         Object oldValue = this.blueBalance;
         this.blueBalance = blueBalance;
+        resetColorMaps();
         firePropertyChange("blueBalance", oldValue, blueBalance);
+        firePropertyChange("colorBalanceGraph", null, getColorBalanceGraph());
         cameraViewHasChanged(null);
     }
 
@@ -452,7 +469,9 @@ public abstract class ReferenceCamera extends AbstractBroadcastingCamera impleme
     public void setRedGamma(double redGamma) {
         Object oldValue = this.redGamma;
         this.redGamma = redGamma;
+        resetColorMaps();
         firePropertyChange("redGamma", oldValue, redGamma);
+        firePropertyChange("colorBalanceGraph", null, getColorBalanceGraph());
         cameraViewHasChanged(null);
     }
 
@@ -463,7 +482,9 @@ public abstract class ReferenceCamera extends AbstractBroadcastingCamera impleme
     public void setGreenGamma(double greenGamma) {
         Object oldValue = this.greenGamma;
         this.greenGamma = greenGamma;
+        resetColorMaps();
         firePropertyChange("greenGamma", oldValue, greenGamma);
+        firePropertyChange("colorBalanceGraph", null, getColorBalanceGraph());
         cameraViewHasChanged(null);
     }
 
@@ -474,10 +495,11 @@ public abstract class ReferenceCamera extends AbstractBroadcastingCamera impleme
     public void setBlueGamma(double blueGamma) {
         Object oldValue = this.blueGamma;
         this.blueGamma = blueGamma;
+        resetColorMaps();
         firePropertyChange("blueGamma", oldValue, blueGamma);
+        firePropertyChange("colorBalanceGraph", null, getColorBalanceGraph());
         cameraViewHasChanged(null);
     }
-
 
     public boolean isDeinterlace() {
         return isDeinterlaced();
@@ -489,7 +511,8 @@ public abstract class ReferenceCamera extends AbstractBroadcastingCamera impleme
 
     public boolean isWhiteBalanced() {
         return redBalance != 1.0 || greenBalance != 1.0 || blueBalance != 1.0
-                || redGamma != 1.0 || greenGamma != 1.0 || blueGamma != 1.0; 
+                || redGamma != 1.0 || greenGamma != 1.0 || blueGamma != 1.0
+                || (redColorMap != null & blueColorMap != null & greenColorMap != null); 
     }
 
     @Override
@@ -588,50 +611,66 @@ public abstract class ReferenceCamera extends AbstractBroadcastingCamera impleme
 
     private Mat whiteBalance(Mat mat) {
         if (isWhiteBalanced() && mat.channels() == 3) {
-            Mat lut;
-            byte[] data = new byte[3];
-            lut = new Mat(256, 1, CvType.CV_8UC3);
-            for (int i = 0; i < 256; i++) {
-                // Indexed BGR.
-                data[2] = (byte)Math.min(255, Math.pow(i/255.0*redBalance, 1/redGamma)*255.0);
-                data[1] = (byte)Math.min(255, Math.pow(i/255.0*greenBalance, 1/greenGamma)*255.0);
-                data[0] = (byte)Math.min(255, Math.pow(i/255.0*blueBalance, 1/blueGamma)*255.0);
-                lut.put(i, 0, data);
-            }
+            initWhiteBalanceLut();
             Mat whiteBalanced = new Mat();
             Core.LUT(mat, lut, whiteBalanced);
-            lut.release();
             mat.release();
             mat = whiteBalanced;
         }
         return mat;
     }
 
+    protected void initWhiteBalanceLut() {
+        if (lut == null) {
+            byte[] data = new byte[3];
+            lut = new Mat(256, 1, CvType.CV_8UC3);
+            if (redColorMap != null & blueColorMap != null & greenColorMap != null) {
+                final int levels = redColorMap.length;
+                final int range = 256/levels;
+                final int halfRange = range/2;
+                for (int i = 0; i < 256; i++) {
+                    // Indexed BGR.
+                    int level1 = (i+halfRange)/range;
+                    int level0 = level1 - 1;
+                    double weight1 = ((i + halfRange) % range)/(double)range; 
+                    double weight0 = 1.0 - weight1;
+                    if (level0 < 0) {
+                        level0 = 0;
+                        weight0 = -weight0;
+                    }
+                    if (level1 >= levels) {
+                        level1 = levels-2;
+                        weight0 += 2*weight1; 
+                        weight1 = -weight1;
+                    }
+                    data[2] = (byte)Math.max(0, Math.min(255, (redColorMap[level0]*weight0 + redColorMap[level1]*weight1)*255.0));
+                    data[1] = (byte)Math.max(0, Math.min(255, (greenColorMap[level0]*weight0 + greenColorMap[level1]*weight1)*255.0));
+                    data[0] = (byte)Math.max(0, Math.min(255, (blueColorMap[level0]*weight0 + blueColorMap[level1]*weight1)*255.0));
+                    lut.put(i, 0, data);
+                }
+            }
+            else {
+                for (int i = 0; i < 256; i++) {
+                    // Indexed BGR.
+                    data[2] = (byte)Math.min(255, Math.pow(i/255.0*redBalance, 1/redGamma)*255.0);
+                    data[1] = (byte)Math.min(255, Math.pow(i/255.0*greenBalance, 1/greenGamma)*255.0);
+                    data[0] = (byte)Math.min(255, Math.pow(i/255.0*blueBalance, 1/blueGamma)*255.0);
+                    lut.put(i, 0, data);
+                }
+            }
+        }
+    }
+
     public void autoAdjustWhiteBalance(boolean averaged) throws Exception {
         // Switch it off to get a neutral image.
-        setRedBalance(1.0);
-        setGreenBalance(1.0);
-        setBlueBalance(1.0);
-        setRedGamma(1.0);
-        setGreenGamma(1.0);
-        setBlueGamma(1.0);
+        resetWhiteBalance();
         // Capture.
         BufferedImage image = lightSettleAndCapture();
         // Calculate the histogram.
-        long[][] histogram = new long[3][256];
-        for (int y = 0; y < image.getHeight(); y++) {
-            for (int x = 0; x < image.getWidth(); x++) {
-                int rgb = image.getRGB(x, y);
-                int r = (rgb >> 16) & 0xff;
-                int g = (rgb >> 8) & 0xff;
-                int b = (rgb >> 0) & 0xff;
-                histogram[0][r]++;
-                histogram[1][g]++;
-                histogram[2][b]++;
-            }
-        }
+        long[][] histogram = computeImageHistogram(image);
         // Analyze the percentiles.
         long pixels = image.getHeight()*image.getWidth();
+        double percentileGamma[] = new double[3];
         double percentileLead[] = new double[3];
         double percentileClip[] = new double[3];
         double sum[] = new double[3];
@@ -641,6 +680,9 @@ public abstract class ReferenceCamera extends AbstractBroadcastingCamera impleme
             for (int bin = 0; bin < 256; bin++) {
                 long value = histogram[ch][bin];
                 accumulated += value;
+                if (accumulated < pixels*0.5) {
+                    percentileGamma[ch] = bin;
+                }
                 if (accumulated < pixels*whiteBalanceLeadFractile) {
                     percentileLead[ch] = bin;
                 }
@@ -665,13 +707,156 @@ public abstract class ReferenceCamera extends AbstractBroadcastingCamera impleme
         double g = lead/resultLead[1];
         double b = lead/resultLead[2];
 
-        // Norm to the maximum clip percentile, but never amplify.
-        double clip = Math.max(1.0, Math.max(Math.max(r*percentileClip[0], g*percentileClip[1]), b*percentileClip[2])/255.0);
+        // We do not: Norm to the maximum clip percentile, but never amplify.
+        double clip = 1.0; //Math.max(1.0, Math.max(Math.max(r*percentileClip[0], g*percentileClip[1]), b*percentileClip[2])/255.0);
 
         // Set the new balance.
         setRedBalance(r/clip);
         setGreenBalance(g/clip);
         setBlueBalance(b/clip);
+        
+        // Scale the gamma percentile.
+        percentileGamma[0] *= r/clip/255; 
+        percentileGamma[1] *= g/clip/255; 
+        percentileGamma[2] *= b/clip/255;
+        
+        // Make them match.
+        double midGamma = (percentileGamma[0] + percentileGamma[1] + percentileGamma[2])/3;
+        setRedGamma(Math.log(percentileGamma[0])/Math.log(midGamma));
+        setGreenGamma(Math.log(percentileGamma[1])/Math.log(midGamma));
+        setBlueGamma(Math.log(percentileGamma[2])/Math.log(midGamma));
+    }
+
+    protected long[][] computeImageHistogram(BufferedImage image) {
+        long[][] histogram = new long[3][256];
+        for (int y = 0; y < image.getHeight(); y++) {
+            for (int x = 0; x < image.getWidth(); x++) {
+                int rgb = image.getRGB(x, y);
+                int r = (rgb >> 16) & 0xff;
+                int g = (rgb >> 8) & 0xff;
+                int b = (rgb >> 0) & 0xff;
+                histogram[0][r]++;
+                histogram[1][g]++;
+                histogram[2][b]++;
+            }
+        }
+        return histogram;
+    }
+
+    public void autoAdjustWhiteBalanceMapped(int levels) throws Exception {
+        // Switch it off to get a neutral image.
+        resetWhiteBalance();
+        // Capture.
+        BufferedImage image = lightSettleAndCapture();
+        // Map the balance on various levels.
+        final int range = 256/levels;
+        final int halfRange = range/2;
+        final int clip = 254; 
+        final int balanceLimit = 2;
+        long[][] histogram = computeImageHistogram(image);
+        double lead[] = new double[3];
+        long pixels = image.getHeight()*image.getWidth();
+        int fractileLead = 0;
+        for (int ch = 0; ch < 3; ch++) {
+            long accumulated = 0;
+            for (int bin = 0; bin < 256; bin++) {
+                long value = histogram[ch][bin];
+                accumulated += value;
+                if (accumulated > pixels*whiteBalanceLeadFractile) {
+                    lead[ch] = bin;
+                    if (bin > fractileLead) {
+                        fractileLead = bin;
+                    }
+                    break;
+                }
+            }
+        }
+        double amplify = fractileLead*3.0/(lead[0] + lead[1] + lead[2]);
+        long[][][] histogramAtLevel = new long[3][levels][255+range];
+        long[][] counts = new long[3][levels];
+        for (int y = 0; y < image.getHeight(); y++) {
+            for (int x = 0; x < image.getWidth(); x++) {
+                int rgb = image.getRGB(x, y);
+                int r = (rgb >> 16) & 0xff;
+                int g = (rgb >> 8) & 0xff;
+                int b = (rgb >> 0) & 0xff;
+                int lum = ((r >= clip || g >= clip || b >= clip) ? 255 // clip all when one is clipped 
+                        : (int)(amplify*(r+g+b)/3));
+                if (lum >= 1) {
+                    if (r >= 1 && lum/r < balanceLimit && r/lum < balanceLimit) {
+                        int level = r/range;
+                        int midLevel = level*range+halfRange;
+                        histogramAtLevel[0][level][Math.min(255, midLevel*lum/r)]++;
+                        counts[0][level]++;
+                    }
+                    if (g >= 1 && lum/g < balanceLimit && g/lum < balanceLimit) {
+                        int level = g/range;
+                        int midLevel = level*range+halfRange;
+                        histogramAtLevel[1][level][Math.min(255, midLevel*lum/g)]++;
+                        counts[1][level]++;
+                    }
+                    if (b >= 1 && lum/b < balanceLimit && b/lum < balanceLimit) {
+                        int level = b/range;
+                        int midLevel = level*range+halfRange;
+                        histogramAtLevel[2][level][Math.min(255, midLevel*lum/b)]++;
+                        counts[2][level]++;
+                    }
+                }
+            }
+        }
+        // Map the colors.
+        double [][] colorMap = new double[3][levels];
+        for (int ch = 0; ch < 3; ch++) {
+            for (int level = 0; level < levels; level++) {
+                long median = counts[ch][level]/2;
+                long accumulated = 0;
+                for (int bin = 0; bin < 256; bin++) {
+                    long value = histogramAtLevel[ch][level][bin];
+                    accumulated += value;
+                    if (accumulated > median) {
+                        colorMap[ch][level] = bin/255.0;
+                        break;
+                    }
+                }
+            }
+            // Sanity check
+            for (int level = 1; level < levels; level++) {
+                if (level == levels) {
+                    if (colorMap[ch][level] > colorMap[ch][level+1]) {
+                        // extrapolate
+                        colorMap[ch][level] = (colorMap[ch][level+1]*3 - colorMap[ch][level+2])/2;
+                    }
+                }
+                else if (colorMap[ch][level-1] > colorMap[ch][level]) {
+                    if (level+1 >= levels) {
+                        // extrapolate
+                        colorMap[ch][level] = (colorMap[ch][level-1]*3 - colorMap[ch][level-2])/2;
+                    }
+                    else {
+                        if (colorMap[ch][level-1] > colorMap[ch][level+1]) {
+                            throw new Exception("Image does not contain grayscales at level "+100*level/levels+" ... "+100*(level+1)/levels+"%.");
+//                            colorMap[ch][level] = colorMap[ch][level-1];
+                        }
+                        else {
+                        // Simply interpolate.
+                        colorMap[ch][level] = (colorMap[ch][level-1] + colorMap[ch][level+1])/2;
+                        }
+                    }
+                }
+            }
+        }
+
+        // As an approximation, compute the parametric white balance (as feedback 
+        // for the user, and basis for manual override).
+        autoAdjustWhiteBalance(true);
+        // But immediately reset the maps and LUT.
+        resetColorMaps();
+        // And assign our new color maps.
+        redColorMap = colorMap[0];
+        greenColorMap = colorMap[1];
+        blueColorMap = colorMap[2];
+        firePropertyChange("colorBalanceGraph", null, getColorBalanceGraph());
+        cameraViewHasChanged(null);
     }
 
     public void resetWhiteBalance() throws Exception {
@@ -681,6 +866,47 @@ public abstract class ReferenceCamera extends AbstractBroadcastingCamera impleme
         setRedGamma(1.0);
         setGreenGamma(1.0);
         setBlueGamma(1.0);
+        resetColorMaps();
+    }
+
+    public SimpleGraph getColorBalanceGraph() {
+        final String COLOR_GRAPH = "C"; 
+        SimpleGraph colorGraph = new SimpleGraph();
+        colorGraph.setRelativePaddingLeft(0.1);
+        colorGraph.setRelativePaddingRight(0.05);
+        SimpleGraph.DataScale scale =  colorGraph.getScale(COLOR_GRAPH);
+        scale.setRelativePaddingTop(0.05);
+        scale.setRelativePaddingBottom(0.1);
+        scale.setColor(SimpleGraph.getDefaultGridColor());
+        scale.setSquareAspectRatio(true);
+        SimpleGraph.DataRow red = colorGraph.getRow(COLOR_GRAPH, "red");
+        red.setColor(new Color(255, 0, 0));
+        SimpleGraph.DataRow green = colorGraph.getRow(COLOR_GRAPH, "green");
+        green.setColor(new Color(0, 255, 0));
+        SimpleGraph.DataRow blue = colorGraph.getRow(COLOR_GRAPH, "blue");
+        blue.setColor(new Color(00, 0, 255));
+        // Make sure the LUT is initialized.
+        initWhiteBalanceLut();
+        Mat lut = this.lut;
+        byte[] data = new byte[3];
+        for (int i = 0; i < 256; i++) {
+            lut.get(i, 0, data);
+            // BGR indexed.
+            red.recordDataPoint(i, Byte.toUnsignedInt(data[2]));
+            green.recordDataPoint(i, Byte.toUnsignedInt(data[1]));
+            blue.recordDataPoint(i, Byte.toUnsignedInt(data[0]));
+        }
+        return colorGraph;
+    }
+
+    protected void resetColorMaps() {
+        redColorMap = null;
+        greenColorMap = null;
+        blueColorMap = null;
+        if (lut != null) {
+            lut.release();
+            lut = null;
+        }
     }
 
     private Mat crop(Mat mat) {

--- a/src/main/java/org/openpnp/machine/reference/wizards/ReferenceCameraTransformsConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/wizards/ReferenceCameraTransformsConfigurationWizard.java
@@ -411,7 +411,7 @@ public class ReferenceCameraTransformsConfigurationWizard extends AbstractConfig
         }
 
         public void actionPerformed(ActionEvent e) {
-            autoMapped(16);
+            autoMapped(32);
         }
     };
 

--- a/src/main/java/org/openpnp/machine/reference/wizards/ReferenceCameraTransformsConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/wizards/ReferenceCameraTransformsConfigurationWizard.java
@@ -1,5 +1,6 @@
 package org.openpnp.machine.reference.wizards;
 
+import java.awt.Dimension;
 import java.awt.event.ActionEvent;
 
 import javax.swing.AbstractAction;
@@ -20,6 +21,7 @@ import org.jdesktop.beansbinding.Bindings;
 import org.openpnp.gui.MainFrame;
 import org.openpnp.gui.components.CameraView;
 import org.openpnp.gui.components.ComponentDecorators;
+import org.openpnp.gui.components.SimpleGraphView;
 import org.openpnp.gui.support.AbstractConfigurationWizard;
 import org.openpnp.gui.support.DoubleConverter;
 import org.openpnp.gui.support.IntegerConverter;
@@ -27,6 +29,7 @@ import org.openpnp.gui.support.PercentIntegerConverter;
 import org.openpnp.machine.reference.ReferenceCamera;
 import org.openpnp.model.Configuration;
 import org.openpnp.util.MovableUtils;
+import org.openpnp.util.SimpleGraph;
 import org.openpnp.util.UiUtils;
 
 import com.jgoodies.forms.layout.ColumnSpec;
@@ -48,6 +51,7 @@ public class ReferenceCameraTransformsConfigurationWizard extends AbstractConfig
     private JLabel lblOffsetY;
     private JTextField textFieldOffsetX;
     private JTextField textFieldOffsetY;
+    private JPanel panelColorBalance;
 
 
     public ReferenceCameraTransformsConfigurationWizard(ReferenceCamera referenceCamera) {
@@ -63,28 +67,14 @@ public class ReferenceCameraTransformsConfigurationWizard extends AbstractConfig
                 ColumnSpec.decode("max(70dlu;default)"),
                 FormSpecs.RELATED_GAP_COLSPEC,
                 FormSpecs.DEFAULT_COLSPEC,
+                FormSpecs.LABEL_COMPONENT_GAP_COLSPEC,
+                FormSpecs.RELATED_GAP_COLSPEC,
                 FormSpecs.DEFAULT_COLSPEC,
                 FormSpecs.RELATED_GAP_COLSPEC,
                 FormSpecs.DEFAULT_COLSPEC,
                 FormSpecs.RELATED_GAP_COLSPEC,
                 FormSpecs.DEFAULT_COLSPEC,},
             new RowSpec[] {
-                FormSpecs.RELATED_GAP_ROWSPEC,
-                FormSpecs.DEFAULT_ROWSPEC,
-                FormSpecs.RELATED_GAP_ROWSPEC,
-                FormSpecs.DEFAULT_ROWSPEC,
-                FormSpecs.RELATED_GAP_ROWSPEC,
-                FormSpecs.DEFAULT_ROWSPEC,
-                FormSpecs.RELATED_GAP_ROWSPEC,
-                FormSpecs.DEFAULT_ROWSPEC,
-                FormSpecs.RELATED_GAP_ROWSPEC,
-                FormSpecs.DEFAULT_ROWSPEC,
-                FormSpecs.RELATED_GAP_ROWSPEC,
-                FormSpecs.DEFAULT_ROWSPEC,
-                FormSpecs.RELATED_GAP_ROWSPEC,
-                FormSpecs.DEFAULT_ROWSPEC,
-                FormSpecs.RELATED_GAP_ROWSPEC,
-                FormSpecs.DEFAULT_ROWSPEC,
                 FormSpecs.RELATED_GAP_ROWSPEC,
                 FormSpecs.DEFAULT_ROWSPEC,
                 FormSpecs.RELATED_GAP_ROWSPEC,
@@ -127,13 +117,13 @@ public class ReferenceCameraTransformsConfigurationWizard extends AbstractConfig
         panelTransforms.add(textFieldOffsetY, "4, 6");
         textFieldOffsetY.setColumns(10);
 
-        lblFlipX = new JLabel("Flip Vertical");
+        lblFlipX = new JLabel("Flip Vertical?");
         panelTransforms.add(lblFlipX, "2, 8, right, default");
 
         chckbxFlipX = new JCheckBox("");
         panelTransforms.add(chckbxFlipX, "4, 8");
 
-        lblFlipY = new JLabel("Flip Horizontal");
+        lblFlipY = new JLabel("Flip Horizontal?");
         panelTransforms.add(lblFlipY, "2, 10, right, default");
 
         checkBoxFlipY = new JCheckBox("");
@@ -147,7 +137,7 @@ public class ReferenceCameraTransformsConfigurationWizard extends AbstractConfig
         cropWidthTextField.setColumns(10);
         
         lblNewLabel = new JLabel("(Use 0 for no cropping)");
-        panelTransforms.add(lblNewLabel, "5, 12");
+        panelTransforms.add(lblNewLabel, "7, 12");
         
         lblCropHeight = new JLabel("Crop Height");
         panelTransforms.add(lblCropHeight, "2, 14, right, default");
@@ -157,7 +147,7 @@ public class ReferenceCameraTransformsConfigurationWizard extends AbstractConfig
         cropHeightTextField.setColumns(10);
         
         lblNewLabel_1 = new JLabel("(Use 0 for no cropping)");
-        panelTransforms.add(lblNewLabel_1, "5, 14");
+        panelTransforms.add(lblNewLabel_1, "7, 14");
         
         lblScaleWidth = new JLabel("Scale Width");
         panelTransforms.add(lblScaleWidth, "2, 16, right, default");
@@ -167,7 +157,7 @@ public class ReferenceCameraTransformsConfigurationWizard extends AbstractConfig
         scaleWidthTf.setColumns(10);
         
         lbluseFor = new JLabel("(Use 0 for no scaling)");
-        panelTransforms.add(lbluseFor, "5, 16");
+        panelTransforms.add(lbluseFor, "7, 16");
         
         lblScaleHeight = new JLabel("Scale Height");
         panelTransforms.add(lblScaleHeight, "2, 18, right, default");
@@ -177,85 +167,154 @@ public class ReferenceCameraTransformsConfigurationWizard extends AbstractConfig
         scaleHeightTf.setColumns(10);
         
         label = new JLabel("(Use 0 for no scaling)");
-        panelTransforms.add(label, "5, 18");
+        panelTransforms.add(label, "7, 18");
         
-        lblDeinterlace = new JLabel("De-Interlace");
-        panelTransforms.add(lblDeinterlace, "2, 20");
+        lblDeinterlace = new JLabel("De-Interlace?");
+        panelTransforms.add(lblDeinterlace, "2, 20, right, default");
         
         deinterlaceChk = new JCheckBox("");
         panelTransforms.add(deinterlaceChk, "4, 20");
         
         lblremovesInterlacingFrom = new JLabel("(Removes interlacing from stacked frames)");
-        panelTransforms.add(lblremovesInterlacingFrom, "5, 20");
+        panelTransforms.add(lblremovesInterlacingFrom, "7, 20");
+        
+        panelColorBalance = new JPanel();
+        panelColorBalance.setBorder(new TitledBorder(new EtchedBorder(EtchedBorder.LOWERED, null, null),
+                "Color Balance", TitledBorder.LEADING, TitledBorder.TOP, null));
+        contentPanel.add(panelColorBalance);
+        panelColorBalance.setLayout(new FormLayout(new ColumnSpec[] {
+                FormSpecs.RELATED_GAP_COLSPEC,
+                ColumnSpec.decode("max(70dlu;default)"),
+                FormSpecs.RELATED_GAP_COLSPEC,
+                FormSpecs.DEFAULT_COLSPEC,
+                FormSpecs.RELATED_GAP_COLSPEC,
+                FormSpecs.DEFAULT_COLSPEC,
+                FormSpecs.RELATED_GAP_COLSPEC,
+                FormSpecs.DEFAULT_COLSPEC,},
+            new RowSpec[] {
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                RowSpec.decode("max(100dlu;default)"),
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,}));
+
         
         lblRedBalance = new JLabel("Red Balance");
-        panelTransforms.add(lblRedBalance, "2, 24, right, default");
+        panelColorBalance.add(lblRedBalance, "2, 2, right, default");
         
         redBalance = new JSlider();
         redBalance.setMajorTickSpacing(100);
         redBalance.setMaximum(200);
         redBalance.setPaintTicks(true);
         redBalance.setValue(100);
-        panelTransforms.add(redBalance, "4, 24, 2, 1");
-        
-        btnAutowhitebalance = new JButton(autoWhiteBalanceAction);
-        panelTransforms.add(btnAutowhitebalance, "7, 24, fill, fill");
+        panelColorBalance.add(redBalance, "4, 2, fill, default");
         
         lblGreenBalance = new JLabel("Green Balance");
-        panelTransforms.add(lblGreenBalance, "2, 26, right, default");
+        panelColorBalance.add(lblGreenBalance, "2, 4, right, default");
         
         greenBalance = new JSlider();
         greenBalance.setPaintTicks(true);
         greenBalance.setValue(100);
         greenBalance.setMaximum(200);
         greenBalance.setMajorTickSpacing(100);
-        panelTransforms.add(greenBalance, "4, 26, 2, 1");
-        
-        btnAutowhitebalance_1 = new JButton(autoWhiteBalanceBrightAction);
-        panelTransforms.add(btnAutowhitebalance_1, "7, 26, default, fill");
+        panelColorBalance.add(greenBalance, "4, 4, fill, default");
         
         lblBlueBalance = new JLabel("Blue Balance");
-        panelTransforms.add(lblBlueBalance, "2, 28, right, default");
+        panelColorBalance.add(lblBlueBalance, "2, 6, right, default");
         
         blueBalance = new JSlider();
         blueBalance.setValue(100);
         blueBalance.setMajorTickSpacing(100);
         blueBalance.setMaximum(200);
         blueBalance.setPaintTicks(true);
-        panelTransforms.add(blueBalance, "4, 28, 2, 1");
-        
-        btnReset = new JButton(resetAction);
-        panelTransforms.add(btnReset, "7, 28");
+        panelColorBalance.add(blueBalance, "4, 6, fill, default");
         
         lblRedGamma = new JLabel("Red Gamma");
-        panelTransforms.add(lblRedGamma, "2, 32, right, default");
+        panelColorBalance.add(lblRedGamma, "2, 10, right, default");
         
         redGammaPercent = new JSlider();
         redGammaPercent.setMajorTickSpacing(100);
         redGammaPercent.setValue(100);
         redGammaPercent.setMaximum(200);
         redGammaPercent.setPaintTicks(true);
-        panelTransforms.add(redGammaPercent, "4, 32, 2, 1");
+        panelColorBalance.add(redGammaPercent, "4, 10, fill, default");
         
         lblGreenGamma = new JLabel("Green Gamma");
-        panelTransforms.add(lblGreenGamma, "2, 34, right, default");
+        panelColorBalance.add(lblGreenGamma, "2, 12, right, default");
         
         greenGammaPercent = new JSlider();
         greenGammaPercent.setValue(100);
         greenGammaPercent.setPaintTicks(true);
         greenGammaPercent.setMaximum(200);
         greenGammaPercent.setMajorTickSpacing(100);
-        panelTransforms.add(greenGammaPercent, "4, 34, 2, 1");
+        panelColorBalance.add(greenGammaPercent, "4, 12, fill, default");
         
         lblBlueGamma = new JLabel("Blue Gamma");
-        panelTransforms.add(lblBlueGamma, "2, 36, right, default");
+        panelColorBalance.add(lblBlueGamma, "2, 14, right, default");
         
         blueGammaPercent = new JSlider();
         blueGammaPercent.setValue(100);
         blueGammaPercent.setPaintTicks(true);
         blueGammaPercent.setMaximum(200);
         blueGammaPercent.setMajorTickSpacing(100);
-        panelTransforms.add(blueGammaPercent, "4, 36, 2, 1");
+        panelColorBalance.add(blueGammaPercent, "4, 14, fill, default");
+        
+        colorGraph = new SimpleGraphView();
+        colorGraph.setPreferredSize(new Dimension(300, 300));
+        panelColorBalance.add(colorGraph, "4, 18, 1, 15, left, fill");
+        
+        lblOutput = new JLabel("Output Level");
+        panelColorBalance.add(lblOutput, "2, 18, 1, 15, right, default");
+        
+        lblAutoWhitebalance = new JLabel("Auto White-Balance");
+        panelColorBalance.add(lblAutoWhitebalance, "6, 18, center, default");
+        
+        btnAutowhitebalance = new JButton(autoWhiteBalanceAction);
+        panelColorBalance.add(btnAutowhitebalance, "6, 20, fill, fill");
+        
+        btnAutowhitebalance_1 = new JButton(autoWhiteBalanceBrightAction);
+        panelColorBalance.add(btnAutowhitebalance_1, "6, 22, default, fill");
+        
+        btnAutowhiteBalanceAdvanced = new JButton(autoWhiteBalanceRoughMapAction);
+        panelColorBalance.add(btnAutowhiteBalanceAdvanced, "6, 26, default, fill");
+        
+        btnAutowhiteBalanceAdvanced_1 = new JButton(autoWhiteBalanceFineMapAction);
+        panelColorBalance.add(btnAutowhiteBalanceAdvanced_1, "6, 28, default, fill");
+        
+        btnReset = new JButton(resetAction);
+        panelColorBalance.add(btnReset, "6, 32");
+        
+        lblInputLevel = new JLabel("Input Level");
+        panelColorBalance.add(lblInputLevel, "4, 34, center, default");
         initDataBindings();
     }
 
@@ -289,7 +348,7 @@ public class ReferenceCameraTransformsConfigurationWizard extends AbstractConfig
 
     private final Action autoWhiteBalanceAction = new AbstractAction() {
         {
-            putValue(NAME, "Auto White-Balance, Overall");
+            putValue(NAME, "Overall");
             putValue(SHORT_DESCRIPTION, 
                     "<html>Hold a neutral bright object in front of the camera and<br/>"
                     + "press this button to automatically calibrate the white-balance.<br/><br/>"
@@ -309,7 +368,7 @@ public class ReferenceCameraTransformsConfigurationWizard extends AbstractConfig
 
     private final Action autoWhiteBalanceBrightAction = new AbstractAction() {
         {
-            putValue(NAME, "Auto White-Balance, Brightest");
+            putValue(NAME, "Brightest");
             putValue(SHORT_DESCRIPTION, 
                     "<html>Hold a neutral bright object in front of the camera and<br/>"
                     + "press this button to automatically calibrate the white-balance.<br/><br/>"
@@ -326,6 +385,44 @@ public class ReferenceCameraTransformsConfigurationWizard extends AbstractConfig
             });
         }
     };
+
+    private final Action autoWhiteBalanceRoughMapAction = new AbstractAction() {
+        {
+            putValue(NAME, "Mapped Roughly");
+            putValue(SHORT_DESCRIPTION, 
+                    "<html>Hold a gradiented gray object in front of the camera and<br/>"
+                    + "press this button to automatically calibrate the white-balance.<br/><br/>"
+                    + "This method uses a rough mapped approach, the image must contain all shades.</html>");
+        }
+
+        public void actionPerformed(ActionEvent e) {
+            autoMapped(8);
+        }
+
+    };
+
+    private final Action autoWhiteBalanceFineMapAction = new AbstractAction() {
+        {
+            putValue(NAME, "Mapped Finely");
+            putValue(SHORT_DESCRIPTION, 
+                    "<html>Hold a gradiented gray object in front of the camera and<br/>"
+                    + "press this button to automatically calibrate the white-balance.<br/><br/>"
+                    + "This method uses a fine mapped approach, the image must contain all shades.</html>");
+        }
+
+        public void actionPerformed(ActionEvent e) {
+            autoMapped(16);
+        }
+    };
+
+    protected void autoMapped(int levels) {
+        UiUtils.messageBoxOnException(() -> {
+            referenceCamera.autoAdjustWhiteBalanceMapped(levels);
+            CameraView cameraView = MainFrame.get().getCameraViews().getCameraView(referenceCamera);
+            cameraView.setShowImageInfo(true);
+            MovableUtils.fireTargetedUserAction(referenceCamera);
+        });
+    }
 
     private final Action resetAction = new AbstractAction() {
         {
@@ -372,6 +469,13 @@ public class ReferenceCameraTransformsConfigurationWizard extends AbstractConfig
     private JSlider redGammaPercent;
     private JSlider greenGammaPercent;
     private JSlider blueGammaPercent;
+    private JButton btnAutowhiteBalanceAdvanced;
+    private SimpleGraphView colorGraph;
+    private JButton btnAutowhiteBalanceAdvanced_1;
+    private JLabel lblOutput;
+    private JLabel lblInputLevel;
+    private JLabel lblAutoWhitebalance;
+
     protected void initDataBindings() {
         BeanProperty<ReferenceCamera, Double> referenceCameraBeanProperty = BeanProperty.create("redBalance");
         BeanProperty<JSlider, Integer> jSliderBeanProperty = BeanProperty.create("value");
@@ -408,5 +512,10 @@ public class ReferenceCameraTransformsConfigurationWizard extends AbstractConfig
         AutoBinding<ReferenceCamera, Double, JSlider, Integer> autoBinding_5 = Bindings.createAutoBinding(UpdateStrategy.READ_WRITE, referenceCamera, referenceCameraBeanProperty_5, blueGammaPercent, jSliderBeanProperty_5);
         autoBinding_5.setConverter(new PercentIntegerConverter());
         autoBinding_5.bind();
+        //
+        BeanProperty<ReferenceCamera, SimpleGraph> referenceCameraBeanProperty_6 = BeanProperty.create("colorBalanceGraph");
+        BeanProperty<SimpleGraphView, SimpleGraph> simpleGraphViewBeanProperty = BeanProperty.create("graph");
+        AutoBinding<ReferenceCamera, SimpleGraph, SimpleGraphView, SimpleGraph> autoBinding_6 = Bindings.createAutoBinding(UpdateStrategy.READ, referenceCamera, referenceCameraBeanProperty_6, colorGraph, simpleGraphViewBeanProperty);
+        autoBinding_6.bind();
     }
 }

--- a/src/main/java/org/openpnp/machine/reference/wizards/ReferenceCameraTransformsConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/wizards/ReferenceCameraTransformsConfigurationWizard.java
@@ -23,6 +23,7 @@ import org.openpnp.gui.components.ComponentDecorators;
 import org.openpnp.gui.support.AbstractConfigurationWizard;
 import org.openpnp.gui.support.DoubleConverter;
 import org.openpnp.gui.support.IntegerConverter;
+import org.openpnp.gui.support.PercentIntegerConverter;
 import org.openpnp.machine.reference.ReferenceCamera;
 import org.openpnp.model.Configuration;
 import org.openpnp.util.MovableUtils;
@@ -68,6 +69,14 @@ public class ReferenceCameraTransformsConfigurationWizard extends AbstractConfig
                 FormSpecs.RELATED_GAP_COLSPEC,
                 FormSpecs.DEFAULT_COLSPEC,},
             new RowSpec[] {
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
                 FormSpecs.RELATED_GAP_ROWSPEC,
                 FormSpecs.DEFAULT_ROWSPEC,
                 FormSpecs.RELATED_GAP_ROWSPEC,
@@ -217,6 +226,36 @@ public class ReferenceCameraTransformsConfigurationWizard extends AbstractConfig
         
         btnReset = new JButton(resetAction);
         panelTransforms.add(btnReset, "7, 28");
+        
+        lblRedGamma = new JLabel("Red Gamma");
+        panelTransforms.add(lblRedGamma, "2, 32, right, default");
+        
+        redGammaPercent = new JSlider();
+        redGammaPercent.setMajorTickSpacing(100);
+        redGammaPercent.setValue(100);
+        redGammaPercent.setMaximum(200);
+        redGammaPercent.setPaintTicks(true);
+        panelTransforms.add(redGammaPercent, "4, 32, 2, 1");
+        
+        lblGreenGamma = new JLabel("Green Gamma");
+        panelTransforms.add(lblGreenGamma, "2, 34, right, default");
+        
+        greenGammaPercent = new JSlider();
+        greenGammaPercent.setValue(100);
+        greenGammaPercent.setPaintTicks(true);
+        greenGammaPercent.setMaximum(200);
+        greenGammaPercent.setMajorTickSpacing(100);
+        panelTransforms.add(greenGammaPercent, "4, 34, 2, 1");
+        
+        lblBlueGamma = new JLabel("Blue Gamma");
+        panelTransforms.add(lblBlueGamma, "2, 36, right, default");
+        
+        blueGammaPercent = new JSlider();
+        blueGammaPercent.setValue(100);
+        blueGammaPercent.setPaintTicks(true);
+        blueGammaPercent.setMaximum(200);
+        blueGammaPercent.setMajorTickSpacing(100);
+        panelTransforms.add(blueGammaPercent, "4, 36, 2, 1");
         initDataBindings();
     }
 
@@ -246,24 +285,6 @@ public class ReferenceCameraTransformsConfigurationWizard extends AbstractConfig
         ComponentDecorators.decorateWithAutoSelect(cropHeightTextField);
         ComponentDecorators.decorateWithAutoSelect(scaleWidthTf);
         ComponentDecorators.decorateWithAutoSelect(scaleHeightTf);
-    }
-
-    protected void initDataBindings() {
-        // These are directly bound to the camera, to see results immediately.
-        BeanProperty<ReferenceCamera, Integer> referenceCameraBeanProperty = BeanProperty.create("redBalancePercent");
-        BeanProperty<JSlider, Integer> jSliderBeanProperty = BeanProperty.create("value");
-        AutoBinding<ReferenceCamera, Integer, JSlider, Integer> autoBinding = Bindings.createAutoBinding(UpdateStrategy.READ_WRITE, referenceCamera, referenceCameraBeanProperty, redBalance, jSliderBeanProperty);
-        autoBinding.bind();
-        //
-        BeanProperty<ReferenceCamera, Integer> referenceCameraBeanProperty_1 = BeanProperty.create("greenBalancePercent");
-        BeanProperty<JSlider, Integer> jSliderBeanProperty_1 = BeanProperty.create("value");
-        AutoBinding<ReferenceCamera, Integer, JSlider, Integer> autoBinding_1 = Bindings.createAutoBinding(UpdateStrategy.READ_WRITE, referenceCamera, referenceCameraBeanProperty_1, greenBalance, jSliderBeanProperty_1);
-        autoBinding_1.bind();
-        //
-        BeanProperty<ReferenceCamera, Integer> referenceCameraBeanProperty_2 = BeanProperty.create("blueBalancePercent");
-        BeanProperty<JSlider, Integer> jSliderBeanProperty_2 = BeanProperty.create("value");
-        AutoBinding<ReferenceCamera, Integer, JSlider, Integer> autoBinding_2 = Bindings.createAutoBinding(UpdateStrategy.READ_WRITE, referenceCamera, referenceCameraBeanProperty_2, blueBalance, jSliderBeanProperty_2);
-        autoBinding_2.bind();
     }
 
     private final Action autoWhiteBalanceAction = new AbstractAction() {
@@ -345,4 +366,47 @@ public class ReferenceCameraTransformsConfigurationWizard extends AbstractConfig
     private JButton btnAutowhitebalance;
     private JButton btnReset;
     private JButton btnAutowhitebalance_1;
+    private JLabel lblRedGamma;
+    private JLabel lblGreenGamma;
+    private JLabel lblBlueGamma;
+    private JSlider redGammaPercent;
+    private JSlider greenGammaPercent;
+    private JSlider blueGammaPercent;
+    protected void initDataBindings() {
+        BeanProperty<ReferenceCamera, Double> referenceCameraBeanProperty = BeanProperty.create("redBalance");
+        BeanProperty<JSlider, Integer> jSliderBeanProperty = BeanProperty.create("value");
+        AutoBinding<ReferenceCamera, Double, JSlider, Integer> autoBinding = Bindings.createAutoBinding(UpdateStrategy.READ_WRITE, referenceCamera, referenceCameraBeanProperty, redBalance, jSliderBeanProperty);
+        autoBinding.setConverter(new PercentIntegerConverter());
+        autoBinding.bind();
+        //
+        BeanProperty<ReferenceCamera, Double> referenceCameraBeanProperty_1 = BeanProperty.create("greenBalance");
+        BeanProperty<JSlider, Integer> jSliderBeanProperty_1 = BeanProperty.create("value");
+        AutoBinding<ReferenceCamera, Double, JSlider, Integer> autoBinding_1 = Bindings.createAutoBinding(UpdateStrategy.READ_WRITE, referenceCamera, referenceCameraBeanProperty_1, greenBalance, jSliderBeanProperty_1);
+        autoBinding_1.setConverter(new PercentIntegerConverter());
+        autoBinding_1.bind();
+        //
+        BeanProperty<ReferenceCamera, Double> referenceCameraBeanProperty_2 = BeanProperty.create("blueBalance");
+        BeanProperty<JSlider, Integer> jSliderBeanProperty_2 = BeanProperty.create("value");
+        AutoBinding<ReferenceCamera, Double, JSlider, Integer> autoBinding_2 = Bindings.createAutoBinding(UpdateStrategy.READ_WRITE, referenceCamera, referenceCameraBeanProperty_2, blueBalance, jSliderBeanProperty_2);
+        autoBinding_2.setConverter(new PercentIntegerConverter());
+        autoBinding_2.bind();
+        //
+        BeanProperty<ReferenceCamera, Double> referenceCameraBeanProperty_3 = BeanProperty.create("redGamma");
+        BeanProperty<JSlider, Integer> jSliderBeanProperty_3 = BeanProperty.create("value");
+        AutoBinding<ReferenceCamera, Double, JSlider, Integer> autoBinding_3 = Bindings.createAutoBinding(UpdateStrategy.READ_WRITE, referenceCamera, referenceCameraBeanProperty_3, redGammaPercent, jSliderBeanProperty_3);
+        autoBinding_3.setConverter(new PercentIntegerConverter());
+        autoBinding_3.bind();
+        //
+        BeanProperty<ReferenceCamera, Double> referenceCameraBeanProperty_4 = BeanProperty.create("greenGamma");
+        BeanProperty<JSlider, Integer> jSliderBeanProperty_4 = BeanProperty.create("value");
+        AutoBinding<ReferenceCamera, Double, JSlider, Integer> autoBinding_4 = Bindings.createAutoBinding(UpdateStrategy.READ_WRITE, referenceCamera, referenceCameraBeanProperty_4, greenGammaPercent, jSliderBeanProperty_4);
+        autoBinding_4.setConverter(new PercentIntegerConverter());
+        autoBinding_4.bind();
+        //
+        BeanProperty<ReferenceCamera, Double> referenceCameraBeanProperty_5 = BeanProperty.create("blueGamma");
+        BeanProperty<JSlider, Integer> jSliderBeanProperty_5 = BeanProperty.create("value");
+        AutoBinding<ReferenceCamera, Double, JSlider, Integer> autoBinding_5 = Bindings.createAutoBinding(UpdateStrategy.READ_WRITE, referenceCamera, referenceCameraBeanProperty_5, blueGammaPercent, jSliderBeanProperty_5);
+        autoBinding_5.setConverter(new PercentIntegerConverter());
+        autoBinding_5.bind();
+    }
 }


### PR DESCRIPTION
# Description
Based on #1276, this adds several improvements to color balance. This proved necessary after the simple linear white balance did not work well on the machine, showing non-linear response in the camera. 

* Added color Gamma to white-balance, implemented LUT based image processing with LUT cache,
* Implemented Gamma estimate in auto-balance method.
* Added a multi-level mapped color balance method.
* Added a graph of the color LUT to the Wizard. 
* Fixed bug in histogram smoothing.
* Fixed CameraView flashing on double-click (capturing snapshot).

![white-balance-methods](https://user-images.githubusercontent.com/9963310/132755434-fc4c8f16-9d77-4fc4-8a10-cc8226799918.gif)

# Justification
It seems the RGB channels do not respond linearly to levels. This might or might not be caused by ambient light having a different cast and mixing in a non-linear fashion. 

# Instructions for Use
The Wiki is work in progress.

# Implementation Details
1. Tested on machine.
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. Successful `mvn test` before submitting the Pull Request.