### PR TITLE
Fix/OpenPnpCaptureCamera Video Format Identity Instability

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/camera/OpenPnpCaptureCamera.java
+++ b/src/main/java/org/openpnp/machine/reference/camera/OpenPnpCaptureCamera.java
@@ -349,11 +349,14 @@ public class OpenPnpCaptureCamera extends ReferenceCamera implements Runnable {
     // method, we provide a format setter/getter by Name.
 
     public String getFormatName() {
-        return format.toString();
+        return format != null ? format.toString() : null;
     }
 
     public void setFormatName(String formatName) {
-        if (device != null) {
+        if (formatName == null) {
+            format = null;
+        }
+        else if (device != null) {
             for (CaptureFormat format : device.getFormats()) {
                 if (format.toString().equals(formatName)) {
                     setFormat(format);

--- a/src/main/java/org/openpnp/machine/reference/camera/OpenPnpCaptureCamera.java
+++ b/src/main/java/org/openpnp/machine/reference/camera/OpenPnpCaptureCamera.java
@@ -157,9 +157,13 @@ public class OpenPnpCaptureCamera extends ReferenceCamera implements Runnable {
             if (uniqueId == null) {
                 return;
             }
+            int n = 0;
             for (CaptureDevice device : capture.getDevices()) {
                 if (device.getUniqueId().equals(uniqueId)) {
                     this.device = device;
+                    if (++n > 1) {
+                        Logger.warn("Multiple cameras found with ID {} for camera {}", uniqueId, getName());
+                    }
                 }
             }
             if (device == null) {
@@ -338,6 +342,25 @@ public class OpenPnpCaptureCamera extends ReferenceCamera implements Runnable {
             this.formatId = format.getFormatId();
         }
         firePropertyChange("format", null, format);
+        firePropertyChange("formatName", null, format.toString());
+    }
+
+    // Note: due to an instability of the CaptureFormat.equals() 
+    // method, we provide a format setter/getter by Name.
+
+    public String getFormatName() {
+        return format.toString();
+    }
+
+    public void setFormatName(String formatName) {
+        if (device != null) {
+            for (CaptureFormat format : device.getFormats()) {
+                if (format.toString().equals(formatName)) {
+                    setFormat(format);
+                    break;
+                }
+            }
+        }
     }
 
     public CapturePropertyHolder getBackLightCompensation() {

--- a/src/main/java/org/openpnp/machine/reference/camera/wizards/OpenPnpCaptureCameraConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/camera/wizards/OpenPnpCaptureCameraConfigurationWizard.java
@@ -223,7 +223,9 @@ public class OpenPnpCaptureCameraConfigurationWizard extends AbstractConfigurati
                                         return;
                                     }
                                     for (CaptureFormat format : dev.getFormats()) {
-                                        formatCb.addItem(format);
+                                        // Note: due to an instability of the CaptureFormat.equals() 
+                                        // method, we use the String representation as selection.
+                                        formatCb.addItem(format.toString());
                                     }
                                 });
 
@@ -634,7 +636,9 @@ public class OpenPnpCaptureCameraConfigurationWizard extends AbstractConfigurati
         DoubleConverter doubleConverter = new DoubleConverter(Configuration.get().getLengthDisplayFormat());
 
         addWrappedBinding(camera, "device", deviceCb, "selectedItem");
-        addWrappedBinding(camera, "format", formatCb, "selectedItem");
+        // Note: due to an instability of the CaptureFormat.equals() 
+        // method, we use the String representation (Name) as selection.
+        addWrappedBinding(camera, "formatName", formatCb, "selectedItem");
 
         bindProperty("backLightCompensation", backLightCompensationAuto, backLightCompensationMin, 
                 backLightCompensationMax, backLightCompensationSlider,


### PR DESCRIPTION
# Description
`OpenPnpCaptureCamera`: Due to an instability in the `CaptureFormat.equals()` method, we use the `toString()` representation (Name) for video format selection in the GUI. A `formatName` getter/setter does the translation.

As an aside, this will also log a warning if two cameras have the same unique ID.

# Justification
Video format selection in the GUI was sometimes lost. Debugging has revealed that the `CaptureDevices` returned by `getCaptureDevices()` sometimes change between calls (different Java Objects). When this happens, the `CaptureFormat` Objects are also different. The `CaptureFormat.equals()` method then makes the formats _falsely_ differ, due to a changed `auto-allocated@` property. The ComboBox will then just select the first entry. 

# Instructions for Use
No changes.

# Implementation Details
1. Tested on the machine.
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. Successful `mvn test` before submitting the Pull Request. 
