### PR TITLE
Feature/SimpleGraph Persistence

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/axis/ReferenceControllerAxis.java
+++ b/src/main/java/org/openpnp/machine/reference/axis/ReferenceControllerAxis.java
@@ -171,8 +171,11 @@ public class ReferenceControllerAxis extends AbstractControllerAxis {
     @Element(required = false)
     private double resolution = 0.0001; // 
 
+    @Element(required = false)
     private SimpleGraph stepTestGraph;
+    @Element(required = false)
     private SimpleGraph backlashDistanceTestGraph;
+    @Element(required = false)
     private SimpleGraph backlashSpeedTestGraph;
 
     public double getResolution() {


### PR DESCRIPTION
# Description
The `SimpleGraph` was made persistable, i.e. graphs can be saved in the `machine.xml` and they will not be lost, when exiting OpenPnP. 

Used on the `ReferenceControllerAxis`, where the Backlash Calibration graphs contain permanently useful info about the axis. 

![Graphs](https://user-images.githubusercontent.com/9963310/133930251-d8c07043-4cf0-4a88-b744-531bee459559.png)

# Justification
Users reported the loss of the graphs as an error, they thought the underlying calibration was lost too. 

See discussion here:
https://groups.google.com/g/openpnp/c/dBg7txMB0R0/m/7yhfwuCQAgAJ

# Instructions for Use
It just works.

# Implementation Details
1. Tested in simulation.
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. Successful `mvn test` before submitting the Pull Request. 
