### PR TITLE
Fix/ReferenceBottomVisionOffsetTest increased Angular Tolerance

### DIFF
--- a/src/test/java/ReferenceBottomVisionOffsetTest.java
+++ b/src/test/java/ReferenceBottomVisionOffsetTest.java
@@ -84,7 +84,7 @@ public class ReferenceBottomVisionOffsetTest {
         };
         
         machine.setEnabled(true);
-        Location maxError = new Location(LengthUnit.Millimeters, 0.1, 0.1, 0, 0.03);
+        Location maxError = new Location(LengthUnit.Millimeters, 0.1, 0.1, 0, 0.07);
         for (Location[] testPair: testData) {
             machine.execute(() -> {
                 nozzle.pick(part);
@@ -127,7 +127,7 @@ public class ReferenceBottomVisionOffsetTest {
         };
         
         machine.setEnabled(true);
-        Location maxError = new Location(LengthUnit.Millimeters, 0.1, 0.1, 0, 0.03);
+        Location maxError = new Location(LengthUnit.Millimeters, 0.1, 0.1, 0, 0.07);
         for (Location[] testPair: testData) {
             machine.execute(() -> {
                 nozzle.pick(part);
@@ -171,7 +171,7 @@ public class ReferenceBottomVisionOffsetTest {
         };
         
         machine.setEnabled(true);
-        Location maxError = new Location(LengthUnit.Millimeters, 0.1, 0.1, 0, 0.03);
+        Location maxError = new Location(LengthUnit.Millimeters, 0.1, 0.1, 0, 0.07);
         for (Location[] testPair: testData) {
             machine.execute(() -> {
                 nozzle.pick(part);
@@ -215,7 +215,7 @@ public class ReferenceBottomVisionOffsetTest {
         };
         
         machine.setEnabled(true);
-        Location maxError = new Location(LengthUnit.Millimeters, 0.1, 0.1, 0, 0.03);
+        Location maxError = new Location(LengthUnit.Millimeters, 0.1, 0.1, 0, 0.07);
         for (Location[] testPair: testData) {
             machine.execute(() -> {
                 nozzle.pick(part);
@@ -258,7 +258,7 @@ public class ReferenceBottomVisionOffsetTest {
         };
         
         machine.setEnabled(true);
-        Location maxError = new Location(LengthUnit.Millimeters, 0.1, 0.1, 0, 0.03);
+        Location maxError = new Location(LengthUnit.Millimeters, 0.1, 0.1, 0, 0.07);
         for (Location[] testPair: testData) {
             machine.execute(() -> {
                 nozzle.pick(part);
@@ -302,7 +302,7 @@ public class ReferenceBottomVisionOffsetTest {
         };
         
         machine.setEnabled(true);
-        Location maxError = new Location(LengthUnit.Millimeters, 0.1, 0.1, 0, 0.03);
+        Location maxError = new Location(LengthUnit.Millimeters, 0.1, 0.1, 0, 0.07);
         for (Location[] testPair: testData) {
             machine.execute(() -> {
                 nozzle.pick(part);
@@ -346,7 +346,7 @@ public class ReferenceBottomVisionOffsetTest {
         };
         
         machine.setEnabled(true);
-        Location maxError = new Location(LengthUnit.Millimeters, 0.1, 0.1, 0, 0.03);
+        Location maxError = new Location(LengthUnit.Millimeters, 0.1, 0.1, 0, 0.07);
         for (Location[] testPair: testData) {
             machine.execute(() -> {
                 nozzle.pick(part);
@@ -394,7 +394,7 @@ public class ReferenceBottomVisionOffsetTest {
         camera.setErrorOffsets(error);
         
         machine.setEnabled(true);
-        Location maxError = new Location(LengthUnit.Millimeters, 0.1, 0.1, 0, 0.03);
+        Location maxError = new Location(LengthUnit.Millimeters, 0.1, 0.1, 0, 0.07);
         for (Location[] testPair: testData) {
             machine.execute(() -> {
                 nozzle.pick(part);
@@ -445,7 +445,7 @@ public class ReferenceBottomVisionOffsetTest {
         camera.setErrorOffsets(error);
 
         machine.setEnabled(true);
-        Location maxError = new Location(LengthUnit.Millimeters, 0.1, 0.1, 0, 0.03);
+        Location maxError = new Location(LengthUnit.Millimeters, 0.1, 0.1, 0, 0.07);
         for (Location[] testPair: testData) {
             machine.execute(() -> {
                 nozzle.pick(part);


### PR DESCRIPTION
# Description
As an attempt to get rid of deployment errors, try increasing `ReferenceBottomVisionOffsetTest` angular tolerances.

These tolerances are subject to pixel artifacts (from anti-aliasing), it is well possible that these are platform/GPU accelerator dependent. 

# Justification
As suggested by @vonnieda 

# Instructions for Use
No change.

# Implementation Details
1. Local tests (which are **not** conclusive i.e. they worked before)
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. Successful `mvn test` before submitting the Pull Request.
