### PR TITLE
Fix/Simulated Camera Yaw

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/camera/ImageCamera.java
+++ b/src/main/java/org/openpnp/machine/reference/camera/ImageCamera.java
@@ -304,7 +304,9 @@ public class ImageCamera extends ReferenceCamera {
         Location fiducial2 = getSecondaryFiducial();
         if (fiducial2.isInitialized()) {
             fiducial2 = fiducial2.convertToUnits(AxesLocation.getUnits()).subtract(location);
-            double secondaryDistance = cameraDistance + fiducial1.getZ() - fiducial2.getZ(); 
+            double secondaryDistance = cameraDistance + fiducial1.getZ() - fiducial2.getZ();
+            double xYawOffset = Math.tan(Math.toRadians(getSimulatedYaw()))*(fiducial1.getZ() - fiducial2.getZ());
+            fiducial2 = fiducial2.add(new Location(AxesLocation.getUnits(), xYawOffset, 0, 0, 0));
             Location upp2 = upp.multiply(secondaryDistance/cameraDistance);
             drawFiducial(gFrame, width, height, upp, upp2, fiducial2);
         }


### PR DESCRIPTION
# Description

This fix accounts for a simulated camera yaw (see #1299) when rendering the fiducial 2. As the fiducial Z is elevated in Z, it is seen displaced by a camera with yaw.

# Justification
Better testing of #1297 

# Instructions for Use
None

# Implementation Details
1. Testing in simulation
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. Successful `mvn test` before submitting the Pull Request. 
