### PR TITLE
Fix/Automatic Machine Calibration using Issues & Solutions - Round 7

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/solutions/CalibrationSolutions.java
+++ b/src/main/java/org/openpnp/machine/reference/solutions/CalibrationSolutions.java
@@ -756,6 +756,8 @@ public class CalibrationSolutions implements Solutions.Subject {
         }
         // Because this change may affect the coordinate system, perform a (visual) homing cycle.
         head.visualHome(machine, true);
+        // Go back to the fiducial.
+        MovableUtils.moveToLocationAtSafeZ(camera, location);
         // Test the new settings with random moves.
         referenceLocation = machine.getVisionSolutions()
                 .centerInOnSubjectLocation(camera, movable,

--- a/src/main/java/org/openpnp/machine/reference/solutions/CalibrationSolutions.java
+++ b/src/main/java/org/openpnp/machine/reference/solutions/CalibrationSolutions.java
@@ -757,7 +757,7 @@ public class CalibrationSolutions implements Solutions.Subject {
         // Because this change may affect the coordinate system, perform a (visual) homing cycle.
         head.visualHome(machine, true);
         // Go back to the fiducial.
-        MovableUtils.moveToLocationAtSafeZ(camera, location);
+        MovableUtils.moveToLocationAtSafeZ(movable, location);
         // Test the new settings with random moves.
         referenceLocation = machine.getVisionSolutions()
                 .centerInOnSubjectLocation(camera, movable,


### PR DESCRIPTION
# Description
This is a quick fix for #1291.

Fix the automatic backlash calibration: After visual homing, a move back to the primary fiducial is needed.

# Justification
See
https://groups.google.com/g/openpnp/c/dBg7txMB0R0/m/p4_oL0CYCAAJ

# Instructions for Use
No change.

# Implementation Details
1. Tested in simulation, this time with a homing fiducial at a different location than the primary calibration fiducial.
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. Successful `mvn test` before submitting the Pull Request. 
