### PR TITLE
Feature/rotation limits

### DIFF
--- a/src/main/java/org/openpnp/gui/JogControlsPanel.java
+++ b/src/main/java/org/openpnp/gui/JogControlsPanel.java
@@ -62,6 +62,7 @@ import org.openpnp.spi.Head;
 import org.openpnp.spi.HeadMountable;
 import org.openpnp.spi.Machine;
 import org.openpnp.spi.Nozzle;
+import org.openpnp.spi.Nozzle.RotationMode;
 import org.openpnp.spi.base.AbstractNozzle;
 import org.openpnp.util.BeanUtils;
 import org.openpnp.util.Cycles;
@@ -605,7 +606,20 @@ public class JogControlsPanel extends JPanel {
             UiUtils.submitUiMachineTask(() -> {
                 HeadMountable hm = machineControlsPanel.getSelectedTool();
                 Location location = hm.getLocation();
-                location = location.derive(null, null, null, 0.);
+                double parkAngle = 0;
+                if (hm instanceof AbstractNozzle) {
+                    AbstractNozzle nozzle = (AbstractNozzle) hm;
+                    if (nozzle.getRotationMode() == RotationMode.LimitedArticulation) {
+                        // Limited axis, select a 90° step position within the limits.
+                        double [] limits = nozzle.getRotationModeLimits();
+                        parkAngle = Math.round((limits[0]+limits[1])/2/90)*90;
+                        if (parkAngle < limits[0] || parkAngle > limits[1]) {
+                            // Rounded mid-point outside limits? Can this ever happen? If yes, fall back to exact mid-point.
+                            parkAngle = (limits[1] + limits[0])/2;
+                        }
+                    }
+                }
+                location = location.derive(null, null, null, parkAngle);
                 hm.moveTo(location);
                 MovableUtils.fireTargetedUserAction(hm, true);
             });

--- a/src/main/java/org/openpnp/machine/reference/ContactProbeNozzle.java
+++ b/src/main/java/org/openpnp/machine/reference/ContactProbeNozzle.java
@@ -633,12 +633,15 @@ public class ContactProbeNozzle extends ReferenceNozzle {
 
     @Override
     public Location toHeadLocation(Location location, Location currentLocation, LocationOption... options) {
+        boolean quiet = Arrays.asList(options).contains(LocationOption.Quiet);
         // Apply the Z calibration.
         // Check SuppressCompensation, in that case disable Z calibration
         if (! Arrays.asList(options).contains(LocationOption.SuppressDynamicCompensation)) {
             if (zCalibratedNozzleTip != null && calibrationOffsetZ != null) {
                 location = location.subtract(new Location(calibrationOffsetZ .getUnits(), 0, 0, calibrationOffsetZ.getValue(), 0));
-                Logger.trace("{}.toHeadLocation({}, ...) Z offset {}", getName(), location, calibrationOffsetZ);
+                if (! quiet) {
+                    Logger.trace("{}.toHeadLocation({}, ...) Z offset {}", getName(), location, calibrationOffsetZ);
+                }
             }
         }
         return super.toHeadLocation(location, currentLocation, options);

--- a/src/main/java/org/openpnp/machine/reference/ReferenceActuator.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceActuator.java
@@ -447,10 +447,6 @@ public class ReferenceActuator extends AbstractActuator implements ReferenceHead
         return getName();
     }
 
-    ReferenceMachine getMachine() {
-        return (ReferenceMachine) Configuration.get().getMachine();
-    }
-
     public void fireProfilesChanged() {
         firePropertyChange("profileValues", null, getProfileValues());
     }

--- a/src/main/java/org/openpnp/machine/reference/ReferenceCamera.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceCamera.java
@@ -1194,10 +1194,6 @@ public abstract class ReferenceCamera extends AbstractBroadcastingCamera impleme
         }
     };
 
-    ReferenceMachine getMachine() {
-        return (ReferenceMachine) Configuration.get().getMachine();
-    }
-
     public interface CalibrationCallback {
         public void callback(int progressCurrent, int progressMax, boolean complete);
     }

--- a/src/main/java/org/openpnp/machine/reference/ReferenceNozzle.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceNozzle.java
@@ -492,10 +492,13 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
 
     @Override
     public Location toHeadLocation(Location location, Location currentLocation, LocationOption... options) {
+        boolean quiet = Arrays.asList(options).contains(LocationOption.Quiet);
         // Apply the rotationModeOffset.
         if (rotationModeOffset != null) { 
             location = location.subtractWithRotation(new Location(location.getUnits(), 0, 0, 0, rotationModeOffset));
-            Logger.trace("{}.toHeadLocation({}, ...) rotation mode offset {}", getName(), location, rotationModeOffset);
+            if (!quiet) {
+                Logger.trace("{}.toHeadLocation({}, ...) rotation mode offset {}", getName(), location, rotationModeOffset);
+            }
         }
         // Apply runout compensation.
         // Check SuppressCompensation, in that case disable nozzle calibration
@@ -504,7 +507,9 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
             if (calibrationNozzleTip != null && calibrationNozzleTip.getCalibration().isCalibrated(this)) {
                 Location correctionOffset = calibrationNozzleTip.getCalibration().getCalibratedOffset(this, location.getRotation());
                 location = location.subtract(correctionOffset);
-                Logger.trace("{}.toHeadLocation({}, ...) runout compensation {}", getName(), location, correctionOffset);
+                if (!quiet) {
+                    Logger.trace("{}.toHeadLocation({}, ...) runout compensation {}", getName(), location, correctionOffset);
+                }
             }
         }
         return super.toHeadLocation(location, currentLocation, options);

--- a/src/main/java/org/openpnp/machine/reference/ReferenceNozzleTipCalibration.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceNozzleTipCalibration.java
@@ -578,6 +578,14 @@ public class ReferenceNozzleTipCalibration extends AbstractModelObject {
         if (nozzle == null) {
             throw new Exception("Nozzle to nozzle tip mismatch.");
         }
+
+        // Make sure to set start and end rotation to the limits.
+        double [] rotationModeLimits = nozzle.getRotationModeLimits();
+        angleStart = rotationModeLimits[0];
+        angleStop = rotationModeLimits[1];
+        // Make sure no rotation mode offset is currently applied.
+        nozzle.setRotationModeOffset(null);
+
         Camera camera = VisionUtils.getBottomVisionCamera();
         ReferenceCamera referenceCamera = null;
         if (camera instanceof ReferenceCamera) {

--- a/src/main/java/org/openpnp/machine/reference/ReferencePnpJobProcessor.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferencePnpJobProcessor.java
@@ -699,7 +699,10 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
             try {
                 fireTextStatus("Pick %s from %s for %s.", part.getId(), feeder.getName(),
                         placement.getId());
-                
+
+                // Prepare the Nozzle for pick-to-place articulation.
+                nozzle.prepareForPickAndPlaceArticulation(feeder.getPickLocation(), placement.getLocation());
+
                 // Move to pick location.
                 nozzle.moveToPickLocation(feeder);
 

--- a/src/main/java/org/openpnp/machine/reference/axis/ReferenceControllerAxis.java
+++ b/src/main/java/org/openpnp/machine/reference/axis/ReferenceControllerAxis.java
@@ -459,40 +459,6 @@ public class ReferenceControllerAxis extends AbstractControllerAxis {
         return true;
     }
 
-    /**
-     * Limit the given rotation axis angle to the valid range.
-     * 
-     * @param axis
-     * @param angle
-     * @return
-     */
-    public double limitedRotationAngle(double angle) {
-        if (isLimitRotation()) {
-            double limit0 = -180;
-            double limit1 = 180;
-            if (isSoftLimitLowEnabled()) {
-                // Set the rotation to be within the soft limit range
-                limit0 = getSoftLimitLow().getValue();
-            }
-            if (isSoftLimitHighEnabled()) {
-                // Set the rotation to be within the soft limit range
-                limit1 = getSoftLimitHigh().getValue();
-            }
-            // We support 360° (normal) and 180° (limited articulation) wrapping.
-            double wrap = 360;
-            if (limit1 - limit0 < 360) {
-                wrap = 180;
-            }
-            while (angle > limit1) {
-                angle -= wrap;
-            }
-            while (angle < limit0) {
-                angle += wrap;
-            }
-        }
-        return angle;
-    }
-
     @Override
     public Wizard getConfigurationWizard() {
         return new ReferenceControllerAxisConfigurationWizard(this);

--- a/src/main/java/org/openpnp/machine/reference/axis/wizards/ReferenceControllerAxisConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/axis/wizards/ReferenceControllerAxisConfigurationWizard.java
@@ -21,7 +21,6 @@
 
 package org.openpnp.machine.reference.axis.wizards;
 
-import java.awt.Color;
 import java.awt.event.ActionEvent;
 import java.awt.event.ItemEvent;
 import java.awt.event.ItemListener;
@@ -38,6 +37,8 @@ import javax.swing.JTextArea;
 import javax.swing.JTextField;
 import javax.swing.SwingUtilities;
 import javax.swing.border.TitledBorder;
+import javax.swing.event.DocumentEvent;
+import javax.swing.event.DocumentListener;
 
 import org.openpnp.gui.components.ComponentDecorators;
 import org.openpnp.gui.support.DoubleConverter;
@@ -77,7 +78,7 @@ public class ReferenceControllerAxisConfigurationWizard extends AbstractAxisConf
     protected NamedConverter<Driver> driverConverter;
     private JPanel panelKinematics;
     private JLabel lblFeedrates;
-    private JTextField feedratePerSecond;
+    private JTextField feedRatePerSecond;
     private JLabel lblAccelerations;
     private JTextField accelerationPerSecond2;
     private JLabel lblJerks;
@@ -106,7 +107,10 @@ public class ReferenceControllerAxisConfigurationWizard extends AbstractAxisConf
     private JButton btnPositionSafeZoneLow;
     private JButton btnCaptureSafeZoneHigh;
     private JButton btnPositionSafeZoneHigh;
-    private JLabel lblNotMmmin;
+    private JLabel lblFeedRatePerMinText;
+    private JTextField feedRatePerMin;
+
+    private boolean converting = false;
 
     private Action captureSoftLimitLowAction = new AbstractAction(null, Icons.captureAxisLow) {
         {
@@ -369,23 +373,23 @@ public class ReferenceControllerAxisConfigurationWizard extends AbstractAxisConf
                 FormSpecs.DEFAULT_COLSPEC,
                 FormSpecs.RELATED_GAP_COLSPEC,
                 FormSpecs.DEFAULT_COLSPEC,},
-                new RowSpec[] {
-                        FormSpecs.RELATED_GAP_ROWSPEC,
-                        FormSpecs.DEFAULT_ROWSPEC,
-                        FormSpecs.RELATED_GAP_ROWSPEC,
-                        FormSpecs.DEFAULT_ROWSPEC,
-                        FormSpecs.RELATED_GAP_ROWSPEC,
-                        FormSpecs.DEFAULT_ROWSPEC,
-                        FormSpecs.RELATED_GAP_ROWSPEC,
-                        FormSpecs.DEFAULT_ROWSPEC,
-                        FormSpecs.RELATED_GAP_ROWSPEC,
-                        FormSpecs.DEFAULT_ROWSPEC,
-                        FormSpecs.RELATED_GAP_ROWSPEC,
-                        FormSpecs.DEFAULT_ROWSPEC,
-                        FormSpecs.RELATED_GAP_ROWSPEC,
-                        FormSpecs.DEFAULT_ROWSPEC,
-                        FormSpecs.RELATED_GAP_ROWSPEC,
-                        FormSpecs.DEFAULT_ROWSPEC,}));
+            new RowSpec[] {
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,}));
 
         lblSoftLimitLow = new JLabel("Soft Limit Low");
         panelKinematics.add(lblSoftLimitLow, "2, 2, right, default");
@@ -451,16 +455,81 @@ public class ReferenceControllerAxisConfigurationWizard extends AbstractAxisConf
         btnCaptureSoftLimitHigh = new JButton(captureSoftLimitHighAction);
         panelKinematics.add(btnCaptureSoftLimitHigh, "10, 8");
 
-        lblFeedrates = new JLabel("Feedrate [/s]");
+        lblFeedrates = new JLabel("Feed Rate [/s]");
         panelKinematics.add(lblFeedrates, "2, 12, right, default");
 
-        feedratePerSecond = new JTextField();
-        panelKinematics.add(feedratePerSecond, "4, 12, fill, default");
-        feedratePerSecond.setColumns(10);
+        feedRatePerSecond = new JTextField();
+        panelKinematics.add(feedRatePerSecond, "4, 12, fill, default");
+        feedRatePerSecond.setColumns(10);
+        feedRatePerSecond.getDocument().addDocumentListener(new DocumentListener() {
+            LengthConverter lengthConverter = new LengthConverter();
+            public void changedUpdate(DocumentEvent e) {
+                convert();
+            }
+            public void removeUpdate(DocumentEvent e) {
+                convert();
+            }
+            public void insertUpdate(DocumentEvent e) {
+                convert();
+            }
 
-        lblNotMmmin = new JLabel("Not [/min]");
-        lblNotMmmin.setForeground(Color.RED);
-        panelKinematics.add(lblNotMmmin, "6, 12");
+            public void convert() {
+                if (converting) { 
+                    return;
+                }
+                converting = true;
+                try {
+                    Length feedRate = lengthConverter.convertReverse(feedRatePerSecond.getText());
+                    feedRate = feedRate.multiply(Math.round(feedRate.getValue()*60)/feedRate.getValue());
+                    String feedRateText = lengthConverter.convertForward(feedRate);
+                    feedRatePerMin.setText(feedRateText);
+                }
+                catch (Exception e) {
+                    // silently ignore?
+                }
+                finally {
+                    converting = false;
+                }
+            }
+        });
+
+        lblFeedRatePerMinText = new JLabel("Feed Rate [/min]");
+        panelKinematics.add(lblFeedRatePerMinText, "6, 12, right, default");
+
+        feedRatePerMin = new JTextField();
+        panelKinematics.add(feedRatePerMin, "8, 12, 3, 1, left, default");
+        feedRatePerMin.setColumns(10);
+        feedRatePerMin.getDocument().addDocumentListener(new DocumentListener() {
+            LengthConverter lengthConverter = new LengthConverter();
+            public void changedUpdate(DocumentEvent e) {
+                convert();
+            }
+            public void removeUpdate(DocumentEvent e) {
+                convert();
+            }
+            public void insertUpdate(DocumentEvent e) {
+                convert();
+            }
+
+            public void convert() {
+                if (converting) { 
+                    return;
+                }
+                converting = true;
+                try {
+                    Length feedRate = lengthConverter.convertReverse(feedRatePerMin.getText());
+                    feedRate = feedRate.divide(60);
+                    String feedRateText = lengthConverter.convertForward(feedRate);
+                    feedRatePerSecond.setText(feedRateText);
+                }
+                catch (Exception e) {
+                    // silently ignore?
+                }
+                finally {
+                    converting = false;
+                }
+            }
+        });
 
         lblAccelerations = new JLabel("Acceleration [/s²]");
         panelKinematics.add(lblAccelerations, "2, 14, right, default");
@@ -548,14 +617,14 @@ public class ReferenceControllerAxisConfigurationWizard extends AbstractAxisConf
         addWrappedBinding(axis, "safeZoneHigh", safeZoneHigh, "text", lengthConverter);
         addWrappedBinding(axis, "safeZoneHighEnabled", safeZoneHighEnabled, "selected");
 
-        addWrappedBinding(axis, "feedratePerSecond", feedratePerSecond, "text", lengthConverter);
+        addWrappedBinding(axis, "feedratePerSecond", feedRatePerSecond, "text", lengthConverter);
         addWrappedBinding(axis, "accelerationPerSecond2", accelerationPerSecond2, "text", lengthConverter);
         addWrappedBinding(axis, "jerkPerSecond3", jerkPerSecond3, "text", lengthConverter);
 
 
         ComponentDecorators.decorateWithAutoSelect(letter);
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(homeCoordinate);
-        ComponentDecorators.decorateWithAutoSelectAndLengthConversion(feedratePerSecond);
+        ComponentDecorators.decorateWithAutoSelectAndLengthConversion(feedRatePerSecond);
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(accelerationPerSecond2);
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(jerkPerSecond3);
         ComponentDecorators.decorateWithAutoSelect(resolution);

--- a/src/main/java/org/openpnp/machine/reference/axis/wizards/ReferenceControllerAxisConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/axis/wizards/ReferenceControllerAxisConfigurationWizard.java
@@ -324,11 +324,16 @@ public class ReferenceControllerAxisConfigurationWizard extends AbstractAxisConf
         panelControllerSettings.add(resolution, "4, 12, fill, default");
         resolution.setColumns(10);
 
-        lblLimitRotation = new JLabel("Limit to ±180°");
-        lblLimitRotation.setToolTipText("Limit the rotation to -180° ... +180°. ");
+        lblLimitRotation = new JLabel("Limit to Range");
+        lblLimitRotation.setToolTipText("Limit the rotation to -180° ... +180° or the custom Soft-Limits if enabled.");
         panelControllerSettings.add(lblLimitRotation, "2, 14, right, default");
 
         limitRotation = new JCheckBox("");
+        limitRotation.addItemListener(new ItemListener() {
+            public void itemStateChanged(ItemEvent e) {
+                adaptDialog();
+            }
+        });
         panelControllerSettings.add(limitRotation, "4, 14");
 
         lblWrapAroundRotation = new JLabel("Wrap Around");
@@ -484,7 +489,7 @@ public class ReferenceControllerAxisConfigurationWizard extends AbstractAxisConf
         Driver selectedDriver = driverConverter.convertReverse((String) driver.getSelectedItem());
         boolean showPreMove = (selectedDriver != null && selectedDriver.isSupportingPreMove());
         boolean showRotationSettings = type.getSelectedItem() == Type.Rotation;
-        boolean showCalibration = (type.getSelectedItem() == Type.X || type.getSelectedItem() == Type.Y);
+        boolean showSoftLimits = type.getSelectedItem() != Type.Rotation || limitRotation.isSelected();
         lblPremoveCommand.setVisible(showPreMove);
         scrollPane.setVisible(showPreMove);
 
@@ -493,16 +498,16 @@ public class ReferenceControllerAxisConfigurationWizard extends AbstractAxisConf
         lblWrapAroundRotation.setVisible(showRotationSettings);
         wrapAroundRotation.setVisible(showRotationSettings);
 
-        lblSoftLimitLow.setVisible(!showRotationSettings);
-        lblSoftLimitHigh.setVisible(!showRotationSettings);
-        softLimitLow.setVisible(!showRotationSettings);
-        softLimitHigh.setVisible(!showRotationSettings);
-        softLimitLowEnabled.setVisible(!showRotationSettings);
-        softLimitHighEnabled.setVisible(!showRotationSettings);
-        btnCaptureSoftLimitLow.setVisible(!showRotationSettings);
-        btnCaptureSoftLimitHigh.setVisible(!showRotationSettings);
-        btnPositionSoftLimitLow.setVisible(!showRotationSettings);
-        btnPositionSoftLimitHigh.setVisible(!showRotationSettings);
+        lblSoftLimitLow.setVisible(showSoftLimits);
+        lblSoftLimitHigh.setVisible(showSoftLimits);
+        softLimitLow.setVisible(showSoftLimits);
+        softLimitHigh.setVisible(showSoftLimits);
+        softLimitLowEnabled.setVisible(showSoftLimits);
+        softLimitHighEnabled.setVisible(showSoftLimits);
+        btnCaptureSoftLimitLow.setVisible(showSoftLimits);
+        btnCaptureSoftLimitHigh.setVisible(showSoftLimits);
+        btnPositionSoftLimitLow.setVisible(showSoftLimits);
+        btnPositionSoftLimitHigh.setVisible(showSoftLimits);
 
         lblSafeZoneLow.setVisible(!showRotationSettings);
         lblSafeZoneHigh.setVisible(!showRotationSettings);

--- a/src/main/java/org/openpnp/machine/reference/driver/AbstractMotionPlanner.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/AbstractMotionPlanner.java
@@ -513,14 +513,14 @@ public abstract class AbstractMotionPlanner extends AbstractModelObject implemen
                         axesLocation = axesLocation.put(new AxesLocation(refAxis, newAngle));
                     }
                     else if (refAxis.isLimitRotation()) {
-                        // Set the rotation to be within the +/-180 degree range
-                        axesLocation = axesLocation.put(new AxesLocation(refAxis, 
-                                Utils2D.normalizeAngle180(axesLocation.getCoordinate(refAxis))));
+                        double angle = axesLocation.getCoordinate(refAxis);
+                        angle = refAxis.limitedRotationAngle(angle);
+                        axesLocation = axesLocation.put(new AxesLocation(refAxis, angle));
                     } 
                     // Note, the combination isLimitRotation() and isWrapAroundRotation() will be handled
                     // when the motion is complete, i.e. in waitForCompletion().
                 }
-                else { // Never soft-limit a rotation axis, as the config is hidden on the GUI and might contain garbage.
+                else { 
                     Length coordinate = axesLocation.getLengthCoordinate(refAxis).convertToUnits(Configuration.get().getSystemUnits());  
                     if (refAxis.isSoftLimitLowEnabled()) {
                         Length limit = refAxis.getSoftLimitLow().convertToUnits(Configuration.get().getSystemUnits());
@@ -643,7 +643,7 @@ public abstract class AbstractMotionPlanner extends AbstractModelObject implemen
                 ReferenceControllerAxis refAxis = (ReferenceControllerAxis) axis;
                 if (refAxis.isLimitRotation() && refAxis.isWrapAroundRotation()) {
                     double anglePresent = refAxis.getDriverCoordinate();
-                    double angleWrappedAround = Utils2D.normalizeAngle180(anglePresent);
+                    double angleWrappedAround = refAxis.limitedRotationAngle(anglePresent);
                     if (anglePresent != angleWrappedAround) {
                         refAxis.getDriver().setGlobalOffsets(getMachine(), 
                                 new AxesLocation(refAxis, angleWrappedAround));

--- a/src/main/java/org/openpnp/machine/reference/solutions/CalibrationSolutions.java
+++ b/src/main/java/org/openpnp/machine/reference/solutions/CalibrationSolutions.java
@@ -993,15 +993,17 @@ public class CalibrationSolutions implements Solutions.Subject {
                 location = location.derive(head.getCalibrationPrimaryFiducialLocation(), false,
                         false, true, false);
                 // Pick the test object at the location.
-                feeder.setLocation(location.derive(null, null, null, angle));
+                Location pickLocation = location.derive(null, null, null, angle);
+                feeder.setLocation(pickLocation);
+               // Place the part 180° rotated. This way we will detect the true nozzle rotation axis, which is 
+                // the true nozzle location, namely in the center of the two detected locations. Note that run-out 
+                // is cancelled out too, so run-out compensation is no prerequisite. 
+                Location placementLocation = location.derive(null, null, null, angle + 180.0);
+                nozzle.prepareForPickAndPlaceArticulation(pickLocation, placementLocation);
                 nozzle.moveToPickLocation(feeder);
                 nozzle.pick(testPart);
                 // Extra wait time.
                 Thread.sleep(extraVacuumDwellMs);
-                // Place the part 180° rotated. This way we will detect the true nozzle rotation axis, which is 
-                // the true nozzle location, namely in the center of the two detected locations. Note that run-out 
-                // is cancelled out too, so run-out compensation is no prerequisite. 
-                Location placementLocation = location.derive(null, null, null, angle + 180.0);
                 nozzle.moveToPlacementLocation(placementLocation, testPart);
                 nozzle.place();
                 // Extra wait time.

--- a/src/main/java/org/openpnp/machine/reference/vision/ReferenceBottomVision.java
+++ b/src/main/java/org/openpnp/machine/reference/vision/ReferenceBottomVision.java
@@ -60,6 +60,9 @@ public class ReferenceBottomVision implements PartAlignment {
     @Attribute(required = false)
     protected double maxAngularOffset = 10;
 
+    @Attribute(required = false)
+    protected double testAlignmentAngle = 0.0;
+
     @ElementMap(required = false)
     protected Map<String, PartSettings> partSettingsByPartId = new HashMap<>();
 
@@ -484,7 +487,15 @@ public class ReferenceBottomVision implements PartAlignment {
     public void setMaxAngularOffset(double maxAngularOffset) {
         this.maxAngularOffset = maxAngularOffset;
     }
-    
+
+    public double getTestAlignmentAngle() {
+        return testAlignmentAngle;
+    }
+
+    public void setTestAlignmentAngle(double testAlignmentAngle) {
+        this.testAlignmentAngle = testAlignmentAngle;
+    }
+
     @Override
     public String getPropertySheetHolderTitle() {
         return "Bottom Vision";

--- a/src/main/java/org/openpnp/machine/reference/vision/wizards/ReferenceBottomVisionPartConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/vision/wizards/ReferenceBottomVisionPartConfigurationWizard.java
@@ -312,6 +312,7 @@ public class ReferenceBottomVisionPartConfigurationWizard extends AbstractConfig
     @Override
     public void createBindings() {
         IntegerConverter intConverter = new IntegerConverter();
+        DoubleConverter doubleConverter = new DoubleConverter(Configuration.get().getLengthDisplayFormat());
 
         addWrappedBinding(partSettings, "enabled", enabledCheckbox, "selected");
         addWrappedBinding(partSettings, "checkPartSizeMethod", comboBoxcheckPartSizeMethod, "selectedItem");
@@ -319,6 +320,7 @@ public class ReferenceBottomVisionPartConfigurationWizard extends AbstractConfig
 
         addWrappedBinding(partSettings, "preRotateUsage", comboBoxPreRotate, "selectedItem");
         addWrappedBinding(partSettings, "maxRotation", comboBoxMaxRotation, "selectedItem");
+        addWrappedBinding(bottomVision, "testAlignmentAngle", testAlignmentAngle, "text", doubleConverter);
         
         
         LengthConverter lengthConverter = new LengthConverter();

--- a/src/main/java/org/openpnp/machine/reference/wizards/ContactProbeNozzleWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/wizards/ContactProbeNozzleWizard.java
@@ -46,7 +46,6 @@ import org.openpnp.gui.support.NamedConverter;
 import org.openpnp.machine.reference.ContactProbeNozzle;
 import org.openpnp.machine.reference.ContactProbeNozzle.ContactProbeMethod;
 import org.openpnp.machine.reference.ContactProbeNozzle.ContactProbeTrigger;
-import org.openpnp.machine.reference.ReferenceNozzle;
 import org.openpnp.model.Configuration;
 import org.openpnp.spi.Actuator;
 import org.openpnp.util.UiUtils;
@@ -58,7 +57,7 @@ import com.jgoodies.forms.layout.RowSpec;
 
 @SuppressWarnings("serial")
 public class ContactProbeNozzleWizard extends AbstractConfigurationWizard {
-    private final ReferenceNozzle nozzle;
+    private final ContactProbeNozzle nozzle;
 
     public ContactProbeNozzleWizard(ContactProbeNozzle nozzle) {
         this.nozzle = nozzle;
@@ -282,8 +281,7 @@ public class ContactProbeNozzleWizard extends AbstractConfigurationWizard {
         public void actionPerformed(ActionEvent e) {
             applyAction.actionPerformed(e);
             UiUtils.submitUiMachineTask(() -> {
-                ContactProbeNozzle contactProbeNozzle = (ContactProbeNozzle) nozzle;
-                contactProbeNozzle.calibrateZ(contactProbeNozzle.getCalibrationNozzleTip());
+                nozzle.calibrateZ(nozzle.getCalibrationNozzleTip());
             });
         }
     };

--- a/src/main/java/org/openpnp/machine/reference/wizards/ReferenceNozzleConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/wizards/ReferenceNozzleConfigurationWizard.java
@@ -39,6 +39,7 @@ import org.openpnp.gui.support.NamedConverter;
 import org.openpnp.machine.reference.ReferenceNozzle;
 import org.openpnp.model.Configuration;
 import org.openpnp.spi.Axis;
+import org.openpnp.spi.Nozzle.RotationMode;
 import org.openpnp.spi.base.AbstractAxis;
 import org.openpnp.spi.base.AbstractMachine;
 
@@ -76,6 +77,8 @@ public class ReferenceNozzleConfigurationWizard extends AbstractConfigurationWiz
     private JComboBox axisRotation;
     private JLabel lblAxis;
     private JLabel lblOffset;
+    private JLabel lblRotationMode;
+    private JComboBox rotationMode;
 
     public ReferenceNozzleConfigurationWizard(AbstractMachine machine, ReferenceNozzle nozzle) {
         this.nozzle = nozzle;
@@ -85,7 +88,7 @@ public class ReferenceNozzleConfigurationWizard extends AbstractConfigurationWiz
         contentPanel.add(panelProperties);
         panelProperties.setLayout(new FormLayout(new ColumnSpec[] {
                 FormSpecs.RELATED_GAP_COLSPEC,
-                FormSpecs.DEFAULT_COLSPEC,
+                ColumnSpec.decode("max(70dlu;default)"),
                 FormSpecs.RELATED_GAP_COLSPEC,
                 FormSpecs.DEFAULT_COLSPEC,},
             new RowSpec[] {
@@ -104,7 +107,7 @@ public class ReferenceNozzleConfigurationWizard extends AbstractConfigurationWiz
                 "Coordinate System", TitledBorder.LEADING, TitledBorder.TOP, null));
         panelOffsets.setLayout(new FormLayout(new ColumnSpec[] {
                 FormSpecs.RELATED_GAP_COLSPEC,
-                FormSpecs.DEFAULT_COLSPEC,
+                ColumnSpec.decode("max(70dlu;default)"),
                 FormSpecs.RELATED_GAP_COLSPEC,
                 FormSpecs.DEFAULT_COLSPEC,
                 FormSpecs.RELATED_GAP_COLSPEC,
@@ -114,6 +117,8 @@ public class ReferenceNozzleConfigurationWizard extends AbstractConfigurationWiz
                 FormSpecs.RELATED_GAP_COLSPEC,
                 FormSpecs.DEFAULT_COLSPEC,},
             new RowSpec[] {
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
                 FormSpecs.RELATED_GAP_ROWSPEC,
                 FormSpecs.DEFAULT_ROWSPEC,
                 FormSpecs.RELATED_GAP_ROWSPEC,
@@ -170,13 +175,19 @@ public class ReferenceNozzleConfigurationWizard extends AbstractConfigurationWiz
         locationRotation = new JTextField();
         panelOffsets.add(locationRotation, "10, 6, fill, default");
         locationRotation.setColumns(10);
+        
+        lblRotationMode = new JLabel("Rotation Mode");
+        panelOffsets.add(lblRotationMode, "2, 10, right, default");
+        
+        rotationMode = new JComboBox(RotationMode.values());
+        panelOffsets.add(rotationMode, "4, 10, fill, default");
 
         JPanel panelSafeZ = new JPanel();
         panelSafeZ.setBorder(new TitledBorder(null, "Safe Z", TitledBorder.LEADING,
                 TitledBorder.TOP, null, null));
         contentPanel.add(panelSafeZ);
         panelSafeZ.setLayout(new FormLayout(new ColumnSpec[] {
-                ColumnSpec.decode("max(81dlu;default)"),
+                ColumnSpec.decode("max(70dlu;default)"),
                 FormSpecs.RELATED_GAP_COLSPEC,
                 ColumnSpec.decode("114px"),
                 FormSpecs.RELATED_GAP_COLSPEC,
@@ -211,7 +222,7 @@ public class ReferenceNozzleConfigurationWizard extends AbstractConfigurationWiz
                 .setLayout(
                         new FormLayout(new ColumnSpec[] {
                 FormSpecs.RELATED_GAP_COLSPEC,
-                FormSpecs.DEFAULT_COLSPEC,
+                ColumnSpec.decode("max(70dlu;default)"),
                 FormSpecs.RELATED_GAP_COLSPEC,
                 FormSpecs.DEFAULT_COLSPEC,
                 FormSpecs.RELATED_GAP_COLSPEC,
@@ -261,6 +272,7 @@ public class ReferenceNozzleConfigurationWizard extends AbstractConfigurationWiz
         addWrappedBinding(nozzle, "axisY", axisY, "selectedItem", axisConverter);
         addWrappedBinding(nozzle, "axisZ", axisZ, "selectedItem", axisConverter);
         addWrappedBinding(nozzle, "axisRotation", axisRotation, "selectedItem", axisConverter);
+        addWrappedBinding(nozzle, "rotationMode", rotationMode, "selectedItem");
 
         MutableLocationProxy headOffsets = new MutableLocationProxy();
         bind(UpdateStrategy.READ_WRITE, nozzle, "headOffsets", headOffsets, "location");

--- a/src/main/java/org/openpnp/spi/Locatable.java
+++ b/src/main/java/org/openpnp/spi/Locatable.java
@@ -43,7 +43,11 @@ public interface Locatable {
         /**
          * Replaces virtual coordinates with the head offset.
          */
-        ReplaceVirtual
+        ReplaceVirtual, 
+        /**
+         * Be quiet about transforms. 
+         */
+        Quiet
     }
 
     /**

--- a/src/main/java/org/openpnp/spi/MotionPlanner.java
+++ b/src/main/java/org/openpnp/spi/MotionPlanner.java
@@ -198,8 +198,9 @@ public interface MotionPlanner extends PropertySheetHolder, Solutions.Subject {
     void clearMotionPlanOlderThan(double time);
 
     /**
+     * @param hm 
      * @param axesLocation
      * @return true if the location is valid, i.e. inside soft limits etc.
      */
-    public boolean isValidLocation(AxesLocation axesLocation);
+    public boolean isValidLocation(HeadMountable hm, AxesLocation axesLocation);
 }

--- a/src/main/java/org/openpnp/spi/Nozzle.java
+++ b/src/main/java/org/openpnp/spi/Nozzle.java
@@ -22,6 +22,45 @@ public interface Nozzle
     NozzleTip getNozzleTip();
 
     /**
+     * Nozzle pick-to-place rotation mode. 
+     *
+     */
+    public enum RotationMode {
+        /**
+         * The part is picked so it is at its absolute angle on the nozzle (as drawn in the E-CAD). This is the default.
+         */
+        AbsolutePartAngle,
+        /**
+         * The part is picked so it is rotated for placement, when the nozzle is at 0°.
+         */
+        PlacementAngle,
+        /**
+         * Rotation is minimized by just picking at whatever angle the nozzle happens to be.
+         */
+        MinimalRotation,
+        
+        /**
+         * Mode needed when the nozzle has limited rotation articulation. 
+         */
+        LimitedArticulation
+    }
+
+    /**
+     * @return the RotationMode of the Nozzle. See {@link Nozzle.RotationMode}.
+     */
+    public RotationMode getRotationMode();
+
+    /**
+     * Prepare the Nozzle for the next placement rotation. This will apply a rotation offset to the Nozzle 
+     * that implements the {@link RotationMode} and is subject to articulation limits, if present.
+     * 
+     * @param pickLocation
+     * @param placementLocation
+     * @throws Exception
+     */
+    void prepareForPickAndPlaceArticulation(Location pickLocation, Location placementLocation) throws Exception;
+
+    /**
      * Move the Nozzle to the given feeder pick location. This will move at safe Z and position the Nozzle
      * so it is ready for {@link #pick(Part)}. This might or might not involve offsets and actions for 
      * contact-probing e.g. to determine the feeder's calibrated Z. 

--- a/src/main/java/org/openpnp/spi/base/AbstractCoordinateAxis.java
+++ b/src/main/java/org/openpnp/spi/base/AbstractCoordinateAxis.java
@@ -114,20 +114,11 @@ public abstract class AbstractCoordinateAxis extends AbstractAxis implements Coo
 
     @Override
     public boolean coordinatesMatch(double coordinateA, double coordinateB) {
-        if (type == Axis.Type.Rotation) {
-            long a = getResolutionTicks(coordinateA);
-            long b = getResolutionTicks(coordinateB);
-            long wraparound = getResolutionTicks(360.0);
-            boolean ret =  (Math.abs(a - b) % wraparound) == 0;
-            return ret;
-        }
-        else {
-            long a = getResolutionTicks(coordinateA);
-            long b = getResolutionTicks(coordinateB);
-            return a == b;
-        }
+        long a = getResolutionTicks(coordinateA);
+        long b = getResolutionTicks(coordinateB);
+        return a == b;
     }
-    
+
     protected abstract long getResolutionTicks(double coordinate);
 
     protected Length convertToSystem(Length length) {

--- a/src/main/java/org/openpnp/spi/base/AbstractHeadMountable.java
+++ b/src/main/java/org/openpnp/spi/base/AbstractHeadMountable.java
@@ -165,7 +165,7 @@ public abstract class AbstractHeadMountable extends AbstractModelObject implemen
         z = z.convertToUnits(location.getUnits());
         location = location.derive(null, null, z.getValue(), null);
         // Transform to Head coordinates.
-        location = toHeadLocation(location);
+        location = toHeadLocation(location, LocationOption.Quiet);
         // From Head to to raw coordinates.
         AxesLocation rawLocation = toRaw(location);
         return rawLocation.getLengthCoordinate(axisZ);

--- a/src/main/java/org/openpnp/spi/base/AbstractHeadMountable.java
+++ b/src/main/java/org/openpnp/spi/base/AbstractHeadMountable.java
@@ -132,7 +132,7 @@ public abstract class AbstractHeadMountable extends AbstractModelObject implemen
     protected CoordinateAxis getCoordinateAxisZ() {
         AbstractAxis zAxis = getAxisZ();
         if (zAxis != null) {
-            Machine machine = Configuration.get().getMachine();
+            Machine machine = getMachine();
             // Get the raw Z Axis.
             try {
                 return zAxis.getCoordinateAxes(machine).getAxis(Axis.Type.Z);
@@ -150,7 +150,7 @@ public abstract class AbstractHeadMountable extends AbstractModelObject implemen
 
     protected Length rawToHeadMountableZ(ReferenceControllerAxis rawAxis, Length z) {
         // Get the raw location, and put z in it.
-        AxesLocation rawLocation = getMappedAxes(Configuration.get().getMachine())
+        AxesLocation rawLocation = getMappedAxes(getMachine())
                 .put(new AxesLocation(rawAxis, z));
         // Transform to Head coordinates.
         Location location = toTransformed(rawLocation);
@@ -266,17 +266,17 @@ public abstract class AbstractHeadMountable extends AbstractModelObject implemen
 
     @Override
     public void moveTo(Location location, MotionOption... options) throws Exception {
-        moveTo(location, getHead().getMachine().getSpeed(), options);
+        moveTo(location, getMachine().getSpeed(), options);
     }
 
     @Override
     public void moveToSafeZ() throws Exception {
-        moveToSafeZ(getHead().getMachine().getSpeed());
+        moveToSafeZ(getMachine().getSpeed());
     }
 
     @Override
     public void waitForCompletion(CompletionType completionType) throws Exception {
-        Machine machine = Configuration.get().getMachine();
+        Machine machine = getMachine();
         if (machine.isEnabled() && machine instanceof ReferenceMachine) {
             ((ReferenceMachine) machine)
                 .getMotionPlanner().waitForCompletion(getHead() == null ? null : this, completionType);
@@ -368,7 +368,7 @@ public abstract class AbstractHeadMountable extends AbstractModelObject implemen
 
     @Override
     public Location getLocation() {
-        AxesLocation axesLocation = getMappedAxes(Configuration.get().getMachine());
+        AxesLocation axesLocation = getMappedAxes(getMachine());
         Location location = toTransformed(axesLocation);
         // From head to HeadMountable.
         return toHeadMountableLocation(location);
@@ -415,7 +415,11 @@ public abstract class AbstractHeadMountable extends AbstractModelObject implemen
             location = substituteUnchangedCoordinates(location, getLocation());
             Location headLocation = toHeadLocation(location);
             AxesLocation axesLocation = toRaw(headLocation);
-            return (Configuration.get().getMachine().getMotionPlanner().isValidLocation(axesLocation));
+            return getMachine().getMotionPlanner().isValidLocation(this, axesLocation);
+    }
+
+    protected ReferenceMachine getMachine() {
+        return (ReferenceMachine) Configuration.get().getMachine();
     }
 
 }

--- a/src/main/java/org/openpnp/spi/base/AbstractNozzle.java
+++ b/src/main/java/org/openpnp/spi/base/AbstractNozzle.java
@@ -116,15 +116,15 @@ public abstract class AbstractNozzle extends AbstractHeadMountable implements No
                 if (refAxis.isSoftLimitLowEnabled()) {
                     AxesLocation axesLimit = getMappedAxes(getMachine())
                             .put(new AxesLocation(refAxis, refAxis.getSoftLimitLow()));
-                    Location limit = toTransformed(axesLimit);
-                    limit = toHeadMountableLocation(limit);
+                    Location limit = toTransformed(axesLimit, LocationOption.Quiet);
+                    limit = toHeadMountableLocation(limit, LocationOption.Quiet);
                     limit0 = limit.getRotation();
                 }
                 if (refAxis.isSoftLimitHighEnabled()) {
                     AxesLocation axesLimit = getMappedAxes(getMachine())
                             .put(new AxesLocation(refAxis, refAxis.getSoftLimitHigh()));
-                    Location limit = toTransformed(axesLimit);
-                    limit = toHeadMountableLocation(limit);
+                    Location limit = toTransformed(axesLimit, LocationOption.Quiet);
+                    limit = toHeadMountableLocation(limit, LocationOption.Quiet);
                     limit1 = limit.getRotation();
                 }
             }
@@ -177,7 +177,8 @@ public abstract class AbstractNozzle extends AbstractHeadMountable implements No
                         // A negative rotation is wanted. Start at the axis higher limit.
                         angleStart = rotationLimits[1];
                     }
-                    newRotationModeOffset = Utils2D.angleNorm(pickLocation.getRotation() - angleStart, 180);
+                    newRotationModeOffset = 
+                            Utils2D.angleNorm(pickLocation.getRotation() - angleStart, 180);
                 }
                 break;
         }

--- a/src/main/java/org/openpnp/spi/base/AbstractNozzle.java
+++ b/src/main/java/org/openpnp/spi/base/AbstractNozzle.java
@@ -156,30 +156,27 @@ public abstract class AbstractNozzle extends AbstractHeadMountable implements No
             case LimitedArticulation:
                 double [] rotationLimits = getRotationModeLimits();
                 double articulation = rotationLimits[1] - rotationLimits[0];
-                double epsilon = 1e-5;
-                if (articulation < 360.0 - epsilon) {
-                    // Axis has limited articulation. 
-                    double pickToPlaceRotation = Utils2D.angleNorm(placementLocation.getRotation() - pickLocation.getRotation(), 180.0);
-                    // Allow for an additional 45° for alignment on the pick-to-place rotation. 
-                    double maximumRotation = pickToPlaceRotation + Math.signum(pickToPlaceRotation)*45;
-                    double angleStart;
-                    if (Math.abs(maximumRotation) < articulation) {
-                        // The needed rotation is lower than the available articulation, therefore limit it 
-                        // around the mid-point. 
-                        double midPoint = (rotationLimits[0] + rotationLimits[1])*0.5;
-                        angleStart = midPoint - maximumRotation*0.5;
-                    }
-                    else if (pickToPlaceRotation > 0) {
-                        // A positive rotation is wanted. Start at the axis lower limit.
-                        angleStart = rotationLimits[0];
-                    }
-                    else {
-                        // A negative rotation is wanted. Start at the axis higher limit.
-                        angleStart = rotationLimits[1];
-                    }
-                    newRotationModeOffset = 
-                            Utils2D.angleNorm(pickLocation.getRotation() - angleStart, 180);
+                // Axis has limited articulation, rotation is centered around the mid-range. 
+                double pickToPlaceRotation = Utils2D.angleNorm(placementLocation.getRotation() - pickLocation.getRotation(), 180.0);
+                // Allow for an additional 45° for alignment on the pick-to-place rotation. 
+                double maximumRotation = pickToPlaceRotation + Math.signum(pickToPlaceRotation)*45;
+                double angleStart;
+                if (Math.abs(maximumRotation) < articulation) {
+                    // The needed rotation is lower than the available articulation, therefore limit it 
+                    // around the mid-point. 
+                    double midPoint = (rotationLimits[0] + rotationLimits[1])*0.5;
+                    angleStart = midPoint - maximumRotation*0.5;
                 }
+                else if (pickToPlaceRotation > 0) {
+                    // A positive rotation is wanted. Start at the axis lower limit.
+                    angleStart = rotationLimits[0];
+                }
+                else {
+                    // A negative rotation is wanted. Start at the axis higher limit.
+                    angleStart = rotationLimits[1];
+                }
+                newRotationModeOffset = 
+                        Utils2D.angleNorm(pickLocation.getRotation() - angleStart, 180);
                 break;
         }
 

--- a/src/main/java/org/openpnp/spi/base/AbstractNozzle.java
+++ b/src/main/java/org/openpnp/spi/base/AbstractNozzle.java
@@ -9,13 +9,18 @@ import java.util.Set;
 import javax.swing.Icon;
 
 import org.openpnp.gui.support.Icons;
+import org.openpnp.machine.reference.axis.ReferenceControllerAxis;
+import org.openpnp.model.AxesLocation;
 import org.openpnp.model.Configuration;
 import org.openpnp.model.Location;
 import org.openpnp.model.Part;
+import org.openpnp.spi.Axis;
 import org.openpnp.spi.Camera;
+import org.openpnp.spi.CoordinateAxis;
 import org.openpnp.spi.Head;
 import org.openpnp.spi.Nozzle;
 import org.openpnp.spi.NozzleTip;
+import org.openpnp.util.Utils2D;
 import org.simpleframework.xml.Attribute;
 import org.simpleframework.xml.ElementList;
 
@@ -25,16 +30,21 @@ public abstract class AbstractNozzle extends AbstractHeadMountable implements No
 
     @Attribute(required = false)
     protected String name;
-    
+
+    @Attribute(required = false)
+    protected RotationMode rotationMode = RotationMode.AbsolutePartAngle;
+
     @ElementList(required = false)
     protected List<String> compatibleNozzleTipIds = new ArrayList<>();
 
     protected Set<NozzleTip> compatibleNozzleTips; 
 
     protected Head head;
-    
+
     protected Part part;
-    
+
+    protected Double rotationModeOffset;
+
     public AbstractNozzle() {
         this.id = Configuration.createId("NOZ");
         this.name = getClass().getSimpleName();
@@ -70,15 +80,127 @@ public abstract class AbstractNozzle extends AbstractHeadMountable implements No
         this.name = name;
         firePropertyChange("name", null, name);
     }
-    
+
     protected void setPart(Part part) {
+        Object oldValue = this.part;
         this.part = part;
-        firePropertyChange("part", null, part);
+        if (rotationModeOffset != null && part == null) {
+            rotationModeOffset = null;
+            getMachine().fireMachineHeadActivity(head);
+        }
+        firePropertyChange("part", oldValue, part);
     }
-    
+
     @Override
     public Part getPart() {
         return part;
+    }
+
+    @Override
+    public RotationMode getRotationMode() {
+        return rotationMode;
+    }
+
+    public void setRotationMode(RotationMode rotationMode) {
+        this.rotationMode = rotationMode;
+    }
+
+    public double[] getRotationModeLimits() throws Exception {
+        double limit0 = -180;
+        double limit1 = 180;
+        CoordinateAxis coordinateAxis = getAxisRotation().getCoordinateAxes(getMachine())
+                .getAxis(Axis.Type.Rotation);
+        if (coordinateAxis instanceof ReferenceControllerAxis) {
+            ReferenceControllerAxis refAxis = (ReferenceControllerAxis) coordinateAxis;
+            if (refAxis.isLimitRotation()) {
+                if (refAxis.isSoftLimitLowEnabled()) {
+                    AxesLocation axesLimit = getMappedAxes(getMachine())
+                            .put(new AxesLocation(refAxis, refAxis.getSoftLimitLow()));
+                    Location limit = toTransformed(axesLimit);
+                    limit = toHeadMountableLocation(limit);
+                    limit0 = limit.getRotation();
+                }
+                if (refAxis.isSoftLimitHighEnabled()) {
+                    AxesLocation axesLimit = getMappedAxes(getMachine())
+                            .put(new AxesLocation(refAxis, refAxis.getSoftLimitHigh()));
+                    Location limit = toTransformed(axesLimit);
+                    limit = toHeadMountableLocation(limit);
+                    limit1 = limit.getRotation();
+                }
+            }
+        }
+        if (limit0 <= limit1) {
+            return new double [] {limit0, limit1};
+        }
+        else {
+            return new double [] {limit1, limit0};
+        }
+    }
+
+    @Override
+    public void prepareForPickAndPlaceArticulation(Location pickLocation, Location placementLocation) throws Exception {
+        Double oldRotationModeOffset = rotationModeOffset;
+        Double newRotationModeOffset = null;
+        // Reset the current rotationModeOffset so all the calculating transforms are not affected.
+        rotationModeOffset = null;
+        switch (getRotationMode()) {
+            case AbsolutePartAngle:
+                newRotationModeOffset = null;
+                break;
+            case PlacementAngle:
+                newRotationModeOffset = placementLocation.getRotation();
+                break;
+            case MinimalRotation:
+                newRotationModeOffset = Utils2D.angleNorm(getLocation().getRotation() - pickLocation.getRotation(), 180);
+                break;
+            case LimitedArticulation:
+                double [] rotationLimits = getRotationModeLimits();
+                double articulation = rotationLimits[1] - rotationLimits[0];
+                double epsilon = 1e-5;
+                if (articulation < 360.0 - epsilon) {
+                    // Axis has limited articulation. 
+                    double pickToPlaceRotation = Utils2D.angleNorm(placementLocation.getRotation() - pickLocation.getRotation(), 180.0);
+                    // Allow for an additional 45° for alignment on the pick-to-place rotation. 
+                    double maximumRotation = pickToPlaceRotation + Math.signum(pickToPlaceRotation)*45;
+                    double angleStart;
+                    if (Math.abs(maximumRotation) < articulation) {
+                        // The needed rotation is lower than the available articulation, therefore limit it 
+                        // around the mid-point. 
+                        double midPoint = (rotationLimits[0] + rotationLimits[1])*0.5;
+                        angleStart = midPoint - maximumRotation*0.5;
+                    }
+                    else if (pickToPlaceRotation > 0) {
+                        // A positive rotation is wanted. Start at the axis lower limit.
+                        angleStart = rotationLimits[0];
+                    }
+                    else {
+                        // A negative rotation is wanted. Start at the axis higher limit.
+                        angleStart = rotationLimits[1];
+                    }
+                    newRotationModeOffset = Utils2D.angleNorm(pickLocation.getRotation() - angleStart, 180);
+                }
+                break;
+        }
+
+        if ((newRotationModeOffset == null) != (oldRotationModeOffset == null)
+                || (newRotationModeOffset != null && newRotationModeOffset.compareTo(oldRotationModeOffset) != 0)) {
+            // The rotationModeOffset has changed, this must be reflected in the DRO etc.
+            rotationModeOffset = newRotationModeOffset;
+            getMachine().fireMachineHeadActivity(head);
+        }
+        else {
+            rotationModeOffset = oldRotationModeOffset;
+        }
+    }
+
+    public Double getRotationModeOffset() {
+        return rotationModeOffset;
+    }
+
+    public void setRotationModeOffset(Double rotationModeOffset) {
+        Object oldValue = this.rotationModeOffset;
+        this.rotationModeOffset = rotationModeOffset;
+        firePropertyChange("rotationModeOffset", oldValue, rotationModeOffset);
     }
 
     @Override

--- a/src/main/java/org/openpnp/util/Cycles.java
+++ b/src/main/java/org/openpnp/util/Cycles.java
@@ -8,6 +8,7 @@ import org.openpnp.model.LengthUnit;
 import org.openpnp.model.Location;
 import org.openpnp.spi.Actuator;
 import org.openpnp.spi.Nozzle;
+import org.openpnp.spi.Nozzle.RotationMode;
 
 public class Cycles {
     /**
@@ -69,8 +70,14 @@ public class Cycles {
         globals.put("nozzle", nozzle);
         Configuration.get().getScripting().on("Job.BeforeDiscard", globals);
 
+        Location discardLocation = Configuration.get().getMachine().getDiscardLocation();
+        if (nozzle.getRotationMode() == RotationMode.LimitedArticulation) {
+            // On a limited articulation nozzle, keep the rotation.
+            discardLocation = discardLocation.derive(nozzle.getLocation(),
+                    false, false, false, true);
+        }
         // move to the discard location
-        nozzle.moveToPlacementLocation(Configuration.get().getMachine().getDiscardLocation(), null);
+        nozzle.moveToPlacementLocation(discardLocation, null);
         // discard the part
         nozzle.place();
         nozzle.moveToSafeZ();

--- a/src/main/java/org/openpnp/util/GcodeServer.java
+++ b/src/main/java/org/openpnp/util/GcodeServer.java
@@ -452,13 +452,14 @@ public class GcodeServer extends Thread {
                     regurg.append('$');
                 }
                 regurg.append(word.letter);
-                if (word.signum < 0) {
-                    regurg.append('-');
-                }
-                regurg.append(word.getNumberIntegral());
                 if (word.getNumberFraction() != 0) {
-                    regurg.append('.');
-                    regurg.append(word.getNumberFraction());
+                    regurg.append(word.getNumberDouble());
+                }
+                else {
+                    if (word.signum < 0) {
+                        regurg.append('-');
+                    }
+                    regurg.append(word.getNumberIntegral());
                 }
                 regurg.append(' ');
             }


### PR DESCRIPTION
# Description

## Nozzle RotationMode

Introduces the `RotationMode` for nozzles, where the angular articulation between the pick and the place is subject to a modal angular offset. This serves the following purposes:

1. Support machines that have nozzles with restricted angular articulation, i.e. that cannot articulate the full 360°. Machines with a bit more than 180° (add the allowance for bottom vision alignment adjustments) are now supported. Even for machines with >= 360° articulation, but still limited range (e.g. tubing that is not free-running), the mode will reduce the angular movements to a minimum. 
2. Optimize the performance of shared rotation (`C`) axes machines: Parts are picked at angular offsets that make them pre-rotated for placement, i.e. all the nozzles are subsequently pre-rotated for alignment and placement at their shared 0° position. No large rotations are therefore needed for alignment and placement (only the small _and fast_ adjustments from bottom vision alignment offsets). The more precise pre-rotate bottom vision is therefore available without performance penalty. 
3. If none of the above applies, there is still an optimization available that simply picks the part at whatever rotation the nozzle currently has. Alignment and placement are then rotated _relative_ to that. This might speed up operation if multiple nozzles pick from the same feeder, or from feeders that are close together, i.e. where the move time between picks is not enough to rotate nozzles fast enough (e.g. in LED panel assembly). 

## Custom Angular Range

Rotation axes can now also optionally define **Soft Limits** to define a custom angular range. Formerly, the standard -180° ... +180° range was the only option. This has the following benefits:

1. Allows defining the angular range for machines with limited articulation (< 360°). See point (1) in the previous section.
2. For machines that have restricted rotation (e.g. tubing that is not free-running), a more relaxed custom range can be defined, e.g. -200° ... 200°, resulting in less "pirouetting", if the placement angle happens to be near the ±180° wrap-around limit. Alternatively, a shifted custom range, like -160° ... 200° can at least make it less likely, that a part placement angle is at the wrap-around limit (e.g. the common 180° placement angle). 
3. Allow defining the range for axes that are transformed, i.e. where 360 axis units ≠ 1 axis revolution. See next section.

## Rotation Axis Transforms

Rotation axes now support axis coordinate transformations. All the [Transformed Axes](https://github.com/openpnp/openpnp/wiki/Transformed-Axes) are supported, as long as the transformation in the articulated range is [strictly monotonic](https://en.wikipedia.org/wiki/Monotonic_function). Negation is also possible (e.g. for gear-coupled shared C axes).

All the relevant angular calculations (wrap-around at modulo 360° limits) are now properly performed in the transformed coordinate space. 

## Detailed Feature List

* Custom range rotational axis limits.
* Completely revised the way axis limits and wrap-arounds are applied in the `AbstractMotionPlanner`. It now supports transformed axes, i.e. the angular math is properly done in the `HeadMountable` coordinate space rather than in the raw axis coordinate space.
* Introduce the `RotationMode` for machines with shared C and/or limited angular articulation. An optimization mode is also available.
* Using `Nozzle.prepareForPickAndPlaceArticulation()`, the upcoming articulation must be announced before a pick-and-place-cycle is executed, so the proper `RotationMode` angular base offset can be applied to the nozzle.
* The Job Processor properly prepares the angular articulation.
* Issues & Solutions precision nozzle-to-head offset calibration properly prepares the angular articulation.
* The Discard cycle does not rotate a limited articulation nozzle.
* The Feeders Panel pick action properly prepares the angular articulation, using the **Test Alignment Angle** as the assumed placement rotation.
* Persist the **Test Alignment Angle** in `ReferenceBottomVision`, and make it publicly accessible.
* The rotation `P` button on the jog controls will now move to the 90° step angle nearest to the mid-position of a limited articulation nozzle (Note: this angle can vary, when a part is on the nozzle, i.e. when a `RotationMode` offset is applied).
* Nozzle tip calibration will respect rotation axis limits and make sure no `RotationMode` offset is currently applied.
* Introduced a `LocationOption.Quiet` option to squelch excessive chatter in the log (because angle math needs to be performed in transformed coordinate space, there are now many more transforms back and forth). 
* Added configuration error diagnostics, if the **Wrap Around** option is set on a limited articulation axis.
* Always apply limited articulation rotation mode offset, even if the articulation range is actually >= 360°. In order to center the rotation mostly around the mid-point, i.e. lessen the stress on tubes etc.

Extras:

* Added a Feed Rate per minute auto-conversion text edit to `ReferenceControllerAxisConfigurationWizard` for those that "think" in per minute units.
* Moved duplicate `getMachine()` code to base class `AbstractHeadMountable`.
* `GcodeServer`: Fixed bug in logging the parsed G-code.

# Justification
See the description.

# Instructions for Use

## Rotational Axis Limits

In the ReferenceControllerAxis configuration, as soon as **Limit to Range** is enabled, the **Soft Limit Low** and **Soft Limit High** are displayed:

![ReferenceControllerAxis](https://user-images.githubusercontent.com/9963310/136701242-6cbf8e36-637c-4ee2-8eda-6e1b535f0e88.png)

The limits can be captured etc. as with linear axes. 

## Rotational Axis Transformations

You can now use axis transformations, the example shown here establishes a 1:10 scaling between the controller axis and the transformed axis: 

![Mapped](https://user-images.githubusercontent.com/9963310/136701340-0c24bedc-fb9e-4723-9af3-b2b505e794d5.png)

The transformed axis can then be assigned to the Nozzle:

![Nozzle axis mapping](https://user-images.githubusercontent.com/9963310/136701429-4c9e7155-92b0-4450-ab91-a4e64a4db755.png)

## Set the Rotational Mode on the Nozzle

Also note the **Rotation Mode** that is configured on the Nozzle:

![Rotation Mode](https://user-images.githubusercontent.com/9963310/136701468-7a676042-54d2-44ed-8030-269cd15382e4.png)

In the example above, we have a controller axis that rotates from -1 ... 19, which is 1:10 transformed to a -10° ... 190° angular range. This is more than 180° to allow for a ±20° alignment offset, but it is less than 360°. Hence, the **LimitedArticulation** mode must be configured on the nozzle. 

## Rotation Modes

The **Rotation Mode** entries work as follows:

- **AbsolutePartAngle**: the part is picked at its absolute angle, i.e. if the nozzle is at 0°, the part is rotated as drawn in the E-CAD library. This is the default and legacy mode, no angular offset is applied. The nozzle must be able to articulate 360° and more. 
- **PlacementAngle**: the part is picked with the placement angle compensated, i.e. if the nozzle is at 0°, the part is rotated as it will be aligned and placed. You must enable the **Pre-Rotate** option in bottom vision, for this to make sense. This is optimal for shared C axes. 
- **MinimalRotation**: the part is picked at whatever angle the nozzle happens to be at, i.e. no rotation is needed prior to the pick. Alignment and placement are done at _relative_ angles. This might speed up operation if multiple nozzles pick from the same feeder, or from feeders that are close together, i.e. where the move time between picks is not enough to rotate nozzles fast enough (e.g. in LED panel assembly). 
- **LimitedArticulation**: the articulation of the pick-to-placement rotation is centered around the midpoint of whatever angular range is available (taking into account a margin for alignment offsets). For the pick, the nozzle is automatically rotated towards either the minimum or maximum range limit, to allow for positive or negative relative rotation, as needed. Once the part is picked, only the placement angle is guaranteed to be reachable. This means you _must_ enable the **Pre-Rotate** option in bottom vision. 

## Working with Limited Articulation

This section describes working with a nozzle that has a limited articulation, i.e. less than 360°, and the **LimitedArticulation** rotation mode set.

Obviously you can no longer rotate the nozzle all the way. Without a part picked, the nozzle will articulate in its native range. If you try to jog beyond the range, an error is displayed. This does not apply to the camera virtual axis, so you should still be able to capture any rotation, e.g. from feeders. However, you might get errors when switching from camera to nozzle. 

![Limited Rotation Error](https://user-images.githubusercontent.com/9963310/136702778-f7300cdb-c1bc-4b61-99ad-a63d2d9038ed.png)

Once a part is picked, the angular offset needed for placement articulation is taken into account (see the **LimitedArticulation** mode description). The effective _part_ angle is displayed as expected in the DRO and through the cross-hairs of the bottom camera view, i.e. the rotation offset is hidden from the user (use the log to see at what absolute angles the controller axis is driven). 

### Use Cases
 

- Inside a Job, the pick-to-place articulation is automatically controlled. 

- ![Pick Button](https://user-images.githubusercontent.com/9963310/136702931-477b112a-bfdf-4ee1-a5da-ff68cd6614bd.png) The **Pick** action in the Parts and Feeders panels takes the **Test Alignment Angle** on the part alignment settings into account. 

- ![Pick Action](https://user-images.githubusercontent.com/9963310/136702905-0b975517-62ef-4893-bd86-9ee5e86d1141.png)
 
- The **Discard** cycle will not try to rotate the part for discard.
 
- [Issues & Solutions precision nozzle-to-head offset calibration](https://github.com/openpnp/openpnp/wiki/Calibration-Solutions#calibrating-precision-camera-to-nozzle-offsets) properly prepares the angular articulation.
 
- The rotation `P` button on the jog controls will now move to the 90° step angle nearest to the mid-position of a limited articulation nozzle (Note: this angle can vary, when a part is on the nozzle, i.e. when a `RotationMode` offset is applied).

**NOTE:** There might be other functions where limited articulation is not yet respected, especially when a rotation is applied to the nozzle were it does not actually matter. Please help with the improvement of OpenPnP and report such functions to the [discussion group](http://groups.google.com/group/openpnp). 

____
# !! HELP WANTED WITH TESTING !! 👍 💯 
____

# Implementation Details
1. Tested in simulation.
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. Changes in the `org.openpnp.spi` packages to introduce the `RotationMode`, the  `Nozzle.prepareForPickAndPlaceArticulation()` and some passed-through HeadMountables in existing methods in order to support axis coordinate transformations.
4. Successful `mvn test` before submitting the Pull Request. 
