### PR TITLE
Feature / Automatic Machine Calibration using Issues & Solutions - Round 8

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/ContactProbeNozzle.java
+++ b/src/main/java/org/openpnp/machine/reference/ContactProbeNozzle.java
@@ -29,6 +29,7 @@ import java.util.Map;
 import org.openpnp.gui.support.PropertySheetWizardAdapter;
 import org.openpnp.machine.reference.ReferenceNozzleTip.VacuumMeasurementMethod;
 import org.openpnp.machine.reference.ReferenceNozzleTip.ZCalibrationTrigger;
+import org.openpnp.machine.reference.axis.ReferenceControllerAxis;
 import org.openpnp.machine.reference.driver.GcodeAsyncDriver;
 import org.openpnp.machine.reference.driver.GcodeDriver;
 import org.openpnp.machine.reference.solutions.GcodeDriverSolutions;
@@ -63,6 +64,7 @@ import org.simpleframework.xml.Attribute;
 import org.simpleframework.xml.Element;
 import org.simpleframework.xml.ElementMap;
 import org.simpleframework.xml.Serializer;
+import org.simpleframework.xml.core.Persist;
 
 public class ContactProbeNozzle extends ReferenceNozzle {
 
@@ -76,7 +78,7 @@ public class ContactProbeNozzle extends ReferenceNozzle {
 
     @Element(required = false)
     private String contactProbeActuatorName = "";
-    private boolean isDisabled;
+    private boolean isDisabled; // for scripts: temporarily disable probing 
 
     @Element(required = false)
     private Length contactProbeStartOffsetZ = new Length(1, LengthUnit.Millimeters);
@@ -86,6 +88,9 @@ public class ContactProbeNozzle extends ReferenceNozzle {
 
     @Element(required = false)
     private Length sniffleIncrementZ = new Length(0.1, LengthUnit.Millimeters); 
+
+    @Attribute(required=false)
+    private double contactProbeSpeed = 0.05;
 
     @Attribute(required=false)
     private long sniffleDwellTime = 250;
@@ -137,6 +142,8 @@ public class ContactProbeNozzle extends ReferenceNozzle {
     private HashMap<String, Length> probedPartHeightOffsets = new HashMap<>();
 
     private ReferenceNozzleTip zCalibratedNozzleTip;
+
+    private Actuator contactProbeActuator;
 
     @Override
     public PropertySheet[] getPropertySheets() {
@@ -222,6 +229,11 @@ public class ContactProbeNozzle extends ReferenceNozzle {
 
     @Override
     public void moveToPickLocation(Feeder feeder) throws Exception {
+        if (getFeederHeightProbing() == ContactProbeTrigger.Off) {
+            super.moveToPickLocation(feeder);
+            return;
+        }
+
         Part part = feeder.getPart();
         Location pickLocation = feeder.getPickLocation();
         Location pickLocationPart = pickLocation;
@@ -288,6 +300,11 @@ public class ContactProbeNozzle extends ReferenceNozzle {
 
     @Override
     public void moveToPlacementLocation(Location placementLocation, Part part) throws Exception {
+        if (getPartHeightProbing() == ContactProbeTrigger.Off) {
+            super.moveToPlacementLocation(placementLocation, part);
+            return;
+        }
+
         // Calculate the probe starting location.
         Length partHeight = ((part == null && nozzleTip != null) ? 
                 nozzleTip.getMaxPartHeight() // for discard 
@@ -354,28 +371,41 @@ public class ContactProbeNozzle extends ReferenceNozzle {
         }
     }
 
-    protected Actuator getContactProbeActuator() throws Exception {
-        Actuator actuator = getHead().getActuatorByName(contactProbeActuatorName);
-        if (actuator == null) {
-            throw new Exception(String.format("Can't find contact probe actuator %s", contactProbeActuatorName));
+    @Persist
+    private void persist() {
+        // Make sure the latest actuator name is persisted.
+        try {
+            setContactProbeActuator(getContactProbeActuator());
         }
-        return actuator;
+        catch (Exception e) {
+        }
+    }
+
+    /**
+     * Set the actuator used to contact probe with the Nozzle.
+     * @param actuator
+     */
+    public void setContactProbeActuator(Actuator actuator) {
+        contactProbeActuator = actuator;
+        contactProbeActuatorName = (actuator != null ? actuator.getName() : null);
+    }
+
+    /**
+     * @return The actuator used to contact probe with the Nozzle. 
+     * @throws Exception when the actuator name cannot be resolved (dangling reference).
+     */
+    public Actuator getContactProbeActuator() throws Exception {
+        if (contactProbeActuator == null && contactProbeActuatorName != null && !contactProbeActuatorName.isEmpty()) {
+            contactProbeActuator = getHead().getActuatorByName(contactProbeActuatorName);
+            if (contactProbeActuator == null) {
+                throw new Exception(String.format("Can't find contact probe actuator %s", contactProbeActuatorName));
+            }
+        }
+        return contactProbeActuator;
     }
 
     public void disableContactProbeActuator(boolean set) {
         isDisabled = set;
-    }
-
-    public String getContactProbeActuatorName() {
-        return contactProbeActuatorName;
-    }
-
-    public void setContactProbeActuatorName(String contactProbeActuatorName) {
-        String oldValue = this.contactProbeActuatorName;
-        this.contactProbeActuatorName = contactProbeActuatorName;
-        if (oldValue != contactProbeActuatorName) {
-            firePropertyChange("contactProbeActuatorName", oldValue, contactProbeActuatorName);
-        }
     }
 
     public Length getContactProbeStartOffsetZ() {
@@ -392,6 +422,14 @@ public class ContactProbeNozzle extends ReferenceNozzle {
 
     public void setContactProbeDepthZ(Length contactProbeDepthZ) {
         this.contactProbeDepthZ = contactProbeDepthZ;
+    }
+
+    public double getContactProbeSpeed() {
+        return contactProbeSpeed;
+    }
+
+    public void setContactProbeSpeed(double contactProbeSpeed) {
+        this.contactProbeSpeed = contactProbeSpeed;
     }
 
     public Length getSniffleIncrementZ() {
@@ -655,8 +693,11 @@ public class ContactProbeNozzle extends ReferenceNozzle {
         if (nt == null) {
             throw new Exception("Nozzle " + getName() + " has no nozzle tip loaded.");
         }
-        resetZCalibration();
         Location nominalLocation = nt.getTouchLocation();
+        if (!nominalLocation.isInitialized()) {
+            throw new Exception("Nozzle tip " + nt.getName() + " has no touch location configured.");
+        }
+        resetZCalibration();
         Location probedLocation = contactProbeCycle(nominalLocation);
         Length offsetZ = nominalLocation.getLengthZ().subtract(probedLocation.getLengthZ());
         Logger.debug("Nozzle "+getName()+" nozzle tip "+nt.getName()+" Z calibration offset "+offsetZ);
@@ -765,9 +806,18 @@ public class ContactProbeNozzle extends ReferenceNozzle {
 
     public void findIssues(Solutions solutions) {
         super.findIssues(solutions);
-        if (solutions.isTargeting(Milestone.Advanced)) {
-            try {
-                if (getContactProbeActuator() instanceof AbstractActuator) {
+        try {
+            if (solutions.isTargeting(Milestone.Basics)) {
+                if (getContactProbeMethod() == ContactProbeMethod.ContactSenseActuator
+                    && getContactProbeActuator() == null) {
+                    solutions.add(new Solutions.PlainIssue(
+                            this, 
+                            "ContactProbeNozzle "+getName()+" has no contact probing actuator.", 
+                            "Create a contact probing actuator and assign it to the nozzle "+getName()+".", 
+                            Severity.Error,
+                            "https://github.com/openpnp/openpnp/wiki/Contact-Probing-Nozzle#contact-sense-method"));
+                }
+                else if (getContactProbeActuator() instanceof AbstractActuator) {
                     AbstractActuator contactProbeActuator = (AbstractActuator) getContactProbeActuator();
                     if (!contactProbeActuator.isCoordinatedAfterActuate()) {
                         solutions.add(new Solutions.Issue(
@@ -784,8 +834,8 @@ public class ContactProbeNozzle extends ReferenceNozzle {
                             }
                         });
                     }
-                    if (getAxisZ() instanceof ControllerAxis) {
-                        Driver driver = ((ControllerAxis) getAxisZ()).getDriver();
+                    if (getCoordinateAxisZ() instanceof ControllerAxis) {
+                        Driver driver = ((ControllerAxis) getCoordinateAxisZ()).getDriver();
                         Driver oldDriver = contactProbeActuator.getDriver();
                         if (driver != null && driver != oldDriver) {
                             solutions.add(new Solutions.Issue(
@@ -825,23 +875,57 @@ public class ContactProbeNozzle extends ReferenceNozzle {
                             solutions.add(new Solutions.PlainIssue(
                                     this, 
                                     "Z driver "+driver.getName()+" must support Location Confirmation for the Z probe actuator to work.", 
-                                    "Only the GcodeAsyncDriver currently supports it.", 
+                                    "Only the GcodeAsyncDriver currently supports it. Advanced milestone required.", 
                                     Severity.Error,
                                     "https://github.com/openpnp/openpnp/wiki/GcodeAsyncDriver#advanced-settings"));
                         }
                     }
                     if (contactProbeActuator.getDriver() instanceof GcodeDriver) {
                         GcodeDriver gcodeDriver = (GcodeDriver) contactProbeActuator.getDriver();
-                        String suggestedCommand = null; 
+                        String suggestedCommand = null;
+                        String letter = "Z";
+                        boolean negatedAxis = false;
+                        double relativeProbe = -42;
+                        double absoluteProbe = -42;
+                        double feedRate = 800;
+                        if (getCoordinateAxisZ() instanceof ReferenceControllerAxis) {
+                            ReferenceControllerAxis axis = (ReferenceControllerAxis) getCoordinateAxisZ();
+                            if (!axis.getLetter().isEmpty()) {
+                                letter = axis.getLetter();
+                            }
+                            if (axis.isSoftLimitLowEnabled()) {
+                                Length overshoot = contactProbeDepthZ.subtract(contactProbeStartOffsetZ);
+                                if (axis.isSoftLimitHighEnabled()) {
+                                    negatedAxis = (0 < rawToHeadMountableZ(axis, axis.getSoftLimitLow()).compareTo(
+                                            rawToHeadMountableZ(axis, axis.getSoftLimitHigh())));
+                                    relativeProbe = axis.getSoftLimitLow().subtract(axis.getSoftLimitHigh())
+                                            .subtract(overshoot).convertToUnits(axis.getUnits()).getValue();
+                                }
+                                if (negatedAxis) {
+                                    relativeProbe = -relativeProbe;
+                                    absoluteProbe = axis.getSoftLimitHigh()
+                                            .add(overshoot).convertToUnits(axis.getUnits()).getValue();
+                                }
+                                else {
+                                    absoluteProbe = axis.getSoftLimitLow()
+                                            .subtract(overshoot).convertToUnits(axis.getUnits()).getValue();
+                                }
+                            }
+                            if (axis.getMotionLimit(1) > 0) {
+                                feedRate = Math.ceil(axis.getMotionLimit(1)*contactProbeSpeed)*60;
+                            }
+                        }
+
                         if (gcodeDriver.getFirmwareProperty("FIRMWARE_NAME", "").contains("Smoothieware")) {
                             suggestedCommand = 
-                                    "{True:G38.2 Z-42 F800 ; probe down max. range for contact with picked/placed part }\n" + 
-                                            "{True:M400            ; wait until machine has stopped }";
+                                    "{True:G38.2 "+letter+relativeProbe+" F"+feedRate+" ; probe down in relative coordinates until limit switch is hit}\n"
+                                            + "{True:M400            ; wait until machine has stopped}";
                         }
-                        else if (gcodeDriver.getFirmwareProperty("FIRMWARE_NAME", "").contains("TinyG")) {
+                        else if (gcodeDriver.getFirmwareProperty("FIRMWARE_NAME", "").contains("TinyG")
+                                || gcodeDriver.getFirmwareProperty("FIRMWARE_NAME", "").contains("GcodeServer")) {
                             suggestedCommand = 
-                                    "{True:G38.2 Z-42 F800 ; probe down in absolute coordinates until zmin switch is hit}\n" + 
-                                            "{True:M400            ; wait for motion to stop}";
+                                    "{True:G38.2 "+letter+absoluteProbe+" F"+feedRate+" ; probe down in absolute coordinates until limit switch is hit}\n" 
+                                            + "{True:M400            ; wait until machine has stopped}";
                         }
                         if (suggestedCommand != null) {
                             GcodeDriverSolutions.suggestGcodeCommand(gcodeDriver, contactProbeActuator, solutions, 
@@ -852,7 +936,8 @@ public class ContactProbeNozzle extends ReferenceNozzle {
                             if (currentCommand == null || currentCommand.isEmpty()) {
                                 solutions.add(new Solutions.PlainIssue(
                                         this, 
-                                        "Missing ACTUATE_BOOLEAN_COMMAND for actuator "+contactProbeActuator.getName()+" on driver "+gcodeDriver.getName()+" (no suggestion available for detected firmware).", 
+                                        "Missing ACTUATE_BOOLEAN_COMMAND for actuator "+contactProbeActuator.getName()+" on driver "+gcodeDriver.getName()
+                                        +" (no suggestion available for detected firmware).", 
                                         "Please add the command manually.",
                                         Severity.Error,
                                         "https://github.com/openpnp/openpnp/wiki/Contact-Probing-Nozzle#setting-up-the-g-code"));
@@ -861,9 +946,9 @@ public class ContactProbeNozzle extends ReferenceNozzle {
                     }
                 }
             }
-            catch (Exception e) {
-                // Ignore a stale Actuator name here.
-            }
+        }
+        catch (Exception e) {
+            // Ignore a stale Actuator name here.
         }
     }
 
@@ -899,13 +984,20 @@ public class ContactProbeNozzle extends ReferenceNozzle {
                         nozzle, 
                         "Converting the ContactProbeNozzle back to a plain ReferenceNozzle may simplify the machine setup.", 
                         "Replace with ReferenceNozzle.", 
-                        Severity.Suggestion,
+                        Severity.Information,
                         "https://github.com/openpnp/openpnp/wiki/Contact-Probing-Nozzle") {
 
                     @Override
                     public boolean isUnhandled( ) {
                         // Never handle a conservative solution as unhandled.
                         return false;
+                    }
+
+                    @Override 
+                    public String getExtendedDescription() {
+                        return "<html><span color=\"red\">CAUTION:</span> This is a troubleshooting option offered to remove the ContactProbeNozzle "
+                                + "if it causes problems, or if you don't want it after all. Going back to the plain ReferenceNozzle will lose you all the "
+                                + "configuration for contact and Z probing and calibration.</html>";
                     }
 
                     @Override
@@ -948,6 +1040,7 @@ public class ContactProbeNozzle extends ReferenceNozzle {
         ContactProbeNozzle contactProbeNozzle = serIn.read(ContactProbeNozzle.class, sr);
         contactProbeNozzle.applyConfiguration(Configuration.get());
         contactProbeNozzle.setHead(nozzle.getHead());
+        contactProbeNozzle.setNozzleTip(nozzle.nozzleTip);
         return contactProbeNozzle;
     }
 
@@ -976,6 +1069,7 @@ public class ContactProbeNozzle extends ReferenceNozzle {
         ReferenceNozzle referenceNozzle = serIn.read(ReferenceNozzle.class, sr);
         referenceNozzle.applyConfiguration(Configuration.get());
         referenceNozzle.setHead(nozzle.getHead());
+        referenceNozzle.setNozzleTip(nozzle.nozzleTip);
         return referenceNozzle;
     }
 

--- a/src/main/java/org/openpnp/machine/reference/ReferenceMachine.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceMachine.java
@@ -553,7 +553,7 @@ public class ReferenceMachine extends AbstractMachine {
                         this, 
                         "Advanced motion planner set. Revert to a simpler, safer planner.", 
                         "Change to NullMotionPlanner", 
-                        Solutions.Severity.Suggestion,
+                        Solutions.Severity.Information,
                         "https://github.com/openpnp/openpnp/wiki/Motion-Planner#choosing-a-motion-planner") {
                     final MotionPlanner oldMotionPlanner =  ReferenceMachine.this.getMotionPlanner();
 
@@ -561,6 +561,13 @@ public class ReferenceMachine extends AbstractMachine {
                     public boolean isUnhandled( ) {
                         // Never handle a conservative solution as unhandled.
                         return false;
+                    }
+
+                    @Override 
+                    public String getExtendedDescription() {
+                        return "<html><span color=\"red\">CAUTION:</span> This is a troubleshooting option, offered to remove the ReferenceAdvancedMotionPlanner "
+                                + "if it causes problems, or if you don't want it after all. Going back to the plain NullPlanner will lose you all the "
+                                + "advanced configuration.</html>";
                     }
 
                     @Override

--- a/src/main/java/org/openpnp/machine/reference/ReferenceNozzle.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceNozzle.java
@@ -314,6 +314,14 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
         return nozzleTip;
     }
 
+    public void setNozzleTip(ReferenceNozzleTip nozzleTip) {
+        Object oldValue = this.nozzleTip;
+        currentNozzleTipId = (nozzleTip != null ? nozzleTip.getId() : null);
+        this.nozzleTip = nozzleTip;
+        firePropertyChange("nozzleTip", oldValue, nozzleTip);
+        ((ReferenceMachine) head.getMachine()).fireMachineHeadActivity(head);
+    }
+
     @Override
     public boolean isNozzleTipChangedOnManualFeed() {
         return nozzleTipChangedOnManualFeed;
@@ -662,10 +670,7 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
             }
         }
 
-        this.nozzleTip = nt;
-        currentNozzleTipId = nozzleTip.getId();
-        firePropertyChange("nozzleTip", null, getNozzleTip());
-        ((ReferenceMachine) head.getMachine()).fireMachineHeadActivity(head);
+        setNozzleTip(nt);
 
         ensureZCalibrated(true);
 
@@ -760,10 +765,7 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
             }
         }
 
-        nozzleTip = null;
-        currentNozzleTipId = null;
-        firePropertyChange("nozzleTip", null, getNozzleTip());
-        ((ReferenceMachine) head.getMachine()).fireMachineHeadActivity(head);
+        setNozzleTip(null);
 
         if (!changerEnabled) {
             waitForCompletion(CompletionType.WaitForStillstand);

--- a/src/main/java/org/openpnp/machine/reference/axis/wizards/ReferenceControllerAxisConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/axis/wizards/ReferenceControllerAxisConfigurationWizard.java
@@ -617,7 +617,7 @@ public class ReferenceControllerAxisConfigurationWizard extends AbstractAxisConf
         panelBacklashDiagnostics.add(backlashSpeedFactor, "4, 6");
         backlashSpeedFactor.setColumns(10);
 
-        lblStepTest = new JLabel("<html>\r\n<body style=\"text-align:right\">\r\n<p>\r\nAbsolute <span style=\"color:#FF0000\">&mdash;&mdash;</span>\r\n</p>\r\n<p>\r\nRandom <span style=\"color:#BB7700\">&mdash;&mdash;</span>\r\n</p>\r\n<p>\r\nRelative <span style=\"color:#005BD9\">&mdash;&mdash;</span>\r\n</p>\r\n<br/>\r\n<p>\r\nTolerance <span style=\"color:#008000\">&mdash;&mdash;</span>\r\n</p>\r\n<br/>\r\n<p>\r\nerror at step.\r\n</p>\r\n</body>\r\n</html>");
+        lblStepTest = new JLabel("<html>\r\n<body style=\"text-align:right\">\r\n<p>\r\nAbsolute <span style=\"color:#FF0000\">&mdash;&mdash;</span>\r\n</p>\r\n<p>\r\nRelative <span style=\"color:#005BD9\">&mdash;&mdash;</span>\r\n</p>\r\n<p>\r\nRandom <span style=\"color:#BB7700\">&mdash;&mdash;</span>\r\n</p>\r\n<br/>\r\n<p>\r\nTolerance <span style=\"color:#008000\">&mdash;&mdash;</span>\r\n</p>\r\n<br/>\r\n<p>\r\nerror at step.\r\n</p>\r\n</body>\r\n</html>");
         panelBacklashDiagnostics.add(lblStepTest, "2, 8, right, default");
 
         stepTestGraph = new SimpleGraphView();
@@ -625,7 +625,7 @@ public class ReferenceControllerAxisConfigurationWizard extends AbstractAxisConf
         stepTestGraph.setFont(new Font("Dialog", Font.PLAIN, 11));
         panelBacklashDiagnostics.add(stepTestGraph, "4, 8, 7, 1, fill, default");
 
-        lblBacklashDistanceTest = new JLabel("<html>\r\n<body style=\"text-align:right\">\r\n<p>\r\nBacklash <span style=\"color:#005BD9\">&mdash;&mdash;</span>\r\n</p>\r\n<p>\r\nOvershoot <span style=\"color:#FF0000\">&mdash;&mdash;</span>\r\n</p>\r\n<br/>\r\n<br/>\r\n<p>\r\nforward/ <span style=\"color:#777777\">reverse</span><br/>\r\nat move distance.\r\n<p/>\r\n</body>\r\n</html>");
+        lblBacklashDistanceTest = new JLabel("<html>\r\n<body style=\"text-align:right\">\r\n<p>\r\nBacklash <span style=\"color:#005BD9\">&mdash;&mdash;</span>\r\n</p>\r\n<p>\r\nOvershoot <span style=\"color:#FF0000\">&mdash;&mdash;</span>\r\n</p>\r\n<p>\r\nRandom <span style=\"color:#BB7700\">&mdash;&mdash;</span>\r\n</p>\r\n<br/>\r\n<br/>\r\n<p>\r\nforward/ <span style=\"color:#777777\">reverse</span><br/>\r\nat move distance.\r\n<p/>\r\n</body>\r\n</html>");
         panelBacklashDiagnostics.add(lblBacklashDistanceTest, "2, 10, right, default");
 
         backlashDistanceTestGraph = new SimpleGraphView();

--- a/src/main/java/org/openpnp/machine/reference/axis/wizards/ReferenceControllerAxisConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/axis/wizards/ReferenceControllerAxisConfigurationWizard.java
@@ -625,11 +625,11 @@ public class ReferenceControllerAxisConfigurationWizard extends AbstractAxisConf
         stepTestGraph.setFont(new Font("Dialog", Font.PLAIN, 11));
         panelBacklashDiagnostics.add(stepTestGraph, "4, 8, 7, 1, fill, default");
 
-        lblBacklashDistanceTest = new JLabel("<html>\r\n<body style=\"text-align:right\">\r\n<p>\r\nBacklash <span style=\"color:#005BD9\">&mdash;&mdash;</span>\r\n</p>\r\n<p>\r\nOvershoot <span style=\"color:#FF0000\">&mdash;&mdash;</span>\r\n</p>\r\n<p>\r\nRandom <span style=\"color:#BB7700\">&mdash;&mdash;</span>\r\n</p>\r\n<br/>\r\n<br/>\r\n<p>\r\nforward/ <span style=\"color:#777777\">reverse</span><br/>\r\nat move distance.\r\n<p/>\r\n</body>\r\n</html>");
+        lblBacklashDistanceTest = new JLabel("<html>\r\n<body style=\"text-align:right\">\r\n<p>\r\nBacklash <span style=\"color:#005BD9\">&mdash;&mdash;</span>\r\n</p>\r\n<p>\r\nOvershoot <span style=\"color:#FF0000\">&mdash;&mdash;</span>\r\n</p>\r\n<p>\r\nRandom <span style=\"color:#BB7700\">&mdash;&mdash;</span>\r\n</p>\r\n<br/>\r\n<p>\r\nMove Time <span style=\"color:#00AA00\">&mdash;&mdash;</span>\r\n</p>\r\n<br/>\r\n<br/>\r\n<p>\r\nforward/ <span style=\"color:#777777\">reverse</span><br/>\r\nat move distance.\r\n<p/>\r\n</body>\r\n</html>");
         panelBacklashDiagnostics.add(lblBacklashDistanceTest, "2, 10, right, default");
 
         backlashDistanceTestGraph = new SimpleGraphView();
-        backlashDistanceTestGraph.setPreferredSize(new Dimension(300, 200));
+        backlashDistanceTestGraph.setPreferredSize(new Dimension(300, 350));
         backlashDistanceTestGraph.setFont(new Font("Dialog", Font.PLAIN, 11));
         panelBacklashDiagnostics.add(backlashDistanceTestGraph, "4, 10, 7, 1, fill, default");
 

--- a/src/main/java/org/openpnp/machine/reference/solutions/CalibrationSolutions.java
+++ b/src/main/java/org/openpnp/machine/reference/solutions/CalibrationSolutions.java
@@ -482,6 +482,12 @@ public class CalibrationSolutions implements Solutions.Subject {
         .setColor(new Color(00, 0x5B, 0xD9, 128)); // the OpenPNP blue
         distanceGraph.getRow(SCALE, OVERSHOOT+1)
         .setColor(new Color(0xFF, 0, 0, 128)); 
+        distanceGraph.getRow(SCALE, ABSOLUTE_RANDOM)
+        .setColor(new Color(0xBB, 0x77, 0));
+        distanceGraph.getRow(SCALE, ABSOLUTE_RANDOM)
+        .setMarkerShown(true);
+        distanceGraph.getRow(SCALE, ABSOLUTE_RANDOM)
+        .setLineShown(false);
 
         SimpleGraph speedGraph = new SimpleGraph();
         speedGraph.setRelativePaddingLeft(0.05);
@@ -538,7 +544,7 @@ public class CalibrationSolutions implements Solutions.Subject {
             }
         }
         // Pseudo-entry for full range.
-        backlashProbingDistances.add(backlashTestMoveMm*2);
+        backlashProbingDistances.add(backlashTestMoveLargeMm);
         Collections.reverse(backlashProbingDistances);
         double[] backlashOffsetByDistance = new double [backlashProbingDistances.size()];
         int iDistance = 0;
@@ -769,8 +775,9 @@ public class CalibrationSolutions implements Solutions.Subject {
         step = 0;
         for (double stepPos = -stepTestMm/2; stepPos < stepTestMm/2; stepPos += stepMm*fraction) {
             step++;
+            double randomDistance = Math.signum(Math.random()-0.5)*Math.exp(Math.random()*rangeLog + minLog);
             Location startMoveLocation = displacedAxisLocation(movable, axis, location, 
-                    Math.signum(Math.random()-0.5)*Math.exp(Math.random()*rangeLog + minLog)*mmAxis, false);
+                    randomDistance*mmAxis, false);
             movable.moveTo(startMoveLocation);
             Location nominalStepLocation = displacedAxisLocation(movable, axis, location, stepPos*mmAxis, false);
             movable.moveTo(nominalStepLocation);
@@ -780,6 +787,8 @@ public class CalibrationSolutions implements Solutions.Subject {
             double absoluteErrUnits = absoluteErr.convertToUnits(axis.getUnits()).getValue();
             stepTestGraph.getRow(ERROR, ABSOLUTE_RANDOM)
             .recordDataPoint(2+(step-1)*fraction, absoluteErrUnits);
+            distanceGraph.getRow(SCALE, ABSOLUTE_RANDOM)
+            .recordDataPoint(Math.abs(randomDistance*mmAxis), absoluteErrUnits);
         }
         // Publish the graphs.
         axis.setStepTestGraph(stepTestGraph);

--- a/src/main/java/org/openpnp/machine/reference/solutions/GcodeDriverSolutions.java
+++ b/src/main/java/org/openpnp/machine/reference/solutions/GcodeDriverSolutions.java
@@ -104,13 +104,20 @@ public class GcodeDriverSolutions implements Solutions.Subject {
                         gcodeDriver, 
                         "Use the GcodeDriver for simpler setup. Accept or Dismiss to continue.", 
                         "Convert to GcodeDriver.", 
-                        Severity.Suggestion,
+                        Severity.Information,
                         "https://github.com/openpnp/openpnp/wiki/GcodeAsyncDriver") {
 
                     @Override
                     public boolean isUnhandled( ) {
                         // Never handle a conservative solution as unhandled.
                         return false;
+                    }
+
+                    @Override 
+                    public String getExtendedDescription() {
+                        return "<html><span color=\"red\">CAUTION:</span>  This is a troubleshooting option offered to remove the GcodeAsyncDriver "
+                                + "if it causes problems, or if you don't want it after all. Going back to the plain GcodeDriver will lose you all the "
+                                + "advanced configuration.</html>";
                     }
 
                     @Override
@@ -471,6 +478,13 @@ public class GcodeDriverSolutions implements Solutions.Subject {
                                     return false;
                                 }
 
+                                @Override 
+                                public String getExtendedDescription() {
+                                    return "<html><span color=\"red\">CAUTION:</span> This is a troubleshooting option, you should only choose "
+                                            + newMotionControlType.name()+" if the current "+oldMotionControlType.name()+" causes problems and you "
+                                            + "want to try a simpler setting.</html>";
+                                }
+
                                 @Override
                                 public void setState(Solutions.State state) throws Exception {
                                     gcodeDriver.setMotionControlType((state == Solutions.State.Solved) ? 
@@ -522,8 +536,20 @@ public class GcodeDriverSolutions implements Solutions.Subject {
                                     gcodeDriver, 
                                     "Disable G-code compression for trouble-free operation with incompatible controllers.", 
                                     "Disable Compress G-code.", 
-                                    Severity.Suggestion,
+                                    Severity.Information,
                                     "https://github.com/openpnp/openpnp/wiki/GcodeAsyncDriver#gcodedriver-new-settings") {
+
+                                @Override
+                                public boolean isUnhandled( ) {
+                                    // Never handle a conservative solution as unhandled.
+                                    return false;
+                                }
+
+                                @Override 
+                                public String getExtendedDescription() {
+                                    return "<html><span color=\"red\">CAUTION:</span> This is a troubleshooting option, you should "
+                                            + "only disable G-code compression if it causes problems.</html>";
+                                }
 
                                 @Override
                                 public void setState(Solutions.State state) throws Exception {
@@ -537,13 +563,19 @@ public class GcodeDriverSolutions implements Solutions.Subject {
                                     gcodeDriver, 
                                     "Keep G-code comments for better debugging.", 
                                     "Disable Remove Comments.", 
-                                    Severity.Suggestion,
+                                    Severity.Information,
                                     "https://github.com/openpnp/openpnp/wiki/GcodeAsyncDriver#gcodedriver-new-settings") {
 
                                 @Override
                                 public boolean isUnhandled( ) {
                                     // Never handle a conservative solution as unhandled.
                                     return false;
+                                }
+
+                                @Override 
+                                public String getExtendedDescription() {
+                                    return "<html><span color=\"red\">CAUTION:</span> This is a troubleshooting option, you should "
+                                            + "only keep G-code comments if removing them causes problems.</html>";
                                 }
 
                                 @Override

--- a/src/main/java/org/openpnp/machine/reference/wizards/ContactProbeNozzleWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/wizards/ContactProbeNozzleWizard.java
@@ -38,13 +38,17 @@ import javax.swing.border.TitledBorder;
 import org.openpnp.gui.components.ComponentDecorators;
 import org.openpnp.gui.support.AbstractConfigurationWizard;
 import org.openpnp.gui.support.ActuatorsComboBoxModel;
+import org.openpnp.gui.support.DoubleConverter;
 import org.openpnp.gui.support.Icons;
 import org.openpnp.gui.support.LengthConverter;
 import org.openpnp.gui.support.LongConverter;
+import org.openpnp.gui.support.NamedConverter;
 import org.openpnp.machine.reference.ContactProbeNozzle;
 import org.openpnp.machine.reference.ContactProbeNozzle.ContactProbeMethod;
 import org.openpnp.machine.reference.ContactProbeNozzle.ContactProbeTrigger;
 import org.openpnp.machine.reference.ReferenceNozzle;
+import org.openpnp.model.Configuration;
+import org.openpnp.spi.Actuator;
 import org.openpnp.util.UiUtils;
 
 import com.jgoodies.forms.layout.ColumnSpec;
@@ -101,6 +105,8 @@ public class ContactProbeNozzleWizard extends AbstractConfigurationWizard {
                 FormSpecs.RELATED_GAP_ROWSPEC,
                 FormSpecs.DEFAULT_ROWSPEC,
                 FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
                 FormSpecs.DEFAULT_ROWSPEC,}));
 
         lblMethod = new JLabel("Method");
@@ -121,75 +127,85 @@ public class ContactProbeNozzleWizard extends AbstractConfigurationWizard {
         comboBoxContactProbeActuator.setMaximumRowCount(15);
         comboBoxContactProbeActuator.setModel(new ActuatorsComboBoxModel(nozzle.getHead()));
         panel.add(comboBoxContactProbeActuator, "4, 4, default, top");
+        
+        lblProbeSpeed = new JLabel("Probe Speed");
+        lblProbeSpeed.setToolTipText("<html>Probing speed factor.<br/>\r\n<strong>NOTE:</strong> this setting will only become effective, once you<br/>\r\naccept the Issues & Solutions G-code suggestion.</html>");
+        panel.add(lblProbeSpeed, "2, 6, right, default");
+        
+        contactProbeSpeed = new JTextField();
+        panel.add(contactProbeSpeed, "4, 6, fill, default");
+        contactProbeSpeed.setColumns(10);
 
         lblStartOffset = new JLabel("Start Offset");
         lblStartOffset.setToolTipText("<html>Contact probing start offset in Z above the nominal location.<br/>\r\nNote: for part height probing, the maximum part height on the NozzleTip <br/>\r\nis used instead, if the part height is not yet known. \r\n</html>");
-        panel.add(lblStartOffset, "2, 6, right, default");
+        panel.add(lblStartOffset, "2, 8, right, default");
 
         contactProbeStartOffsetZ = new JTextField();
-        panel.add(contactProbeStartOffsetZ, "4, 6, fill, default");
+        panel.add(contactProbeStartOffsetZ, "4, 8, fill, default");
         contactProbeStartOffsetZ.setColumns(10);
 
         lblProbeDepth = new JLabel("Probe Depth");
         lblProbeDepth.setToolTipText("Maximum contact probing depth in Z, from the Start Offset.");
-        panel.add(lblProbeDepth, "2, 8, right, default");
+        panel.add(lblProbeDepth, "2, 10, right, default");
 
         contactProbeDepthZ = new JTextField();
-        panel.add(contactProbeDepthZ, "4, 8, fill, default");
+        panel.add(contactProbeDepthZ, "4, 10, fill, default");
         contactProbeDepthZ.setColumns(10);
 
         lblSniffleIncrement = new JLabel("Sniffle Increment");
         lblSniffleIncrement.setToolTipText("Vacuum sensing \"sniffle\" increment in Z. ");
-        panel.add(lblSniffleIncrement, "2, 10, right, default");
+        panel.add(lblSniffleIncrement, "2, 12, right, default");
 
         sniffleIncrementZ = new JTextField();
-        panel.add(sniffleIncrementZ, "4, 10, fill, default");
+        panel.add(sniffleIncrementZ, "4, 12, fill, default");
         sniffleIncrementZ.setColumns(10);
         
         lblSniffleDwellTime = new JLabel("Sniffle Dwell Time [ms]");
-        panel.add(lblSniffleDwellTime, "2, 12, right, default");
+        panel.add(lblSniffleDwellTime, "2, 14, right, default");
         
         sniffleDwellTime = new JTextField();
-        panel.add(sniffleDwellTime, "4, 12, fill, default");
+        panel.add(sniffleDwellTime, "4, 14, fill, default");
         sniffleDwellTime.setColumns(10);
 
         lblFinalAdjustment = new JLabel("Final Adjustment");
         lblFinalAdjustment.setToolTipText("<html>\r\nContact probing final adjustment in Z (positive values point upwards in Z).<br/>\r\n<ul>\r\n<li>Use positive values to compensate probing overshoot.</li>\r\n<li>Use negative values to add additional nozzle tip spring tensioning.</li>\r\n</ul>\r\n</html>");
-        panel.add(lblFinalAdjustment, "2, 14, right, default");
+        panel.add(lblFinalAdjustment, "2, 16, right, default");
 
         contactProbeAdjustZ = new JTextField();
-        panel.add(contactProbeAdjustZ, "4, 14, fill, default");
+        panel.add(contactProbeAdjustZ, "4, 16, fill, default");
         contactProbeAdjustZ.setColumns(10);
 
         lblFeederHeightProbing = new JLabel("Feeder Height Probing");
-        panel.add(lblFeederHeightProbing, "2, 18, right, default");
+        lblFeederHeightProbing.setToolTipText("<html>Probe for feeder heights. On some feeder types, this can probe for the <strong>Part Height</strong>, when it is unknown.</html>");
+        panel.add(lblFeederHeightProbing, "2, 20, right, default");
 
         feederHeightProbing = new JComboBox(ContactProbeTrigger.values());
-        panel.add(feederHeightProbing, "4, 18, fill, default");
+        panel.add(feederHeightProbing, "4, 20, fill, default");
 
-        lblPartHeightProbing = new JLabel("Part Height Probing");
-        panel.add(lblPartHeightProbing, "2, 20, right, default");
+        lblPartHeightProbing = new JLabel("Placement Height Probing");
+        lblPartHeightProbing.setToolTipText("<html>Probe for placement heights. Includes probing for <strong>Part Height</strong>, when it is unknown.</html>");
+        panel.add(lblPartHeightProbing, "2, 22, right, default");
 
         partHeightProbing = new JComboBox(ContactProbeTrigger.values());
-        panel.add(partHeightProbing, "4, 20, fill, default");
+        panel.add(partHeightProbing, "4, 22, fill, default");
         
         lblDiscardProbing = new JLabel("Discard Probing");
         lblDiscardProbing.setToolTipText("<html>Enable contact probing for discard. There must be a surface that the nozzle<br/>\r\ncan probe into that is likely to brush/tilt off a part from the nozzle, like a (ESD safe) soft<br/>\r\nmaterial or a slanted surface. \r\n</html>");
-        panel.add(lblDiscardProbing, "2, 22, right, default");
+        panel.add(lblDiscardProbing, "2, 24, right, default");
 
         discardProbing = new JCheckBox("");
-        panel.add(discardProbing, "4, 22");
+        panel.add(discardProbing, "4, 24");
 
         lblZCalibration = new JLabel("Calibration Z Offset");
-        panel.add(lblZCalibration, "2, 26, right, default");
+        panel.add(lblZCalibration, "2, 28, right, default");
         
         calibrationOffsetZ = new JTextField();
         calibrationOffsetZ.setEditable(false);
-        panel.add(calibrationOffsetZ, "4, 26, fill, default");
+        panel.add(calibrationOffsetZ, "4, 28, fill, default");
         calibrationOffsetZ.setColumns(10);
         
         btnCalibrateNow = new JButton(calibrateZAction);
-        panel.add(btnCalibrateNow, "6, 26");
+        panel.add(btnCalibrateNow, "6, 28");
     }
 
     protected void adaptDialog() {
@@ -210,6 +226,8 @@ public class ContactProbeNozzleWizard extends AbstractConfigurationWizard {
         contactProbeDepthZ.setVisible(isProbing);
         lblFinalAdjustment.setVisible(isProbing);
         contactProbeAdjustZ.setVisible(isProbing);
+        lblProbeSpeed.setVisible(isProbing);
+        contactProbeSpeed.setVisible(isProbing);
 
         lblFeederHeightProbing.setVisible(isActuator);
         feederHeightProbing.setVisible(isActuator);
@@ -227,12 +245,15 @@ public class ContactProbeNozzleWizard extends AbstractConfigurationWizard {
     public void createBindings() {
         LengthConverter lengthConverter = new LengthConverter();
         LongConverter longConverter = new LongConverter();
+        DoubleConverter doubleConverter = new DoubleConverter(Configuration.get().getLengthDisplayFormat());
+        NamedConverter<Actuator> actuatorConverter = (new NamedConverter<>(nozzle.getHead().getActuators()));
 
         addWrappedBinding(nozzle, "contactProbeMethod", contactProbeMethod, "selectedItem");
-        addWrappedBinding(nozzle, "contactProbeActuatorName", comboBoxContactProbeActuator, "selectedItem");
+        addWrappedBinding(nozzle, "contactProbeActuator", comboBoxContactProbeActuator, "selectedItem", actuatorConverter);
 
         addWrappedBinding(nozzle, "contactProbeStartOffsetZ", contactProbeStartOffsetZ, "text", lengthConverter);
         addWrappedBinding(nozzle, "contactProbeDepthZ", contactProbeDepthZ, "text", lengthConverter);
+        addWrappedBinding(nozzle, "contactProbeSpeed", contactProbeSpeed, "text", doubleConverter);
         addWrappedBinding(nozzle, "sniffleIncrementZ", sniffleIncrementZ, "text", lengthConverter);
         addWrappedBinding(nozzle, "sniffleDwellTime", sniffleDwellTime, "text", longConverter);
         addWrappedBinding(nozzle, "contactProbeAdjustZ", contactProbeAdjustZ, "text", lengthConverter);
@@ -291,5 +312,7 @@ public class ContactProbeNozzleWizard extends AbstractConfigurationWizard {
     private JTextField sniffleDwellTime;
     private JLabel lblDiscardProbing;
     private JCheckBox discardProbing;
+    private JLabel lblProbeSpeed;
+    private JTextField contactProbeSpeed;
 
 }

--- a/src/main/java/org/openpnp/util/SimpleGraph.java
+++ b/src/main/java/org/openpnp/util/SimpleGraph.java
@@ -47,6 +47,8 @@ public class SimpleGraph {
     @Attribute(required=false)
     private double relativePaddingRight;
     @Attribute(required=false)
+    private boolean logarithmic;
+    @Attribute(required=false)
     private long zeroNanoTime = Long.MIN_VALUE;
     @Attribute(required=false)
     private long lastT = 0;
@@ -65,6 +67,8 @@ public class SimpleGraph {
         private double relativePaddingTop;
         @Attribute(required=false)
         private double relativePaddingBottom;
+        @Attribute(required=false)
+        private boolean logarithmic;
         @Attribute(required=false)
         private boolean symmetricIfSigned;
         @Attribute(required=false)
@@ -119,6 +123,12 @@ public class SimpleGraph {
         public boolean isSymmetricIfSigned() {
             return symmetricIfSigned;
         }
+        public boolean isLogarithmic() {
+            return logarithmic;
+        }
+        public void setLogarithmic(boolean logarithmic) {
+            this.logarithmic = logarithmic;
+        }
         public void setSymmetricIfSigned(boolean symmetricIfSigned) {
             this.symmetricIfSigned = symmetricIfSigned;
         }
@@ -164,6 +174,13 @@ public class SimpleGraph {
                 }
             }
             return maximum; 
+        }
+
+        public double graphY(double y) {
+            return isLogarithmic() ? Math.exp(y) : y;
+        }
+        public Double displayY(Double y) {
+            return y == null ? null : (isLogarithmic() ? Math.log(y > 0 ? y : 1e-4) : y);
         }
     } 
 
@@ -228,6 +245,12 @@ public class SimpleGraph {
     }
     public void setRelativePaddingRight(double relativePaddingRight) {
         this.relativePaddingRight = relativePaddingRight;
+    }
+    public boolean isLogarithmic() {
+        return logarithmic;
+    }
+    public void setLogarithmic(boolean logarithmic) {
+        this.logarithmic = logarithmic;
     }
 
     public static class DataRow {
@@ -438,6 +461,13 @@ public class SimpleGraph {
             }
         }
         return maximum; 
+    }
+
+    public double graphX(double x) {
+        return isLogarithmic() ? Math.exp(x) : x;
+    }
+    public Double displayX(Double x) {
+        return x == null ? null : (isLogarithmic() ? Math.log(x > 0 ? x : 1e-4) : x);
     }
 
     public List<DataScale> getScales() {


### PR DESCRIPTION
# Description
Another round in the [Automatic Machine Calibration using Issues & Solutions series](https://github.com/openpnp/openpnp/issues?q=label%3Aautomatic-calibration+is%3Aclosed).

* The `ContactProbeNozzle` now references its probing actuator by object, rather than by name. The name is only used for XML persistence.
* Added `ContactProbeNozzle` Issues & Solutions error for missing contact sensing actuator.
* Using `ContactProbeNozzle` cached Z offsets is immediately switched off, when the method is switched to **Off**. Previously, this has only become effective after a machine homing.
* Support dual shared axis nozzles, i.e. axis transforms in Issues & Solutions checks against the Z axis.
* Generate probing G-code with proper axis letter, probing limit according to soft-limit(s), and feed-rate according to (new) speed factor.
* Add cautionary note to the Issues & Solutions issues that offer to revert an advanced configuration. Make them "Information" rather than "Suggestion".

    ![Troubleshooting](https://user-images.githubusercontent.com/9963310/133943047-590f8b15-7c90-4c0f-8ec5-d74210ab7b85.png)


* When converting `ReferenceNozzle` to `ContactProbeNozzle` and vice versa, the loaded nozzle tip is reassigned. This was previously missing.
* Extracted new `Nozzle.setNozzleTip()` method from existing duplicate code.
* Added random move errors to the distance graph too.
* Added a logarithmic scale option to `SimpleGraph`
* Employed a logarithmic scale for the distance graph in backlash calibration.
* Added a time over distance measurement to the backlash calibration.

    ![Logarithmic](https://user-images.githubusercontent.com/9963310/133942944-5613a8eb-d4a0-4790-bc03-3672ba7521cb.png)
    (non-typical simulation data)

# Justification
Ongoing testing and feedback from the discussion, since this point:
https://groups.google.com/g/openpnp/c/dBg7txMB0R0/m/czPqQVSNCAAJ

# Instructions for Use
Mostly the same as before.

For the ContactProbeNozzle, use the new Probe Speed factor to define the probing speed relative to the axis feed-rate:
![Probe Speed](https://user-images.githubusercontent.com/9963310/133943201-f6623399-b1a8-4e29-a80d-7c5feed4331c.png)

Then use Issues & Solutions to generate new probing G-code (on supported controllers):

![I&S G code](https://user-images.githubusercontent.com/9963310/133943263-054dc476-6e4d-4571-bc56-bb544b213925.png)

This will also use the soft-limits on the axis to propose the maximum probe limit. 

# Implementation Details
1. Tested in simulation.
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. Successful `mvn test` before submitting the Pull Request. 
