### PR TITLE
Fix / Bump org.tinylog to Version 1.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -128,7 +128,7 @@
 		<dependency>
 			<groupId>org.tinylog</groupId>
 			<artifactId>tinylog</artifactId>
-			<version>1.1</version>
+			<version>1.3</version>
 		</dependency>
 		<dependency>
 			<groupId>com.google.zxing</groupId>


### PR DESCRIPTION
# Description
Bump org.tinylog to version 1.3 in an attempt to solve a deployment error.

# Justification
See here:
https://github.com/openpnp/openpnp/actions/runs/1323645843

# Instructions for Use
None.

# Implementation Details
1. Local mvn package.
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. Successful `mvn test` before submitting the Pull Request.
