### PR TITLE
Remove unused logger and slf4j/log4j dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,11 +40,6 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-log4j12</artifactId>
-			<version>1.7.21</version>
-		</dependency>
-		<dependency>
 			<groupId>org.simpleframework</groupId>
 			<artifactId>simple-xml</artifactId>
 			<version>2.7.1</version>

--- a/src/main/java/org/openpnp/machine/reference/feeder/ReferenceHeapFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/ReferenceHeapFeeder.java
@@ -39,8 +39,6 @@ import org.simpleframework.xml.ElementList;
 import org.simpleframework.xml.Root;
 import org.simpleframework.xml.core.Commit;
 import org.simpleframework.xml.core.Persist;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * 
@@ -53,8 +51,6 @@ import org.slf4j.LoggerFactory;
  *
  */
 public class ReferenceHeapFeeder extends ReferenceFeeder {
-    private final static Logger logger = LoggerFactory.getLogger(ReferenceHeapFeeder.class);
-
     // some settings that I might expose later
     final static int maxThrowRetries = 12;
 


### PR DESCRIPTION
# Description
Remove unused private logger in ReferenceHeapFeeder class and associated dependency from pom.xml.

# Justification
ReferenceHeapFeeder class creates a private logger instance using sfl4j which in turn depends on log4j
but pulls in an old, old version of it. Since version 1.x series of log4j is described as having "multiple security issues"
it's better to remove the unneeded dependency.

# Instructions for Use
N/A

# Implementation Details
1. How did you test the change? Be descriptive. Untested code will not be accepted.
Static code analysis only.
2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)?
N/A (removal only)
3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing.
N/A
4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted.
[INFO] Tests run: 139, Failures: 0, Errors: 0, Skipped: 0

I don't know if any of these tests exercise the HeapFeeder. Git blame indicates this code originates from @doppelgrau and this PR should ideally be reviewed by them.
