### PR TITLE
Fix/Issues & Solutions Backlash Calibration Checks

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/solutions/CalibrationSolutions.java
+++ b/src/main/java/org/openpnp/machine/reference/solutions/CalibrationSolutions.java
@@ -408,7 +408,8 @@ public class CalibrationSolutions implements Solutions.Subject {
         if (! head.getCalibrationPrimaryFiducialLocation().isInitialized()) {
             throw new Exception("Head "+head.getName()+" primary fiducial location must be set for backlash calibration.");
         }
-        if (! head.getCalibrationPrimaryFiducialDiameter().isInitialized()) {
+        if (head.getCalibrationPrimaryFiducialDiameter() == null 
+                || ! head.getCalibrationPrimaryFiducialDiameter().isInitialized()) {
             throw new Exception("Head "+head.getName()+" primary fiducial diameter must be set for backlash calibration.");
         }
         // Make sure to disable any backlash compensation.


### PR DESCRIPTION
# Description
Adds some sanity checks for backlash calibration:

- Checks for a `null` Primary Fiducial Diameter.
- Checks if camera Units per Pixel and/or the primary fiducial Z plane are right.

Also reorders the code a bit. 

# Justification
These are user reported issues out of testing. The Units per Pixel problem was very hard to diagnose, i.e. it was long mistaken as a motion problem. This check will prevent such a wild goose chase in the future.  

* Missing Diameter:
    https://groups.google.com/g/openpnp/c/VDEKlvYKfTY/m/sQy4ghndAAAJ
* Units per Pixel not right:
    https://groups.google.com/g/openpnp/c/gQLHuHWtkVY/m/6ZvuIRWUBAAJ

# Instructions for Use
When backlash calibration detects a large absolute error (more than twice the acceptable tolerance at 1mm), it will report the error:

![UPP wrong](https://user-images.githubusercontent.com/9963310/140085187-441d8bb1-f828-405d-9447-505b5460e984.png)


# Implementation Details
1. Tested in simulation. Positive and negative tests. Accuracy of the reported scaling error.
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. Successful `mvn test` before submitting the Pull Request. 
