### PR TITLE
Fix / Advanced Camera Calibration Tilt Head Offsets in Simulation

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/ReferenceCamera.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceCamera.java
@@ -23,6 +23,7 @@ import java.awt.Color;
 import java.awt.event.ActionEvent;
 import java.awt.image.BufferedImage;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -340,10 +341,15 @@ public abstract class ReferenceCamera extends AbstractBroadcastingCamera impleme
     }
 
     @Override
-    public Location getCalibratedHeadOffsets() {
-        return getHeadOffsets().add(advancedCalibration.getCalibratedOffsets());
+    public Location getCalibratedHeadOffsets(LocationOption... options) {
+        if (! Arrays.asList(options).contains(LocationOption.SuppressCameraCalibration)) {
+            return getHeadOffsets().add(advancedCalibration.getCalibratedOffsets());
+        }
+        else {
+            return getHeadOffsets();
+        }
     }
-        
+
     @Override
     public void home() throws Exception {
     }

--- a/src/main/java/org/openpnp/machine/reference/SimulationModeMachine.java
+++ b/src/main/java/org/openpnp/machine/reference/SimulationModeMachine.java
@@ -415,7 +415,8 @@ public class SimulationModeMachine extends ReferenceMachine {
                         .getMomentaryMotion(cameraTime);
                 AxesLocation axesLocation = momentary.getMomentaryLocation(cameraTime - momentary.getPlannedTime0());
                 location = hm.toTransformed(axesLocation);
-                location = hm.toHeadMountableLocation(location);
+                location = hm.toHeadMountableLocation(location, 
+                        LocationOption.SuppressCameraCalibration);
             }
             // else: Configuration is still being loaded (Unit tests).
         } 
@@ -486,6 +487,7 @@ public class SimulationModeMachine extends ReferenceMachine {
                         && machine.getSimulationMode().isDynamicallyImperfectMachine()) {
                     // Need to convert to transformed (head) coordinates for real rotation:
                     Location rotationLocation = hm.toTransformed(axesLocation, 
+                            LocationOption.SuppressCameraCalibration,
                             LocationOption.SuppressStaticCompensation,
                             LocationOption.SuppressDynamicCompensation);
                     double rotation = rotationLocation.getRotation();
@@ -510,10 +512,12 @@ public class SimulationModeMachine extends ReferenceMachine {
 
                 // NOTE this specifically makes the assumption that the axes transform from raw 1:1
                 location = hm.toTransformed(axesLocation, 
+                        LocationOption.SuppressCameraCalibration,
                         LocationOption.SuppressStaticCompensation,
                         LocationOption.SuppressDynamicCompensation);
                 // Transform back. This bypasses any compensations, such as runout compensation.
                 location = hm.toHeadMountableLocation(location, 
+                        LocationOption.SuppressCameraCalibration,
                         LocationOption.SuppressStaticCompensation,
                         LocationOption.SuppressDynamicCompensation);
             }

--- a/src/main/java/org/openpnp/spi/Locatable.java
+++ b/src/main/java/org/openpnp/spi/Locatable.java
@@ -32,6 +32,11 @@ public interface Locatable {
          */
         KeepRotation, 
         /**
+         * Suppress camera calibration, such as advanced camera calibration head offsets, 
+         * i.e. tilt compensation.
+         */
+        SuppressCameraCalibration, 
+        /**
          * Suppress static compensations, such as non-squareness compensation.
          */
         SuppressStaticCompensation, 

--- a/src/main/java/org/openpnp/spi/base/AbstractHeadMountable.java
+++ b/src/main/java/org/openpnp/spi/base/AbstractHeadMountable.java
@@ -295,7 +295,7 @@ public abstract class AbstractHeadMountable extends AbstractModelObject implemen
 
     public Location toHeadLocation(Location location, Location currentLocation, LocationOption... options) {
         // Subtract the calibrated Head offset.
-        location = location.subtract(getCalibratedHeadOffsets());
+        location = location.subtract(getCalibratedHeadOffsets(options));
         return location;
     }
 
@@ -319,13 +319,13 @@ public abstract class AbstractHeadMountable extends AbstractModelObject implemen
         return toHeadLocation(location, getLocation(), options);
     }
 
-    public Location getCalibratedHeadOffsets() {
+    public Location getCalibratedHeadOffsets(LocationOption... options) {
         return getHeadOffsets();
     }
     
     public Location toHeadMountableLocation(Location location, Location currentLocation, LocationOption... options) {
         // Add the calibrated Head offset.
-        location = location.add(getCalibratedHeadOffsets());
+        location = location.add(getCalibratedHeadOffsets(options));
         return location;
     }
     @Override


### PR DESCRIPTION
# Description

Bug: When using the advanced camera calibration of #1297, the cameras would show a wrong location. Example: the visual homing performed at the end of advanced camera calibration would fail, as the fiducial is too far off. This is because the new calibration head offsets - used to compensate for camera tilt - were applied in the camera "physical" location calculation (i.e. they actually cancelled-out the applied tilt offsets). 

Fix: Added `LocationOption.SuppressCameraCalibration` to suppress the new advanced camera calibration head offsets, when obtaining HeadMountable locations. This new option is now used in the simulated cameras to get correct "physical" camera locations.

# Justification
The simulated cameras need to render the raw camera view, _before_ advanced camera calibration applies. 

# Instructions for Use
No change in use.

# Implementation Details
1. Tested in simulation (bug does only affect simulation).
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. Successful `mvn test` before submitting the Pull Request.
