### PR TITLE
Feature / Chronological Ressource File Naming

### DIFF
--- a/src/main/java/org/openpnp/model/Configuration.java
+++ b/src/main/java/org/openpnp/model/Configuration.java
@@ -19,15 +19,18 @@
 
 package org.openpnp.model;
 
-import java.io.*;
-import java.nio.file.CopyOption;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
-import java.time.temporal.TemporalUnit;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
@@ -285,8 +288,8 @@ public class Configuration extends AbstractModelObject {
      * uniquely identify the file within the application and a unique name is generated within that
      * namespace. suffix is appended to the unique part of the filename. The result of calling
      * File.getName() on the returned file can be used to load the same file in the future by
-     * calling getResourceFile(). This method uses File.createTemporaryFile() and so the rules for
-     * that method must be followed when calling this one.
+     * calling getResourceFile(). This method uses NanosecondTime.get() so the files names
+     * will be unique and ordered.
      * 
      * @param forClass
      * @param suffix
@@ -299,7 +302,7 @@ public class Configuration extends AbstractModelObject {
         if (!directory.exists()) {
             directory.mkdirs();
         }
-        File file = File.createTempFile(prefix, suffix, directory);
+        File file = new File(directory, prefix+NanosecondTime.get()+suffix);
         return file;
     }
 


### PR DESCRIPTION

# Description
Changes `Configuration.createResourceFile(Class, String, String)` to create files numbered by the [epoch time](https://en.wikipedia.org/wiki/Unix_time) in nanosecond, instead of random numbers. The nanosecond timer used is guaranteed to generate unique numbers (per Java VM). This makes sure files can be ordered chronologically by name, regardless of file system timestamps and their limited resolution (and whether they are preserved). 

These file names are typically generated when debug images are written in the `ImageWriteDebug` pipeline stage and from other places.

# Justification
At least Windows has limited timestamp resolution (1s), so rapidly written files will not be ordered chronologically. 

Furthermore, some tools require files ordered by name, as an example I used an online animated gif maker. 

# Instructions for Use
No change in usage. But if you go look into `$HOME/.openpnp2/org.openpnp.vision.pipeline.stages.ImageWriteDebug/` you will see files appear with chronological order names.

Note, obviously this does not apply to already existing files. Order is only guaranteed for new files. 

# Implementation Details
1. Used to create animations from `ImageWriteDebug` images.
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. The change is in the `org.openpnp.model` package.
4. Successful `mvn test` before submitting the Pull Request.
