### PR TITLE
Fix / Remove all EdgedBorder.LOWERED Borders

### DIFF
--- a/src/main/java/org/openpnp/gui/JobPanel.java
+++ b/src/main/java/org/openpnp/gui/JobPanel.java
@@ -57,7 +57,6 @@ import javax.swing.JToolBar;
 import javax.swing.KeyStroke;
 import javax.swing.ListSelectionModel;
 import javax.swing.SwingUtilities;
-import javax.swing.border.EtchedBorder;
 import javax.swing.border.TitledBorder;
 import javax.swing.event.ListSelectionEvent;
 import javax.swing.event.ListSelectionListener;
@@ -288,7 +287,7 @@ public class JobPanel extends JPanel {
         });
 
         JPanel pnlBoards = new JPanel();
-        pnlBoards.setBorder(new TitledBorder(new EtchedBorder(EtchedBorder.LOWERED, null, null),
+        pnlBoards.setBorder(new TitledBorder(null,
                 Translations.getString("JobPanel.Tab.Boards"),
                 TitledBorder.LEADING, TitledBorder.TOP, null)); //$NON-NLS-1$
         pnlBoards.setLayout(new BorderLayout(0, 0));

--- a/src/main/java/org/openpnp/gui/LogPanel.java
+++ b/src/main/java/org/openpnp/gui/LogPanel.java
@@ -25,7 +25,6 @@ import javax.swing.JScrollBar;
 import javax.swing.JScrollPane;
 import javax.swing.JTextField;
 import javax.swing.KeyStroke;
-import javax.swing.border.EtchedBorder;
 import javax.swing.border.TitledBorder;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
@@ -85,7 +84,7 @@ public class LogPanel extends JPanel {
         // The Global Filter settings
         JPanel settingsPanel = new JPanel(new FlowLayout(FlowLayout.LEFT));
 
-        settingsPanel.setBorder(new TitledBorder(new EtchedBorder(EtchedBorder.LOWERED, null, null),
+        settingsPanel.setBorder(new TitledBorder(null,
                 "Global Logging Settings", TitledBorder.LEADING, TitledBorder.TOP, null));
 
         settingsPanel.add(createGlobalLogLevelPanel());
@@ -95,7 +94,7 @@ public class LogPanel extends JPanel {
         // The filter settings
         JPanel filterPanel = new JPanel(new BorderLayout(0, 0));
 
-        filterPanel.setBorder(new TitledBorder(new EtchedBorder(EtchedBorder.LOWERED, null, null),
+        filterPanel.setBorder(new TitledBorder(null,
                 "Filter Logging Panel", TitledBorder.LEADING, TitledBorder.TOP, null));
 
         JPanel filterContentPanel = new JPanel(new FlowLayout(FlowLayout.LEFT));

--- a/src/main/java/org/openpnp/gui/PackageVisionPanel.java
+++ b/src/main/java/org/openpnp/gui/PackageVisionPanel.java
@@ -20,7 +20,6 @@
 package org.openpnp.gui;
 
 import java.awt.BorderLayout;
-import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.event.ActionEvent;
 
@@ -35,7 +34,6 @@ import javax.swing.JTable;
 import javax.swing.JTextField;
 import javax.swing.JToolBar;
 import javax.swing.ListSelectionModel;
-import javax.swing.border.EtchedBorder;
 import javax.swing.border.TitledBorder;
 import javax.swing.event.ListSelectionEvent;
 import javax.swing.event.ListSelectionListener;
@@ -82,7 +80,7 @@ public class PackageVisionPanel extends JPanel {
         JPanel propertiesPanel = new JPanel();
         add(propertiesPanel, BorderLayout.NORTH);
         propertiesPanel.setBorder(
-                new TitledBorder(new EtchedBorder(EtchedBorder.LOWERED, null, null), "Settings",
+                new TitledBorder(null, "Settings",
                         TitledBorder.LEADING, TitledBorder.TOP, null));
         propertiesPanel.setLayout(new FormLayout(
                 new ColumnSpec[] {FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,

--- a/src/main/java/org/openpnp/gui/PartSettingsPanel.java
+++ b/src/main/java/org/openpnp/gui/PartSettingsPanel.java
@@ -19,13 +19,10 @@
 
 package org.openpnp.gui;
 
-import java.awt.Color;
-
 import javax.swing.BoxLayout;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JTextField;
-import javax.swing.border.EtchedBorder;
 import javax.swing.border.TitledBorder;
 
 import org.jdesktop.beansbinding.AutoBinding;
@@ -57,7 +54,7 @@ public class PartSettingsPanel extends JPanel {
         setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
         
         pickConditionsPanel = new JPanel();
-        pickConditionsPanel.setBorder(new TitledBorder(new EtchedBorder(EtchedBorder.LOWERED, null, null), "Pick Conditions", TitledBorder.LEADING, TitledBorder.TOP, null));
+        pickConditionsPanel.setBorder(new TitledBorder(null, "Pick Conditions", TitledBorder.LEADING, TitledBorder.TOP, null));
         add(pickConditionsPanel);
         pickConditionsPanel.setLayout(new FormLayout(new ColumnSpec[] {
                 FormSpecs.RELATED_GAP_COLSPEC,

--- a/src/main/java/org/openpnp/gui/components/ClassSelectionDialog.java
+++ b/src/main/java/org/openpnp/gui/components/ClassSelectionDialog.java
@@ -88,7 +88,7 @@ public class ClassSelectionDialog<T> extends JDialog {
             }
         });
         list.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
-        list.setBorder(new EtchedBorder(EtchedBorder.LOWERED, null, null));
+        list.setBorder(null);
         panel.add(new JScrollPane(list), BorderLayout.CENTER);
         // setDefaultCloseOperation(WindowConstants.DO_NOTHING_ON_CLOSE);
         setSize(400, 400);

--- a/src/main/java/org/openpnp/machine/index/sheets/gui/FeederConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/index/sheets/gui/FeederConfigurationWizard.java
@@ -1,28 +1,38 @@
 package org.openpnp.machine.index.sheets.gui;
 
-import javax.swing.*;
+import java.awt.Color;
+import java.awt.event.ActionEvent;
+
+import javax.swing.AbstractAction;
+import javax.swing.Action;
+import javax.swing.JButton;
+import javax.swing.JComboBox;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JTextField;
+import javax.swing.border.TitledBorder;
 
 import org.jdesktop.beansbinding.AutoBinding;
 import org.jdesktop.beansbinding.AutoBinding.UpdateStrategy;
 import org.jdesktop.beansbinding.BeanProperty;
 import org.jdesktop.beansbinding.Bindings;
-import org.openpnp.gui.support.*;
+import org.openpnp.gui.components.LocationButtonsPanel;
+import org.openpnp.gui.support.AbstractConfigurationWizard;
+import org.openpnp.gui.support.DoubleConverter;
+import org.openpnp.gui.support.IdentifiableListCellRenderer;
+import org.openpnp.gui.support.IntegerConverter;
+import org.openpnp.gui.support.LengthConverter;
+import org.openpnp.gui.support.MutableLocationProxy;
+import org.openpnp.gui.support.PartsComboBoxModel;
 import org.openpnp.machine.index.IndexFeeder;
 import org.openpnp.model.Configuration;
 import org.openpnp.model.Part;
-
-import javax.swing.border.TitledBorder;
-
-import com.jgoodies.forms.layout.FormLayout;
-import com.jgoodies.forms.layout.ColumnSpec;
-import com.jgoodies.forms.layout.RowSpec;
-import com.jgoodies.forms.layout.FormSpecs;
-import org.openpnp.gui.components.LocationButtonsPanel;
 import org.openpnp.util.UiUtils;
 
-import javax.swing.border.EtchedBorder;
-import java.awt.Color;
-import java.awt.event.ActionEvent;
+import com.jgoodies.forms.layout.ColumnSpec;
+import com.jgoodies.forms.layout.FormLayout;
+import com.jgoodies.forms.layout.FormSpecs;
+import com.jgoodies.forms.layout.RowSpec;
 
 public class FeederConfigurationWizard extends AbstractConfigurationWizard {
 
@@ -86,7 +96,7 @@ public class FeederConfigurationWizard extends AbstractConfigurationWizard {
 		infoPanel.add(findButton, "6, 4");
 		
 		JPanel partPanel = new JPanel();
-		partPanel.setBorder(new TitledBorder(new EtchedBorder(EtchedBorder.LOWERED, null, null), "Part", TitledBorder.LEADING, TitledBorder.TOP, null, new Color(0, 0, 0)));
+		partPanel.setBorder(new TitledBorder(null, "Part", TitledBorder.LEADING, TitledBorder.TOP, null, new Color(0, 0, 0)));
 		contentPanel.add(partPanel);
 		partPanel.setLayout(new FormLayout(new ColumnSpec[] {
 				FormSpecs.RELATED_GAP_COLSPEC,

--- a/src/main/java/org/openpnp/machine/neoden4/wizards/Neoden4CameraConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/neoden4/wizards/Neoden4CameraConfigurationWizard.java
@@ -19,17 +19,12 @@
 
 package org.openpnp.machine.neoden4.wizards;
 
-import java.awt.Color;
-import java.util.List;
-
-import javax.swing.JComboBox;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JTextField;
-import javax.swing.border.EtchedBorder;
+import javax.swing.SwingConstants;
 import javax.swing.border.TitledBorder;
 
-import org.openpnp.gui.components.ComponentDecorators;
 import org.openpnp.gui.support.AbstractConfigurationWizard;
 import org.openpnp.gui.support.IntegerConverter;
 import org.openpnp.machine.neoden4.Neoden4Camera;
@@ -39,7 +34,6 @@ import com.jgoodies.forms.layout.ColumnSpec;
 import com.jgoodies.forms.layout.FormLayout;
 import com.jgoodies.forms.layout.FormSpecs;
 import com.jgoodies.forms.layout.RowSpec;
-import javax.swing.SwingConstants;
 
 @SuppressWarnings("serial")
 public class Neoden4CameraConfigurationWizard extends AbstractConfigurationWizard {
@@ -52,7 +46,7 @@ public class Neoden4CameraConfigurationWizard extends AbstractConfigurationWizar
 
         panelGeneral = new JPanel();
         contentPanel.add(panelGeneral);
-        panelGeneral.setBorder(new TitledBorder(new EtchedBorder(EtchedBorder.LOWERED, null, null),
+        panelGeneral.setBorder(new TitledBorder(null,
                 "General", TitledBorder.LEADING, TitledBorder.TOP, null));
         panelGeneral.setLayout(new FormLayout(new ColumnSpec[] {
                 FormSpecs.RELATED_GAP_COLSPEC,
@@ -114,7 +108,7 @@ public class Neoden4CameraConfigurationWizard extends AbstractConfigurationWizar
                 
         panelImage = new JPanel();
         contentPanel.add(panelImage);
-        panelImage.setBorder(new TitledBorder(new EtchedBorder(EtchedBorder.LOWERED, null, null), 
+        panelImage.setBorder(new TitledBorder(null, 
         		"Image settings", TitledBorder.LEADING, TitledBorder.TOP, null));
         panelImage.setLayout(new FormLayout(new ColumnSpec[] {
         		FormSpecs.RELATED_GAP_COLSPEC,

--- a/src/main/java/org/openpnp/machine/neoden4/wizards/Neoden4DriverConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/neoden4/wizards/Neoden4DriverConfigurationWizard.java
@@ -20,24 +20,19 @@
 
 package org.openpnp.machine.neoden4.wizards;
 
-import java.awt.Color;
-
-import javax.swing.SwingConstants;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
-import javax.swing.border.EtchedBorder;
+import javax.swing.JTextField;
 import javax.swing.border.TitledBorder;
+
+import org.openpnp.gui.support.AbstractConfigurationWizard;
+import org.openpnp.gui.support.DoubleConverter;
+import org.openpnp.machine.neoden4.NeoDen4Driver;
 
 import com.jgoodies.forms.layout.ColumnSpec;
 import com.jgoodies.forms.layout.FormLayout;
 import com.jgoodies.forms.layout.FormSpecs;
 import com.jgoodies.forms.layout.RowSpec;
-
-import org.openpnp.gui.support.AbstractConfigurationWizard;
-import org.openpnp.gui.support.DoubleConverter;
-import org.openpnp.gui.support.IntegerConverter;
-import org.openpnp.machine.neoden4.NeoDen4Driver;
-import javax.swing.JTextField;
 
 @SuppressWarnings("serial")
 public class Neoden4DriverConfigurationWizard extends AbstractConfigurationWizard {
@@ -53,7 +48,7 @@ public class Neoden4DriverConfigurationWizard extends AbstractConfigurationWizar
         this.driver = driver;
 
         JPanel panelMachineDetails = new JPanel();
-        panelMachineDetails.setBorder(new TitledBorder(new EtchedBorder(EtchedBorder.LOWERED, null, null),
+        panelMachineDetails.setBorder(new TitledBorder(null,
                 "Machine Details", TitledBorder.LEADING, TitledBorder.TOP, null));
         contentPanel.add(panelMachineDetails);
         panelMachineDetails.setLayout(new FormLayout(

--- a/src/main/java/org/openpnp/machine/rapidplacer/RapidFeederConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/rapidplacer/RapidFeederConfigurationWizard.java
@@ -19,7 +19,6 @@
 
 package org.openpnp.machine.rapidplacer;
 
-import java.awt.Color;
 import java.awt.event.ActionEvent;
 import java.awt.image.BufferedImage;
 import java.util.HashSet;
@@ -31,7 +30,6 @@ import javax.swing.JButton;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JTextField;
-import javax.swing.border.EtchedBorder;
 import javax.swing.border.TitledBorder;
 
 import org.jdesktop.beansbinding.AutoBinding.UpdateStrategy;
@@ -104,7 +102,7 @@ public class RapidFeederConfigurationWizard
         pitch.setColumns(10);
         
         JPanel panelRapidFeederScan = new JPanel();
-        panelRapidFeederScan.setBorder(new TitledBorder(new EtchedBorder(EtchedBorder.LOWERED, null, null), "Rapid Feeder Scanning", TitledBorder.LEADING, TitledBorder.TOP, null));
+        panelRapidFeederScan.setBorder(new TitledBorder(null, "Rapid Feeder Scanning", TitledBorder.LEADING, TitledBorder.TOP, null));
         contentPanel.add(panelRapidFeederScan);
         panelRapidFeederScan.setLayout(new FormLayout(new ColumnSpec[] {
                 FormSpecs.RELATED_GAP_COLSPEC,

--- a/src/main/java/org/openpnp/machine/reference/camera/wizards/AutoFocusProviderConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/camera/wizards/AutoFocusProviderConfigurationWizard.java
@@ -30,7 +30,6 @@ import javax.swing.JLabel;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.JTextField;
-import javax.swing.border.EtchedBorder;
 import javax.swing.border.TitledBorder;
 
 import org.openpnp.gui.MainFrame;
@@ -71,7 +70,7 @@ public class AutoFocusProviderConfigurationWizard extends AbstractConfigurationW
 
         panelGeneral = new JPanel();
         contentPanel.add(panelGeneral);
-        panelGeneral.setBorder(new TitledBorder(new EtchedBorder(EtchedBorder.LOWERED, null, null), "Auto Focus Settings", TitledBorder.LEADING, TitledBorder.TOP, null, new Color(0, 0, 0)));
+        panelGeneral.setBorder(new TitledBorder(null, "Auto Focus Settings", TitledBorder.LEADING, TitledBorder.TOP, null, new Color(0, 0, 0)));
         panelGeneral.setLayout(new FormLayout(new ColumnSpec[] {
                 FormSpecs.RELATED_GAP_COLSPEC,
                 ColumnSpec.decode("max(70dlu;default)"),

--- a/src/main/java/org/openpnp/machine/reference/camera/wizards/ImageCameraConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/camera/wizards/ImageCameraConfigurationWizard.java
@@ -33,7 +33,6 @@ import javax.swing.JCheckBox;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JTextField;
-import javax.swing.border.EtchedBorder;
 import javax.swing.border.TitledBorder;
 
 import org.jdesktop.beansbinding.AutoBinding.UpdateStrategy;
@@ -62,7 +61,7 @@ public class ImageCameraConfigurationWizard extends AbstractConfigurationWizard 
 
         panelGeneral = new JPanel();
         contentPanel.add(panelGeneral);
-        panelGeneral.setBorder(new TitledBorder(new EtchedBorder(EtchedBorder.LOWERED, null, null),
+        panelGeneral.setBorder(new TitledBorder(null,
                 "General", TitledBorder.LEADING, TitledBorder.TOP, null));
         panelGeneral.setLayout(new FormLayout(new ColumnSpec[] {
                 FormSpecs.RELATED_GAP_COLSPEC,
@@ -164,7 +163,7 @@ public class ImageCameraConfigurationWizard extends AbstractConfigurationWizard 
         
         panelExtra = new JPanel();
         contentPanel.add(panelExtra);
-        panelExtra.setBorder(new TitledBorder(new EtchedBorder(EtchedBorder.LOWERED, null, null), "Simulated Calibration Rig", TitledBorder.LEADING, TitledBorder.TOP, null, new Color(0, 0, 0)));
+        panelExtra.setBorder(new TitledBorder(null, "Simulated Calibration Rig", TitledBorder.LEADING, TitledBorder.TOP, null, new Color(0, 0, 0)));
         panelExtra.setLayout(new FormLayout(new ColumnSpec[] {
                 FormSpecs.RELATED_GAP_COLSPEC,
                 ColumnSpec.decode("max(70dlu;default)"),

--- a/src/main/java/org/openpnp/machine/reference/camera/wizards/MjpgCaptureCameraWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/camera/wizards/MjpgCaptureCameraWizard.java
@@ -1,12 +1,9 @@
 package org.openpnp.machine.reference.camera.wizards;
 
 
-import java.awt.Color;
-
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JTextField;
-import javax.swing.border.EtchedBorder;
 import javax.swing.border.TitledBorder;
 
 import org.openpnp.gui.components.ComponentDecorators;
@@ -31,7 +28,7 @@ public class MjpgCaptureCameraWizard extends AbstractConfigurationWizard {
 
         panelGeneral = new JPanel();
         contentPanel.add(panelGeneral);
-        panelGeneral.setBorder(new TitledBorder(new EtchedBorder(EtchedBorder.LOWERED, null, null),
+        panelGeneral.setBorder(new TitledBorder(null,
                 "General", TitledBorder.LEADING, TitledBorder.TOP, null));
         panelGeneral.setLayout(new FormLayout(new ColumnSpec[] {
                 FormSpecs.RELATED_GAP_COLSPEC,

--- a/src/main/java/org/openpnp/machine/reference/camera/wizards/OnvifIPCameraConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/camera/wizards/OnvifIPCameraConfigurationWizard.java
@@ -19,14 +19,12 @@
 
 package org.openpnp.machine.reference.camera.wizards;
 
-import java.awt.Color;
 import java.util.List;
 
 import javax.swing.JComboBox;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JTextField;
-import javax.swing.border.EtchedBorder;
 import javax.swing.border.TitledBorder;
 
 import org.onvif.ver10.schema.VideoResolution;
@@ -52,7 +50,7 @@ public class OnvifIPCameraConfigurationWizard extends AbstractConfigurationWizar
 
         panelGeneral = new JPanel();
         contentPanel.add(panelGeneral);
-        panelGeneral.setBorder(new TitledBorder(new EtchedBorder(EtchedBorder.LOWERED, null, null),
+        panelGeneral.setBorder(new TitledBorder(null,
                 "General", TitledBorder.LEADING, TitledBorder.TOP, null));
         panelGeneral.setLayout(new FormLayout(new ColumnSpec[] {
                 FormSpecs.RELATED_GAP_COLSPEC,

--- a/src/main/java/org/openpnp/machine/reference/camera/wizards/OpenCvCameraConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/camera/wizards/OpenCvCameraConfigurationWizard.java
@@ -19,7 +19,6 @@
 
 package org.openpnp.machine.reference.camera.wizards;
 
-import java.awt.Color;
 import java.awt.event.ActionEvent;
 import java.util.ArrayList;
 import java.util.List;
@@ -32,7 +31,6 @@ import javax.swing.JComboBox;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JTextField;
-import javax.swing.border.EtchedBorder;
 import javax.swing.border.TitledBorder;
 import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
@@ -70,7 +68,7 @@ public class OpenCvCameraConfigurationWizard extends AbstractConfigurationWizard
 
         panelGeneral = new JPanel();
         contentPanel.add(panelGeneral);
-        panelGeneral.setBorder(new TitledBorder(new EtchedBorder(EtchedBorder.LOWERED, null, null),
+        panelGeneral.setBorder(new TitledBorder(null,
                 "General", TitledBorder.LEADING, TitledBorder.TOP, null));
         panelGeneral.setLayout(new FormLayout(new ColumnSpec[] {
                 FormSpecs.RELATED_GAP_COLSPEC,

--- a/src/main/java/org/openpnp/machine/reference/camera/wizards/OpenPnpCaptureCameraConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/camera/wizards/OpenPnpCaptureCameraConfigurationWizard.java
@@ -19,12 +19,12 @@
 
 package org.openpnp.machine.reference.camera.wizards;
 
-import java.awt.Color;
 import java.awt.Cursor;
-import java.util.ArrayList;
-import java.util.List;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
 import java.util.Locale;
 
+import javax.swing.JButton;
 import javax.swing.JCheckBox;
 import javax.swing.JComboBox;
 import javax.swing.JLabel;
@@ -32,7 +32,6 @@ import javax.swing.JPanel;
 import javax.swing.JSlider;
 import javax.swing.JTextField;
 import javax.swing.SwingUtilities;
-import javax.swing.border.EtchedBorder;
 import javax.swing.border.TitledBorder;
 
 import org.jdesktop.beansbinding.AutoBinding.UpdateStrategy;
@@ -43,7 +42,6 @@ import org.openpnp.gui.components.ComponentDecorators;
 import org.openpnp.gui.support.AbstractConfigurationWizard;
 import org.openpnp.gui.support.DoubleConverter;
 import org.openpnp.gui.support.IntegerConverter;
-import org.openpnp.machine.reference.camera.OpenCvCamera.OpenCvCapturePropertyValue;
 import org.openpnp.machine.reference.camera.OpenPnpCaptureCamera;
 import org.openpnp.model.Configuration;
 import org.openpnp.util.UiUtils;
@@ -52,9 +50,6 @@ import com.jgoodies.forms.layout.ColumnSpec;
 import com.jgoodies.forms.layout.FormLayout;
 import com.jgoodies.forms.layout.FormSpecs;
 import com.jgoodies.forms.layout.RowSpec;
-import javax.swing.JButton;
-import java.awt.event.ActionListener;
-import java.awt.event.ActionEvent;
 
 @SuppressWarnings("serial")
 public class OpenPnpCaptureCameraConfigurationWizard extends AbstractConfigurationWizard {
@@ -233,7 +228,7 @@ public class OpenPnpCaptureCameraConfigurationWizard extends AbstractConfigurati
                                 });
 
         panelProperties = new JPanel();
-        panelProperties.setBorder(new TitledBorder(new EtchedBorder(EtchedBorder.LOWERED, null, null), "Properties", TitledBorder.LEADING, TitledBorder.TOP, null));
+        panelProperties.setBorder(new TitledBorder(null, "Properties", TitledBorder.LEADING, TitledBorder.TOP, null));
         contentPanel.add(panelProperties);
         panelProperties.setLayout(new FormLayout(new ColumnSpec[] {
                 FormSpecs.RELATED_GAP_COLSPEC,

--- a/src/main/java/org/openpnp/machine/reference/camera/wizards/SimulatedUpCameraConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/camera/wizards/SimulatedUpCameraConfigurationWizard.java
@@ -24,7 +24,6 @@ import javax.swing.JCheckBox;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JTextField;
-import javax.swing.border.EtchedBorder;
 import javax.swing.border.TitledBorder;
 
 import org.jdesktop.beansbinding.AutoBinding.UpdateStrategy;
@@ -79,7 +78,7 @@ public class SimulatedUpCameraConfigurationWizard extends AbstractConfigurationW
 
         panelGeneral = new JPanel();
         contentPanel.add(panelGeneral);
-        panelGeneral.setBorder(new TitledBorder(new EtchedBorder(EtchedBorder.LOWERED, null, null),
+        panelGeneral.setBorder(new TitledBorder(null,
                 "General", TitledBorder.LEADING, TitledBorder.TOP, null));
         panelGeneral.setLayout(new FormLayout(new ColumnSpec[] {
                 FormSpecs.RELATED_GAP_COLSPEC,

--- a/src/main/java/org/openpnp/machine/reference/camera/wizards/WebcamConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/camera/wizards/WebcamConfigurationWizard.java
@@ -19,13 +19,10 @@
 
 package org.openpnp.machine.reference.camera.wizards;
 
-import java.awt.Color;
-
 import javax.swing.JCheckBox;
 import javax.swing.JComboBox;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
-import javax.swing.border.EtchedBorder;
 import javax.swing.border.TitledBorder;
 
 import org.openpnp.gui.support.AbstractConfigurationWizard;
@@ -54,7 +51,7 @@ public class WebcamConfigurationWizard extends AbstractConfigurationWizard
 
         panelGeneral = new JPanel();
         contentPanel.add(panelGeneral);
-        panelGeneral.setBorder(new TitledBorder(new EtchedBorder(EtchedBorder.LOWERED, null, null),
+        panelGeneral.setBorder(new TitledBorder(null,
                 "General", TitledBorder.LEADING, TitledBorder.TOP, null));
         panelGeneral.setLayout(new FormLayout(
                 new ColumnSpec[] {FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,

--- a/src/main/java/org/openpnp/machine/reference/driver/wizards/GcodeDriverConsole.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/wizards/GcodeDriverConsole.java
@@ -1,6 +1,5 @@
 package org.openpnp.machine.reference.driver.wizards;
 
-import java.awt.Color;
 import java.awt.Font;
 import java.awt.event.ActionEvent;
 import java.awt.event.KeyAdapter;
@@ -16,7 +15,6 @@ import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.JTextArea;
 import javax.swing.JTextField;
-import javax.swing.border.EtchedBorder;
 import javax.swing.border.TitledBorder;
 
 import org.openpnp.gui.support.AbstractConfigurationWizard;
@@ -44,7 +42,7 @@ public class GcodeDriverConsole extends AbstractConfigurationWizard {
         historyCursor = 0;
 
         JPanel gcodeConsole = new JPanel();
-        gcodeConsole.setBorder(new TitledBorder(new EtchedBorder(EtchedBorder.LOWERED, null, null),
+        gcodeConsole.setBorder(new TitledBorder(null,
                 "Gcode console", TitledBorder.LEADING, TitledBorder.TOP, null));
         contentPanel.add(gcodeConsole);
 

--- a/src/main/java/org/openpnp/machine/reference/driver/wizards/GcodeDriverGcodes.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/wizards/GcodeDriverGcodes.java
@@ -1,6 +1,5 @@
 package org.openpnp.machine.reference.driver.wizards;
 
-import java.awt.Color;
 import java.awt.FileDialog;
 import java.awt.Toolkit;
 import java.awt.datatransfer.Clipboard;
@@ -26,7 +25,6 @@ import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.JTextArea;
-import javax.swing.border.EtchedBorder;
 import javax.swing.border.TitledBorder;
 import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
@@ -61,7 +59,7 @@ public class GcodeDriverGcodes extends AbstractConfigurationWizard {
         this.driver = driver;
 
         JPanel gcodePanel = new JPanel();
-        gcodePanel.setBorder(new TitledBorder(new EtchedBorder(EtchedBorder.LOWERED, null, null), "Gcode", TitledBorder.LEADING, TitledBorder.TOP, null));
+        gcodePanel.setBorder(new TitledBorder(null, "Gcode", TitledBorder.LEADING, TitledBorder.TOP, null));
         contentPanel.add(gcodePanel);
         gcodePanel.setLayout(new FormLayout(
                 new ColumnSpec[] {FormSpecs.RELATED_GAP_COLSPEC, ColumnSpec.decode("default:grow"),

--- a/src/main/java/org/openpnp/machine/reference/feeder/wizards/AbstractReferenceFeederConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/wizards/AbstractReferenceFeederConfigurationWizard.java
@@ -19,13 +19,10 @@
 
 package org.openpnp.machine.reference.feeder.wizards;
 
-import java.awt.Color;
-
 import javax.swing.JComboBox;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JTextField;
-import javax.swing.border.EtchedBorder;
 import javax.swing.border.TitledBorder;
 
 import org.jdesktop.beansbinding.AutoBinding.UpdateStrategy;
@@ -87,7 +84,7 @@ public abstract class AbstractReferenceFeederConfigurationWizard
 
         panelPart = new JPanel();
         panelPart.setBorder(
-                new TitledBorder(new EtchedBorder(EtchedBorder.LOWERED, null, null), "General Settings", TitledBorder.LEADING, TitledBorder.TOP, null));
+                new TitledBorder(null, "General Settings", TitledBorder.LEADING, TitledBorder.TOP, null));
         contentPanel.add(panelPart);
         panelPart.setLayout(new FormLayout(new ColumnSpec[] {
                 FormSpecs.RELATED_GAP_COLSPEC,
@@ -138,7 +135,7 @@ public abstract class AbstractReferenceFeederConfigurationWizard
         if (includePickLocation) {
             panelLocation = new JPanel();
             panelLocation.setBorder(new TitledBorder(
-                    new EtchedBorder(EtchedBorder.LOWERED, null, null), "Pick Location",
+                    null, "Pick Location",
                     TitledBorder.LEADING, TitledBorder.TOP, null));
             contentPanel.add(panelLocation);
             panelLocation

--- a/src/main/java/org/openpnp/machine/reference/feeder/wizards/ReferenceAutoFeederConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/wizards/ReferenceAutoFeederConfigurationWizard.java
@@ -63,7 +63,7 @@ public class ReferenceAutoFeederConfigurationWizard extends AbstractReferenceFee
         this.feeder = feeder;
 
         JPanel panelActuator = new JPanel();
-        panelActuator.setBorder(new TitledBorder(new EtchedBorder(EtchedBorder.LOWERED, null, null),
+        panelActuator.setBorder(new TitledBorder(null,
                 "Actuators", TitledBorder.LEADING, TitledBorder.TOP, null));
         contentPanel.add(panelActuator);
         panelActuator.setLayout(new FormLayout(new ColumnSpec[] {

--- a/src/main/java/org/openpnp/machine/reference/feeder/wizards/ReferenceDragFeederConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/wizards/ReferenceDragFeederConfigurationWizard.java
@@ -276,7 +276,7 @@ public class ReferenceDragFeederConfigurationWizard
                 new RowSpec[] {FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,}));
 
         panelTemplate = new JPanel();
-        panelTemplate.setBorder(new TitledBorder(new EtchedBorder(EtchedBorder.LOWERED, null, null),
+        panelTemplate.setBorder(new TitledBorder(null,
                 "Template Image", TitledBorder.LEADING, TitledBorder.TOP, null));
         panelVisionTemplateAndAoe.add(panelTemplate, "2, 2, center, fill");
         panelTemplate.setLayout(new BoxLayout(panelTemplate, BoxLayout.Y_AXIS));

--- a/src/main/java/org/openpnp/machine/reference/feeder/wizards/ReferenceHeapFeederConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/wizards/ReferenceHeapFeederConfigurationWizard.java
@@ -183,7 +183,7 @@ public class ReferenceHeapFeederConfigurationWizard
         whateverPanel.add(dropBoxCb, "4, 2, 2, 1");
         
         JPanel dropBoxPanel = new JPanel();
-        dropBoxPanel.setBorder(new TitledBorder(new EtchedBorder(EtchedBorder.LOWERED, null, null), "DropBox", TitledBorder.LEADING, TitledBorder.TOP, null, new Color(0, 0, 0)));
+        dropBoxPanel.setBorder(new TitledBorder(null, "DropBox", TitledBorder.LEADING, TitledBorder.TOP, null, new Color(0, 0, 0)));
         contentPanel.add(dropBoxPanel);
         FormLayout fl_dropBoxPanel = new FormLayout(new ColumnSpec[] {
                 FormSpecs.RELATED_GAP_COLSPEC,

--- a/src/main/java/org/openpnp/machine/reference/feeder/wizards/ReferenceLeverFeederConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/wizards/ReferenceLeverFeederConfigurationWizard.java
@@ -263,7 +263,7 @@ public class ReferenceLeverFeederConfigurationWizard
                 new RowSpec[] {FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,}));
 
         panelTemplate = new JPanel();
-        panelTemplate.setBorder(new TitledBorder(new EtchedBorder(EtchedBorder.LOWERED, null, null),
+        panelTemplate.setBorder(new TitledBorder(null,
                 "Template Image", TitledBorder.LEADING, TitledBorder.TOP, null));
         panelVisionTemplateAndAoe.add(panelTemplate, "2, 2, center, fill");
         panelTemplate.setLayout(new BoxLayout(panelTemplate, BoxLayout.Y_AXIS));

--- a/src/main/java/org/openpnp/machine/reference/feeder/wizards/ReferenceRotatedTrayFeederConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/wizards/ReferenceRotatedTrayFeederConfigurationWizard.java
@@ -113,7 +113,7 @@ public class ReferenceRotatedTrayFeederConfigurationWizard extends AbstractConfi
 		this.includePickLocation = includePickLocation;
 
 		panelPart = new JPanel();
-		panelPart.setBorder(new TitledBorder(new EtchedBorder(EtchedBorder.LOWERED, null, null), "General Settings",
+		panelPart.setBorder(new TitledBorder(null, "General Settings",
 				TitledBorder.LEADING, TitledBorder.TOP, null));
 		contentPanel.add(panelPart);
 		panelPart.setLayout(new FormLayout(new ColumnSpec[] {
@@ -173,7 +173,7 @@ public class ReferenceRotatedTrayFeederConfigurationWizard extends AbstractConfi
 
 		if (includePickLocation) {
 			panelLocation = new JPanel();
-			panelLocation.setBorder(new TitledBorder(new EtchedBorder(EtchedBorder.LOWERED, null, null),
+			panelLocation.setBorder(new TitledBorder(null,
 					"Tray Component Locations", TitledBorder.LEADING, TitledBorder.TOP, null));
 			contentPanel.add(panelLocation);
 			panelLocation.setLayout(new FormLayout(
@@ -241,7 +241,7 @@ public class ReferenceRotatedTrayFeederConfigurationWizard extends AbstractConfi
 			panelLocation.add(lastLocationButtonsPanel, "8, 8");
 
 			panelParameters = new JPanel();
-			panelParameters.setBorder(new TitledBorder(new EtchedBorder(EtchedBorder.LOWERED, null, null),
+			panelParameters.setBorder(new TitledBorder(null,
 					"Tray Parameters", TitledBorder.LEADING, TitledBorder.TOP, null));
 			contentPanel.add(panelParameters);
 
@@ -384,7 +384,7 @@ public class ReferenceRotatedTrayFeederConfigurationWizard extends AbstractConfi
 			textFieldTrayRotation.setColumns(10);
 
 			panelIllustration = new JPanel();
-			panelIllustration.setBorder(new TitledBorder(new EtchedBorder(EtchedBorder.LOWERED, null, null),
+			panelIllustration.setBorder(new TitledBorder(null,
 					"Tray Illustration", TitledBorder.LEADING, TitledBorder.TOP, null));
 			contentPanel.add(panelIllustration);
 

--- a/src/main/java/org/openpnp/machine/reference/feeder/wizards/ReferenceSlotAutoFeederConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/wizards/ReferenceSlotAutoFeederConfigurationWizard.java
@@ -171,7 +171,7 @@ public class ReferenceSlotAutoFeederConfigurationWizard
         whateverPanel.add(feederCb, "4, 2, 3, 1");
         
         JPanel feederPanel = new JPanel();
-        feederPanel.setBorder(new TitledBorder(new EtchedBorder(EtchedBorder.LOWERED, null, null), "Feeder", TitledBorder.LEADING, TitledBorder.TOP, null));
+        feederPanel.setBorder(new TitledBorder(null, "Feeder", TitledBorder.LEADING, TitledBorder.TOP, null));
         contentPanel.add(feederPanel);
         FormLayout fl_feederPanel = new FormLayout(new ColumnSpec[] {
                 FormSpecs.RELATED_GAP_COLSPEC,
@@ -239,7 +239,7 @@ public class ReferenceSlotAutoFeederConfigurationWizard
         feederPartCb.setRenderer(new IdentifiableListCellRenderer<Part>());
 
         JPanel panelActuator = new JPanel();
-        panelActuator.setBorder(new TitledBorder(new EtchedBorder(EtchedBorder.LOWERED, null, null),
+        panelActuator.setBorder(new TitledBorder(null,
                 "Actuators", TitledBorder.LEADING, TitledBorder.TOP, null));
         contentPanel.add(panelActuator);
         panelActuator.setLayout(new FormLayout(new ColumnSpec[] {

--- a/src/main/java/org/openpnp/machine/reference/feeder/wizards/ReferenceStripFeederConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/wizards/ReferenceStripFeederConfigurationWizard.java
@@ -142,7 +142,7 @@ public class ReferenceStripFeederConfigurationWizard extends AbstractConfigurati
         this.feeder = feeder;
 
         panelPart = new JPanel();
-        panelPart.setBorder(new TitledBorder(new EtchedBorder(EtchedBorder.LOWERED, null, null),
+        panelPart.setBorder(new TitledBorder(null,
                 "General Settings", TitledBorder.LEADING, TitledBorder.TOP, null));
         contentPanel.add(panelPart);
         panelPart.setLayout(new FormLayout(new ColumnSpec[] {
@@ -211,7 +211,7 @@ public class ReferenceStripFeederConfigurationWizard extends AbstractConfigurati
         panelTapeSettings = new JPanel();
         contentPanel.add(panelTapeSettings);
         panelTapeSettings.setBorder(new TitledBorder(
-                new EtchedBorder(EtchedBorder.LOWERED, null, null), "Tape Settings",
+                null, "Tape Settings",
                 TitledBorder.LEADING, TitledBorder.TOP, null));
         panelTapeSettings.setLayout(new FormLayout(
                 new ColumnSpec[] {FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,

--- a/src/main/java/org/openpnp/machine/reference/feeder/wizards/SchultzFeederConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/wizards/SchultzFeederConfigurationWizard.java
@@ -93,7 +93,7 @@ public class SchultzFeederConfigurationWizard extends AbstractReferenceFeederCon
         this.feeder = feeder;
 
         JPanel panelActuator = new JPanel();
-        panelActuator.setBorder(new TitledBorder(new EtchedBorder(EtchedBorder.LOWERED, null, null),
+        panelActuator.setBorder(new TitledBorder(null,
                 "Actuators", TitledBorder.LEADING, TitledBorder.TOP, null));
         contentPanel.add(panelActuator);
         panelActuator.setLayout(new FormLayout(new ColumnSpec[] {

--- a/src/main/java/org/openpnp/machine/reference/feeder/wizards/SlotSchultzFeederConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/wizards/SlotSchultzFeederConfigurationWizard.java
@@ -215,7 +215,7 @@ extends AbstractConfigurationWizard {
         whateverPanel.add(feederCb, "4, 2, 3, 1");
 
         JPanel feederPanel = new JPanel();
-        feederPanel.setBorder(new TitledBorder(new EtchedBorder(EtchedBorder.LOWERED, null, null), "Feeder", TitledBorder.LEADING, TitledBorder.TOP, null));
+        feederPanel.setBorder(new TitledBorder(null, "Feeder", TitledBorder.LEADING, TitledBorder.TOP, null));
         contentPanel.add(feederPanel);
         FormLayout fl_feederPanel = new FormLayout(new ColumnSpec[] {
                 FormSpecs.RELATED_GAP_COLSPEC,
@@ -284,7 +284,7 @@ extends AbstractConfigurationWizard {
         feederPartCb.setRenderer(new IdentifiableListCellRenderer<Part>());
 
         JPanel panelActuator = new JPanel();
-        panelActuator.setBorder(new TitledBorder(new EtchedBorder(EtchedBorder.LOWERED, null, null),
+        panelActuator.setBorder(new TitledBorder(null,
                 "Actuators", TitledBorder.LEADING, TitledBorder.TOP, null));
         contentPanel.add(panelActuator);
         panelActuator.setLayout(new FormLayout(new ColumnSpec[] {


### PR DESCRIPTION
# Description
Simply removes all the inconsistent and old-style-looking `EdgedBorder.LOWERED` panel borders. 

# Justification
Looks ugly:

![inconsisten edges](https://user-images.githubusercontent.com/9963310/132953967-db8b4722-cce4-4d4d-947b-9d1d734ec597.png)

# Instructions for Use
No change.

# Implementation Details
1. Clicked around in OpenPnP.
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. Successful `mvn test` before submitting the Pull Request.
