### PR TITLE
Feature / Finer Grid Reticle

### DIFF
--- a/src/main/java/org/openpnp/gui/components/reticle/RulerReticle.java
+++ b/src/main/java/org/openpnp/gui/components/reticle/RulerReticle.java
@@ -93,8 +93,10 @@ public class RulerReticle extends CrosshairReticle {
         int tickLength = drawRulerOnly ? 3 : halfDiagonal;
         int fivetickLength = drawRulerOnly ? 6 : halfDiagonal;
         int tentickLength = drawRulerOnly ? 12 : halfDiagonal;
-
-        g2d.setColor(color);
+        int alpha = drawRulerOnly ? 255 : 72;
+        Color colorAlpha = new Color(color.getRed(), color.getGreen(), color.getBlue(), alpha);
+        Color complimentaryColorAlpha = new Color(complimentaryColor.getRed(), complimentaryColor.getGreen(), complimentaryColor.getBlue(), alpha);
+        g2d.setColor(colorAlpha);
         for (int i = 1; i < (halfDiagonal / pixelsPerTickX); i++) {
             int x = (int) (i * pixelsPerTickX);
             
@@ -113,7 +115,7 @@ public class RulerReticle extends CrosshairReticle {
 
         for (int i = 1; i < (halfDiagonal / pixelsPerTickY); i++) {
             int y = (int) (i * pixelsPerTickY);
-            g2d.setColor(color);
+            g2d.setColor(colorAlpha);
             if (i % 10 == 0){
             	g2d.drawLine(-tentickLength, y, tentickLength, y);
             }
@@ -122,7 +124,7 @@ public class RulerReticle extends CrosshairReticle {
             } else { 
             	g2d.drawLine(-tickLength, y, tickLength, y);
             }
-            g2d.setColor(complimentaryColor);
+            g2d.setColor(complimentaryColorAlpha);
             if (i % 10 == 0){
             	g2d.drawLine(-tentickLength, -y, tentickLength, -y);
             }


### PR DESCRIPTION
# Description
* The grid reticle is made to appear finer by applying transparency.
* The cross-hairs therefore also stand out.

Before:
![Before](https://user-images.githubusercontent.com/9963310/135711065-e7f85fb2-f682-48e0-9c93-413334c93456.png)

After:
![After](https://user-images.githubusercontent.com/9963310/135711070-a601122d-4a7f-4931-bdfc-c59f30f8716f.png)


# Justification
The grid almost makes the underlying image unreadable. The cross-hairs are no longer visible.

# Instructions for Use
No chnage.

# Implementation Details
1. Tested in simulation.
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. Successful `mvn test` before submitting the Pull Request.
