### PR TITLE
Feature / Dynamic HOME_COMMAND with Issues & Solutions Support

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/driver/GcodeDriver.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/GcodeDriver.java
@@ -434,6 +434,63 @@ public class GcodeDriver extends AbstractReferenceDriver implements Named {
         Head head = machine.getDefaultHead();
         command = substituteVariable(command, "Id", head.getId()); 
         command = substituteVariable(command, "Name", head.getName());
+        AxesLocation axesHomeLocation =  new AxesLocation(machine, 
+                (axis) -> (axis.getHomeCoordinate())); 
+        Double feedrate = null;
+        Double acceleration = null;
+        Double jerk = null;
+        for (String variable : getAxisVariables((ReferenceMachine) machine)) {
+            ControllerAxis axis = axesHomeLocation.getAxisByVariable(this, variable);
+            if (axis != null) {
+                double coordinate;
+                if (axis.getType() == Type.Rotation) {
+                    // Never convert rotation to driver units.
+                    coordinate = axesHomeLocation.getCoordinate(axis);
+                }
+                else {
+                    coordinate = axesHomeLocation.getCoordinate(axis, getUnits());
+                }
+                command = substituteVariable(command, variable, coordinate);
+                command = substituteVariable(command, variable+"L", 
+                        axis.getLetter());
+
+                // Because in homing we don't know which axis is moved when and in what combination, 
+                // we need to find the lowest rates of any axis.
+                if (axis.getMotionLimit(1) != 0.0) {
+                    if (feedrate == null || feedrate > axis.getMotionLimit(1)) {
+                        feedrate = axis.getMotionLimit(1);
+                    }
+                }
+                if (axis.getMotionLimit(2) != 0.0) {
+                    if (acceleration == null || acceleration > axis.getMotionLimit(2)) {
+                        acceleration = axis.getMotionLimit(2);
+                    }
+                }
+                if (axis.getMotionLimit(3) != 0.0) {
+                    if (jerk == null || jerk > axis.getMotionLimit(3)) {
+                        feedrate = axis.getMotionLimit(3);
+                    }
+                }
+            }
+            else {
+                command = substituteVariable(command, variable, null);
+                command = substituteVariable(command, variable+"L", null); 
+            }
+        }
+
+        if (getMotionControlType().isUnpredictable()) {
+            // Do not initialize rates, as the motion control is unpredictable, i.e. not controlled by us.  
+            command = substituteVariable(command, "FeedRate", null);
+            command = substituteVariable(command, "Acceleration", null);
+            command = substituteVariable(command, "Jerk", null);
+        }
+        else {
+            // For the purpose of homing, initialize the rates to the lowest of any axis. 
+            command = substituteVariable(command, "FeedRate", feedrate);
+            command = substituteVariable(command, "Acceleration", acceleration);
+            command = substituteVariable(command, "Jerk", jerk);
+        }
+
         long timeout = -1;
         sendGcode(command, timeout);
 

--- a/src/main/java/org/openpnp/machine/reference/solutions/GcodeDriverSolutions.java
+++ b/src/main/java/org/openpnp/machine/reference/solutions/GcodeDriverSolutions.java
@@ -731,17 +731,18 @@ public class GcodeDriverSolutions implements Solutions.Subject {
                                             }
                                         }
                                         commandBuilt += "; Home all axes\n";
-                                        commandBuilt += "G28.3 ";
-                                        for (ControllerAxis axis : gcodeDriver.getAxes(machine)) {
-                                            if (!axis.getLetter().isEmpty()) {
-                                                commandBuilt += axis.getLetter()+axis.getHomeCoordinate()+" ";
-                                            }
+                                        commandBuilt += "G28.3";
+                                        for (String variable : gcodeDriver.getAxisVariables(machine)) {
+                                            commandBuilt += " {"+variable+":"+variable+"%.4f}";
                                         }
-                                        commandBuilt += "; Set all axes to home coordinates\n";
+                                        commandBuilt += " ; Set all axes to home coordinates\n";
                                         commandBuilt += "G92.1 ; Reset all offsets\n";
                                     }
                                     else {
-                                        commandBuilt = "G28 ; Home all axes";
+                                        // Reset the acceleration (it is not automatically reset on some controllers). 
+                                        commandBuilt = "{Acceleration:M204 S%.2f} ; Initialize acceleration\n";
+                                        // Home all axes.
+                                        commandBuilt += "G28 ; Home all axes";
                                     }
                                 }
                                 break;


### PR DESCRIPTION
# Description
* Add variable substitution to `HOME_COMMAND`. Commands can now set the OpenPnP controlled home coordinates (much like `MOVE_TO_COMMAND`).
* Adds the ability to set initial rate limits with variables: `{FeedRate}`, `{Acceleration}` and `{Jerk}`. These are substituted with the lowest rate limit of all the homes axes, as set in OpenPnP.
* Issues & Solutions suggest a `HOME_COMMAND` with the above-mentioned dynamic variables, for TinyG and generic controllers.

# Justification
For TinyG homing, see here:
https://groups.google.com/g/openpnp/c/mkyYin0N_QA/m/ofAEG2i9AQAJ

For the acceleration in homing issue, see here:
https://groups.google.com/g/openpnp/c/o8g9psai-sU/m/AKerSPodBgAJ

# Instructions for Use
For manual setup, see the Wiki page that was already updated:
https://github.com/openpnp/openpnp/wiki/GcodeDriver%3A-Command-Reference#home_command

Issues & Solutions suggested setup is automatic: 

![issues-and-solutions-home-command](https://user-images.githubusercontent.com/9963310/139129006-cbc08d18-b312-435b-bad3-bb7d30601755.gif)

Existing Users can delete their `HOME_COMMAND` to get the new, dynamic suggestion.  **Be careful if you have special/additional homing steps!** 

Select All, press Delete, click Accept:

![Press Delete](https://user-images.githubusercontent.com/9963310/139125175-a888a0c6-5404-417c-a68f-746d3785ae71.png)

Then use Issues & Solutions and accept the solution.

# Implementation Details
1. Tested on the three-controller testing rig.
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. Successful `mvn test` before submitting the Pull Request.
