### PR TITLE
Fix / Remove Threading Race when Detecting Firmware

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/driver/GcodeDriver.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/GcodeDriver.java
@@ -1471,7 +1471,7 @@ public class GcodeDriver extends AbstractReferenceDriver implements Named {
     }
 
     public String getFirmwareConfiguration() {
-        return detectedFirmware+"\n\n"
+        return (detectedFirmware != null ? detectedFirmware : "")+"\n\n"
                 +(reportedAxes != null ? reportedAxes : "")+"\n\n"
                 +(configuredAxes != null ? configuredAxes : "");
     }

--- a/src/main/java/org/openpnp/machine/reference/driver/wizards/GcodeDriverSettings.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/wizards/GcodeDriverSettings.java
@@ -34,7 +34,6 @@ import javax.swing.border.TitledBorder;
 import org.openpnp.gui.MainFrame;
 import org.openpnp.gui.components.ComponentDecorators;
 import org.openpnp.gui.support.AbstractConfigurationWizard;
-import org.openpnp.gui.support.DoubleConverter;
 import org.openpnp.gui.support.Icons;
 import org.openpnp.gui.support.IntegerConverter;
 import org.openpnp.gui.support.MessageBoxes;
@@ -221,9 +220,6 @@ public class GcodeDriverSettings extends AbstractConfigurationWizard {
     @Override
     public void createBindings() {
         IntegerConverter intConverter = new IntegerConverter();
-        DoubleConverter doubleConverter =
-                new DoubleConverter(Configuration.get().getLengthDisplayFormat());
-        DoubleConverter doubleConverterFine = new DoubleConverter("%f");
 
         addWrappedBinding(driver, "motionControlType", motionControlType, "selectedItem");
         addWrappedBinding(driver, "units", unitsCb, "selectedItem");

--- a/src/main/java/org/openpnp/machine/reference/driver/wizards/GcodeDriverSettings.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/wizards/GcodeDriverSettings.java
@@ -2,11 +2,13 @@ package org.openpnp.machine.reference.driver.wizards;
 
 import java.awt.Cursor;
 import java.awt.FileDialog;
+import java.awt.Font;
 import java.awt.Toolkit;
 import java.awt.datatransfer.Clipboard;
 import java.awt.datatransfer.DataFlavor;
 import java.awt.datatransfer.StringSelection;
 import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
 import java.io.File;
 import java.io.FileReader;
 import java.io.FileWriter;
@@ -14,8 +16,19 @@ import java.io.FilenameFilter;
 import java.io.StringReader;
 import java.io.StringWriter;
 
-import javax.swing.*;
-import javax.swing.border.LineBorder;
+import javax.swing.AbstractAction;
+import javax.swing.Action;
+import javax.swing.BorderFactory;
+import javax.swing.JButton;
+import javax.swing.JCheckBox;
+import javax.swing.JComboBox;
+import javax.swing.JLabel;
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+import javax.swing.JTextArea;
+import javax.swing.JTextField;
+import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
 import javax.swing.border.TitledBorder;
 
 import org.openpnp.gui.MainFrame;
@@ -25,25 +38,22 @@ import org.openpnp.gui.support.DoubleConverter;
 import org.openpnp.gui.support.Icons;
 import org.openpnp.gui.support.IntegerConverter;
 import org.openpnp.gui.support.MessageBoxes;
+import org.openpnp.machine.reference.ReferenceMachine;
 import org.openpnp.machine.reference.driver.GcodeDriver;
 import org.openpnp.model.Configuration;
 import org.openpnp.model.LengthUnit;
 import org.openpnp.spi.Actuator;
 import org.openpnp.spi.Camera;
 import org.openpnp.spi.Driver.MotionControlType;
-import org.openpnp.util.UiUtils;
 import org.openpnp.spi.HeadMountable;
 import org.openpnp.spi.Nozzle;
+import org.openpnp.util.UiUtils;
 import org.simpleframework.xml.Serializer;
 
 import com.jgoodies.forms.layout.ColumnSpec;
 import com.jgoodies.forms.layout.FormLayout;
 import com.jgoodies.forms.layout.FormSpecs;
 import com.jgoodies.forms.layout.RowSpec;
-
-import java.awt.SystemColor;
-import java.awt.event.ActionListener;
-import java.awt.Font;
 
 public class GcodeDriverSettings extends AbstractConfigurationWizard {
     private final GcodeDriver driver;
@@ -172,9 +182,21 @@ public class GcodeDriverSettings extends AbstractConfigurationWizard {
             public void actionPerformed(ActionEvent e) {
                 setCursor(Cursor.getPredefinedCursor(Cursor.WAIT_CURSOR));
                 firmwareConfiguration.setText("Detecting...");
-                SwingUtilities.invokeLater(() -> {
-                    UiUtils.messageBoxOnException(() -> driver.detectFirmware(false));
-                    setCursor(Cursor.getPredefinedCursor(Cursor.DEFAULT_CURSOR));
+                ReferenceMachine machine = (ReferenceMachine) Configuration.get().getMachine();
+                UiUtils.messageBoxOnException(() -> {
+                    if (machine.isEnabled()) {
+                        machine.execute(() -> {
+                            driver.detectFirmware(false);
+                            return true;
+                        });
+                    }
+                    else {
+                        // Use an ad hoc connection.
+                        driver.detectFirmware(false);
+                    }
+                    SwingUtilities.invokeLater(() -> {
+                        setCursor(Cursor.getPredefinedCursor(Cursor.DEFAULT_CURSOR));
+                    });
                 });
             }
         });

--- a/src/main/java/org/openpnp/machine/reference/solutions/GcodeDriverSolutions.java
+++ b/src/main/java/org/openpnp/machine/reference/solutions/GcodeDriverSolutions.java
@@ -42,6 +42,7 @@ import org.openpnp.model.Configuration;
 import org.openpnp.model.Solutions;
 import org.openpnp.model.Solutions.Milestone;
 import org.openpnp.model.Solutions.Severity;
+import org.openpnp.model.Solutions.State;
 import org.openpnp.spi.Actuator;
 import org.openpnp.spi.ControllerAxis;
 import org.openpnp.spi.Driver;
@@ -50,6 +51,7 @@ import org.openpnp.spi.Head;
 import org.openpnp.spi.HeadMountable;
 import org.openpnp.spi.Machine;
 import org.openpnp.util.GcodeServer;
+import org.openpnp.util.UiUtils;
 import org.openpnp.util.XmlSerialize;
 import org.pmw.tinylog.Logger;
 import org.simpleframework.xml.Serializer;
@@ -147,7 +149,9 @@ public class GcodeDriverSolutions implements Solutions.Subject {
             }
             if (machine.isEnabled() && gcodeDriver.isSpeakingGcode()) {
                 try {
-                    gcodeDriver.detectFirmware(true);
+                    UiUtils.submitUiMachineTask(
+                            () -> gcodeDriver.detectFirmware(true)
+                            ).get();
                 }
                 catch (Exception e) {
                     Logger.warn(e, gcodeDriver.getName()+" failure to detect firmware");
@@ -197,13 +201,35 @@ public class GcodeDriverSolutions implements Solutions.Subject {
                     public void setState(Solutions.State state) throws Exception {
                         if (state == Solutions.State.Solved) {
                             if ((Boolean)getChoice()) {
-                                gcodeDriver.detectFirmware(false);
+                                final State oldState = getState();
+                                try {
+                                    if (machine.isEnabled()) {
+                                        machine.execute(() -> {
+                                            gcodeDriver.detectFirmware(false);
+                                            return true;
+                                        });
+                                    }
+                                    else {
+                                        // Use an ad hoc connection.
+                                        gcodeDriver.detectFirmware(false);
+                                    }
+                                    super.setState(state);
+                                }
+                                catch (Exception e) { 
+                                    UiUtils.showError(e);
+                                    // restore old state
+                                    UiUtils.messageBoxOnException(() -> setState(oldState));
+                                }
                             }
                             else {
                                 gcodeDriver.setDetectedFirmware(GcodeServer.getGenericFirmware());
+                                super.setState(state);
                             }
                         }
-                        super.setState(state);
+                        else {
+                            gcodeDriver.setDetectedFirmware(null);
+                            super.setState(state);
+                        }
                     }
                 });
             }

--- a/src/main/java/org/openpnp/util/GcodeServer.java
+++ b/src/main/java/org/openpnp/util/GcodeServer.java
@@ -513,8 +513,9 @@ public class GcodeServer extends Thread {
                         if (controllerAxis.getDriver() == getDriver()) {
                             String letter = controllerAxis.getLetter(); 
                             if (letter.isEmpty() || letter.length() > 1) {
-                                // We're in GcodeServer simulation on this machine. Provide some usual defaults.  
-                                if (axis.getName().equals("x") || axis.getName().equals("y") || axis.getName().equals("z") || axis.getName().equals("Z1")) {
+                                // We're in GcodeServer simulation on this machine. Provide some useful defaults.  
+                                if (axis.getName().equals("x") || axis.getName().equals("y") 
+                                        || axis.getName().toLowerCase().substring(0, 1).equals("z")) {
                                     controllerAxis.setLetter(axis.getName().toUpperCase().substring(0, 1));
                                 }
                                 else if (axis.getName().equals("C") || axis.getName().equals("C1")) {

--- a/src/main/java/org/openpnp/util/GcodeServer.java
+++ b/src/main/java/org/openpnp/util/GcodeServer.java
@@ -509,10 +509,24 @@ public class GcodeServer extends Thread {
                 AxesLocation axesGiven = AxesLocation.zero;
                 for (Axis axis : machine.getAxes()) {
                     if (axis instanceof ControllerAxis) {
-                        if (((ControllerAxis) axis).getDriver() == getDriver()) {
-                            String letter = ((ControllerAxis) axis).getLetter(); 
+                        ControllerAxis controllerAxis = (ControllerAxis) axis;
+                        if (controllerAxis.getDriver() == getDriver()) {
+                            String letter = controllerAxis.getLetter(); 
                             if (letter.isEmpty() || letter.length() > 1) {
-                                throw new Exception("Invalid letter on axis "+axis.getName());
+                                // We're in GcodeServer simulation on this machine. Provide some usual defaults.  
+                                if (axis.getName().equals("x") || axis.getName().equals("y") || axis.getName().equals("z") || axis.getName().equals("Z1")) {
+                                    controllerAxis.setLetter(axis.getName().toUpperCase().substring(0, 1));
+                                }
+                                else if (axis.getName().equals("C") || axis.getName().equals("C1")) {
+                                    controllerAxis.setLetter("A");
+                                }
+                                else if (axis.getName().equals("C2")) {
+                                    controllerAxis.setLetter("B");
+                                }
+                                else {
+                                    throw new Exception("Invalid letter on axis "+axis.getName());
+                                }
+                                letter = controllerAxis.getLetter(); 
                             }
                             GcodeWord axisWord = getLetterWord(letter.toCharArray()[0], commandWords);
                             if (axisWord != null) {


### PR DESCRIPTION
# Description
Fix to remove a potential threading race condition when detecting the firmware from the driver (button) or from Issues & Solutions. When the machine is enabled, this must be properly done inside a machine task.

When I tested this using a fresh `machine.xml`, I also noticed a chicken-egg situation in the early Issues & Solutions setup. The GcodeServer would throw if an axis letter is missing. But when using the GcodeServer to detect the firmware, we are in a simulated environment, i.e. a reasonable axis letters assignment can be assumed. This has been added for single and dual nozzle configurations.

# Justification
The race might (or might not) be the reason for unexplained connection issues. See here:
https://groups.google.com/g/openpnp/c/taXWhONJ6zY/m/oHLn00cWAQAJ

# Instructions for Use
No change.

# Implementation Details
1. Tested in simulation.
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. Successful `mvn test` before submitting the Pull Request. 
