### PR TITLE
Fix / AbstractMotionPlanner Startup Null Exception

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/driver/AbstractMotionPlanner.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/AbstractMotionPlanner.java
@@ -741,8 +741,8 @@ public abstract class AbstractMotionPlanner extends AbstractModelObject implemen
      */
     protected synchronized void wrapUpCoordinates(HeadMountable hm) throws Exception {
         AxesLocation mappedAxes = (hm != null ? 
-                hm.getMappedAxes(machine) 
-                : new AxesLocation(machine)).byType(Type.Rotation);
+                hm.getMappedAxes(getMachine()) 
+                : new AxesLocation(getMachine())).byType(Type.Rotation);
         for (ControllerAxis axis : mappedAxes.getControllerAxes()) {
             if (axis instanceof ReferenceControllerAxis) {
                 ReferenceControllerAxis refAxis = (ReferenceControllerAxis) axis;


### PR DESCRIPTION

# Description
Fixes a bug from #1334 where the `AbstractMotionPlanner ` throws a `NullPointerException` on startup.

As the `AbstractMotionPlanner.wrapUpCoordinates()` method now can be called before any motion actually took place, the `machine` member may not yet be initialized.

# Justification
Bugfix.

# Instructions for Use
No change.

# Implementation Details
1. Tested on the machine.
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. Successful `mvn test` before submitting the Pull Request.
