### PR TITLE
[Neoden4][FeederActuator] Add support to change Feeder IDs

### DIFF
--- a/src/main/java/org/openpnp/machine/neoden4/NeoDen4Driver.java
+++ b/src/main/java/org/openpnp/machine/neoden4/NeoDen4Driver.java
@@ -698,7 +698,43 @@ public class NeoDen4Driver extends AbstractReferenceDriver {
     		throw new IOException("Feed error.");
     	}
     }
+    private void changeFeederIdInternal(int oldId, int newId) throws Exception {
+        byte[] b = new byte[9];
 
+        b[0] = (byte) newId;
+        b[7] = (byte) 0x01;
+        b[8] = (byte) oldId;
+        writeWithChecksum(b);
+    }
+    
+    public void changeFeederId(int oldId, int newId) throws Exception {
+        Logger.debug(String.format("changeFeederId, oldId=%d, newId=%d", oldId, newId));
+        if((oldId <= 0)||(oldId > 50))
+            throw new IOException("changeFeederId oldId must be between 1-50.");
+        else 
+            if((newId <= 0)||(newId > 50))
+                throw new IOException("changeFeederId newId must be between 1-50.");
+            else {
+                boolean success = false;
+                for(int i=0; i<3; i++) {
+                    try {
+                        changeFeederIdInternal(oldId, newId);
+                        success = true;
+                        break;
+                    }
+                    catch (Exception e){
+                        Thread.sleep(1000);
+                        flushInput();
+                        Logger.warn("Recovered changeFeederId");
+                        Thread.sleep(1000);
+                    }
+                }
+                
+                if(!success) {
+                    throw new IOException("changeFeederId error.");
+                }
+            }
+    }
     private void peelInternal(int id, int strength, int feedRate) throws Exception {
 
     	boolean isTopHalf = false;

--- a/src/main/java/org/openpnp/machine/neoden4/NeoDen4Driver.java
+++ b/src/main/java/org/openpnp/machine/neoden4/NeoDen4Driver.java
@@ -721,7 +721,7 @@ public class NeoDen4Driver extends AbstractReferenceDriver {
         write(0x3f);
         expect(0x0c);
         
-        write(0x46+newId);
+        write(0x46+oldId);
         read();        
     }
     

--- a/src/main/java/org/openpnp/machine/neoden4/NeoDen4Driver.java
+++ b/src/main/java/org/openpnp/machine/neoden4/NeoDen4Driver.java
@@ -709,11 +709,13 @@ public class NeoDen4Driver extends AbstractReferenceDriver {
     
     public void changeFeederId(int oldId, int newId) throws Exception {
         Logger.debug(String.format("changeFeederId, oldId=%d, newId=%d", oldId, newId));
-        if((oldId < 0)||(oldId >= 100))
+        if((oldId < 0)||(oldId >= 100)) {
             throw new IOException("changeFeederId oldId must be between 0-99.");
-        else 
-            if((newId < 0)||(newId >= 100))
+        }
+        else {
+            if((newId < 0)||(newId >= 100)) {
                 throw new IOException("changeFeederId newId must be between 0-99.");
+            }
             else {
                 boolean success = false;
                 for(int i=0; i<3; i++) {
@@ -734,6 +736,7 @@ public class NeoDen4Driver extends AbstractReferenceDriver {
                     throw new IOException("changeFeederId error.");
                 }
             }
+        }
     }
     private void peelInternal(int id, int strength, int feedRate) throws Exception {
 

--- a/src/main/java/org/openpnp/machine/neoden4/NeoDen4Driver.java
+++ b/src/main/java/org/openpnp/machine/neoden4/NeoDen4Driver.java
@@ -698,13 +698,31 @@ public class NeoDen4Driver extends AbstractReferenceDriver {
     		throw new IOException("Feed error.");
     	}
     }
+    
     private void changeFeederIdInternal(int oldId, int newId) throws Exception {
-        byte[] b = new byte[9];
+        write(0x3f);
+        expect(0x0c);
+        
+        write(0x46+oldId);
+        read();
+
+        write(0xff);
+        expect(0x00);
+        
+        write(0x46+oldId);
+        read();
+        
+        byte[] b = new byte[8];
 
         b[0] = (byte) newId;
         b[7] = (byte) 0x01;
-        b[8] = (byte) oldId;
         writeWithChecksum(b);
+        
+        write(0x3f);
+        expect(0x0c);
+        
+        write(0x46+newId);
+        read();        
     }
     
     public void changeFeederId(int oldId, int newId) throws Exception {

--- a/src/main/java/org/openpnp/machine/neoden4/NeoDen4Driver.java
+++ b/src/main/java/org/openpnp/machine/neoden4/NeoDen4Driver.java
@@ -709,11 +709,11 @@ public class NeoDen4Driver extends AbstractReferenceDriver {
     
     public void changeFeederId(int oldId, int newId) throws Exception {
         Logger.debug(String.format("changeFeederId, oldId=%d, newId=%d", oldId, newId));
-        if((oldId <= 0)||(oldId > 50))
-            throw new IOException("changeFeederId oldId must be between 1-50.");
+        if((oldId < 0)||(oldId >= 100))
+            throw new IOException("changeFeederId oldId must be between 0-99.");
         else 
-            if((newId <= 0)||(newId > 50))
-                throw new IOException("changeFeederId newId must be between 1-50.");
+            if((newId < 0)||(newId >= 100))
+                throw new IOException("changeFeederId newId must be between 0-99.");
             else {
                 boolean success = false;
                 for(int i=0; i<3; i++) {

--- a/src/main/java/org/openpnp/machine/neoden4/wizards/NeoDen4FeederActuatorConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/neoden4/wizards/NeoDen4FeederActuatorConfigurationWizard.java
@@ -19,35 +19,27 @@
 
 package org.openpnp.machine.neoden4.wizards;
 
-import java.awt.Component;
 import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
 
 import javax.swing.AbstractAction;
-import javax.swing.Action;
 import javax.swing.JButton;
 import javax.swing.JComboBox;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JTextField;
-import javax.swing.Timer;
 import javax.swing.border.TitledBorder;
 
 import org.openpnp.gui.components.ComponentDecorators;
 import org.openpnp.gui.support.DriversComboBoxModel;
 import org.openpnp.gui.support.IntegerConverter;
-import org.openpnp.gui.support.MessageBoxes;
 import org.openpnp.gui.support.NamedConverter;
 import org.openpnp.machine.neoden4.NeoDen4Driver;
 import org.openpnp.machine.neoden4.NeoDen4FeederActuator;
 import org.openpnp.machine.reference.wizards.AbstractActuatorConfigurationWizard;
 import org.openpnp.model.Configuration;
-import org.openpnp.spi.Actuator;
-import org.openpnp.spi.Camera;
 import org.openpnp.spi.Driver;
 import org.openpnp.spi.base.AbstractMachine;
 import org.openpnp.util.UiUtils;
-import org.pmw.tinylog.Logger;
 
 import com.jgoodies.forms.layout.ColumnSpec;
 import com.jgoodies.forms.layout.FormLayout;
@@ -86,9 +78,8 @@ public class NeoDen4FeederActuatorConfigurationWizard extends AbstractActuatorCo
     private JButton btnChangeFeederIdAction;
     private JLabel lblOldText;
     private JLabel lblNewText;
-    private JComboBox oldId;
-    private JComboBox newId;
-    
+    private JComboBox<Integer> oldId;
+    private JComboBox<Integer> newId;
     
     public NeoDen4FeederActuatorConfigurationWizard(AbstractMachine machine, NeoDen4FeederActuator actuator) {
         super(machine,  actuator);
@@ -214,9 +205,9 @@ public class NeoDen4FeederActuatorConfigurationWizard extends AbstractActuatorCo
         lblOldText = new JLabel("Old ID");
         panelProperties.add(lblOldText, "6, 18, right, default");
         
-        oldId = new JComboBox();
-        newId = new JComboBox();
-        for(int i = 1; i <= 100; i++)
+        oldId = new JComboBox<Integer>();
+        newId = new JComboBox<Integer>();
+        for(int i = 0; i <= 99; i++)
         {
             oldId.addItem(i);        
             newId.addItem(i);        
@@ -240,8 +231,7 @@ public class NeoDen4FeederActuatorConfigurationWizard extends AbstractActuatorCo
             }
         });
         
-//        btnChangeFeederIdAction.setText("Change Feeder ID");
-//        btnChangeFeederIdAction.setEnabled(true);
+
         panelProperties.add(btnChangeFeederIdAction, "14, 18, fill, default");
         
         super.createUi(machine);

--- a/src/main/java/org/openpnp/machine/neoden4/wizards/NeoDen4FeederActuatorConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/neoden4/wizards/NeoDen4FeederActuatorConfigurationWizard.java
@@ -197,8 +197,8 @@ public class NeoDen4FeederActuatorConfigurationWizard extends AbstractActuatorCo
         panelProperties.add(lblChangeIdNote, "4, 18, center, default");
         
         newId = new JComboBox<Integer>();
-        for(int i = 0; i <= 99; i++)
-            newId.addItem(i);        
+        for(int i = 0; i <= 99; i++) {
+            newId.addItem(i);        }
 
         lblNewText = new JLabel("New ID");
         panelProperties.add(lblNewText, "6, 18, right, default");

--- a/src/main/java/org/openpnp/machine/neoden4/wizards/NeoDen4FeederActuatorConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/neoden4/wizards/NeoDen4FeederActuatorConfigurationWizard.java
@@ -76,9 +76,7 @@ public class NeoDen4FeederActuatorConfigurationWizard extends AbstractActuatorCo
     private JLabel lblChangeId;
     private JLabel lblChangeIdNote;
     private JButton btnChangeFeederIdAction;
-    private JLabel lblOldText;
     private JLabel lblNewText;
-    private JComboBox<Integer> oldId;
     private JComboBox<Integer> newId;
     
     public NeoDen4FeederActuatorConfigurationWizard(AbstractMachine machine, NeoDen4FeederActuator actuator) {
@@ -98,10 +96,6 @@ public class NeoDen4FeederActuatorConfigurationWizard extends AbstractActuatorCo
                 ColumnSpec.decode("max(70dlu;default)"),
                 FormSpecs.RELATED_GAP_COLSPEC,
                 FormSpecs.DEFAULT_COLSPEC,  
-                FormSpecs.RELATED_GAP_COLSPEC,
-                FormSpecs.DEFAULT_COLSPEC,
-                FormSpecs.RELATED_GAP_COLSPEC,
-                FormSpecs.DEFAULT_COLSPEC,
                 FormSpecs.RELATED_GAP_COLSPEC,
                 FormSpecs.DEFAULT_COLSPEC,
                 FormSpecs.RELATED_GAP_COLSPEC,
@@ -131,7 +125,7 @@ public class NeoDen4FeederActuatorConfigurationWizard extends AbstractActuatorCo
                 FormSpecs.DEFAULT_ROWSPEC,
                 
                 FormSpecs.RELATED_GAP_ROWSPEC,
-                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC
         }));
         
         lblDriver = new JLabel("Driver");
@@ -202,28 +196,20 @@ public class NeoDen4FeederActuatorConfigurationWizard extends AbstractActuatorCo
         lblChangeIdNote = new JLabel("(Stored in Feeder NVMEM)");
         panelProperties.add(lblChangeIdNote, "4, 18, center, default");
         
-        lblOldText = new JLabel("Old ID");
-        panelProperties.add(lblOldText, "6, 18, right, default");
-        
-        oldId = new JComboBox<Integer>();
         newId = new JComboBox<Integer>();
         for(int i = 0; i <= 99; i++)
-        {
-            oldId.addItem(i);        
             newId.addItem(i);        
-        }
-        panelProperties.add(oldId, "8, 18, fill, default");
-        
+
         lblNewText = new JLabel("New ID");
-        panelProperties.add(lblNewText, "10, 18, right, default");
+        panelProperties.add(lblNewText, "6, 18, right, default");
         
-        panelProperties.add(newId, "12, 18, fill, default");
+        panelProperties.add(newId, "8, 18, fill, default");
         
         btnChangeFeederIdAction = new JButton(new AbstractAction("Change") {
             @Override
             public void actionPerformed(ActionEvent e) {
                 NeoDen4Driver driver = getNeoden4Driver();
-                int oldIdInteger = (int)oldId.getSelectedItem();
+                int oldIdInteger = Integer.parseInt(feederIdTextField.getText());
                 int newIdInteger = (int)newId.getSelectedItem();
                 UiUtils.messageBoxOnException(() -> {
                     driver.changeFeederId(oldIdInteger, newIdInteger);
@@ -232,7 +218,7 @@ public class NeoDen4FeederActuatorConfigurationWizard extends AbstractActuatorCo
         });
         
 
-        panelProperties.add(btnChangeFeederIdAction, "14, 18, fill, default");
+        panelProperties.add(btnChangeFeederIdAction, "10, 18, fill, default");
         
         super.createUi(machine);
     }

--- a/src/main/java/org/openpnp/machine/reference/ReferenceMachine.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceMachine.java
@@ -386,6 +386,7 @@ public class ReferenceMachine extends AbstractMachine {
         l.add(HttpActuator.class);
         l.add(ScriptActuator.class);
         l.add(ThermistorToLinearSensorActuator.class);
+        l.add(NeoDen4FeederActuator.class);
         return l;
     }
 


### PR DESCRIPTION
# Description
Enable driver support and GUI element to allow changing the Neoden4 Feeder ID. Each feeder internally stores an ID for the machine to address it (typically 1-50, new feeders ship default to 50). We will allow range from 0-99. Feature request #1344 

# Justification
Updates the Neoden4 machine specific class

# Instructions for Use
In a Neoden4 Feeder Actuator, select the old and new ID numbers from the dropdowns, and click 'Change'

![image](https://user-images.githubusercontent.com/84988403/144733219-024e58a6-1ecf-42ed-b9b6-67a4c4694c36.png)

# Implementation Details
1. How did you test the change? Be descriptive. Untested code will not be accepted.
2. I think this follows similar style
3. Changes local to only Neoden4 machine classes
4. Ran mvn test