### PR TITLE
Feature / Automatic Machine Calibration using Issues & Solutions - Round 10

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/solutions/CalibrationSolutions.java
+++ b/src/main/java/org/openpnp/machine/reference/solutions/CalibrationSolutions.java
@@ -33,6 +33,7 @@ import org.openpnp.machine.reference.ReferenceMachine;
 import org.openpnp.machine.reference.ReferenceNozzle;
 import org.openpnp.machine.reference.axis.ReferenceControllerAxis;
 import org.openpnp.machine.reference.axis.ReferenceControllerAxis.BacklashCompensationMethod;
+import org.openpnp.machine.reference.camera.ImageCamera;
 import org.openpnp.machine.reference.feeder.ReferenceTubeFeeder;
 import org.openpnp.model.AxesLocation;
 import org.openpnp.model.Length;
@@ -50,6 +51,7 @@ import org.openpnp.spi.Head;
 import org.openpnp.spi.HeadMountable;
 import org.openpnp.spi.MotionPlanner.CompletionType;
 import org.openpnp.spi.Nozzle;
+import org.openpnp.spi.base.AbstractHead.VisualHomingMethod;
 import org.openpnp.util.MovableUtils;
 import org.openpnp.util.NanosecondTime;
 import org.openpnp.util.SimpleGraph;
@@ -298,8 +300,10 @@ public class CalibrationSolutions implements Solutions.Subject {
     private void perNozzleSolutions(Solutions solutions, ReferenceHead head, ReferenceCamera defaultCamera,
             Nozzle defaultNozzle, ReferenceNozzle nozzle) {
         VisionSolutions visualSolutions = machine.getVisionSolutions();
+        // Allow zero offsets on the simulated default nozzle.
+        boolean isSimulatedNozzle = (nozzle == defaultNozzle && defaultCamera instanceof ImageCamera);
         if (visualSolutions.isSolvedPrimaryXY(head) && visualSolutions.isSolvedPrimaryZ(head) 
-                && (nozzle == defaultNozzle || nozzle.getHeadOffsets().isInitialized())) {
+                && (nozzle.getHeadOffsets().isInitialized() || isSimulatedNozzle)) {
             final Location oldNozzleOffsets = nozzle.getHeadOffsets();
             final Length oldTestObjectDiameter = head.getCalibrationTestObjectDiameter(); 
             // Get the test subject diameter.
@@ -878,7 +882,9 @@ public class CalibrationSolutions implements Solutions.Subject {
                     + "Automatic compensation not possible.");
         }
         // Because this change may affect the coordinate system, perform a (visual) homing cycle.
-        head.visualHome(machine, true);
+        if (head.getVisualHomingMethod() == VisualHomingMethod.ResetToFiducialLocation) {
+            head.visualHome(machine, true);
+        }
         // Go back to the fiducial.
         MovableUtils.moveToLocationAtSafeZ(movable, location);
         // Test the new settings with random moves.

--- a/src/main/java/org/openpnp/machine/reference/solutions/CalibrationSolutions.java
+++ b/src/main/java/org/openpnp/machine/reference/solutions/CalibrationSolutions.java
@@ -957,7 +957,10 @@ public class CalibrationSolutions implements Solutions.Subject {
                         new AxesLocation(axis, axis.getSoftLimitHigh()));
         }
         else {
-            axesLocation = axesLocation.add(new AxesLocation(axis, displacement));
+            axesLocation = axesLocation.put(new AxesLocation(axis, 
+                    Math.max(axis.getSoftLimitLow().convertToUnits(axis.getUnits()).getValue(),
+                            Math.min(axis.getSoftLimitHigh().convertToUnits(axis.getUnits()).getValue(),
+                                    axesLocation.getCoordinate(axis) + displacement))));
         }
         Location newLocation = movable.toTransformed(axesLocation);
         newLocation = movable.toHeadMountableLocation(newLocation);

--- a/src/main/java/org/openpnp/machine/reference/solutions/VisionSolutions.java
+++ b/src/main/java/org/openpnp/machine/reference/solutions/VisionSolutions.java
@@ -675,7 +675,7 @@ public class VisionSolutions implements Solutions.Subject {
         if (isSolvedPrimaryXY(head) 
                 && (isSolvedPrimaryZ(head) || defaultNozzle == nozzle)) {
             final Location oldPrimaryFiducialLocation = head.getCalibrationPrimaryFiducialLocation();
-            final Location oldSecondaryFiducialLocation = head.getCalibrationPrimaryFiducialLocation();
+            final Location oldSecondaryFiducialLocation = head.getCalibrationSecondaryFiducialLocation();
             final Location oldPrimaryUpp = defaultCamera.getUnitsPerPixelPrimary();
             final Location oldSecondaryUpp = defaultCamera.getUnitsPerPixelSecondary();
             


### PR DESCRIPTION
# Description

Another round in the [Automatic Machine Calibration using Issues & Solutions series](https://github.com/openpnp/openpnp/issues?q=label%3Aautomatic-calibration+is%3Aclosed).

* Only re-home in backlash calibration, if the **ResetToFiducialLocation** homing method is set. For **ResetToHomeCoordinates** a full homing cycle would be needed, and this is not generally do-able.
* Fixed bug in secondary fiducial offsets calibration: Undoing/Re-opening the solution would mistakenly restore the secondary fiducial Z to the primary fiducial Z.
* Limit the calibration displacement to the soft limits (by @tonyluken). 
* Make the zero nozzle offsets exception for the simulated machine more explicit, so it won't be applied to real machines.

# Justification
Ongoing testing and feedback from the discussion:
https://groups.google.com/g/openpnp/c/dBg7txMB0R0/m/czPqQVSNCAAJ

# Instructions for Use
Same as before.

# Implementation Details
1. Tested in simulation.
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. Successful `mvn test` before submitting the Pull Request. 
