### PR TITLE
Feature/Automatic Machine Calibration using Issues & Solutions - Round 7

### DIFF
--- a/src/main/java/org/openpnp/gui/IssuesAndSolutionsPanel.java
+++ b/src/main/java/org/openpnp/gui/IssuesAndSolutionsPanel.java
@@ -355,6 +355,10 @@ public class IssuesAndSolutionsPanel extends JPanel {
     }
 
     public void updateIssueIndicator() {
+        if (!machine.getSolutions().isShowIndicator()) {
+            // See Issue https://github.com/openpnp/openpnp/issues/1199. 
+            return;
+        }
         Solutions.Severity maxSeverity = Solutions.Severity.None;
         for (Solutions.Issue issue : machine.getSolutions().getIssues()) {
             if (issue.getSeverity().ordinal() >= maxSeverity.ordinal() 
@@ -363,22 +367,18 @@ public class IssuesAndSolutionsPanel extends JPanel {
             }
         }
         JTabbedPane tabs = frame.getTabs();
-        // Note this strange way to find the right tab is due to some inexplicable instability with 
-        // tabs.indexOfComponent(). See https://github.com/openpnp/openpnp/issues/1199
-        for (int index = 0; index < tabs.getTabCount(); index++) {
-            if (tabs.getTitleAt(index).contains("Issues")) {
-                if (maxSeverity.ordinal() > Solutions.Severity.Information.ordinal()) {
-                    int indicatorUnicode = 0x2B24;
-                    Color color = maxSeverity.color;
-                    color = saturate(color);
-                    tabs.setTitleAt(index, "<html>Issues &amp; Solutions <span style=\"color:#"
-                            +String.format("%02x%02x%02x", color.getRed(), color.getGreen(), color.getBlue())
-                            +";\">&#"+(indicatorUnicode)+";</span></html>");
-                }
-                else {
-                    tabs.setTitleAt(index, "Issues & Solutions");
-                }
-                break;
+        int index = tabs.indexOfComponent(frame.getIssuesAndSolutionsTab());
+        if (index >= 0) {
+            if (maxSeverity.ordinal() > Solutions.Severity.Information.ordinal()) {
+                int indicatorUnicode = 0x2B24;
+                Color color = maxSeverity.color;
+                color = saturate(color);
+                tabs.setTitleAt(index, "<html>Issues &amp; Solutions <span style=\"color:#"
+                        +String.format("%02x%02x%02x", color.getRed(), color.getGreen(), color.getBlue())
+                        +";\">&#"+(indicatorUnicode)+";</span></html>");
+            }
+            else {
+                tabs.setTitleAt(index, "Issues & Solutions");
             }
         }
     }

--- a/src/main/java/org/openpnp/machine/reference/solutions/CalibrationSolutions.java
+++ b/src/main/java/org/openpnp/machine/reference/solutions/CalibrationSolutions.java
@@ -207,9 +207,11 @@ public class CalibrationSolutions implements Solutions.Subject {
                                         + "linkages of machine axes. More information can be found in the Wiki (press the blue Info button below).</p><br/>"
                                         + "<p>Set the acceptable <strong>Tolerance ±</strong> as high as possible to allow for a more efficient backlash "
                                         + "compensation method, avoiding extra moves and direction changes.</p><br/>"
-                                        + "<p><span color=\"red\">CAUTION</span>: The camera "+camera.getName()+" will move over the fiducial "
-                                        + "and then perform a calibration motion pattern, moving the axis "
-                                        + axis.getName()+" on its full soft-limit range.</p><br/>"
+                                        + "<p><span color=\"red\">CAUTION 1</span>: The camera "+camera.getName()+" will move over the primary fiducial "
+                                        + "and then perform a calibration motion pattern, moving the axis "+axis.getName()+" over its full soft-limit range.</p><br/>"
+                                        + "<p><span color=\"red\">CAUTION 2</span>: The machine will also perform a visual homing cycle, once the new backlash "
+                                        + "compensation method is established. This is done to recalibrate the coordinate system that might be affected by the "
+                                        + "new method.</p><br/>"
                                         + "<p>When ready, press Accept.</p>"
                                         + (getState() == State.Solved ? 
                                                 "<br/><h4>Results:</h4>"
@@ -222,7 +224,7 @@ public class CalibrationSolutions implements Solutions.Subject {
                                                 + "<td>"+axis.getSneakUpOffset()+"</td></tr>"
                                                 + "<tr><td align=\"right\">Speed Factor:</td>"
                                                 + "<td>"+axis.getBacklashSpeedFactor()+"</td></tr>"
-                                                + "<tr><td align=\"right\">Applicable Tolerance:</td>"
+                                                + "<tr><td align=\"right\">Applicable Resolution:</td>"
                                                 + "<td>"+String.format("%.4f", getAxisCalibrationTolerance(camera, axis, true))+" mm</td></tr>"
                                                 + "</table>" 
                                                 : "")
@@ -752,6 +754,8 @@ public class CalibrationSolutions implements Solutions.Subject {
                     + "Make sure OpenPnP has effective acceleration/jerk control. "
                     + "Automatic compensation not possible.");
         }
+        // Because this change may affect the coordinate system, perform a (visual) homing cycle.
+        head.visualHome(machine, true);
         // Test the new settings with random moves.
         referenceLocation = machine.getVisionSolutions()
                 .centerInOnSubjectLocation(camera, movable,
@@ -785,7 +789,7 @@ public class CalibrationSolutions implements Solutions.Subject {
             ReferenceControllerAxis axis, boolean tolerance) {
         // Get the axis resolution (it might still be at the default 0.0001).
         Length resolution = new Length(axis.getResolution(), axis.getDriver().getUnits());
-        // Make sure it's >= 0.01mm
+        // Take a multiple of the native resolution that is >= 0.01mm
         Length finestResolution = new Length(0.01, LengthUnit.Millimeters);
         resolution = resolution.multiply(Math.ceil(finestResolution.divide(resolution)));
         // Get the sub-pixel resolution of the detection capability. 

--- a/src/main/java/org/openpnp/machine/reference/solutions/VisionSolutions.java
+++ b/src/main/java/org/openpnp/machine/reference/solutions/VisionSolutions.java
@@ -771,6 +771,7 @@ public class VisionSolutions implements Solutions.Subject {
                                                 // to keep them so i.e. these rough nozzle-aimed offsets are likely worse. 
                                                 Logger.info("Not setting nozzle "+nozzle.getName()+" head offsets to rough "+headOffsets+" as these are close to "
                                                         + "existing offsets "+headOffsetsBefore+" and existing offsets might already have been calibrated.");
+                                                nozzle.setHeadOffsets(headOffsetsBefore);
                                             }
                                             else {
                                                 nozzle.setHeadOffsets(headOffsets);

--- a/src/main/java/org/openpnp/machine/reference/solutions/VisionSolutions.java
+++ b/src/main/java/org/openpnp/machine/reference/solutions/VisionSolutions.java
@@ -123,6 +123,9 @@ public class VisionSolutions implements Solutions.Subject {
     private double zeroKnowledgeDisplacementMm = 1;
     /**
      * How to perform one-sided backlash compensation, before we know anything about the machine. 
+     * Note, due to this having evolved, these are no longer backlash offsets in the classic sense, instead they 
+     * give a "final approach vector". Hence the negative sign, to be as compatible as possible with backlash 
+     * compensation (more specifically with sneak-up offsets), once these are calibrated in turn.
      */
     @Element(required = false)
     private Location zeroKnowledgeBacklashOffsets = new Location(LengthUnit.Millimeters, -1, -1, 0.0, -5);
@@ -1334,7 +1337,7 @@ public class VisionSolutions implements Solutions.Subject {
      * @throws Exception
      */
     public void zeroKnowledgeMoveTo(HeadMountable hm, Location location, boolean safeZ) throws Exception {
-        Location backlashCompensatedLocation = location.add(zeroKnowledgeBacklashOffsets);
+        Location backlashCompensatedLocation = location.subtract(zeroKnowledgeBacklashOffsets);
         if (safeZ) {
             MovableUtils.moveToLocationAtSafeZ(hm, backlashCompensatedLocation);
         }
@@ -1371,9 +1374,10 @@ public class VisionSolutions implements Solutions.Subject {
      * 
      * @param head
      * @param defaultCamera
+     * @param fiducialDiameter
      * @throws Exception
      */
-    public void calibrateVisualHoming(ReferenceHead head, Camera defaultCamera, Length fiducialDiameter) throws Exception {
+    public void calibrateVisualHoming(ReferenceHead head, ReferenceCamera defaultCamera, Length fiducialDiameter) throws Exception {
         // Make sure we got the homing fiducial set up properly.
         setHomingFiducialDiameter(fiducialDiameter);
         // Set rough location as homing fiducial location.
@@ -1381,9 +1385,10 @@ public class VisionSolutions implements Solutions.Subject {
         head.setHomingFiducialLocation(homingFiducialLocation);
         head.setVisualHomingMethod(VisualHomingMethod.ResetToFiducialLocation);
         // Perform homing to it, but don't reset machine position. 
-        head.visualHome(machine, false);
+        // Note, we do not use the "official" head.visualHome(machine, false), as this is not yet a good thing to do with no backlash calibration.
+        // Instead we use our own method with "built-in" worst case backlash compensation. 
+        homingFiducialLocation = centerInOnSubjectLocation(defaultCamera, defaultCamera, fiducialDiameter, "Visual Homing", false);
         // With the precise location, set the homing fiducial again.
-        homingFiducialLocation = defaultCamera.getLocation();
         head.setHomingFiducialLocation(homingFiducialLocation);
     }
 

--- a/src/main/java/org/openpnp/model/Solutions.java
+++ b/src/main/java/org/openpnp/model/Solutions.java
@@ -64,6 +64,9 @@ public class Solutions extends AbstractTableModel {
     @ElementList(required = false)
     private Set<String> solvedSolutions = new HashSet<>();
 
+    @Attribute(required = false)
+    private boolean showIndicator = true;
+
     private boolean showSolved;
 
     private boolean showDismissed;
@@ -185,6 +188,14 @@ public class Solutions extends AbstractTableModel {
         Object oldValue = this.targetMilestone;
         this.targetMilestone = targetMilestone;
         propertyChangeSupport.firePropertyChange("targetMilestone", oldValue, targetMilestone);
+    }
+
+    public boolean isShowIndicator() {
+        return showIndicator;
+    }
+
+    public void setShowIndicator(boolean showIndicator) {
+        this.showIndicator = showIndicator;
     }
 
     public boolean isShowSolved() {


### PR DESCRIPTION
# Description

Another round of bug-fixes and improvements in the Automatic Machine Calibration using Issues & Solutions: 

* Make sure visual homing and backlash calibration are in no chicken and egg relation: The standard fiducial locator is (for once) replaced by the calibration locator, which has built-in worst case backlash calibration. 
* Reverse the sign of the built-in worst case backlash calibration to better correspond to what is later automatically calibrated.
* Perform a fresh visual homing after the backlash calibration, as the coordinate system might (still) slightly change. 
* Fix a nozzle head offsets calibration bug, that reset X, Y to zero, when only a small change in the offsets was detected. 
* Allow switching off the Issues & Solutions tab indicator through the `machine.xml` (there seems to be no working solution for #1199).
* Only lament missing vacuum sensing config in Issues&Solutions when one or more nozzle tips are actually configured for sensing.

# Justification
See discussion since this point:
https://groups.google.com/g/openpnp/c/dBg7txMB0R0/m/7m9mLTchAQAJ

**Thanks to all testers for the feedback!** 👍👍👍

# Instructions for Use
Mostly as before.

For the Issues & Solutions tab indicator issue, see how to "fix" in #1199.

# Implementation Details
1. Tested in simulation, ongoing testing also on the machine.
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. Successful `mvn test` before submitting the Pull Request. 
