### PR TITLE
Feature/Simulated Lens Distortion and Mounting Yaw

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/camera/ImageCamera.java
+++ b/src/main/java/org/openpnp/machine/reference/camera/ImageCamera.java
@@ -52,6 +52,7 @@ import org.openpnp.model.Solutions.Severity;
 import org.openpnp.spi.Nozzle;
 import org.openpnp.spi.PropertySheetHolder;
 import org.openpnp.spi.VisionProvider.TemplateMatch;
+import org.openpnp.util.ImageUtils;
 import org.openpnp.util.OpenCvUtils;
 import org.openpnp.vision.FluentCv;
 import org.pmw.tinylog.Logger;
@@ -76,6 +77,12 @@ public class ImageCamera extends ReferenceCamera {
 
     @Attribute(required = false)
     private double simulatedScale = 1.0;
+
+    @Attribute(required = false)
+    private double simulatedDistortion = 0.0;
+
+    @Attribute(required = false)
+    private double simulatedYaw = 0.0;
 
     @Attribute(required = false)
     private boolean simulatedFlipped = false;
@@ -150,6 +157,22 @@ public class ImageCamera extends ReferenceCamera {
 
     public void setSimulatedScale(double simulatedScale) {
         this.simulatedScale = simulatedScale;
+    }
+
+    public double getSimulatedDistortion() {
+        return simulatedDistortion;
+    }
+
+    public void setSimulatedDistortion(double simulatedDistortion) {
+        this.simulatedDistortion = simulatedDistortion;
+    }
+
+    public double getSimulatedYaw() {
+        return simulatedYaw;
+    }
+
+    public void setSimulatedYaw(double simulatedYaw) {
+        this.simulatedYaw = simulatedYaw;
     }
 
     public boolean isSimulatedFlipped() {
@@ -268,6 +291,10 @@ public class ImageCamera extends ReferenceCamera {
         }
         gFrame.drawImage(source, t, null);
 
+        double cameraViewDiagonal = Math.sqrt(Math.pow(upp.getX()*width, 2) + Math.pow(upp.getY()*height, 2));
+        double sensorDiagonal = getSensorDiagonal().convertToUnits(AxesLocation.getUnits()).getValue();
+        double focalLength = getFocalLength().convertToUnits(AxesLocation.getUnits()).getValue();
+        double cameraDistance = focalLength*cameraViewDiagonal/sensorDiagonal;
         // Draw the calibration fiducials. 
         Location fiducial1 = getPrimaryFiducial();
         if (fiducial1.isInitialized()) {
@@ -277,15 +304,105 @@ public class ImageCamera extends ReferenceCamera {
         Location fiducial2 = getSecondaryFiducial();
         if (fiducial2.isInitialized()) {
             fiducial2 = fiducial2.convertToUnits(AxesLocation.getUnits()).subtract(location);
-            double cameraViewDiagonal = Math.sqrt(Math.pow(upp.getX()*width, 2) + Math.pow(upp.getY()*height, 2));
-            double sensorDiagonal = getSensorDiagonal().convertToUnits(AxesLocation.getUnits()).getValue();
-            double focalLength = getFocalLength().convertToUnits(AxesLocation.getUnits()).getValue();
-            double cameraDistance = focalLength*cameraViewDiagonal/sensorDiagonal;
             double secondaryDistance = cameraDistance + fiducial1.getZ() - fiducial2.getZ(); 
             Location upp2 = upp.multiply(secondaryDistance/cameraDistance);
             drawFiducial(gFrame, width, height, upp, upp2, fiducial2);
         }
 
+        if (getSimulatedDistortion() != 0.0 || getSimulatedYaw() != 0.0) {
+            // Simulate camera lens distortion and mounting yaw.
+            BufferedImage undistorted  = ImageUtils.clone(frame);
+            final double sampling = 0.5;
+            final int scansize = 3;
+            int [] pixels = new int[scansize*scansize];
+            double xo = 0.5 - width/2;
+            double yo = 0.5 - height/2;
+            double radius = Math.sqrt(width*width+height*height)/2;
+            double dist = cameraDistance/(upp.getX()*radius);
+            double factor = 1.0/radius;
+            double zFactor = 1.0/dist;
+            double yawRad = Math.toRadians(getSimulatedYaw());
+            double sinYaw = Math.sin(yawRad);
+            double cosYaw = Math.cos(yawRad);
+            double tanYaw = sinYaw/cosYaw;
+            double zFactorYaw = zFactor*sinYaw;
+            double distort = 0.01*getSimulatedDistortion();
+            double projectionFactor = radius;
+            // First pass: stake out the projection by 9 points and calculate the projectionFactor.
+            for (int x = 0; x <= width; x += width/2) {
+                for (int y = 0; y <= height; y += height/2) {
+                    // NOTE: as this cannot be refactored without performance penalty,
+                    // the following code block is an exact duplicate in both passes.
+                    // BEGIN:-------------------------------------- //
+                    // Normed to ±1.0
+                    double xN = (x + xo)*factor; 
+                    double yN = (y + yo)*factor;
+                    // Distortion
+                    double vect = Math.sqrt(xN*xN + yN*yN);
+                    double distortion = vect*distort + (1.0-distort);
+                    double xD = xN*distortion;
+                    double yD = yN*distortion;
+                    // Reverse perspective transform
+                    double alpha = Math.atan2(xD, dist)-yawRad;
+                    double xT = (Math.tan(alpha)+tanYaw)*dist;
+                    double zT = 1.0 - xT*zFactorYaw;
+                    double yT = yD*zT;
+                    // Pixel coordinates
+                    int xP = (int) (xT*projectionFactor - xo);
+                    int yP = (int) (yT*projectionFactor - yo);
+                    // END:---------------------------------------- //
+
+                    // Minimize the projectionFactor.
+                    if (xP < 0) {
+                        projectionFactor = xo/xT;
+                    }
+                    else if (xP > width) {
+                        projectionFactor = (width + xo)/xT;
+                    }
+                    else if (yP < 0) {
+                        projectionFactor = yo/yT;
+                    }
+                    else if (yP > width) {
+                        projectionFactor = (width + yo)/yT;
+                    }
+                }
+            }
+            // Second pass: transform the image.
+            int grayRGB = new Color(128, 128, 128).getRGB();
+            for (int x = 0; x < width; x++) {
+                for (int y = 0; y < height; y++) {
+                    // NOTE: as this cannot be refactored without performance penalty,
+                    // the following code block is an exact duplicate in both passes.
+                    // BEGIN:-------------------------------------- //
+                    // Normed to ±1.0
+                    double xN = (x + xo)*factor; 
+                    double yN = (y + yo)*factor;
+                    // Distortion
+                    double vect = Math.sqrt(xN*xN + yN*yN);
+                    double distortion = vect*distort + (1.0-distort);
+                    double xD = xN*distortion;
+                    double yD = yN*distortion;
+                    // Reverse perspective transform
+                    double alpha = Math.atan2(xD, dist)-yawRad;
+                    double xT = (Math.tan(alpha)+tanYaw)*dist;
+                    double zT = 1.0 - xT*zFactorYaw;
+                    double yT = yD*zT;
+                    // Pixel coordinates
+                    int xP = (int) (xT*projectionFactor - xo);
+                    int yP = (int) (yT*projectionFactor - yo);
+                    // END:---------------------------------------- //
+
+                    // Set the pixel.
+                    if (xP >= 0 && xP < width && yP >= 0 && yP < height) {
+                        int rgb = undistorted.getRGB(xP, yP);
+                        frame.setRGB(x, y, rgb);
+                    }
+                    else {
+                        frame.setRGB(x, y, grayRGB);
+                    }
+                }
+            }
+        }
         if (simulation) {
             SimulationModeMachine.simulateCameraExposure(this, gFrame, width, height);
         }

--- a/src/main/java/org/openpnp/machine/reference/camera/wizards/ImageCameraConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/camera/wizards/ImageCameraConfigurationWizard.java
@@ -92,6 +92,10 @@ public class ImageCameraConfigurationWizard extends AbstractConfigurationWizard 
                 FormSpecs.RELATED_GAP_ROWSPEC,
                 FormSpecs.DEFAULT_ROWSPEC,
                 FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
                 FormSpecs.DEFAULT_ROWSPEC,}));
         
         lblWidth = new JLabel("X");
@@ -139,27 +143,43 @@ public class ImageCameraConfigurationWizard extends AbstractConfigurationWizard 
         simulatedScale = new JTextField();
         panelGeneral.add(simulatedScale, "4, 10, fill, default");
         simulatedScale.setColumns(10);
+        
+        lblDistortion = new JLabel("Distortion [%]");
+        lblDistortion.setToolTipText("<html>Simulated lens distortion. Positive values create Barrel distortion, negative values create a Pincushion distortion.</html>");
+        panelGeneral.add(lblDistortion, "2, 12, right, default");
+        
+        simulatedDistortion = new JTextField();
+        panelGeneral.add(simulatedDistortion, "4, 12, fill, default");
+        simulatedDistortion.setColumns(10);
+        
+        lblYaw = new JLabel("Mounting Yaw");
+        lblYaw.setToolTipText("Simulated camera yaw angle, i.e. mounting error as an angle around the Y axis.");
+        panelGeneral.add(lblYaw, "2, 14, right, default");
+        
+        simulatedYaw = new JTextField();
+        panelGeneral.add(simulatedYaw, "4, 14, fill, default");
+        simulatedYaw.setColumns(10);
 
 
         lblCameraFlipped = new JLabel("View mirrored?");
         lblCameraFlipped.setToolTipText("Simulate the camera as showing a mirrored view");
-        panelGeneral.add(lblCameraFlipped, "2, 12, right, default");
+        panelGeneral.add(lblCameraFlipped, "2, 16, right, default");
 
         simulatedFlipped = new JCheckBox("");
-        panelGeneral.add(simulatedFlipped, "4, 12");
+        panelGeneral.add(simulatedFlipped, "4, 16");
 
         label = new JLabel(" ");
-        panelGeneral.add(label, "8, 12");
+        panelGeneral.add(label, "8, 16");
 
         lblSourceUrl = new JLabel("Source URL");
-        panelGeneral.add(lblSourceUrl, "2, 16, right, default");
+        panelGeneral.add(lblSourceUrl, "2, 20, right, default");
 
         textFieldSourceUrl = new JTextField();
-        panelGeneral.add(textFieldSourceUrl, "4, 16, 7, 1, fill, default");
+        panelGeneral.add(textFieldSourceUrl, "4, 20, 7, 1, fill, default");
         textFieldSourceUrl.setColumns(40);
 
         btnBrowse = new JButton(browseAction);
-        panelGeneral.add(btnBrowse, "12, 16");
+        panelGeneral.add(btnBrowse, "12, 20");
         
         panelExtra = new JPanel();
         contentPanel.add(panelExtra);
@@ -257,6 +277,8 @@ public class ImageCameraConfigurationWizard extends AbstractConfigurationWizard 
 
         addWrappedBinding(camera, "simulatedRotation", simulatedRotation, "text", doubleConverter);
         addWrappedBinding(camera, "simulatedScale", simulatedScale, "text", doubleConverter);
+        addWrappedBinding(camera, "simulatedDistortion", simulatedDistortion, "text", doubleConverter);
+        addWrappedBinding(camera, "simulatedYaw", simulatedYaw, "text", doubleConverter);
         addWrappedBinding(camera, "simulatedFlipped", simulatedFlipped, "selected");
 
         addWrappedBinding(camera, "sourceUri", textFieldSourceUrl, "text");
@@ -364,6 +386,10 @@ public class ImageCameraConfigurationWizard extends AbstractConfigurationWizard 
     private JLabel lblSensorDiagonal;
     private JTextField sensorDiagonal;
     private JLabel lblDimension;
+    private JLabel lblDistortion;
+    private JTextField simulatedDistortion;
+    private JLabel lblYaw;
+    private JTextField simulatedYaw;
 
     @Override
     protected void saveToModel() {


### PR DESCRIPTION
# Description
Allows simulation of Lens Distortion and Mounting Yaw for the ImageCamera. 

![Image Camera Wizard](https://user-images.githubusercontent.com/9963310/135465493-cbcb4a13-9d42-4ced-9c0f-5e62df651110.png)

Note: this is a simple implementation, not performing any sub-pixel sampling. The resulting images are rather crude. 

# Justification
Intended for testing #1297 by @tonyluken.

# Instructions for Use
Use the new **Distortion [%]** field for setting the [lens distortion](https://en.wikipedia.org/wiki/Distortion_(optics)). 

Positive **Distortion [%]** for Barrel:

![Top_2021-09-30_15 32 30 497](https://user-images.githubusercontent.com/9963310/135465886-746ea1d4-3e42-4a98-8f06-84bfd80e1674.png)

Negative **Distortion [%]** for Pincushion:

![Top_2021-09-30_15 32 23 576](https://user-images.githubusercontent.com/9963310/135465903-0114da1e-cb9d-4b6a-9289-fdc1f10ab597.png)

Use the **Mounting Yaw** field to configure an imperfect mounting yaw angle (i.e. around the Y axis):

![Top_2021-09-30_15 33 03 784](https://user-images.githubusercontent.com/9963310/135466137-92e05d82-e1a9-4bda-b859-1b4e0adec917.png)

Combinations are allowed.

Then use the classical or the new #1297 by @tonyluken.

# Implementation Details
1. Tested in simulation (obviously).
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. Successful `mvn test` before submitting the Pull Request. 
