### PR TITLE
Fix / Add Missing Before-Pick Part-Off Vacuum Check to UI Action

### DIFF
--- a/src/main/java/org/openpnp/gui/FeedersPanel.java
+++ b/src/main/java/org/openpnp/gui/FeedersPanel.java
@@ -647,6 +647,16 @@ public class FeedersPanel extends JPanel implements WizardContainer {
         // Do the feed an get the nozzle for the pick.
         Nozzle nozzle = feedFeeder(feeder);
 
+        // Perform the vacuum check, if enabled.
+        if (nozzle.isPartOffEnabled(Nozzle.PartOffStep.BeforePick)) {
+            // Part-off check can only be done at safe Z. An explicit move to safe Z is needed, because some feeder classes 
+            // may move the nozzle to (near) the pick location i.e. down in Z in feed().
+            nozzle.moveToSafeZ();
+            if(!nozzle.isPartOff()) {
+                throw new JobProcessorException(nozzle, "Part vacuum-detected on nozzle before pick.");
+            }
+        }
+
         // Make sure the nozzle can articulate from pick to placement. 
         Location placementLocation = getTestPlacementLocation(feeder.getPart());
         nozzle.prepareForPickAndPlaceArticulation(feeder.getPickLocation(), 


### PR DESCRIPTION
# Description

Adds a job-like **Before Pick** part-off vacuum test to the UI **Pick** button ![Pick Action](https://user-images.githubusercontent.com/9963310/138586876-864f2e6d-0688-4df5-ba84-35bc6c80f9f1.png), if enabled. 

# Justification
See the discussion here.
https://github.com/openpnp/openpnp/issues/1281#issuecomment-950276262

# Instructions for Use
Make sure the **Before Pick** option on the nozzle tip is enabled in tab **Part Detection**:

![Before Pick](https://user-images.githubusercontent.com/9963310/138586913-a7041879-2f3a-44b2-9a3b-782ac99e1998.png)

See also:
https://github.com/openpnp/openpnp/wiki/Setup-and-Calibration%3A-Vacuum-Sensing#nozzle-tip-setup

The Part-Off check will now also be performed when the UI pick button is pressed in the Parts or Feeder panel:

![Parts Panel](https://user-images.githubusercontent.com/9963310/138587073-5e803664-f6cf-4dc6-9baf-241b00a9f9c2.png)

![Feeders Panel](https://user-images.githubusercontent.com/9963310/138587093-0009db87-9b2f-44f9-a69f-b4eb08b08af4.png)

# Implementation Details
1. Tested in simulation.
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. Successful `mvn test` before submitting the Pull Request.
