### PR TITLE
Fix: Advanced Camera Calibration startup race.

### DIFF
--- a/src/main/java/org/openpnp/gui/IssuesAndSolutionsPanel.java
+++ b/src/main/java/org/openpnp/gui/IssuesAndSolutionsPanel.java
@@ -250,9 +250,17 @@ public class IssuesAndSolutionsPanel extends JPanel {
                     }
                 });
 
-                SwingUtilities.invokeLater(() -> {
-                    findIssuesAndSolutions(); 
-                });
+                // Execute the first issue search after a delay (the delay prevents a
+                // race condition with configuration loading and camera startup).
+                new java.util.Timer().schedule( 
+                        new java.util.TimerTask() {
+                            @Override
+                            public void run() {
+                                findIssuesAndSolutions(); 
+                            }
+                        },
+                        2500
+                );
             }
         });
 

--- a/src/main/java/org/openpnp/gui/IssuesAndSolutionsPanel.java
+++ b/src/main/java/org/openpnp/gui/IssuesAndSolutionsPanel.java
@@ -259,7 +259,7 @@ public class IssuesAndSolutionsPanel extends JPanel {
                                 findIssuesAndSolutions(); 
                             }
                         },
-                        2500
+                        5000
                 );
             }
         });


### PR DESCRIPTION

# Description
Advanced Camera Calibration configuration needs to be properly loaded and committed before the first frame is captured, as  undistort maps need to be created. 

On startup, Issues & Solutions is finding issues, and displaying the first one. Some issues query the camera for dimension, prompting a camera capture to get the frame size. This was done before the camera was properly started. By delaying the Issues & Solutions startup, we can circumvent that. 

The delay also somewhat makes startup of OpenPnP faster. 

# Justification
OpenPnP would throw this:

```java
2021-11-27 17:09:21.332 ReferenceCamera ERROR: org.opencv.core.CvException: cv::Exception: OpenCV(4.5.1) /home/runner/work/opencv/opencv/opencv-4.5.1/modules/imgproc/src/imgwarp.cpp:1703: error: (-215:Assertion failed) !_map1.empty() in function 'remap'

	at org.opencv.imgproc.Imgproc.remap_2(Native Method)
	at org.opencv.imgproc.Imgproc.remap(Imgproc.java:4340)
	at org.openpnp.machine.reference.ReferenceCamera.advancedUndistort(ReferenceCamera.java:670)
	at org.openpnp.machine.reference.ReferenceCamera.transformImage(ReferenceCamera.java:591)
	at org.openpnp.machine.reference.ReferenceCamera.captureTransformed(ReferenceCamera.java:246)
	at org.openpnp.machine.reference.ReferenceCamera.determineSize(ReferenceCamera.java:322)
	at org.openpnp.machine.reference.ReferenceCamera.getWidth(ReferenceCamera.java:307)
	at org.openpnp.machine.reference.solutions.VisionSolutions$VisionFeatureIssue.getProperties(VisionSolutions.java:252)
	at org.openpnp.gui.components.IssuePanel.getDynamicRows(IssuePanel.java:170)
	at org.openpnp.gui.components.IssuePanel.<init>(IssuePanel.java:76)
	at org.openpnp.gui.IssuesAndSolutionsPanel.selectionActions(IssuesAndSolutionsPanel.java:349)
	at org.openpnp.gui.IssuesAndSolutionsPanel$8$2.valueChanged(IssuesAndSolutionsPanel.java:235)
	at java.desktop/javax.swing.DefaultListSelectionModel.fireValueChanged(DefaultListSelectionModel.java:219)
	at java.desktop/javax.swing.DefaultListSelectionModel.fireValueChanged(DefaultListSelectionModel.java:199)
	at java.desktop/javax.swing.DefaultListSelectionModel.fireValueChanged(DefaultListSelectionModel.java:246)
	at java.desktop/javax.swing.DefaultListSelectionModel.changeSelection(DefaultListSelectionModel.java:443)
	at java.desktop/javax.swing.DefaultListSelectionModel.changeSelection(DefaultListSelectionModel.java:453)
	at java.desktop/javax.swing.DefaultListSelectionModel.setSelectionInterval(DefaultListSelectionModel.java:497)
	at java.desktop/javax.swing.JTable.setRowSelectionInterval(JTable.java:2173)
	at org.openpnp.gui.IssuesAndSolutionsPanel.lambda$0(IssuesAndSolutionsPanel.java:400)
	at org.openpnp.util.UiUtils.messageBoxOnException(UiUtils.java:110)
	at org.openpnp.gui.IssuesAndSolutionsPanel.findIssuesAndSolutions(IssuesAndSolutionsPanel.java:395)
	at org.openpnp.gui.IssuesAndSolutionsPanel$8.lambda$0(IssuesAndSolutionsPanel.java:254)
```
# Instructions for Use
On startup, the Issues & Solutions tab will now update with a 5s delay. 

# Implementation Details
1. Tested in simulation.
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. Successful `mvn test` before submitting the Pull Request. 
