### PR TITLE
Feature/SimulatedUpCamera 3D Emulation

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/camera/SimulatedUpCamera.java
+++ b/src/main/java/org/openpnp/machine/reference/camera/SimulatedUpCamera.java
@@ -17,8 +17,10 @@ import org.openpnp.gui.support.Wizard;
 import org.openpnp.machine.reference.ReferenceCamera;
 import org.openpnp.machine.reference.SimulationModeMachine;
 import org.openpnp.machine.reference.camera.wizards.SimulatedUpCameraConfigurationWizard;
+import org.openpnp.model.AxesLocation;
 import org.openpnp.model.Configuration;
 import org.openpnp.model.Footprint;
+import org.openpnp.model.Length;
 import org.openpnp.model.LengthUnit;
 import org.openpnp.model.Location;
 import org.openpnp.model.Part;
@@ -58,6 +60,12 @@ public class SimulatedUpCamera extends ReferenceCamera {
     @Attribute(required=false)
     private boolean simulatedFlipped;
 
+    @Element(required = false)
+    private Length focalLength = new Length(6, LengthUnit.Millimeters);
+
+    @Element(required = false)
+    private Length sensorDiagonal = new Length(4.4, LengthUnit.Millimeters);
+
     public SimulatedUpCamera() {
         setUnitsPerPixel(new Location(LengthUnit.Millimeters, 0.0234375D, 0.0234375D, 0, 0));
         setLooking(Looking.Up);
@@ -88,10 +96,10 @@ public class SimulatedUpCamera extends ReferenceCamera {
         double phyWidth = phySize.getX();
         double phyHeight = phySize.getY();
 
-        // and bounds
+        // and bounds (times two to cover perspective projection)
         Location location = getSimulatedLocation().convertToUnits(LengthUnit.Millimeters);
-        Rectangle2D.Double phyBounds = new Rectangle2D.Double(location.getX() - phyWidth / 2,
-                location.getY() - phyHeight / 2, phyWidth, phyHeight);
+        Rectangle2D.Double phyBounds = new Rectangle2D.Double(location.getX() - phyWidth,
+                location.getY() - phyHeight, phyWidth*2, phyHeight*2);
 
         // determine if there are any nozzles within our bounds and if so render them
         Machine machine = Configuration.get()
@@ -143,49 +151,56 @@ public class SimulatedUpCamera extends ReferenceCamera {
 
         LengthUnit units = LengthUnit.Millimeters;
         Location unitsPerPixel = getSimulatedUnitsPerPixel().convertToUnits(units);
+        
+        boolean hasDrawn;
 
         // Draw the nozzle
         // Get nozzle offsets from camera
         Location offsets = l.subtractWithRotation(getSimulatedLocation());
 
         // Create a nozzle shape
-        fillShape(g, new Ellipse2D.Double(-0.5, -0.5, 1, 1), new Color(0, 220, 0), unitsPerPixel, offsets, false);
-
-        if (frame != null) {
-            blurObjectIntoView(gView, frame, nozzle, l);
-
-            // Clear with transparent background
-            g.setBackground(new Color(0, 0, 0, 0));
-            g.clearRect(-width/2, -height/2, width, height);
+        if (fillShape(g, new Ellipse2D.Double(-0.5, -0.5, 1, 1), new Color(0, 220, 0), unitsPerPixel, offsets, false)) {
+            if (frame != null) {
+                blurObjectIntoView(gView, frame, nozzle, l);
+    
+                // Clear with transparent background
+                g.setBackground(new Color(0, 0, 0, 0));
+                g.clearRect(-width/2, -height/2, width, height);
+            }
+    
+            // Draw the part
+            Part part = nozzle.getPart();
+            if (part == null) {
+                return;
+            }
+    
+            org.openpnp.model.Package pkg = part.getPackage();
+            Footprint footprint = pkg.getFootprint();
+            if (footprint == null) {
+                return;
+            }
+    
+            if (footprint.getUnits() != units) {
+                throw new Error("Not yet supported.");
+            }
+    
+            // First draw the body in dark grey.
+            fillShape(g, footprint.getBodyShape(), new Color(60, 60, 60), unitsPerPixel, offsets, true);
+    
+            // Then draw the pads in white
+            fillShape(g, footprint.getPadsShape(), Color.white, unitsPerPixel, offsets, true);
+    
+            if (frame != null) {
+                blurObjectIntoView(gView, frame, nozzle, 
+                    l.subtract(new Location(part.getHeight().getUnits(), 0, 0, Math.abs(part.getHeight().getValue()), 0)));
+    
+                g.dispose();
+            }
         }
-
-        // Draw the part
-        Part part = nozzle.getPart();
-        if (part == null) {
-            return;
-        }
-
-        org.openpnp.model.Package pkg = part.getPackage();
-        Footprint footprint = pkg.getFootprint();
-        if (footprint == null) {
-            return;
-        }
-
-        if (footprint.getUnits() != units) {
-            throw new Error("Not yet supported.");
-        }
-
-        // First draw the body in dark grey.
-        fillShape(g, footprint.getBodyShape(), new Color(60, 60, 60), unitsPerPixel, offsets, true);
-
-        // Then draw the pads in white
-        fillShape(g, footprint.getPadsShape(), Color.white, unitsPerPixel, offsets, true);
-
-        if (frame != null) {
-            blurObjectIntoView(gView, frame, nozzle, 
-                l.subtract(new Location(part.getHeight().getUnits(), 0, 0, Math.abs(part.getHeight().getValue()), 0)));
-
-            g.dispose();
+        else {
+            if (frame != null) {
+               g.dispose();
+            }
         }
     }
 
@@ -195,7 +210,7 @@ public class SimulatedUpCamera extends ReferenceCamera {
         gView.setTransform(new AffineTransform());
         double distanceMm = Math.abs(l.subtract(getSimulatedLocation()).convertToUnits(LengthUnit.Millimeters).getZ());
         final double bokeh = 0.01/getSimulatedUnitsPerPixel().convertToUnits(LengthUnit.Millimeters).getX();
-        double radius = distanceMm*bokeh;
+        double radius = Math.min(distanceMm*bokeh, 5); // Be reasonable.
         ConvolveOp op = null;
         if (radius > 0.01) {
             int size = (int)Math.ceil(radius) * 2 + 1;
@@ -227,23 +242,40 @@ public class SimulatedUpCamera extends ReferenceCamera {
         gView.setTransform(tx);
     }
 
-    private void fillShape(Graphics2D g, Shape shape, Color color, Location unitsPerPixel, Location offsets, boolean addError) {
+    private boolean fillShape(Graphics2D g, Shape shape, Color color, Location unitsPerPixel, Location offsets, boolean addError) {
         AffineTransform tx = new AffineTransform();
-        // Scale to pixels
-        tx.scale(1.0 / unitsPerPixel.getX(), 1.0 / unitsPerPixel.getY());
-        // Translate and rotate to offsets
-        tx.translate(offsets.getX(), offsets.getY());
-        tx.rotate(Math.toRadians(Utils2D.normalizeAngle(offsets.getRotation())));
-        if (addError) {
-            // Translate and rotate to error offsets
-            tx.translate(errorOffsets.getX(), errorOffsets.getY());
-            tx.rotate(Math.toRadians(Utils2D.normalizeAngle(errorOffsets.getRotation())));
+        double cameraViewDiagonal = Math.sqrt(Math.pow(unitsPerPixel.getX()*width, 2) + Math.pow(unitsPerPixel.getY()*height, 2));
+        double sensorDiagonal = getSensorDiagonal().convertToUnits(AxesLocation.getUnits()).getValue();
+        double focalLength = getFocalLength().convertToUnits(AxesLocation.getUnits()).getValue();
+        double cameraDistance = focalLength*cameraViewDiagonal/sensorDiagonal;
+        double zDistance = cameraDistance + offsets.getZ();
+        double perspective = zDistance/cameraDistance;
+        if (perspective <= 2) { // Limit the perspective projection "frustrum" to twice the view size. 
+            Location unitsPerPixelAtZ = unitsPerPixel.multiply(perspective);
+                    
+            // Scale to pixels
+            tx.scale(1.0 / unitsPerPixelAtZ.getX(), 1.0 / unitsPerPixelAtZ.getY());
+            // Translate and rotate to offsets
+            tx.translate(offsets.getX(), offsets.getY());
+            tx.rotate(Math.toRadians(Utils2D.normalizeAngle(offsets.getRotation())));
+            if (addError) {
+                // Translate and rotate to error offsets
+                tx.translate(errorOffsets.getX(), errorOffsets.getY());
+                tx.rotate(Math.toRadians(Utils2D.normalizeAngle(errorOffsets.getRotation())));
+            }
+            // Transform
+            shape = tx.createTransformedShape(shape);
+            // Draw
+            double shade = Math.pow(perspective, 2); 
+            Color colorShade = new Color(
+                    (int)Math.min(255, color.getRed()/shade), 
+                    (int)Math.min(255, color.getGreen()/shade), 
+                    (int)Math.min(255, color.getBlue()/shade));
+            g.setColor(colorShade);
+            g.fill(shape);
+            return true;
         }
-        // Transform
-        shape = tx.createTransformedShape(shape);
-        // Draw
-        g.setColor(color);
-        g.fill(shape);
+        return false;
     }
 
     public int getViewWidth() {
@@ -290,6 +322,22 @@ public class SimulatedUpCamera extends ReferenceCamera {
 
     public void setSimulatedFlipped(boolean simulatedFlipped) {
         this.simulatedFlipped = simulatedFlipped;
+    }
+
+    public Length getFocalLength() {
+        return focalLength;
+    }
+
+    public void setFocalLength(Length focalLength) {
+        this.focalLength = focalLength;
+    }
+
+    public Length getSensorDiagonal() {
+        return sensorDiagonal;
+    }
+
+    public void setSensorDiagonal(Length sensorDiagonal) {
+        this.sensorDiagonal = sensorDiagonal;
     }
 
     public boolean isSimulateFocalBlur() {

--- a/src/main/java/org/openpnp/machine/reference/camera/SimulatedUpCamera.java
+++ b/src/main/java/org/openpnp/machine/reference/camera/SimulatedUpCamera.java
@@ -151,7 +151,7 @@ public class SimulatedUpCamera extends ReferenceCamera {
 
         LengthUnit units = LengthUnit.Millimeters;
         Location unitsPerPixel = getSimulatedUnitsPerPixel().convertToUnits(units);
-        
+
         boolean hasDrawn;
 
         // Draw the nozzle
@@ -162,44 +162,48 @@ public class SimulatedUpCamera extends ReferenceCamera {
         if (fillShape(g, new Ellipse2D.Double(-0.5, -0.5, 1, 1), new Color(0, 220, 0), unitsPerPixel, offsets, false)) {
             if (frame != null) {
                 blurObjectIntoView(gView, frame, nozzle, l);
-    
+
                 // Clear with transparent background
                 g.setBackground(new Color(0, 0, 0, 0));
                 g.clearRect(-width/2, -height/2, width, height);
             }
-    
+
             // Draw the part
             Part part = nozzle.getPart();
             if (part == null) {
                 return;
             }
-    
+
             org.openpnp.model.Package pkg = part.getPackage();
             Footprint footprint = pkg.getFootprint();
             if (footprint == null) {
                 return;
             }
-    
+
             if (footprint.getUnits() != units) {
                 throw new Error("Not yet supported.");
             }
-    
+
+            // Account for the patu height.
+            Location partUndersideLocation = l.subtract(new Location(part.getHeight().getUnits(), 0, 0, Math.abs(part.getHeight().getValue()), 0));
+            offsets = partUndersideLocation.subtractWithRotation(getSimulatedLocation());
+
             // First draw the body in dark grey.
             fillShape(g, footprint.getBodyShape(), new Color(60, 60, 60), unitsPerPixel, offsets, true);
-    
+
             // Then draw the pads in white
             fillShape(g, footprint.getPadsShape(), Color.white, unitsPerPixel, offsets, true);
-    
+
             if (frame != null) {
                 blurObjectIntoView(gView, frame, nozzle, 
-                    l.subtract(new Location(part.getHeight().getUnits(), 0, 0, Math.abs(part.getHeight().getValue()), 0)));
-    
+                        partUndersideLocation);
+
                 g.dispose();
             }
         }
         else {
             if (frame != null) {
-               g.dispose();
+                g.dispose();
             }
         }
     }

--- a/src/main/java/org/openpnp/machine/reference/camera/wizards/SimulatedUpCameraConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/camera/wizards/SimulatedUpCameraConfigurationWizard.java
@@ -72,6 +72,10 @@ public class SimulatedUpCameraConfigurationWizard extends AbstractConfigurationW
     private JTextField simulatedLocationRotation;
     private JLabel lblCameraFlipped;
     private JCheckBox simulatedFlipped;
+    private JLabel lblFocalLength;
+    private JTextField focalLength;
+    private JLabel lblSensorDiagonal;
+    private JTextField sensorDiagonal;
 
     public SimulatedUpCameraConfigurationWizard(SimulatedUpCamera camera) {
         this.camera = camera;
@@ -92,6 +96,10 @@ public class SimulatedUpCameraConfigurationWizard extends AbstractConfigurationW
                 FormSpecs.RELATED_GAP_COLSPEC,
                 FormSpecs.DEFAULT_COLSPEC,},
             new RowSpec[] {
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
                 FormSpecs.RELATED_GAP_ROWSPEC,
                 FormSpecs.DEFAULT_ROWSPEC,
                 FormSpecs.RELATED_GAP_ROWSPEC,
@@ -167,39 +175,53 @@ public class SimulatedUpCameraConfigurationWizard extends AbstractConfigurationW
         panelGeneral.add(simulatedUnitsPerPixelY, "6, 8, fill, default");
         simulatedUnitsPerPixelY.setColumns(10);
         
+        lblFocalLength = new JLabel("Focal Length");
+        panelGeneral.add(lblFocalLength, "2, 10, right, default");
+        
+        focalLength = new JTextField();
+        panelGeneral.add(focalLength, "4, 10, fill, default");
+        focalLength.setColumns(10);
+        
+        lblSensorDiagonal = new JLabel("Sensor Diagonal");
+        panelGeneral.add(lblSensorDiagonal, "2, 12, right, default");
+        
+        sensorDiagonal = new JTextField();
+        panelGeneral.add(sensorDiagonal, "4, 12, fill, default");
+        sensorDiagonal.setColumns(10);
+        
         lblErrorOffsets = new JLabel("Pick Error Offsets");
         lblErrorOffsets.setToolTipText("Picked part on nozzle error offsets in simulation.");
-        panelGeneral.add(lblErrorOffsets, "2, 12, right, default");
+        panelGeneral.add(lblErrorOffsets, "2, 16, right, default");
         
         errorOffsetsX = new JTextField();
-        panelGeneral.add(errorOffsetsX, "4, 12, fill, default");
+        panelGeneral.add(errorOffsetsX, "4, 16, fill, default");
         errorOffsetsX.setColumns(10);
         
         errorOffsetsY = new JTextField();
-        panelGeneral.add(errorOffsetsY, "6, 12, fill, default");
+        panelGeneral.add(errorOffsetsY, "6, 16, fill, default");
         errorOffsetsY.setColumns(10);
         
         errorOffsetsZ = new JTextField();
-        panelGeneral.add(errorOffsetsZ, "8, 12, fill, default");
+        panelGeneral.add(errorOffsetsZ, "8, 16, fill, default");
         errorOffsetsZ.setColumns(10);
         
         errorOffsetsRotation = new JTextField();
-        panelGeneral.add(errorOffsetsRotation, "10, 12, fill, default");
+        panelGeneral.add(errorOffsetsRotation, "10, 16, fill, default");
         errorOffsetsRotation.setColumns(10);
         
         lblCameraFlipped = new JLabel("View mirrored?");
         lblCameraFlipped.setToolTipText("Simulate the camera as showing a mirrored view");
-        panelGeneral.add(lblCameraFlipped, "2, 16, right, default");
+        panelGeneral.add(lblCameraFlipped, "2, 20, right, default");
         
         simulatedFlipped = new JCheckBox("");
-        panelGeneral.add(simulatedFlipped, "4, 16");
+        panelGeneral.add(simulatedFlipped, "4, 20");
         
         lblFocalBlur = new JLabel("Simulate Focal Blur?");
         lblFocalBlur.setToolTipText("Simulate focal blur in order to test Auto Focus. This is very slow!");
-        panelGeneral.add(lblFocalBlur, "2, 18, right, default");
+        panelGeneral.add(lblFocalBlur, "2, 22, right, default");
         
         simulateFocalBlur = new JCheckBox("");
-        panelGeneral.add(simulateFocalBlur, "4, 18");
+        panelGeneral.add(simulateFocalBlur, "4, 22");
     }
 
     @Override
@@ -239,6 +261,9 @@ public class SimulatedUpCameraConfigurationWizard extends AbstractConfigurationW
         addWrappedBinding(simulatedUnitsPerPixel, "lengthX", simulatedUnitsPerPixelX, "text", uppConverter);
         addWrappedBinding(simulatedUnitsPerPixel, "lengthY", simulatedUnitsPerPixelY, "text", uppConverter);
 
+        addWrappedBinding(camera, "focalLength", focalLength, "text", lengthConverter);
+        addWrappedBinding(camera, "sensorDiagonal", sensorDiagonal, "text", lengthConverter);
+
         ComponentDecorators.decorateWithAutoSelect(width);
         ComponentDecorators.decorateWithAutoSelect(height);
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(errorOffsetsX);
@@ -250,6 +275,9 @@ public class SimulatedUpCameraConfigurationWizard extends AbstractConfigurationW
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(simulatedLocationY);
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(simulatedLocationZ);
         ComponentDecorators.decorateWithAutoSelect(simulatedLocationRotation);
+
+        ComponentDecorators.decorateWithAutoSelectAndLengthConversion(focalLength);
+        ComponentDecorators.decorateWithAutoSelectAndLengthConversion(sensorDiagonal);
 
         //ComponentDecorators.decorateWithAutoSelect(simulatedUnitsPerPixelX);
         //ComponentDecorators.decorateWithAutoSelect(simulatedUnitsPerPixelY);

--- a/src/main/java/org/openpnp/machine/reference/solutions/VisionSolutions.java
+++ b/src/main/java/org/openpnp/machine/reference/solutions/VisionSolutions.java
@@ -45,6 +45,7 @@ import org.openpnp.machine.reference.ReferenceMachine;
 import org.openpnp.machine.reference.ReferenceNozzle;
 import org.openpnp.machine.reference.ReferenceNozzleTip;
 import org.openpnp.machine.reference.camera.AutoFocusProvider;
+import org.openpnp.machine.reference.camera.SimulatedUpCamera;
 import org.openpnp.machine.reference.vision.ReferenceBottomVision;
 import org.openpnp.machine.reference.vision.ReferenceFiducialLocator;
 import org.openpnp.machine.reference.vision.ReferenceFiducialLocator.PartSettings;
@@ -568,7 +569,7 @@ public class VisionSolutions implements Solutions.Subject {
     private void perUpLookingCameraSolutions(Solutions solutions, ReferenceHead head, 
             Camera defaultCamera, ReferenceNozzle defaultNozzle, ReferenceCamera camera) {
         if (isSolvedPrimaryXY(head) && isSolvedPrimaryZ(head)
-                && defaultNozzle.getHeadOffsets().isInitialized()) {
+                && (defaultNozzle.getHeadOffsets().isInitialized() || camera instanceof SimulatedUpCamera)) {
             final Location oldCameraOffsets = camera.getHeadOffsets();
             final CameraCalibrationState cameraCalibrationState = new CameraCalibrationState(camera); 
             final ReferenceNozzleTip referenceNozzleTip = ((defaultNozzle.getNozzleTip() instanceof ReferenceNozzleTip) ?
@@ -621,7 +622,7 @@ public class VisionSolutions implements Solutions.Subject {
                 @Override
                 public void setState(Solutions.State state) throws Exception {
                     if (state == State.Solved) {
-                        if (! defaultNozzle.getHeadOffsets().isInitialized()) {
+                        if (! (defaultNozzle.getHeadOffsets().isInitialized() || camera instanceof SimulatedUpCamera)) {
                             throw new Exception("The nozzle "+defaultNozzle.getName()+" head offsets are not yet set. "
                                     + "You need to perform the \"Nozzle "+defaultNozzle.getName()+" offsets for the primary fiducial\" calibration first.");
                         }


### PR DESCRIPTION
# Description
The SimulatedUpCamera has been improved to simulate a more "3D" view. 

* Simulate perspective (focal length).
* Added shading, i.e. colors get darker as objects move away. 
* Optimized blur (limitation to reasonable radii and [viewing frustrum](https://en.wikipedia.org/wiki/Viewing_frustum) for speed).
* Unblock Issues & Solutions SimulatedUpCamera calibration when the nozzle offsets are zero (as usual on a simulated machine).

![perspective-and-blur-and-shading](https://user-images.githubusercontent.com/9963310/140201445-46d0027e-77a3-41c6-9964-667003dea893.gif)

# Justification
Needed for testing #1297 (bottom camera advanced calibration).

# Instructions for Use
The SimulatedUpCamera now has **Focal Length** and **Sensor Diagonal** to simulate the perspective of its view:
 
![Camera settings](https://user-images.githubusercontent.com/9963310/140204883-43efc649-a161-4f8f-9901-3d5bb6e7bd47.png)

# Implementation Details
1. Tested in simulation and with #1297.
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. Successful `mvn test` before submitting the Pull Request. 
