### PR TITLE
Fix / Issues and Solutions Advanced Camera Calibration Problems

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/camera/calibration/AdvancedCalibration.java
+++ b/src/main/java/org/openpnp/machine/reference/camera/calibration/AdvancedCalibration.java
@@ -1316,6 +1316,9 @@ public class AdvancedCalibration extends LensCalibrationParams {
         }
         setCalibratedOffsets(calibratedOffsets);
         setValid(true);
+        // Make sure the camera undistort and virtual matrix are updated.
+        camera.clearCalibrationCache();
         setEnabled(true);
+        camera.captureTransformed();
     }
 }

--- a/src/main/java/org/openpnp/machine/reference/solutions/CalibrationSolutions.java
+++ b/src/main/java/org/openpnp/machine/reference/solutions/CalibrationSolutions.java
@@ -1154,8 +1154,9 @@ public class CalibrationSolutions implements Solutions.Subject {
         // in the raw format.
         advCal.setOverridingOldTransformsAndDistortionCorrectionSettings(true);
         advCal.setEnabled(false);
-        camera.lightSettleAndCapture();
-        camera.lightSettleAndCapture();
+        camera.clearCalibrationCache();
+        camera.captureTransformed(); //force image width and height to be recomputed
+        
 
         Location primaryLocation;
         Location secondaryLocation;
@@ -1201,6 +1202,8 @@ public class CalibrationSolutions implements Solutions.Subject {
         ArrayList<Integer> detectionDiameters = new ArrayList<>();
         detectionDiameters.add(primaryDiameter);
         detectionDiameters.add(secondaryDiameter);
+        Length oldDefaultZ = camera.getDefaultZ();
+        camera.setDefaultZ(primaryLocation.getLengthZ());
 
         CameraView cameraView = MainFrame.get().getCameraViews().
                 getCameraView(camera);
@@ -1242,6 +1245,7 @@ public class CalibrationSolutions implements Solutions.Subject {
                     advCal.setEnabled(false);
                     advCal.setOverridingOldTransformsAndDistortionCorrectionSettings(false);
                     issue.setState(State.Open);
+                    camera.setDefaultZ(oldDefaultZ);
                 }
                 MainFrame.get().getIssuesAndSolutionsTab().solutionChanged();
             }
@@ -1251,6 +1255,7 @@ public class CalibrationSolutions implements Solutions.Subject {
                 advCal.setValid(false);
                 advCal.setEnabled(false);
                 advCal.setOverridingOldTransformsAndDistortionCorrectionSettings(false);
+                camera.setDefaultZ(oldDefaultZ);
 
                 try {
                     issue.setState(State.Open);

--- a/src/main/java/org/openpnp/machine/reference/solutions/CalibrationSolutions.java
+++ b/src/main/java/org/openpnp/machine/reference/solutions/CalibrationSolutions.java
@@ -1156,7 +1156,6 @@ public class CalibrationSolutions implements Solutions.Subject {
         advCal.setEnabled(false);
         camera.clearCalibrationCache();
         camera.captureTransformed(); //force image width and height to be recomputed
-        
 
         Location primaryLocation;
         Location secondaryLocation;
@@ -1235,7 +1234,7 @@ public class CalibrationSolutions implements Solutions.Subject {
                             head.visualHome(machine, true);
                         }
                         else {
-                            MovableUtils.moveToLocationAtSafeZ(movable, primaryLocation);
+                            MovableUtils.moveToLocationAtSafeZ(movable, camera.getLocation(movable));
                         }
                     });
                 }

--- a/src/main/java/org/openpnp/machine/reference/wizards/ReferenceCameraCalibrationConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/wizards/ReferenceCameraCalibrationConfigurationWizard.java
@@ -1,5 +1,7 @@
 package org.openpnp.machine.reference.wizards;
 
+import java.awt.Color;
+import java.awt.Component;
 import java.awt.event.ActionEvent;
 
 import javax.swing.AbstractAction;
@@ -36,19 +38,37 @@ public class ReferenceCameraCalibrationConfigurationWizard extends AbstractConfi
         panelLensCalibration.setBorder(new TitledBorder(null, "Lens Calibration",
                 TitledBorder.LEADING, TitledBorder.TOP, null, null));
         contentPanel.add(panelLensCalibration);
-        panelLensCalibration.setLayout(new FormLayout(
-                new ColumnSpec[] {FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,
-                        FormSpecs.RELATED_GAP_COLSPEC, ColumnSpec.decode("default:grow"),},
-                new RowSpec[] {FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
-                        FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
-                        FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
-                        FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
-                        FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
-                        FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
-                        FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,}));
+        panelLensCalibration.setLayout(new FormLayout(new ColumnSpec[] {
+                FormSpecs.RELATED_GAP_COLSPEC,
+                ColumnSpec.decode("max(70dlu;default)"),
+                FormSpecs.RELATED_GAP_COLSPEC,
+                ColumnSpec.decode("max(70dlu;default)"),
+                FormSpecs.RELATED_GAP_COLSPEC,
+                FormSpecs.DEFAULT_COLSPEC,
+                FormSpecs.RELATED_GAP_COLSPEC,
+                ColumnSpec.decode("default:grow"),},
+            new RowSpec[] {
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,}));
 
         startLensCalibrationBtn = new JButton(startCalibration);
         panelLensCalibration.add(startLensCalibrationBtn, "2, 2, 3, 1");
+        
+        advancedCalWarning = new JLabel("Advanced Calibration Active");
+        advancedCalWarning.setForeground(Color.RED);
+        panelLensCalibration.add(advancedCalWarning, "8, 2, left, default");
 
         lblApplyCalibration = new JLabel("Apply Calibration?");
         panelLensCalibration.add(lblApplyCalibration, "2, 4, right, default");
@@ -57,8 +77,23 @@ public class ReferenceCameraCalibrationConfigurationWizard extends AbstractConfi
         panelLensCalibration.add(calibrationEnabledChk, "4, 4");
     }
 
+    public boolean isOverriddenClassicTransforms() {
+        return calibrationEnabledChk.isEnabled();
+    }
+
+    public void setOverriddenClassicTransforms(boolean overriddenClassicTransforms) {
+        for (Component comp : panelLensCalibration.getComponents()) {
+            comp.setEnabled(!overriddenClassicTransforms);
+        }
+        advancedCalWarning.setVisible(overriddenClassicTransforms);
+        advancedCalWarning.setEnabled(overriddenClassicTransforms);
+    }
+
     @Override
     public void createBindings() {
+        addWrappedBinding(referenceCamera.getAdvancedCalibration(), "overridingOldTransformsAndDistortionCorrectionSettings", 
+                this, "overriddenClassicTransforms");
+
         bind(UpdateStrategy.READ_WRITE, referenceCamera.getCalibration(), "enabled",
                 calibrationEnabledChk, "selected");
         // addWrappedBinding(referenceCamera.getCalibration(), "enabled", calibrationEnabledChk,
@@ -108,4 +143,5 @@ public class ReferenceCameraCalibrationConfigurationWizard extends AbstractConfi
         }
     };
     private JButton startLensCalibrationBtn;
+    private JLabel advancedCalWarning;
 }


### PR DESCRIPTION
# Description

- Fixes a race condition in #1335 where the virtual camera matrix is on-demand calculated along with the undistort map, but also used for 3D Units per Pixel. So if Units per Pixel are required too early, calculation would fail. Immediate recalculation of the undistort map and virtual camera matrix is now enforced after calibration.
- Disables the classic Lens Calibration Wizard when the Advanced Camera Calibration is active.
   
   ![Lens Calibration](https://user-images.githubusercontent.com/9963310/143511703-1c2813f6-3662-4312-997b-c9daabdb0d18.png)


# Justification
Running the calibration from Issues & Solutions would sometimes result in corrupt units per pixel. 

# Instructions for Use
No change.

# Implementation Details
1. Tested on the machine.
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. Successful `mvn test` before submitting the Pull Request.
