### PR TITLE
Feature / Automatic Machine Calibration using Issues & Solutions - Round 9

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/axis/ReferenceControllerAxis.java
+++ b/src/main/java/org/openpnp/machine/reference/axis/ReferenceControllerAxis.java
@@ -246,7 +246,9 @@ public class ReferenceControllerAxis extends AbstractControllerAxis {
     }
 
     public void setAcceptableTolerance(Length acceptableTolerance) {
+        Object oldValue = this.acceptableTolerance;
         this.acceptableTolerance = acceptableTolerance;
+        firePropertyChange("acceptableTolerance", oldValue, acceptableTolerance);
     }
 
     public Length getBacklashOffset() {

--- a/src/main/java/org/openpnp/machine/reference/axis/ReferenceControllerAxis.java
+++ b/src/main/java/org/openpnp/machine/reference/axis/ReferenceControllerAxis.java
@@ -21,7 +21,9 @@
 
 package org.openpnp.machine.reference.axis;
 
+import org.openpnp.gui.support.PropertySheetWizardAdapter;
 import org.openpnp.gui.support.Wizard;
+import org.openpnp.machine.reference.axis.wizards.BacklashCompensationConfigurationWizard;
 import org.openpnp.machine.reference.axis.wizards.ReferenceControllerAxisConfigurationWizard;
 import org.openpnp.model.AxesLocation;
 import org.openpnp.model.Length;
@@ -440,6 +442,14 @@ public class ReferenceControllerAxis extends AbstractControllerAxis {
     @Override
     public Wizard getConfigurationWizard() {
         return new ReferenceControllerAxisConfigurationWizard(this);
+    }
+
+    @Override
+    public PropertySheet[] getPropertySheets() {
+        return new PropertySheet[] {
+                new PropertySheetWizardAdapter(getConfigurationWizard()),
+                new PropertySheetWizardAdapter(new BacklashCompensationConfigurationWizard(this), "Backlash Compensation"),
+        };
     }
 
     @Override

--- a/src/main/java/org/openpnp/machine/reference/axis/wizards/BacklashCompensationConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/axis/wizards/BacklashCompensationConfigurationWizard.java
@@ -121,8 +121,7 @@ public class BacklashCompensationConfigurationWizard extends AbstractConfigurati
                             ReferenceMachine refMachine = (ReferenceMachine) Configuration.get().getMachine();
                             refMachine.getCalibrationSolutions()
                             .calibrateAxisBacklash((ReferenceHead)(camera.getHead()), camera,
-                                    camera, (ReferenceControllerAxis)axis, 
-                                    ((ReferenceControllerAxis)axis).getAcceptableTolerance());
+                                    camera, (ReferenceControllerAxis)axis);
                             MainFrame.get().getMachineSetupTab().selectCurrentTreePath();
                             return true;
                         }
@@ -207,19 +206,19 @@ public class BacklashCompensationConfigurationWizard extends AbstractConfigurati
         panelBacklashDiagnostics.add(backlashSpeedFactor, "4, 6");
         backlashSpeedFactor.setColumns(10);
 
-        lblStepTest = new JLabel("<html>\r\n<body style=\"text-align:right\">\r\n<p>\r\nAbsolute <span style=\"color:#FF0000\">&mdash;&mdash;</span>\r\n</p>\r\n<p>\r\nRelative <span style=\"color:#005BD9\">&mdash;&mdash;</span>\r\n</p>\r\n<p>\r\nRandom <span style=\"color:#BB7700\">&mdash;&mdash;</span>\r\n</p>\r\n<br/>\r\n<p>\r\nTolerance <span style=\"color:#008000\">&mdash;&mdash;</span>\r\n</p>\r\n<br/>\r\n<p>\r\nerror at step.\r\n</p>\r\n</body>\r\n</html>");
+        lblStepTest = new JLabel("<html>\r\n<body style=\"text-align:right\">\r\n<p>\r\nAbsolute <span style=\"color:#FF0000\">&mdash;&mdash;</span>\r\n</p>\r\n<p>\r\nRelative <span style=\"color:#005BD9\">&mdash;&mdash;</span>\r\n</p>\r\n<p>\r\nRandom <span style=\"color:#BB7700\">&mdash;&mdash;</span>\r\n</p>\r\n<br/>\r\n<p>\r\nTolerance <span style=\"color:#000077\">&mdash;&mdash;</span>\r\n</p>\r\n<br/>\r\n<p>\r\nerror at step.\r\n</p>\r\n</body>\r\n</html>");
         panelBacklashDiagnostics.add(lblStepTest, "2, 8, right, default");
 
         stepTestGraph = new SimpleGraphView();
-        stepTestGraph.setPreferredSize(new Dimension(300, 200));
+        stepTestGraph.setPreferredSize(new Dimension(300, 100));
         stepTestGraph.setFont(new Font("Dialog", Font.PLAIN, 11));
         panelBacklashDiagnostics.add(stepTestGraph, "4, 8, 7, 1, fill, fill");
 
-        lblBacklashDistanceTest = new JLabel("<html>\r\n<body style=\"text-align:right\">\r\n<p>\r\nBacklash <span style=\"color:#005BD9\">&mdash;&mdash;</span>\r\n</p>\r\n<p>\r\nOvershoot <span style=\"color:#FF0000\">&mdash;&mdash;</span>\r\n</p>\r\n<p>\r\nRandom <span style=\"color:#BB7700\">&mdash;&mdash;</span>\r\n</p>\r\n<br/>\r\n<p>\r\nMove Time <span style=\"color:#00AA00\">&mdash;&mdash;</span>\r\n</p>\r\n<br/>\r\n<br/>\r\n<p>\r\nforward/ <span style=\"color:#777777\">reverse</span><br/>\r\nat move distance.\r\n<p/>\r\n</body>\r\n</html>");
+        lblBacklashDistanceTest = new JLabel("<html>\r\n<body style=\"text-align:right\">\r\n<p>\r\nBacklash <span style=\"color:#005BD9\">&mdash;&mdash;</span>\r\n</p>\r\n<p>\r\nEnvelope <span style=\"color:#000077\">&mdash;&mdash;</span>\r\n</p>\r\n<p>\r\nOvershoot <span style=\"color:#FF0000\">&mdash;&mdash;</span>\r\n</p>\r\n<p>\r\nRandom <span style=\"color:#BB7700\">&mdash;&mdash;</span>\r\n</p>\r\n<br/>\r\n<p>\r\nMove Time <span style=\"color:#00AA00\">&mdash;&mdash;</span>\r\n</p>\r\n<br/>\r\n<br/>\r\n<p>\r\nforward/ <span style=\"color:#777777\">reverse</span><br/>\r\nat move distance.\r\n<p/>\r\n</body>\r\n</html>");
         panelBacklashDiagnostics.add(lblBacklashDistanceTest, "2, 10, right, default");
 
         backlashDistanceTestGraph = new SimpleGraphView();
-        backlashDistanceTestGraph.setPreferredSize(new Dimension(300, 400));
+        backlashDistanceTestGraph.setPreferredSize(new Dimension(300, 200));
         backlashDistanceTestGraph.setFont(new Font("Dialog", Font.PLAIN, 11));
         panelBacklashDiagnostics.add(backlashDistanceTestGraph, "4, 10, 7, 1, fill, fill");
 
@@ -227,7 +226,7 @@ public class BacklashCompensationConfigurationWizard extends AbstractConfigurati
         panelBacklashDiagnostics.add(lblBacklashSpeedTest, "2, 12, right, default");
 
         backlashSpeedTestGraph = new SimpleGraphView();
-        backlashSpeedTestGraph.setPreferredSize(new Dimension(300, 200));
+        backlashSpeedTestGraph.setPreferredSize(new Dimension(300, 100));
         backlashSpeedTestGraph.setFont(new Font("Dialog", Font.PLAIN, 11));
         panelBacklashDiagnostics.add(backlashSpeedTestGraph, "4, 12, 7, 1, fill, fill");
     }

--- a/src/main/java/org/openpnp/machine/reference/axis/wizards/BacklashCompensationConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/axis/wizards/BacklashCompensationConfigurationWizard.java
@@ -1,0 +1,280 @@
+/*
+ * Copyright (C) 2021 <mark@makr.zone>
+ * inspired and based on work
+ * Copyright (C) 2011 Jason von Nieda <jason@vonnieda.org>
+ * 
+ * This file is part of OpenPnP.
+ * 
+ * OpenPnP is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * OpenPnP is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License along with OpenPnP. If not, see
+ * <http://www.gnu.org/licenses/>.
+ * 
+ * For more information about OpenPnP visit http://openpnp.org
+ */
+
+package org.openpnp.machine.reference.axis.wizards;
+
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.Font;
+import java.awt.event.ActionEvent;
+import java.awt.event.ItemEvent;
+import java.awt.event.ItemListener;
+
+import javax.swing.AbstractAction;
+import javax.swing.Action;
+import javax.swing.JButton;
+import javax.swing.JComboBox;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JTextField;
+import javax.swing.UIManager;
+import javax.swing.border.TitledBorder;
+
+import org.openpnp.gui.MainFrame;
+import org.openpnp.gui.components.ComponentDecorators;
+import org.openpnp.gui.components.SimpleGraphView;
+import org.openpnp.gui.support.AbstractConfigurationWizard;
+import org.openpnp.gui.support.DoubleConverter;
+import org.openpnp.gui.support.Icons;
+import org.openpnp.gui.support.LengthConverter;
+import org.openpnp.gui.support.NamedConverter;
+import org.openpnp.machine.reference.ReferenceCamera;
+import org.openpnp.machine.reference.ReferenceHead;
+import org.openpnp.machine.reference.ReferenceMachine;
+import org.openpnp.machine.reference.axis.ReferenceControllerAxis;
+import org.openpnp.machine.reference.axis.ReferenceControllerAxis.BacklashCompensationMethod;
+import org.openpnp.model.Configuration;
+import org.openpnp.spi.Axis;
+import org.openpnp.spi.Axis.Type;
+import org.openpnp.spi.Camera.Looking;
+import org.openpnp.spi.Driver;
+import org.openpnp.spi.HeadMountable;
+import org.openpnp.spi.base.AbstractControllerAxis;
+import org.openpnp.util.UiUtils;
+
+import com.jgoodies.forms.layout.ColumnSpec;
+import com.jgoodies.forms.layout.FormLayout;
+import com.jgoodies.forms.layout.FormSpecs;
+import com.jgoodies.forms.layout.RowSpec;
+
+@SuppressWarnings("serial")
+public class BacklashCompensationConfigurationWizard extends AbstractConfigurationWizard {
+    protected NamedConverter<Driver> driverConverter;
+    private JLabel lblBacklashOffset;
+    private JTextField backlashOffset;
+    private JLabel lblBacklashCompensation;
+    private JComboBox backlashCompensationMethod;
+    private JLabel lblBacklashSpeedFactor;
+    private JTextField backlashSpeedFactor;
+
+    private JPanel panelBacklashDiagnostics;
+    private JLabel lblStepTest;
+    private SimpleGraphView stepTestGraph;
+    private JLabel lblBacklashSpeedTest;
+    private SimpleGraphView backlashSpeedTestGraph;
+    private JLabel lblBacklashDistanceTest;
+    private SimpleGraphView backlashDistanceTestGraph;
+    private JLabel lblSneakupDistance;
+    private JTextField sneakUpOffset;
+    private JButton btnCalibrate;
+    private JLabel lblAcceptableTolerance;
+    private JTextField acceptableTolerance;
+    private ReferenceControllerAxis axis;
+    protected Axis.Type type;
+
+    public Axis.Type getType() {
+        return type;
+    }
+    public void setType(Axis.Type type) {
+        this.type = type;
+        adaptDialog();
+    }
+
+    private Action backlashCalibrateAction = new AbstractAction("Calibrate now", Icons.axisCartesian) {
+        {
+            putValue(Action.SHORT_DESCRIPTION,
+                    "<html>\r\n" + 
+                            "<p>Calibrate the axis backlash compensation settings using the calibration fiducial.</p>\r\n" + 
+                            "<p>Make sure the calibration rig is set up and present.</p>" +
+                            "<p>Consider using this function from Issues & Solutions where you get step by step instructions,<br/>\r\n" + 
+                            "for the needed preparatory steps and the calibration in proper sequence. You also get extensive Wiki links.</p>\r\n" + 
+                    "</html>");
+        }
+
+        @Override
+        public void actionPerformed(ActionEvent e) {
+            applyAction.actionPerformed(e);
+            UiUtils.submitUiMachineTask(() -> {
+                HeadMountable hm = ((AbstractControllerAxis) axis).getDefaultHeadMountable();
+                if (hm instanceof ReferenceCamera) {
+                    ReferenceCamera camera = (ReferenceCamera) hm;
+                    if (camera.getHead() != null && camera.getLooking() == Looking.Down) {
+                        if (Configuration.get().getMachine() instanceof ReferenceMachine) {
+                            ReferenceMachine refMachine = (ReferenceMachine) Configuration.get().getMachine();
+                            refMachine.getCalibrationSolutions()
+                            .calibrateAxisBacklash((ReferenceHead)(camera.getHead()), camera,
+                                    camera, (ReferenceControllerAxis)axis, 
+                                    ((ReferenceControllerAxis)axis).getAcceptableTolerance());
+                            MainFrame.get().getMachineSetupTab().selectCurrentTreePath();
+                            return true;
+                        }
+                    }
+                }
+                throw new Exception("Only an axis on a down-looking camera can be calibrated.");
+            });
+        }
+    };    
+
+    public BacklashCompensationConfigurationWizard(ReferenceControllerAxis axis) {
+        this.axis = axis;
+        panelBacklashDiagnostics = new JPanel();
+        panelBacklashDiagnostics.setBorder(new TitledBorder(UIManager.getBorder("TitledBorder.border"), "Backlash Compensation and Calibration", TitledBorder.LEADING, TitledBorder.TOP, null, new Color(0, 0, 0)));
+        contentPanel.add(panelBacklashDiagnostics);
+        panelBacklashDiagnostics.setLayout(new FormLayout(new ColumnSpec[] {
+                FormSpecs.RELATED_GAP_COLSPEC,
+                ColumnSpec.decode("max(70dlu;default)"),
+                FormSpecs.RELATED_GAP_COLSPEC,
+                FormSpecs.DEFAULT_COLSPEC,
+                FormSpecs.RELATED_GAP_COLSPEC,
+                FormSpecs.DEFAULT_COLSPEC,
+                FormSpecs.RELATED_GAP_COLSPEC,
+                FormSpecs.DEFAULT_COLSPEC,
+                FormSpecs.RELATED_GAP_COLSPEC,
+                ColumnSpec.decode("default:grow"),},
+                new RowSpec[] {
+                        FormSpecs.RELATED_GAP_ROWSPEC,
+                        FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC,
+                        FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC,
+                        FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC,
+                        RowSpec.decode("default:grow"),
+                        FormSpecs.RELATED_GAP_ROWSPEC,
+                        RowSpec.decode("default:grow"),
+                        FormSpecs.RELATED_GAP_ROWSPEC,
+                        RowSpec.decode("default:grow"),}));
+
+        lblBacklashCompensation = new JLabel("Compensation Method");
+        panelBacklashDiagnostics.add(lblBacklashCompensation, "2, 2, right, default");
+        lblBacklashCompensation.setToolTipText("<html>\r\n<p>Backlash compensation is used to avoid the effects of any looseness or play in the <br/>\r\nmechanical linkages of the given axis.  When the actuator reverses the direction of travel, <br/>\r\nthere is often a moment where nothing happens, because the slack from a belt or play <br/>\r\nfrom a screw or rack and pinion etc. needs to be bridged, before mechanical force can again <br/>\r\nbe transmitted.</p>\r\n\r\n<ul>\r\n<li>\r\n<strong>None:</strong>\r\nNo backlash compensation is performed. </li>\r\n<li>\r\n<strong>OneSidedPositioning:</strong><br/>\r\nBacklash compensation is applied by always moving to the end position from one side.<br/>\r\nThe backlash offset does not need to be very precise, i.e. it can be larger than the actual<br/> \r\nbacklash and the machine will still end up in the correct precise position.<br/>\r\nThe machine always needs to perform an extra move and it will force a complete machine<br/>\r\n still-stand between motion segments.</li>\r\n<li>\r\n<strong>OneSidedOptimizedPositioning:</strong><br/>\r\nWorks like OneSidedPositioning except it will only perform an extra move when moving <br/>\r\nfrom the wrong side. Only half of the extra moves are needed.</li>\r\n<li>\r\n<strong>DirectionalCompensation (Experimental!):</strong><br/>\r\nBacklash compensation is applied in the direction of travel. The offset is added to the <br/>\r\nactual target coordinate, if moving in the direction of the offset (which can be positive <br/>\r\nor negative), no offset is added if moving against the offset.<br/>\r\nNo extra moves are needed. The machine can also move more fluidly, as there is no <br/>\r\ndirection change needed.<br/>\r\nHowever: the offset needs to precisely match the physical backlash.</li>\r\n</ul>\r\n</html>");
+
+        backlashCompensationMethod = new JComboBox(BacklashCompensationMethod.values());
+        panelBacklashDiagnostics.add(backlashCompensationMethod, "4, 2");
+        backlashCompensationMethod.addItemListener(new ItemListener() {
+            public void itemStateChanged(ItemEvent e) {
+                adaptDialog();
+            }
+        });
+
+        lblAcceptableTolerance = new JLabel("Tolerance ±");
+        lblAcceptableTolerance.setToolTipText("<html>\r\n<p>Acceptable backlash compensation tolerance (±) for calibration.</p>\r\n<p>A larger tolerance will possibly allow for a more efficient backlash compensation method.</p>\r\n</html>");
+        panelBacklashDiagnostics.add(lblAcceptableTolerance, "6, 2, right, default");
+
+        acceptableTolerance = new JTextField();
+        panelBacklashDiagnostics.add(acceptableTolerance, "8, 2, fill, default");
+        acceptableTolerance.setColumns(10);
+
+        btnCalibrate = new JButton(backlashCalibrateAction);
+        panelBacklashDiagnostics.add(btnCalibrate, "10, 1, 1, 3, left, default");
+
+        lblBacklashOffset = new JLabel("Backlash Offset");
+        panelBacklashDiagnostics.add(lblBacklashOffset, "2, 4, right, default");
+
+        backlashOffset = new JTextField();
+        panelBacklashDiagnostics.add(backlashOffset, "4, 4");
+        backlashOffset.setColumns(10);
+
+        lblSneakupDistance = new JLabel("Sneak-up Distance");
+        panelBacklashDiagnostics.add(lblSneakupDistance, "6, 4, right, default");
+
+        sneakUpOffset = new JTextField();
+        panelBacklashDiagnostics.add(sneakUpOffset, "8, 4");
+        sneakUpOffset.setColumns(10);
+
+        lblBacklashSpeedFactor = new JLabel("Speed Factor");
+        panelBacklashDiagnostics.add(lblBacklashSpeedFactor, "2, 6, right, default");
+
+        backlashSpeedFactor = new JTextField();
+        panelBacklashDiagnostics.add(backlashSpeedFactor, "4, 6");
+        backlashSpeedFactor.setColumns(10);
+
+        lblStepTest = new JLabel("<html>\r\n<body style=\"text-align:right\">\r\n<p>\r\nAbsolute <span style=\"color:#FF0000\">&mdash;&mdash;</span>\r\n</p>\r\n<p>\r\nRelative <span style=\"color:#005BD9\">&mdash;&mdash;</span>\r\n</p>\r\n<p>\r\nRandom <span style=\"color:#BB7700\">&mdash;&mdash;</span>\r\n</p>\r\n<br/>\r\n<p>\r\nTolerance <span style=\"color:#008000\">&mdash;&mdash;</span>\r\n</p>\r\n<br/>\r\n<p>\r\nerror at step.\r\n</p>\r\n</body>\r\n</html>");
+        panelBacklashDiagnostics.add(lblStepTest, "2, 8, right, default");
+
+        stepTestGraph = new SimpleGraphView();
+        stepTestGraph.setPreferredSize(new Dimension(300, 200));
+        stepTestGraph.setFont(new Font("Dialog", Font.PLAIN, 11));
+        panelBacklashDiagnostics.add(stepTestGraph, "4, 8, 7, 1, fill, fill");
+
+        lblBacklashDistanceTest = new JLabel("<html>\r\n<body style=\"text-align:right\">\r\n<p>\r\nBacklash <span style=\"color:#005BD9\">&mdash;&mdash;</span>\r\n</p>\r\n<p>\r\nOvershoot <span style=\"color:#FF0000\">&mdash;&mdash;</span>\r\n</p>\r\n<p>\r\nRandom <span style=\"color:#BB7700\">&mdash;&mdash;</span>\r\n</p>\r\n<br/>\r\n<p>\r\nMove Time <span style=\"color:#00AA00\">&mdash;&mdash;</span>\r\n</p>\r\n<br/>\r\n<br/>\r\n<p>\r\nforward/ <span style=\"color:#777777\">reverse</span><br/>\r\nat move distance.\r\n<p/>\r\n</body>\r\n</html>");
+        panelBacklashDiagnostics.add(lblBacklashDistanceTest, "2, 10, right, default");
+
+        backlashDistanceTestGraph = new SimpleGraphView();
+        backlashDistanceTestGraph.setPreferredSize(new Dimension(300, 400));
+        backlashDistanceTestGraph.setFont(new Font("Dialog", Font.PLAIN, 11));
+        panelBacklashDiagnostics.add(backlashDistanceTestGraph, "4, 10, 7, 1, fill, fill");
+
+        lblBacklashSpeedTest = new JLabel("<html>\r\n<body style=\"text-align:right\">\r\n<p>\r\nBacklash <span style=\"color:#FF0000\">&mdash;&mdash;</span>\r\n</p>\r\n<br/>\r\n<p>\r\nat move speed.\r\n</p>\r\n</body>\r\n</html>");
+        panelBacklashDiagnostics.add(lblBacklashSpeedTest, "2, 12, right, default");
+
+        backlashSpeedTestGraph = new SimpleGraphView();
+        backlashSpeedTestGraph.setPreferredSize(new Dimension(300, 200));
+        backlashSpeedTestGraph.setFont(new Font("Dialog", Font.PLAIN, 11));
+        panelBacklashDiagnostics.add(backlashSpeedTestGraph, "4, 12, 7, 1, fill, fill");
+    }
+
+    protected void adaptDialog() {
+        BacklashCompensationMethod backlashMethod = (BacklashCompensationMethod) backlashCompensationMethod.getSelectedItem();
+        boolean showCalibration = (type == Type.X || type == Type.Y);
+
+        lblBacklashOffset.setVisible(backlashMethod != BacklashCompensationMethod.None);
+        backlashOffset.setVisible(backlashMethod != BacklashCompensationMethod.None);
+        lblSneakupDistance.setVisible(backlashMethod == BacklashCompensationMethod.DirectionalSneakUp);
+        sneakUpOffset.setVisible(backlashMethod == BacklashCompensationMethod.DirectionalSneakUp);
+        lblBacklashSpeedFactor.setVisible(backlashMethod.isSpeedControlledMethod());
+        backlashSpeedFactor.setVisible(backlashMethod.isSpeedControlledMethod());
+
+        lblAcceptableTolerance.setVisible(showCalibration);
+        acceptableTolerance.setVisible(showCalibration);
+        btnCalibrate.setVisible(showCalibration);
+        lblStepTest.setVisible(showCalibration);
+        stepTestGraph.setVisible(showCalibration);
+        lblBacklashDistanceTest.setVisible(showCalibration);
+        backlashDistanceTestGraph.setVisible(showCalibration);
+        lblBacklashSpeedTest.setVisible(showCalibration);
+        backlashSpeedTestGraph.setVisible(showCalibration);
+    }
+
+    @Override
+    public void createBindings() {
+        LengthConverter lengthConverter = new LengthConverter();
+        DoubleConverter doubleConverter = new DoubleConverter("%f"); 
+
+        addWrappedBinding(axis, "type", this, "type");
+
+        addWrappedBinding(axis, "backlashCompensationMethod", backlashCompensationMethod, "selectedItem");
+        addWrappedBinding(axis, "acceptableTolerance", acceptableTolerance, "text", lengthConverter);
+        addWrappedBinding(axis, "backlashOffset", backlashOffset, "text", lengthConverter);
+        addWrappedBinding(axis, "sneakUpOffset", sneakUpOffset, "text", lengthConverter);
+        addWrappedBinding(axis, "backlashSpeedFactor", backlashSpeedFactor, "text", doubleConverter);
+
+        addWrappedBinding(axis, "stepTestGraph", stepTestGraph, "graph");
+        addWrappedBinding(axis, "backlashDistanceTestGraph", backlashDistanceTestGraph, "graph");
+        addWrappedBinding(axis, "backlashSpeedTestGraph", backlashSpeedTestGraph, "graph");
+
+        ComponentDecorators.decorateWithAutoSelectAndLengthConversion(acceptableTolerance);
+        ComponentDecorators.decorateWithAutoSelectAndLengthConversion(backlashOffset);
+        ComponentDecorators.decorateWithAutoSelectAndLengthConversion(sneakUpOffset);
+
+        adaptDialog();
+    }
+}

--- a/src/main/java/org/openpnp/machine/reference/axis/wizards/BacklashCompensationConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/axis/wizards/BacklashCompensationConfigurationWizard.java
@@ -223,7 +223,7 @@ public class BacklashCompensationConfigurationWizard extends AbstractConfigurati
         backlashDistanceTestGraph.setFont(new Font("Dialog", Font.PLAIN, 11));
         panelBacklashDiagnostics.add(backlashDistanceTestGraph, "4, 10, 7, 1, fill, fill");
 
-        lblBacklashSpeedTest = new JLabel("<html>\r\n<body style=\"text-align:right\">\r\n<p>\r\nBacklash <span style=\"color:#FF0000\">&mdash;&mdash;</span>\r\n</p>\r\n<br/>\r\n<p>\r\nat move speed.\r\n</p>\r\n</body>\r\n</html>");
+        lblBacklashSpeedTest = new JLabel("<html>\r\n<body style=\"text-align:right\">\r\n<p>\r\nBacklash <span style=\"color:#FF0000\">&mdash;&mdash;</span>\r\n</p>\r\n<br/>\r\n<p>\r\nEffective Speed <span style=\"color:#00AA00\">&mdash;&mdash;</span>\r\n</p>\r\n<br/>\r\n<br/>\r\n<p>\r\nforward/ <span style=\"color:#777777\">reverse</span><br/>\r\nat nominal speed.\r\n</p>\r\n</body>\r\n</html>");
         panelBacklashDiagnostics.add(lblBacklashSpeedTest, "2, 12, right, default");
 
         backlashSpeedTestGraph = new SimpleGraphView();

--- a/src/main/java/org/openpnp/machine/reference/axis/wizards/ReferenceControllerAxisConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/axis/wizards/ReferenceControllerAxisConfigurationWizard.java
@@ -22,8 +22,6 @@
 package org.openpnp.machine.reference.axis.wizards;
 
 import java.awt.Color;
-import java.awt.Dimension;
-import java.awt.Font;
 import java.awt.event.ActionEvent;
 import java.awt.event.ItemEvent;
 import java.awt.event.ItemListener;
@@ -39,28 +37,19 @@ import javax.swing.JScrollPane;
 import javax.swing.JTextArea;
 import javax.swing.JTextField;
 import javax.swing.SwingUtilities;
-import javax.swing.UIManager;
 import javax.swing.border.TitledBorder;
 
-import org.openpnp.gui.MainFrame;
 import org.openpnp.gui.components.ComponentDecorators;
-import org.openpnp.gui.components.SimpleGraphView;
 import org.openpnp.gui.support.DoubleConverter;
 import org.openpnp.gui.support.DriversComboBoxModel;
 import org.openpnp.gui.support.Icons;
 import org.openpnp.gui.support.LengthConverter;
 import org.openpnp.gui.support.NamedConverter;
-import org.openpnp.machine.reference.ReferenceCamera;
-import org.openpnp.machine.reference.ReferenceHead;
-import org.openpnp.machine.reference.ReferenceMachine;
 import org.openpnp.machine.reference.axis.ReferenceControllerAxis;
-import org.openpnp.machine.reference.axis.ReferenceControllerAxis.BacklashCompensationMethod;
 import org.openpnp.model.Configuration;
 import org.openpnp.model.Length;
 import org.openpnp.spi.Axis.Type;
-import org.openpnp.spi.Camera.Looking;
 import org.openpnp.spi.Driver;
-import org.openpnp.spi.HeadMountable;
 import org.openpnp.spi.base.AbstractControllerAxis;
 import org.openpnp.spi.base.AbstractMachine;
 import org.openpnp.util.UiUtils;
@@ -86,8 +75,6 @@ public class ReferenceControllerAxisConfigurationWizard extends AbstractAxisConf
     private JTextArea preMoveCommand;
     private JScrollPane scrollPane;
     protected NamedConverter<Driver> driverConverter;
-    private JLabel lblBacklashOffset;
-    private JTextField backlashOffset;
     private JPanel panelKinematics;
     private JLabel lblFeedrates;
     private JTextField feedratePerSecond;
@@ -109,10 +96,6 @@ public class ReferenceControllerAxisConfigurationWizard extends AbstractAxisConf
     private JButton btnCaptureSoftLimitHigh;
     private JButton btnPositionSoftLimitLow;
     private JButton btnPositionSoftLimitHigh;
-    private JLabel lblBacklashCompensation;
-    private JComboBox backlashCompensationMethod;
-    private JLabel lblBacklashSpeedFactor;
-    private JTextField backlashSpeedFactor;
     private JLabel lblSafeZoneLow;
     private JLabel lblSafeZoneHigh;
     private JTextField safeZoneLow;
@@ -123,6 +106,7 @@ public class ReferenceControllerAxisConfigurationWizard extends AbstractAxisConf
     private JButton btnPositionSafeZoneLow;
     private JButton btnCaptureSafeZoneHigh;
     private JButton btnPositionSafeZoneHigh;
+    private JLabel lblNotMmmin;
 
     private Action captureSoftLimitLowAction = new AbstractAction(null, Icons.captureAxisLow) {
         {
@@ -191,7 +175,7 @@ public class ReferenceControllerAxisConfigurationWizard extends AbstractAxisConf
             });
         }
     };
-    
+
 
     private Action captureSafeZoneLowAction = new AbstractAction(null, Icons.captureAxisLow) {
         {
@@ -261,56 +245,6 @@ public class ReferenceControllerAxisConfigurationWizard extends AbstractAxisConf
         }
     };    
 
-    private Action backlashCalibrateAction = new AbstractAction("Calibrate now", Icons.axisCartesian) {
-        {
-            putValue(Action.SHORT_DESCRIPTION,
-                    "<html>\r\n" + 
-                    "<p>Calibrate the axis backlash compensation settings using the calibration fiducial.</p>\r\n" + 
-                    "<p>Make sure the calibration rig is set up and present.</p>" +
-                    "<p>Consider using this function from Issues & Solutions where you get step by step instructions,<br/>\r\n" + 
-                    "for the needed preparatory steps and the calibration in proper sequence. You also get extensive Wiki links.</p>\r\n" + 
-                    "</html>");
-        }
-
-        @Override
-        public void actionPerformed(ActionEvent e) {
-            applyAction.actionPerformed(e);
-            UiUtils.submitUiMachineTask(() -> {
-                HeadMountable hm = ((AbstractControllerAxis) axis).getDefaultHeadMountable();
-                if (hm instanceof ReferenceCamera) {
-                    ReferenceCamera camera = (ReferenceCamera) hm;
-                    if (camera.getHead() != null && camera.getLooking() == Looking.Down) {
-                        if (Configuration.get().getMachine() instanceof ReferenceMachine) {
-                            ReferenceMachine refMachine = (ReferenceMachine) Configuration.get().getMachine();
-                            refMachine.getCalibrationSolutions()
-                            .calibrateAxisBacklash((ReferenceHead)(camera.getHead()), camera,
-                                    camera, (ReferenceControllerAxis)axis, 
-                                    ((ReferenceControllerAxis)axis).getAcceptableTolerance());
-                            MainFrame.get().getMachineSetupTab().selectCurrentTreePath();
-                            return true;
-                        }
-                    }
-                }
-                throw new Exception("Only an axis on a down-looking camera can be calibrated.");
-            });
-        }
-    };    
-
-    private JLabel lblNotMmmin;
-    private JPanel panelBacklashDiagnostics;
-    private JLabel lblStepTest;
-    private JLabel lblNewLabel;
-    private SimpleGraphView stepTestGraph;
-    private JLabel lblBacklashSpeedTest;
-    private SimpleGraphView backlashSpeedTestGraph;
-    private JLabel lblBacklashDistanceTest;
-    private SimpleGraphView backlashDistanceTestGraph;
-    private JLabel lblSneakupDistance;
-    private JTextField sneakUpOffset;
-    private JButton btnCalibrate;
-    private JLabel lblAcceptableTolerance;
-    private JTextField acceptableTolerance;
-
     public ReferenceControllerAxisConfigurationWizard(ReferenceControllerAxis axis) {
         super(axis);
 
@@ -326,27 +260,27 @@ public class ReferenceControllerAxisConfigurationWizard extends AbstractAxisConf
                 ColumnSpec.decode("max(50dlu;default)"),
                 FormSpecs.RELATED_GAP_COLSPEC,
                 FormSpecs.DEFAULT_COLSPEC,},
-            new RowSpec[] {
-                FormSpecs.RELATED_GAP_ROWSPEC,
-                FormSpecs.DEFAULT_ROWSPEC,
-                FormSpecs.RELATED_GAP_ROWSPEC,
-                FormSpecs.DEFAULT_ROWSPEC,
-                FormSpecs.RELATED_GAP_ROWSPEC,
-                FormSpecs.DEFAULT_ROWSPEC,
-                FormSpecs.RELATED_GAP_ROWSPEC,
-                FormSpecs.DEFAULT_ROWSPEC,
-                FormSpecs.RELATED_GAP_ROWSPEC,
-                FormSpecs.DEFAULT_ROWSPEC,
-                FormSpecs.RELATED_GAP_ROWSPEC,
-                FormSpecs.DEFAULT_ROWSPEC,
-                FormSpecs.RELATED_GAP_ROWSPEC,
-                FormSpecs.DEFAULT_ROWSPEC,
-                FormSpecs.RELATED_GAP_ROWSPEC,
-                FormSpecs.DEFAULT_ROWSPEC,
-                FormSpecs.RELATED_GAP_ROWSPEC,
-                FormSpecs.DEFAULT_ROWSPEC,
-                FormSpecs.RELATED_GAP_ROWSPEC,
-                RowSpec.decode("default:grow"),}));
+                new RowSpec[] {
+                        FormSpecs.RELATED_GAP_ROWSPEC,
+                        FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC,
+                        FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC,
+                        FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC,
+                        FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC,
+                        FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC,
+                        FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC,
+                        FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC,
+                        FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC,
+                        FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC,
+                        RowSpec.decode("default:grow"),}));
 
         lblDriver = new JLabel("Driver");
         panelControllerSettings.add(lblDriver, "2, 2, right, default");
@@ -366,11 +300,11 @@ public class ReferenceControllerAxisConfigurationWizard extends AbstractAxisConf
         letter = new JTextField();
         panelControllerSettings.add(letter, "4, 4, fill, default");
         letter.setColumns(10);
-        
+
         lblInvertLinearrotational = new JLabel("Switch Linear ↔ Rotational?");
         lblInvertLinearrotational.setToolTipText("<html>\r\n<p>It is important that OpenPnP understands whether an Axis is linear or rotational in <br/>\r\nthe controller. </p> \r\n<p>Most of the times this is already determined by the Axis Type, i.e. X, Y, Z are linear <br/>\r\nand Rotation is rotational. But sometimes you may run out of proper axes on the <br/>\r\ncontroller and then have to use a linear controller axis for a rotational OpenPnP axis <br/>\r\nor vice versa.</p>\r\n<p>If you cannot configure your controller to switch this meaning, it is important to enable <br/>\r\nthe Switch Linear ↔ Rotational checkbox.</p>\r\n<p>This is relevant in computing proper limits for feed-rate, acceleration and jerk in mixed<br/>\r\naxes moves, as only the motion of linear axes is taken into consideration for the limts in \\br/>\r\nstandard G-Code.</p>\r\n</html>");
         panelControllerSettings.add(lblInvertLinearrotational, "2, 6, right, default");
-        
+
         invertLinearRotational = new JCheckBox("");
         invertLinearRotational.setToolTipText("");
         panelControllerSettings.add(invertLinearRotational, "4, 6");
@@ -430,23 +364,23 @@ public class ReferenceControllerAxisConfigurationWizard extends AbstractAxisConf
                 FormSpecs.DEFAULT_COLSPEC,
                 FormSpecs.RELATED_GAP_COLSPEC,
                 FormSpecs.DEFAULT_COLSPEC,},
-            new RowSpec[] {
-                FormSpecs.RELATED_GAP_ROWSPEC,
-                FormSpecs.DEFAULT_ROWSPEC,
-                FormSpecs.RELATED_GAP_ROWSPEC,
-                FormSpecs.DEFAULT_ROWSPEC,
-                FormSpecs.RELATED_GAP_ROWSPEC,
-                FormSpecs.DEFAULT_ROWSPEC,
-                FormSpecs.RELATED_GAP_ROWSPEC,
-                FormSpecs.DEFAULT_ROWSPEC,
-                FormSpecs.RELATED_GAP_ROWSPEC,
-                FormSpecs.DEFAULT_ROWSPEC,
-                FormSpecs.RELATED_GAP_ROWSPEC,
-                FormSpecs.DEFAULT_ROWSPEC,
-                FormSpecs.RELATED_GAP_ROWSPEC,
-                FormSpecs.DEFAULT_ROWSPEC,
-                FormSpecs.RELATED_GAP_ROWSPEC,
-                FormSpecs.DEFAULT_ROWSPEC,}));
+                new RowSpec[] {
+                        FormSpecs.RELATED_GAP_ROWSPEC,
+                        FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC,
+                        FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC,
+                        FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC,
+                        FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC,
+                        FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC,
+                        FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC,
+                        FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC,
+                        FormSpecs.DEFAULT_ROWSPEC,}));
 
         lblSoftLimitLow = new JLabel("Soft Limit Low");
         panelKinematics.add(lblSoftLimitLow, "2, 2, right, default");
@@ -457,42 +391,42 @@ public class ReferenceControllerAxisConfigurationWizard extends AbstractAxisConf
 
         softLimitLowEnabled = new JCheckBox("Enabled?");
         panelKinematics.add(softLimitLowEnabled, "6, 2");
-        
-                btnPositionSoftLimitLow = new JButton(positionSoftLimitLowAction);
-                panelKinematics.add(btnPositionSoftLimitLow, "8, 2");
+
+        btnPositionSoftLimitLow = new JButton(positionSoftLimitLowAction);
+        panelKinematics.add(btnPositionSoftLimitLow, "8, 2");
 
         btnCaptureSoftLimitLow = new JButton(captureSoftLimitLowAction);
         panelKinematics.add(btnCaptureSoftLimitLow, "10, 2");
-        
+
         lblSafeZoneLow = new JLabel("Safe Zone Low");
         panelKinematics.add(lblSafeZoneLow, "2, 4, right, default");
-        
+
         safeZoneLow = new JTextField();
         panelKinematics.add(safeZoneLow, "4, 4, fill, default");
         safeZoneLow.setColumns(10);
-        
+
         safeZoneLowEnabled = new JCheckBox("Enabled?");
         panelKinematics.add(safeZoneLowEnabled, "6, 4");
-        
+
         btnPositionSafeZoneLow = new JButton(positionSafeZoneLowAction);
         panelKinematics.add(btnPositionSafeZoneLow, "8, 4");
-        
+
         btnCaptureSafeZoneLow = new JButton(captureSafeZoneLowAction);
         panelKinematics.add(btnCaptureSafeZoneLow, "10, 4");
-        
+
         lblSafeZoneHigh = new JLabel("Safe Zone High");
         panelKinematics.add(lblSafeZoneHigh, "2, 6, right, default");
-        
+
         safeZoneHigh = new JTextField();
         panelKinematics.add(safeZoneHigh, "4, 6, fill, default");
         safeZoneHigh.setColumns(10);
-        
+
         safeZoneHighEnabled = new JCheckBox("Enabled?");
         panelKinematics.add(safeZoneHighEnabled, "6, 6");
-        
+
         btnPositionSafeZoneHigh = new JButton(positionSafeZoneHighAction);
         panelKinematics.add(btnPositionSafeZoneHigh, "8, 6");
-        
+
         btnCaptureSafeZoneHigh = new JButton(captureSafeZoneHighAction);
         panelKinematics.add(btnCaptureSafeZoneHigh, "10, 6");
 
@@ -505,9 +439,9 @@ public class ReferenceControllerAxisConfigurationWizard extends AbstractAxisConf
 
         softLimitHighEnabled = new JCheckBox("Enabled?");
         panelKinematics.add(softLimitHighEnabled, "6, 8");
-        
-                btnPositionSoftLimitHigh = new JButton(positionSoftLimitHighAction);
-                panelKinematics.add(btnPositionSoftLimitHigh, "8, 8");
+
+        btnPositionSoftLimitHigh = new JButton(positionSoftLimitHighAction);
+        panelKinematics.add(btnPositionSoftLimitHigh, "8, 8");
 
         btnCaptureSoftLimitHigh = new JButton(captureSoftLimitHighAction);
         panelKinematics.add(btnCaptureSoftLimitHigh, "10, 8");
@@ -518,7 +452,7 @@ public class ReferenceControllerAxisConfigurationWizard extends AbstractAxisConf
         feedratePerSecond = new JTextField();
         panelKinematics.add(feedratePerSecond, "4, 12, fill, default");
         feedratePerSecond.setColumns(10);
-        
+
         lblNotMmmin = new JLabel("Not [/min]");
         lblNotMmmin.setForeground(Color.RED);
         panelKinematics.add(lblNotMmmin, "6, 12");
@@ -544,121 +478,15 @@ public class ReferenceControllerAxisConfigurationWizard extends AbstractAxisConf
                 adaptDialog();
             }
         });
-
-        panelBacklashDiagnostics = new JPanel();
-        panelBacklashDiagnostics.setBorder(new TitledBorder(UIManager.getBorder("TitledBorder.border"), "Backlash Calibration", TitledBorder.LEADING, TitledBorder.TOP, null, new Color(0, 0, 0)));
-        contentPanel.add(panelBacklashDiagnostics);
-        panelBacklashDiagnostics.setLayout(new FormLayout(new ColumnSpec[] {
-                FormSpecs.RELATED_GAP_COLSPEC,
-                ColumnSpec.decode("max(70dlu;default)"),
-                FormSpecs.RELATED_GAP_COLSPEC,
-                FormSpecs.DEFAULT_COLSPEC,
-                FormSpecs.RELATED_GAP_COLSPEC,
-                FormSpecs.DEFAULT_COLSPEC,
-                FormSpecs.RELATED_GAP_COLSPEC,
-                FormSpecs.DEFAULT_COLSPEC,
-                FormSpecs.RELATED_GAP_COLSPEC,
-                ColumnSpec.decode("default:grow"),},
-                new RowSpec[] {
-                        FormSpecs.RELATED_GAP_ROWSPEC,
-                        FormSpecs.DEFAULT_ROWSPEC,
-                        FormSpecs.RELATED_GAP_ROWSPEC,
-                        FormSpecs.DEFAULT_ROWSPEC,
-                        FormSpecs.RELATED_GAP_ROWSPEC,
-                        FormSpecs.DEFAULT_ROWSPEC,
-                        FormSpecs.RELATED_GAP_ROWSPEC,
-                        RowSpec.decode("max(100dlu;default)"),
-                        FormSpecs.RELATED_GAP_ROWSPEC,
-                        RowSpec.decode("max(100dlu;default)"),
-                        FormSpecs.RELATED_GAP_ROWSPEC,
-                        RowSpec.decode("max(100dlu;default)"),}));
-
-        lblBacklashCompensation = new JLabel("Backlash Compensation");
-        panelBacklashDiagnostics.add(lblBacklashCompensation, "2, 2, right, default");
-        lblBacklashCompensation.setToolTipText("<html>\r\n<p>Backlash compensation is used to avoid the effects of any looseness or play in the <br/>\r\nmechanical linkages of the given axis.  When the actuator reverses the direction of travel, <br/>\r\nthere is often a moment where nothing happens, because the slack from a belt or play <br/>\r\nfrom a screw or rack and pinion etc. needs to be bridged, before mechanical force can again <br/>\r\nbe transmitted.</p>\r\n\r\n<ul>\r\n<li>\r\n<strong>None:</strong>\r\nNo backlash compensation is performed. </li>\r\n<li>\r\n<strong>OneSidedPositioning:</strong><br/>\r\nBacklash compensation is applied by always moving to the end position from one side.<br/>\r\nThe backlash offset does not need to be very precise, i.e. it can be larger than the actual<br/> \r\nbacklash and the machine will still end up in the correct precise position.<br/>\r\nThe machine always needs to perform an extra move and it will force a complete machine<br/>\r\n still-stand between motion segments.</li>\r\n<li>\r\n<strong>OneSidedOptimizedPositioning:</strong><br/>\r\nWorks like OneSidedPositioning except it will only perform an extra move when moving <br/>\r\nfrom the wrong side. Only half of the extra moves are needed.</li>\r\n<li>\r\n<strong>DirectionalCompensation (Experimental!):</strong><br/>\r\nBacklash compensation is applied in the direction of travel. The offset is added to the <br/>\r\nactual target coordinate, if moving in the direction of the offset (which can be positive <br/>\r\nor negative), no offset is added if moving against the offset.<br/>\r\nNo extra moves are needed. The machine can also move more fluidly, as there is no <br/>\r\ndirection change needed.<br/>\r\nHowever: the offset needs to precisely match the physical backlash.</li>\r\n</ul>\r\n</html>");
-
-        backlashCompensationMethod = new JComboBox(BacklashCompensationMethod.values());
-        panelBacklashDiagnostics.add(backlashCompensationMethod, "4, 2");
-        backlashCompensationMethod.addItemListener(new ItemListener() {
-            public void itemStateChanged(ItemEvent e) {
-                adaptDialog();
-            }
-        });
-
-        lblAcceptableTolerance = new JLabel("Tolerance ±");
-        lblAcceptableTolerance.setToolTipText("<html>\r\n<p>Acceptable backlash compensation tolerance (±) for calibration.</p>\r\n<p>A larger tolerance will possibly allow for a more efficient backlash compensation method.</p>\r\n</html>");
-        panelBacklashDiagnostics.add(lblAcceptableTolerance, "6, 2, right, default");
-
-        acceptableTolerance = new JTextField();
-        panelBacklashDiagnostics.add(acceptableTolerance, "8, 2, fill, default");
-        acceptableTolerance.setColumns(10);
-
-        btnCalibrate = new JButton(backlashCalibrateAction);
-        panelBacklashDiagnostics.add(btnCalibrate, "10, 1, 1, 3, left, default");
-
-        lblBacklashOffset = new JLabel("Backlash Offset");
-        panelBacklashDiagnostics.add(lblBacklashOffset, "2, 4, right, default");
-
-        backlashOffset = new JTextField();
-        panelBacklashDiagnostics.add(backlashOffset, "4, 4");
-        backlashOffset.setColumns(10);
-
-        lblSneakupDistance = new JLabel("Sneak-up Distance");
-        panelBacklashDiagnostics.add(lblSneakupDistance, "6, 4, right, default");
-
-        sneakUpOffset = new JTextField();
-        panelBacklashDiagnostics.add(sneakUpOffset, "8, 4");
-        sneakUpOffset.setColumns(10);
-
-        lblBacklashSpeedFactor = new JLabel("Backlash Speed Factor");
-        panelBacklashDiagnostics.add(lblBacklashSpeedFactor, "2, 6, right, default");
-
-        backlashSpeedFactor = new JTextField();
-        panelBacklashDiagnostics.add(backlashSpeedFactor, "4, 6");
-        backlashSpeedFactor.setColumns(10);
-
-        lblStepTest = new JLabel("<html>\r\n<body style=\"text-align:right\">\r\n<p>\r\nAbsolute <span style=\"color:#FF0000\">&mdash;&mdash;</span>\r\n</p>\r\n<p>\r\nRelative <span style=\"color:#005BD9\">&mdash;&mdash;</span>\r\n</p>\r\n<p>\r\nRandom <span style=\"color:#BB7700\">&mdash;&mdash;</span>\r\n</p>\r\n<br/>\r\n<p>\r\nTolerance <span style=\"color:#008000\">&mdash;&mdash;</span>\r\n</p>\r\n<br/>\r\n<p>\r\nerror at step.\r\n</p>\r\n</body>\r\n</html>");
-        panelBacklashDiagnostics.add(lblStepTest, "2, 8, right, default");
-
-        stepTestGraph = new SimpleGraphView();
-        stepTestGraph.setPreferredSize(new Dimension(300, 200));
-        stepTestGraph.setFont(new Font("Dialog", Font.PLAIN, 11));
-        panelBacklashDiagnostics.add(stepTestGraph, "4, 8, 7, 1, fill, default");
-
-        lblBacklashDistanceTest = new JLabel("<html>\r\n<body style=\"text-align:right\">\r\n<p>\r\nBacklash <span style=\"color:#005BD9\">&mdash;&mdash;</span>\r\n</p>\r\n<p>\r\nOvershoot <span style=\"color:#FF0000\">&mdash;&mdash;</span>\r\n</p>\r\n<p>\r\nRandom <span style=\"color:#BB7700\">&mdash;&mdash;</span>\r\n</p>\r\n<br/>\r\n<p>\r\nMove Time <span style=\"color:#00AA00\">&mdash;&mdash;</span>\r\n</p>\r\n<br/>\r\n<br/>\r\n<p>\r\nforward/ <span style=\"color:#777777\">reverse</span><br/>\r\nat move distance.\r\n<p/>\r\n</body>\r\n</html>");
-        panelBacklashDiagnostics.add(lblBacklashDistanceTest, "2, 10, right, default");
-
-        backlashDistanceTestGraph = new SimpleGraphView();
-        backlashDistanceTestGraph.setPreferredSize(new Dimension(300, 350));
-        backlashDistanceTestGraph.setFont(new Font("Dialog", Font.PLAIN, 11));
-        panelBacklashDiagnostics.add(backlashDistanceTestGraph, "4, 10, 7, 1, fill, default");
-
-        lblBacklashSpeedTest = new JLabel("<html>\r\n<body style=\"text-align:right\">\r\n<p>\r\nBacklash <span style=\"color:#FF0000\">&mdash;&mdash;</span>\r\n</p>\r\n<br/>\r\n<p>\r\nat move speed.\r\n</p>\r\n</body>\r\n</html>");
-        panelBacklashDiagnostics.add(lblBacklashSpeedTest, "2, 12, right, default");
-
-        backlashSpeedTestGraph = new SimpleGraphView();
-        backlashSpeedTestGraph.setPreferredSize(new Dimension(300, 200));
-        backlashSpeedTestGraph.setFont(new Font("Dialog", Font.PLAIN, 11));
-        panelBacklashDiagnostics.add(backlashSpeedTestGraph, "4, 12, 7, 1, fill, default");
     }
 
     protected void adaptDialog() {
         Driver selectedDriver = driverConverter.convertReverse((String) driver.getSelectedItem());
-        BacklashCompensationMethod backlashMethod = (BacklashCompensationMethod) backlashCompensationMethod.getSelectedItem();
         boolean showPreMove = (selectedDriver != null && selectedDriver.isSupportingPreMove());
         boolean showRotationSettings = type.getSelectedItem() == Type.Rotation;
-        boolean showDiagnostics = type.getSelectedItem() == Type.X || type.getSelectedItem() == Type.Y;
+        boolean showCalibration = (type.getSelectedItem() == Type.X || type.getSelectedItem() == Type.Y);
         lblPremoveCommand.setVisible(showPreMove);
         scrollPane.setVisible(showPreMove);
-
-        //lblAcceptableTolerance.setVisible(backlashMethod != BacklashCompensationMethod.None);
-        //acceptableTolerance.setVisible(backlashMethod != BacklashCompensationMethod.None);
-        lblBacklashOffset.setVisible(backlashMethod != BacklashCompensationMethod.None);
-        backlashOffset.setVisible(backlashMethod != BacklashCompensationMethod.None);
-        lblSneakupDistance.setVisible(backlashMethod == BacklashCompensationMethod.DirectionalSneakUp);
-        sneakUpOffset.setVisible(backlashMethod == BacklashCompensationMethod.DirectionalSneakUp);
-        lblBacklashSpeedFactor.setVisible(backlashMethod.isSpeedControlledMethod());
-        backlashSpeedFactor.setVisible(backlashMethod.isSpeedControlledMethod());
 
         lblLimitRotation.setVisible(showRotationSettings);
         limitRotation.setVisible(showRotationSettings);
@@ -686,9 +514,7 @@ public class ReferenceControllerAxisConfigurationWizard extends AbstractAxisConf
         btnCaptureSafeZoneHigh.setVisible(!showRotationSettings);
         btnPositionSafeZoneLow.setVisible(!showRotationSettings);
         btnPositionSafeZoneHigh.setVisible(!showRotationSettings);
-        
-        panelBacklashDiagnostics.setVisible(showDiagnostics);
-        btnCalibrate.setVisible(showDiagnostics);
+
     }
 
     @Override
@@ -701,11 +527,6 @@ public class ReferenceControllerAxisConfigurationWizard extends AbstractAxisConf
         addWrappedBinding(axis, "letter", letter, "text");
         addWrappedBinding(axis, "invertLinearRotational", invertLinearRotational, "selected");
         addWrappedBinding(axis, "homeCoordinate", homeCoordinate, "text", lengthConverter);
-        addWrappedBinding(axis, "backlashCompensationMethod", backlashCompensationMethod, "selectedItem");
-        addWrappedBinding(axis, "acceptableTolerance", acceptableTolerance, "text", lengthConverter);
-        addWrappedBinding(axis, "backlashOffset", backlashOffset, "text", lengthConverter);
-        addWrappedBinding(axis, "sneakUpOffset", sneakUpOffset, "text", lengthConverter);
-        addWrappedBinding(axis, "backlashSpeedFactor", backlashSpeedFactor, "text", doubleConverter);
         addWrappedBinding(axis, "resolution", resolution, "text", doubleConverter);
         addWrappedBinding(axis, "preMoveCommand", preMoveCommand, "text");
 
@@ -726,15 +547,9 @@ public class ReferenceControllerAxisConfigurationWizard extends AbstractAxisConf
         addWrappedBinding(axis, "accelerationPerSecond2", accelerationPerSecond2, "text", lengthConverter);
         addWrappedBinding(axis, "jerkPerSecond3", jerkPerSecond3, "text", lengthConverter);
 
-        addWrappedBinding(axis, "stepTestGraph", stepTestGraph, "graph");
-        addWrappedBinding(axis, "backlashDistanceTestGraph", backlashDistanceTestGraph, "graph");
-        addWrappedBinding(axis, "backlashSpeedTestGraph", backlashSpeedTestGraph, "graph");
 
         ComponentDecorators.decorateWithAutoSelect(letter);
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(homeCoordinate);
-        ComponentDecorators.decorateWithAutoSelectAndLengthConversion(acceptableTolerance);
-        ComponentDecorators.decorateWithAutoSelectAndLengthConversion(backlashOffset);
-        ComponentDecorators.decorateWithAutoSelectAndLengthConversion(sneakUpOffset);
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(feedratePerSecond);
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(accelerationPerSecond2);
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(jerkPerSecond3);

--- a/src/main/java/org/openpnp/machine/reference/driver/GcodeDriver.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/GcodeDriver.java
@@ -452,14 +452,10 @@ public class GcodeDriver extends AbstractReferenceDriver implements Named {
     public List<String> getAxisVariables(ReferenceMachine machine) {
         List<String> variables = new ArrayList<>();
         if (usingLetterVariables) {
-            for (org.openpnp.spi.Axis axis : machine.getAxes()) {
-                if (axis instanceof ControllerAxis) {
-                    if (((ControllerAxis) axis).getDriver() == this) {
-                        String letter = ((ControllerAxis) axis).getLetter(); 
-                        if (letter != null && !letter.isEmpty()) {
-                            variables.add(letter);
-                        }
-                    }
+            for (ControllerAxis axis : getAxes(machine)) {
+                String letter = axis.getLetter(); 
+                if (letter != null && !letter.isEmpty()) {
+                    variables.add(letter);
                 }
             }
         }

--- a/src/main/java/org/openpnp/machine/reference/solutions/GcodeDriverSolutions.java
+++ b/src/main/java/org/openpnp/machine/reference/solutions/GcodeDriverSolutions.java
@@ -700,10 +700,19 @@ public class GcodeDriverSolutions implements Solutions.Subject {
                                         commandBuilt = "G28.2 ";
                                         for (String variable : gcodeDriver.getAxisVariables(machine)) {
                                             if ("XYZ".indexOf(variable) >= 0) {
-                                                commandBuilt += variable+"0 "; // In TinyG you need to indicate the axis and only 0 is possible. 
+                                                // In TinyG you need to indicate the axis and only 0 is possible as coordinate.
+                                                commandBuilt += variable+"0 ";  
                                             }
                                         }
-                                        commandBuilt += "; Home all axes";
+                                        commandBuilt += "; Home all axes\n";
+                                        commandBuilt += "G28.3 ";
+                                        for (ControllerAxis axis : gcodeDriver.getAxes(machine)) {
+                                            if (!axis.getLetter().isEmpty()) {
+                                                commandBuilt += axis.getLetter()+axis.getHomeCoordinate()+" ";
+                                            }
+                                        }
+                                        commandBuilt += "; Set all axes to home coordinates\n";
+                                        commandBuilt += "G92.1 ; Reset all offsets\n";
                                     }
                                     else {
                                         commandBuilt = "G28 ; Home all axes";

--- a/src/main/java/org/openpnp/spi/base/AbstractDriver.java
+++ b/src/main/java/org/openpnp/spi/base/AbstractDriver.java
@@ -1,6 +1,8 @@
 package org.openpnp.spi.base;
 
 import java.awt.event.ActionEvent;
+import java.util.ArrayList;
+import java.util.List;
 
 import javax.swing.AbstractAction;
 import javax.swing.Action;
@@ -18,12 +20,13 @@ import org.openpnp.model.AbstractModelObject;
 import org.openpnp.model.Configuration;
 import org.openpnp.model.Length;
 import org.openpnp.spi.Axis;
+import org.openpnp.spi.Axis.Type;
 import org.openpnp.spi.Camera;
+import org.openpnp.spi.ControllerAxis;
 import org.openpnp.spi.Driver;
 import org.openpnp.spi.Machine;
 import org.openpnp.spi.Nozzle;
 import org.openpnp.spi.PropertySheetHolder;
-import org.openpnp.spi.Axis.Type;
 import org.simpleframework.xml.Attribute;
 
 public abstract class AbstractDriver extends AbstractModelObject implements Driver {
@@ -81,6 +84,18 @@ public abstract class AbstractDriver extends AbstractModelObject implements Driv
     @Override
     public String toString() {
         return getName();
+    }
+
+    public List<ControllerAxis> getAxes(ReferenceMachine machine) {
+        List<ControllerAxis> list = new ArrayList<>(); 
+        for (org.openpnp.spi.Axis axis : machine.getAxes()) {
+            if (axis instanceof ControllerAxis) {
+                if (((ControllerAxis) axis).getDriver() == this) {
+                    list.add((ControllerAxis) axis);
+                }
+            }
+        }
+        return list;
     }
 
     protected void createAxisMappingDefaults(ReferenceMachine machine) throws Exception {


### PR DESCRIPTION
# Description
Another round in the [Automatic Machine Calibration using Issues & Solutions series](https://github.com/openpnp/openpnp/issues?q=label%3Aautomatic-calibration+is%3Aclosed).

* Separated the Backlash Compensation Calibration into a separate Wizard.

    ![Backlash Wizard](https://user-images.githubusercontent.com/9963310/134782398-0faaac87-1cbf-4c15-9f02-4bfb6ddb9ccb.png)

* Improved the logarithmic view of SimpleGraphView.
* Improved the backlash over distance and time over distance graph recording in I&S backlash calibration.
* Better TinyG `HOME_COMMAND`.
* Refactored getting a driver's axes.
* Added speed-factor test and graph to backlash calibration. 
* Handle Acceptable Tolerance better, i.e. store effective tolerance back to axis.
* Indicate backlash envelope on graph.

# Justification
Ongoing testing and feedback from the discussion:
https://groups.google.com/g/openpnp/c/dBg7txMB0R0/m/czPqQVSNCAAJ

# Instructions for Use
The interpreted backlash tolerance envelope and sneak-up offset is now indicated on the graph. Look for the letter-F-shaped dark blue indicator:

![F](https://user-images.githubusercontent.com/9963310/134782691-3f7a60ed-9f43-40b4-90f5-62c99c841f00.png)

* The vertical line gives you the required sneak-up offset.

* The horizontal lines limit the backlash offsets within the tolerance.

# Implementation Details
1. Tested in simulation and on the machine.
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. Successful `mvn test` before submitting the Pull Request.
