### PR TITLE
Feature/Issues & Solutions: Integrate Advanced Camera Calibration

### DIFF
--- a/src/main/java/org/openpnp/gui/IssuesAndSolutionsPanel.java
+++ b/src/main/java/org/openpnp/gui/IssuesAndSolutionsPanel.java
@@ -565,7 +565,7 @@ public class IssuesAndSolutionsPanel extends JPanel {
 
 
     /**
-     * 
+     * Rebuild the UI as needed, when solutions have changed state, perhaps asynchronously.
      */
     public void solutionChanged() {
         SwingUtilities.invokeLater(() -> {

--- a/src/main/java/org/openpnp/gui/MainFrame.java
+++ b/src/main/java/org/openpnp/gui/MainFrame.java
@@ -877,8 +877,10 @@ public class MainFrame extends JFrame {
     }
 
     public void hideInstructions() {
-        scheduledExecutor.shutdown();
-        scheduledExecutor = null;
+        if (scheduledExecutor != null) {
+            scheduledExecutor.shutdown();
+            scheduledExecutor = null;
+        }
         panelInstructions.setVisible(false);
         doLayout();
     }

--- a/src/main/java/org/openpnp/gui/processes/CalibrateCameraProcess.java
+++ b/src/main/java/org/openpnp/gui/processes/CalibrateCameraProcess.java
@@ -20,8 +20,12 @@
 package org.openpnp.gui.processes;
 
 import java.awt.Color;
+import java.awt.Graphics2D;
+import java.awt.RenderingHints;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import java.awt.geom.Ellipse2D;
+import java.awt.geom.Line2D;
 import java.awt.geom.Point2D;
 import java.awt.image.BufferedImage;
 import java.util.ArrayList;
@@ -29,13 +33,13 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Random;
 import java.util.concurrent.Future;
+
 import javax.swing.SwingUtilities;
 import javax.swing.SwingWorker;
 
 import org.opencv.core.KeyPoint;
 import org.opencv.core.Mat;
 import org.opencv.core.Size;
-import org.opencv.imgproc.Imgproc;
 import org.openpnp.gui.MainFrame;
 import org.openpnp.gui.components.CameraView;
 import org.openpnp.gui.components.CameraViewFilter;
@@ -45,7 +49,6 @@ import org.openpnp.machine.reference.ReferenceMachine;
 import org.openpnp.machine.reference.ReferenceNozzleTip;
 import org.openpnp.machine.reference.camera.calibration.AdvancedCalibration;
 import org.openpnp.model.Configuration;
-import org.openpnp.model.Length;
 import org.openpnp.model.LengthUnit;
 import org.openpnp.model.Location;
 import org.openpnp.model.Point;
@@ -53,12 +56,12 @@ import org.openpnp.spi.Camera;
 import org.openpnp.spi.HeadMountable;
 import org.openpnp.spi.Nozzle;
 import org.openpnp.util.CameraWalker;
+import org.openpnp.util.ImageUtils;
 import org.openpnp.util.MovableUtils;
 import org.openpnp.util.OpenCvUtils;
 import org.openpnp.util.UiUtils;
 import org.openpnp.util.UiUtils.Thrunnable;
 import org.openpnp.util.VisionUtils;
-import org.openpnp.vision.FluentCv;
 import org.openpnp.vision.pipeline.CvPipeline;
 import org.pmw.tinylog.Logger;
 
@@ -76,6 +79,7 @@ public abstract class CalibrateCameraProcess {
     private final int numberOfCalibrationHeights;
     private final MainFrame mainFrame;
     private final CameraView cameraView;
+    private boolean automatic;
     private final Camera camera;
     private final boolean isHeadMountedCamera;
     private Nozzle nozzle;
@@ -134,15 +138,18 @@ public abstract class CalibrateCameraProcess {
     protected Boolean previousProceedActionResult;
 
     protected CameraWalker cameraWalker;
+    private BufferedImage resultImage;
 
 
     public CalibrateCameraProcess(MainFrame mainFrame, CameraView cameraView, 
-            List<Location> calibrationLocations, ArrayList<Integer> detectionDiameters)
+            List<Location> calibrationLocations, ArrayList<Integer> detectionDiameters, boolean automatic)
             throws Exception {
         this.mainFrame = mainFrame;
         this.cameraView = cameraView;
         this.calibrationLocations = new ArrayList<Location>(calibrationLocations);
         this.detectionDiameters = detectionDiameters;
+        this.automatic = automatic;
+
         numberOfCalibrationHeights = calibrationLocations.size();
         
         camera = cameraView.getCamera();
@@ -220,13 +227,14 @@ public abstract class CalibrateCameraProcess {
 
         if (isHeadMountedCamera) {
             movable = camera;
-            movableZ = 0;
-            
+
             maskDiameter = initialMaskDiameter;
+            resultImage = null;
             showCircle(new org.opencv.core.Point(imageCenterPoint.getX(), imageCenterPoint.getY()), 
                     (int)(centeringDiameterFraction*maskDiameter/2), Color.GREEN);
-            
-            Location moveLocation = calibrationLocations.get(calibrationHeightIndex).derive(null, null, 0.0, 0.0);
+
+            Location moveLocation = calibrationLocations.get(calibrationHeightIndex).deriveLengths(null, null, camera.getSafeZ(), null);
+            movableZ = moveLocation.convertToUnits(LengthUnit.Millimeters).getZ();
             if (Double.isFinite(moveLocation.getX()) && Double.isFinite(moveLocation.getY())) {
                 Future<Void> future = UiUtils.submitUiMachineTask(() -> {
                     MovableUtils.moveToLocationAtSafeZ(camera, moveLocation, 1.0);
@@ -238,6 +246,11 @@ public abstract class CalibrateCameraProcess {
                     MessageBoxes.errorBox(MainFrame.get(), "Error", ex);
                     cleanUpWhenCancelled();
                 }
+                // Note, automatic is only available if the moveLocation is already set.
+                if (automatic) {
+                    requestOperatorToAdjustDiameterAction();
+                    return true;
+                }
             }
             setInstructionsAndProceedAction("Using the jog controls on the Machine Controls panel, jog the camera so that the calibration fiducial at Z = %s is approximately centered in the green circle.  Click Next when ready to proceed.", 
                     ()->requestOperatorToAdjustDiameterAction(),
@@ -245,11 +258,14 @@ public abstract class CalibrateCameraProcess {
         }
         else { //bottom camera
             movableZ = testPatternZ;
-            
+
+            if (automatic) {
+                requestOperatorToCenterNozzleTipAction();
+                return true;
+            }
             setInstructionsAndProceedAction("Select a nozzle and load it with the smallest available nozzle tip. Click Next when ready to proceed.",
                     ()->requestOperatorToCenterNozzleTipAction());
         }
-            
         return true;
     }
     
@@ -260,17 +276,19 @@ public abstract class CalibrateCameraProcess {
      * @return true when complete
      */
     private boolean requestOperatorToAdjustDiameterAction() {
-        setInstructionsAndProceedAction("Use the mouse scroll wheel to zoom in on the fiducial/nozzle tip and then adjust the Detection Diameter spinner until the red circle turns green with a + at its center and is sized to just fit the fiducial/nozzle tip with the + centered on the fiducial/nozzle tip. When ready, click Next to begin the automated calibration collection sequence.", 
-                ()->fiducialDiameterIsSetAction());
-        
         Point2D expectedPoint = new Point2D.Double((pixelsX-1)/2.0, (pixelsY-1)/2.0);
         pipeline.setProperty("MaskCircle.center", new org.opencv.core.Point(expectedPoint.getX(), 
                 expectedPoint.getY()));
         pipeline.setProperty("DetectCircularSymmetry.center", new org.openpnp.model.Point(
                 expectedPoint.getX(), expectedPoint.getY()));
-        
+
         if (detectionDiameters.get(calibrationHeightIndex) != null) {
             advCal.setFiducialDiameter(detectionDiameters.get(calibrationHeightIndex));
+            if (automatic) {
+                swingWorker = null;
+                fiducialDiameterIsSetAction();
+                return true;
+            }
         }
         else {
             if (isHeadMountedCamera) {
@@ -319,6 +337,7 @@ public abstract class CalibrateCameraProcess {
                         keyPoints = pipeline.getExpectedResult(VisionUtils.PIPELINE_RESULTS_NAME)
                                 .getExpectedListModel(KeyPoint.class, 
                                         new Exception("Calibration rig fiducial not found."));
+                        resultImage = OpenCvUtils.toBufferedImage(pipeline.getWorkingImage());
                     }
                     catch (Exception e) {
                         keyPoints = null;
@@ -361,9 +380,12 @@ public abstract class CalibrateCameraProcess {
                 cameraView.setCameraViewFilter(null);
             }
         };
-        
+
+        setInstructionsAndProceedAction("Use the mouse scroll wheel to zoom in on the fiducial/nozzle tip and then adjust the Detection Diameter spinner until the red circle turns green with a + at its center and is sized to just fit the fiducial/nozzle tip with the + centered on the fiducial/nozzle tip. When ready, click Next to begin the automated calibration collection sequence.", 
+                ()->fiducialDiameterIsSetAction());
+
         swingWorker.execute();
-        
+
         return true;
     }
     
@@ -374,9 +396,11 @@ public abstract class CalibrateCameraProcess {
      * @return true when complete
      */
     private boolean fiducialDiameterIsSetAction() {
-        swingWorker.cancel(true);
-        while (!swingWorker.isDone()) {
-            //spin
+        if (swingWorker != null) {
+            swingWorker.cancel(true);
+            while (!swingWorker.isDone()) {
+                //spin
+            }
         }
         estimateUnitsPerPixelAction();
         
@@ -656,6 +680,7 @@ public abstract class CalibrateCameraProcess {
      */
     protected boolean repeatAction() {
         maskDiameter = initialMaskDiameter;
+        resultImage = null;
         showCircle(new org.opencv.core.Point(imageCenterPoint.getX(), imageCenterPoint.getY()), 
                 (int)(centeringDiameterFraction*maskDiameter/2), Color.GREEN);
 
@@ -663,9 +688,8 @@ public abstract class CalibrateCameraProcess {
                 convertToUnits(LengthUnit.Millimeters).getZ();
         
         if (isHeadMountedCamera) {
-            movableZ = 0;
-            
-            Location moveLocation = calibrationLocations.get(calibrationHeightIndex).derive(null, null, 0.0, 0.0);
+            Location moveLocation = calibrationLocations.get(calibrationHeightIndex).deriveLengths(null, null, camera.getSafeZ(), null);
+            movableZ = moveLocation.convertToUnits(LengthUnit.Millimeters).getZ();
             if (Double.isFinite(moveLocation.getX()) && Double.isFinite(moveLocation.getY())) {
                 Future<Void> future = UiUtils.submitUiMachineTask(() -> {
                     camera.moveTo(moveLocation);
@@ -676,6 +700,11 @@ public abstract class CalibrateCameraProcess {
                 catch (Exception ex) {
                     MessageBoxes.errorBox(MainFrame.get(), "Error", ex);
                     cleanUpWhenCancelled();
+                }
+                // Note, automatic only available when location set. 
+                if (automatic) {
+                    requestOperatorToAdjustDiameterAction();
+                    return true;
                 }
             }
             
@@ -713,13 +742,15 @@ public abstract class CalibrateCameraProcess {
      */
     private boolean requestOperatorToCenterNozzleTipAction() {
         maskDiameter = initialMaskDiameter;
+        resultImage = null;
         showCircle(new org.opencv.core.Point(imageCenterPoint.getX(), imageCenterPoint.getY()), 
                 (int)(centeringDiameterFraction*maskDiameter/2), Color.GREEN);
         
-        Location moveLocation = calibrationLocations.get(calibrationHeightIndex).derive(null, null, 0.0, 0.0);
+        Nozzle selectedNozzle = MainFrame.get().getMachineControls().getSelectedNozzle();
+        Location moveLocation = calibrationLocations.get(calibrationHeightIndex).deriveLengths(null, null, selectedNozzle.getSafeZ(), null);
         if (Double.isFinite(moveLocation.getX()) && Double.isFinite(moveLocation.getY())) {
             Future<Void> future = UiUtils.submitUiMachineTask(() -> {
-                MovableUtils.moveToLocationAtSafeZ(MainFrame.get().getMachineControls().getSelectedNozzle(), moveLocation);
+                MovableUtils.moveToLocationAtSafeZ(selectedNozzle, moveLocation);
             });
             try {
                 future.get();
@@ -728,8 +759,12 @@ public abstract class CalibrateCameraProcess {
                 MessageBoxes.errorBox(MainFrame.get(), "Error", ex);
                 cleanUpWhenCancelled();
             }
+            // Note, automatic only available when location set. 
+            if (automatic) {
+                captureCentralLocationAction();
+                return true;
+            }
         }
-        
         setInstructionsAndProceedAction("Using the jog controls on the Machine Controls panel, jog the nozzle tip so that it is approximately in the center of the green circle. When ready, click Next to lower/raise the nozzle tip to the calibration height.", 
                 ()->captureCentralLocationAction());
         return true;
@@ -784,6 +819,10 @@ public abstract class CalibrateCameraProcess {
      * @return true when complete
      */
     private boolean requestOperatorToVerifyNozzleTipIsCenteredAction() {
+        if (automatic) {
+            captureVerifiedCentralLocationAction();
+            return true;
+        }
         setInstructionsAndProceedAction("Using the jog controls on the Machine Controls panel, rotate the nozzle tip through 360 degrees and verify it stays within the green circle. If necessary, jog it in X and/or Y so that it remains within the circle when it is rotated. Click Next when ready.", 
                 ()->captureVerifiedCentralLocationAction());
         return true;
@@ -892,6 +931,7 @@ public abstract class CalibrateCameraProcess {
                 keypoints = pipeline.getExpectedResult(VisionUtils.PIPELINE_RESULTS_NAME)
                         .getExpectedListModel(KeyPoint.class, 
                                 new Exception("Calibration rig fiducial not found."));
+                resultImage = OpenCvUtils.toBufferedImage(pipeline.getWorkingImage());
             }
             catch (Exception e) {
                 keypoints = null;
@@ -1101,21 +1141,22 @@ public abstract class CalibrateCameraProcess {
             cameraView.setCameraViewFilter(new CameraViewFilter() {
                 @Override
                 public BufferedImage filterCameraImage(Camera camera, BufferedImage image) {
-                    Mat mat = OpenCvUtils.toMat(image);
+                    BufferedImage result = ImageUtils.clone(resultImage != null ? resultImage : image);
+                    Graphics2D g2D = result.createGraphics();
+
+                    g2D.setRenderingHint(RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_QUALITY);
+                    g2D.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+
                     if (point != null) {
                         double pointSize = Math.min(pixelsX, pixelsY) * 0.05;
-                        org.opencv.core.Point p1 = new org.opencv.core.Point(point.x-pointSize, point.y);
-                        org.opencv.core.Point p2 = new org.opencv.core.Point(point.x+pointSize, point.y);
-                        Imgproc.line(mat, p1, p2, FluentCv.colorToScalar(pointColor), 1);
-                        p1 = new org.opencv.core.Point(point.x, point.y-pointSize);
-                        p2 = new org.opencv.core.Point(point.x, point.y+pointSize);
-                        Imgproc.line(mat, p1, p2, FluentCv.colorToScalar(pointColor), 1);
+                        g2D.setColor(pointColor);
+                        g2D.draw(new Line2D.Double(point.x-pointSize, point.y, point.x+pointSize, point.y));
+                        g2D.draw(new Line2D.Double(point.x, point.y-pointSize, point.x, point.y+pointSize));
                     }
                     if (center != null) {
-                        Imgproc.circle(mat, center, radius, FluentCv.colorToScalar(circleColor), 1);
+                        g2D.setColor(circleColor);
+                        g2D.draw(new Ellipse2D.Double(center.x - radius, center.y - radius, radius*2, radius*2));
                     }
-                    BufferedImage result = OpenCvUtils.toBufferedImage(mat);
-                    mat.release();
                     return result;
                 }
             });

--- a/src/main/java/org/openpnp/gui/wizards/CameraConfigurationWizard.java
+++ b/src/main/java/org/openpnp/gui/wizards/CameraConfigurationWizard.java
@@ -19,6 +19,8 @@
 
 package org.openpnp.gui.wizards;
 
+import java.awt.Color;
+import java.awt.Component;
 import java.awt.Rectangle;
 import java.awt.event.ActionEvent;
 import java.awt.event.ItemEvent;
@@ -50,6 +52,7 @@ import org.openpnp.gui.support.MessageBoxes;
 import org.openpnp.gui.support.MutableLocationProxy;
 import org.openpnp.gui.support.NamedConverter;
 import org.openpnp.machine.reference.AbstractBroadcastingCamera;
+import org.openpnp.machine.reference.ReferenceCamera;
 import org.openpnp.machine.reference.ReferenceCamera.FocusSensingMethod;
 import org.openpnp.machine.reference.axis.ReferenceVirtualAxis;
 import org.openpnp.model.Configuration;
@@ -355,6 +358,10 @@ public class CameraConfigurationWizard extends AbstractConfigurationWizard {
             }
         });
         panelUpp.add(enableUnitsPerPixel3D, "4, 2");
+        
+        advancedCalWarning = new JLabel("Advanced Calibration Active");
+        advancedCalWarning.setForeground(Color.RED);
+        panelUpp.add(advancedCalWarning, "6, 2, 9, 1, right, default");
 
         lblX = new JLabel("X");
         panelUpp.add(lblX, "4, 4, center, default");
@@ -531,8 +538,29 @@ public class CameraConfigurationWizard extends AbstractConfigurationWizard {
         focusSensingMethod.setVisible(camera.getHead() == null);
     };
 
+    public boolean isOverriddenClassicTransforms() {
+        return enableUnitsPerPixel3D.isEnabled();
+    }
+
+    public void setOverriddenClassicTransforms(boolean overriddenClassicTransforms) {
+        for (Component comp : panelUpp.getComponents()) {
+            comp.setEnabled(!overriddenClassicTransforms);
+        }
+        for (Component comp : panelCal.getComponents()) {
+            comp.setEnabled(!overriddenClassicTransforms);
+        }
+        advancedCalWarning.setVisible(overriddenClassicTransforms);
+        advancedCalWarning.setEnabled(overriddenClassicTransforms);
+    }
+
     @Override
     public void createBindings() {
+        if (camera instanceof ReferenceCamera) {
+            addWrappedBinding(((ReferenceCamera) camera).getAdvancedCalibration(), 
+                    "overridingOldTransformsAndDistortionCorrectionSettings", 
+                this, "overriddenClassicTransforms");
+        }
+
         AbstractMachine machine = (AbstractMachine) Configuration.get().getMachine();
         LengthConverter uppLengthConverter = new LengthConverter(uppFormat);
         LengthConverter lengthConverter = new LengthConverter();
@@ -905,4 +933,5 @@ public class CameraConfigurationWizard extends AbstractConfigurationWizard {
     private JLabel lblFocusSensing;
     private JComboBox focusSensingMethod;
     private boolean reloadWizard;
+    private JLabel advancedCalWarning;
 }

--- a/src/main/java/org/openpnp/machine/reference/ReferenceCamera.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceCamera.java
@@ -1220,7 +1220,7 @@ public abstract class ReferenceCamera extends AbstractBroadcastingCamera impleme
                 new PropertySheetWizardAdapter(WizardUtils.configurationWizardFactory(ReferenceCameraPositionConfigurationWizard.class, this.getId(), getMachine(), this), "Position"),
                 new PropertySheetWizardAdapter(WizardUtils.configurationWizardFactory(ReferenceCameraCalibrationConfigurationWizard.class, this.getId(), this), "Lens Calibration"),
                 new PropertySheetWizardAdapter(WizardUtils.configurationWizardFactory(ReferenceCameraTransformsConfigurationWizard.class, this.getId(), this), "Image Transforms"),
-                new PropertySheetWizardAdapter(WizardUtils.configurationWizardFactory(ReferenceCameraCalibrationWizard.class, this.getId(), this), "Experimental Calibration")
+                new PropertySheetWizardAdapter(WizardUtils.configurationWizardFactory(ReferenceCameraCalibrationWizard.class, this.getId(), this), "Advanced Calibration")
         };
         if (getFocusSensingMethod() != FocusSensingMethod.None) {
                 sheets = Collect.concat(sheets, new PropertySheet[] {

--- a/src/main/java/org/openpnp/machine/reference/solutions/VisionSolutions.java
+++ b/src/main/java/org/openpnp/machine/reference/solutions/VisionSolutions.java
@@ -959,6 +959,10 @@ public class VisionSolutions implements Solutions.Subject {
      */
     public Length autoCalibrateCamera(ReferenceCamera camera, HeadMountable movable, Double expectedDiameter, String diagnostics, boolean secondary) 
             throws Exception {
+        if (camera.getAdvancedCalibration().isOverridingOldTransformsAndDistortionCorrectionSettings()) {
+            throw new Exception("Preliminary camera "+camera.getName()+" calibration cannot be performed, "
+                    + "because the Advanced Camera Calibration is already active.");
+        }
         Location initialLocation = movable.getLocation();
         try {
             if (!secondary) {

--- a/src/main/java/org/openpnp/machine/reference/wizards/ReferenceCameraCalibrationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/wizards/ReferenceCameraCalibrationWizard.java
@@ -25,11 +25,19 @@ import java.awt.event.ActionEvent;
 import java.awt.image.BufferedImage;
 import java.util.ArrayList;
 import java.util.List;
+
 import javax.swing.AbstractAction;
 import javax.swing.Action;
 import javax.swing.JButton;
+import javax.swing.JCheckBox;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
+import javax.swing.JSeparator;
+import javax.swing.JSlider;
+import javax.swing.JSpinner;
+import javax.swing.JTextField;
+import javax.swing.SpinnerListModel;
+import javax.swing.SwingConstants;
 import javax.swing.border.TitledBorder;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
@@ -51,10 +59,10 @@ import org.openpnp.gui.support.LengthConverter;
 import org.openpnp.gui.support.MessageBoxes;
 import org.openpnp.gui.support.MutableLocationProxy;
 import org.openpnp.machine.reference.ReferenceCamera;
+import org.openpnp.machine.reference.ReferenceHead;
+import org.openpnp.machine.reference.camera.ImageCamera;
 import org.openpnp.machine.reference.camera.calibration.AdvancedCalibration;
 import org.openpnp.machine.reference.camera.calibration.CameraCalibrationUtils;
-import org.openpnp.machine.reference.camera.ImageCamera;
-import org.openpnp.machine.reference.ReferenceHead;
 import org.openpnp.model.Configuration;
 import org.openpnp.model.Length;
 import org.openpnp.model.LengthUnit;
@@ -64,17 +72,11 @@ import org.openpnp.util.SimpleGraph;
 import org.openpnp.util.SimpleGraph.DataRow;
 import org.openpnp.util.UiUtils;
 import org.openpnp.vision.pipeline.ui.MatView;
+
 import com.jgoodies.forms.layout.ColumnSpec;
 import com.jgoodies.forms.layout.FormLayout;
 import com.jgoodies.forms.layout.FormSpecs;
 import com.jgoodies.forms.layout.RowSpec;
-import javax.swing.JCheckBox;
-import javax.swing.JSlider;
-import javax.swing.JTextField;
-import javax.swing.SwingConstants;
-import javax.swing.SpinnerListModel;
-import javax.swing.JSeparator;
-import javax.swing.JSpinner;
 
 @SuppressWarnings("serial")
 public class ReferenceCameraCalibrationWizard extends AbstractConfigurationWizard {
@@ -199,7 +201,7 @@ public class ReferenceCameraCalibrationWizard extends AbstractConfigurationWizar
                 secondaryZ = new Length(advCal.getSavedTestPattern3dPointsList()[1][0][2], LengthUnit.Millimeters);
             }
             else {
-                secondaryZ = primaryLocation.getLengthZ().multiply(0.5); //default to half-way between primaryZ and 0
+                secondaryZ = primaryLocation.getLengthZ().multiply(0.5); //default to half-way between primaryZ and 0 <- TODO: use Nozzle SafeZ ! 
             }
             secondaryLocation = primaryLocation.deriveLengths(null, null, secondaryZ, null);
             
@@ -326,7 +328,7 @@ public class ReferenceCameraCalibrationWizard extends AbstractConfigurationWizar
                 FormSpecs.RELATED_GAP_ROWSPEC,
                 RowSpec.decode("default:grow"),}));
         
-        chckbxAdvancedCalOverride = new JCheckBox("Enable experimental calibration to override old"
+        chckbxAdvancedCalOverride = new JCheckBox("Enable the advanced calibration to override old"
                 + " style image transforms and distortion correction settings");
         chckbxAdvancedCalOverride.setToolTipText("Enable this to use advanced calibration.  "
                 + "Disable this to restore usage of old settings.");
@@ -1026,7 +1028,7 @@ public class ReferenceCameraCalibrationWizard extends AbstractConfigurationWizar
         
                     UiUtils.messageBoxOnException(() -> {
                         new CalibrateCameraProcess(MainFrame.get(), cameraView, 
-                                calibrationLocations, detectionDiameters) {
+                                calibrationLocations, detectionDiameters, false) {
         
                             @Override 
                             public void processRawCalibrationData(double[][][] testPattern3dPointsList, 
@@ -1108,6 +1110,8 @@ public class ReferenceCameraCalibrationWizard extends AbstractConfigurationWizar
     };
 
     private void postCalibrationProcessing() throws Exception {
+        advCal.applyCalibrationToMachine(referenceHead, referenceCamera);
+
         //Reload the calibration heights and refresh the table
         calibrationHeightSelections = new ArrayList<LengthCellValue>();
         int numberOfCalibrationHeights = advCal.
@@ -1121,23 +1125,6 @@ public class ReferenceCameraCalibrationWizard extends AbstractConfigurationWizar
         
         spinnerModel.setList(calibrationHeightSelections);
         
-        Location calibratedOffsets = new Location(LengthUnit.Millimeters);
-   
-        if (isMovable) {
-            calibratedOffsets = calibratedOffsets.subtract(advCal.getCameraOffsetAtZ(referenceHead.getCalibrationPrimaryFiducialLocation().getLengthZ()).derive(null, null, 0.0, 0.0));
-        }
-        else {
-            Location camLocation = new Location(LengthUnit.Millimeters, 
-                    advCal.getVectorFromMachToVirCamInMachRefFrame().get(0, 0)[0],
-                    advCal.getVectorFromMachToVirCamInMachRefFrame().get(1, 0)[0],
-                    0, 0);
-              
-            calibratedOffsets = camLocation.subtract(referenceCamera.getHeadOffsets().derive(null, null, 0.0, 0.0));
-        }
-        advCal.setCalibratedOffsets(calibratedOffsets);
-        
-        advCal.setValid(true);
-        advCal.setEnabled(true);
         chckbxEnable.setSelected(true);
         chckbxEnable.setEnabled(true);
         spinnerIndex.setEnabled(true);

--- a/src/main/java/org/openpnp/machine/reference/wizards/ReferenceCameraTransformsConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/wizards/ReferenceCameraTransformsConfigurationWizard.java
@@ -1,5 +1,8 @@
 package org.openpnp.machine.reference.wizards;
 
+import java.awt.Color;
+import java.awt.Component;
+
 import javax.swing.JCheckBox;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
@@ -82,6 +85,10 @@ public class ReferenceCameraTransformsConfigurationWizard extends AbstractConfig
         textFieldRotation = new JTextField();
         panelTransforms.add(textFieldRotation, "4, 2");
         textFieldRotation.setColumns(10);
+        
+        advancedCalWarning = new JLabel("Advanced Calibration Active");
+        advancedCalWarning.setForeground(Color.RED);
+        panelTransforms.add(advancedCalWarning, "7, 2, right, default");
 
         lblOffsetX = new JLabel("Offset X");
         panelTransforms.add(lblOffsetX, "2, 4, right, default");
@@ -159,8 +166,23 @@ public class ReferenceCameraTransformsConfigurationWizard extends AbstractConfig
         panelTransforms.add(lblremovesInterlacingFrom, "7, 20");
     }
 
+    public boolean isOverriddenClassicTransforms() {
+        return textFieldRotation.isEnabled();
+    }
+
+    public void setOverriddenClassicTransforms(boolean overriddenClassicTransforms) {
+        for (Component comp : panelTransforms.getComponents()) {
+            comp.setEnabled(!overriddenClassicTransforms);
+        }
+        advancedCalWarning.setVisible(overriddenClassicTransforms);
+        advancedCalWarning.setEnabled(overriddenClassicTransforms);
+    }
+
     @Override
     public void createBindings() {
+        addWrappedBinding(referenceCamera.getAdvancedCalibration(), "overridingOldTransformsAndDistortionCorrectionSettings", 
+                this, "overriddenClassicTransforms");
+
         IntegerConverter intConverter = new IntegerConverter();
         DoubleConverter doubleConverter =
                 new DoubleConverter(Configuration.get().getLengthDisplayFormat());
@@ -175,7 +197,6 @@ public class ReferenceCameraTransformsConfigurationWizard extends AbstractConfig
         addWrappedBinding(referenceCamera, "scaleWidth", scaleWidthTf, "text", intConverter);
         addWrappedBinding(referenceCamera, "scaleHeight", scaleHeightTf, "text", intConverter);
         addWrappedBinding(referenceCamera, "deinterlace", deinterlaceChk, "selected");
-
 
         ComponentDecorators.decorateWithAutoSelect(textFieldRotation);
         ComponentDecorators.decorateWithAutoSelect(textFieldOffsetX);
@@ -202,5 +223,6 @@ public class ReferenceCameraTransformsConfigurationWizard extends AbstractConfig
     private JCheckBox deinterlaceChk;
     private JLabel lblDeinterlace;
     private JLabel lblremovesInterlacingFrom;
+    private JLabel advancedCalWarning;
 
 }


### PR DESCRIPTION
# Description
This PR integrates the Advanced Camera Calibration by @tonyluken (#1297) into the Issues & Solutions machine setup process.

![Issues & Solutions](https://user-images.githubusercontent.com/9963310/143315874-10847d34-a86f-4f55-9cc4-60e0414c9656.png)

## Feature List

- Advanced Camera Calibrations is available as regular Issues & Solutions calibration steps.
- The invoked calibration is automatic, i.e. it does not interactively ask the user for fiducial location/diameters etc. Instead it reuses the already setup locations/diameters etc. from the preliminary calibration rig. 
- Camera feedback does no longer lag behind, camera image and cross-hairs do match. Furthermore, markers are drawn with anti-aliasing and sub-pixel accuracy:

   ![Screenshot_20211124_223601](https://user-images.githubusercontent.com/9963310/143316591-503c1701-e1f9-4d68-9564-fbd5453773a7.png)

- The classical Transforms and Units per Pixel wizard settings are grayed out when the Advanced Camera Calibration is active.
   
     ![Grayed out](https://user-images.githubusercontent.com/9963310/143317363-be1a7d19-3172-4291-88b8-6622c1e88fd8.png)

- The preliminary calibration is locked, when the Advanced Camera Calibration is active:

   ![I&S blocked](https://user-images.githubusercontent.com/9963310/143317229-66d58507-7474-4a31-bb5c-361805a3b539.png)

- Default Z is now always set to the primary location Z when a new calibration is applied. 

# Justification
The Advanced Camera Calibration should be available like all the other automatic calibration steps, so users need not learn a new interface.

# Instructions for Use

See above and the Wiki:

https://github.com/openpnp/openpnp/wiki/Calibration-Solutions#advanced-camera-calibration

# Implementation Details
1. Tested in simulation.
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. Successful `mvn test` before submitting the Pull Request.

