### PR TITLE
Fix/Issues & Solutions Should Allow Shared C Axes

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/solutions/HeadSolutions.java
+++ b/src/main/java/org/openpnp/machine/reference/solutions/HeadSolutions.java
@@ -240,8 +240,8 @@ public class HeadSolutions implements Solutions.Subject {
                                         solutions.add(new Solutions.PlainIssue(
                                                 head, 
                                                 "Nozzles "+nozzle2.getName()+" and "+hm.getName()+" have the same Rotation axis assigned.", 
-                                                "Please assign a different Rotation axis.", 
-                                                Severity.Error,
+                                                "It is OK to share rotation axes. If intentional, just dismiss this issue. Otherwise assign a different Rotation axis.", 
+                                                Severity.Information,
                                                 "https://github.com/openpnp/openpnp/wiki/Mapping-Axes"));
                                     }
                                 }


### PR DESCRIPTION
# Description
Issues & Solutions should not report shared C (Rotation) axes as an Error. Instead, only an Information is displayed, and the user is asked to confirm it is intentional by pressing **Dismiss**. 

![Info](https://user-images.githubusercontent.com/9963310/136659599-2822c560-8e62-4870-9c6c-3da2c3685690.png)

# Justification
The issue was previously reported as an Error:

![Error](https://user-images.githubusercontent.com/9963310/136659826-7d07a44c-0b33-4043-9288-1424b886e044.png)

Which is wrong for machines with intentionally shared C axes.

See the use case:
https://groups.google.com/g/openpnp/c/taXWhONJ6zY/m/LzV6rwKyAAAJ

# Instructions for Use
Press **Dismiss**, if you intentionally assigned shared C axes.

# Implementation Details
1. Tested in simulation with the users `machine.xml`.
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. Successful `mvn test` before submitting the Pull Request. 
