### PR TITLE
Fix / Unconditional Wait For Completion On Drivers Without Axes

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/ReferenceNozzle.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceNozzle.java
@@ -1365,7 +1365,8 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
         super.findIssues(solutions);
         try {
             if (solutions.isTargeting(Milestone.Basics)) {
-                if (getVacuumActuator().getValueType() == ActuatorValueType.Double) {
+                if (getVacuumActuator() != null 
+                        && getVacuumActuator().getValueType() == ActuatorValueType.Double) {
                     findActuatorIssues(solutions, getVacuumActuator(), "vacuum valve", 
                         new CommandType[] { CommandType.ACTUATE_DOUBLE_COMMAND });
                 }

--- a/src/main/java/org/openpnp/machine/reference/driver/AbstractMotionPlanner.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/AbstractMotionPlanner.java
@@ -782,17 +782,29 @@ public abstract class AbstractMotionPlanner extends AbstractModelObject implemen
         }
     }
 
+    /**
+     * Wait for the drivers.
+     * 
+     * @param hm
+     * @param completionType
+     * @throws Exception
+     */
     protected void waitForDriverCompletion(HeadMountable hm, CompletionType completionType)
             throws Exception {
-        // Wait for the driver(s).
         ReferenceMachine machine = getMachine();
-        // If the hm is given, we just wait for the drivers of that hm, otherwise we wait for all drivers of the machine axes.
-        AxesLocation mappedAxes = (hm != null ? 
-                hm.getMappedAxes(machine) 
-                : new AxesLocation(machine));
-        if (!mappedAxes.isEmpty()) {
-            for (Driver driver : mappedAxes.getAxesDrivers(machine)) {
-                driver.waitForCompletion((ReferenceHeadMountable) hm, completionType);
+        // If the hm is given, we just wait for the drivers of that hm, otherwise we wait for all drivers,
+        // including those that do not have any axes attached.
+        if (hm != null) {
+            AxesLocation mappedAxes = hm.getMappedAxes(machine);
+            if (!mappedAxes.isEmpty()) {
+                for (Driver driver : mappedAxes.getAxesDrivers(machine)) {
+                    driver.waitForCompletion((ReferenceHeadMountable) hm, completionType);
+                }
+            }
+        }
+        else {
+            for (Driver driver : machine.getDrivers()) {
+                driver.waitForCompletion(null, completionType);
             }
         }
     }

--- a/src/test/java/GcodeDriverTest.java
+++ b/src/test/java/GcodeDriverTest.java
@@ -1,3 +1,5 @@
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import java.io.File;
 
 import org.junit.jupiter.api.AfterEach;
@@ -13,10 +15,9 @@ import org.openpnp.model.Configuration;
 import org.openpnp.spi.Actuator;
 import org.openpnp.spi.Machine;
 import org.openpnp.util.GcodeServer;
+import org.pmw.tinylog.Logger;
 
 import com.google.common.io.Files;
-
-import static org.junit.jupiter.api.Assertions.*;
 
 public class GcodeDriverTest {
     GcodeServer server;
@@ -40,6 +41,7 @@ public class GcodeDriverTest {
         server.addCommandResponse("G90 ; Set absolute positioning mode", "ok");
         server.addCommandResponse("M82 ; Set absolute mode for extruder", "ok");
         server.addCommandResponse("G28 ; Home all axes", "ok");
+        server.addCommandResponse("M400 ; Wait for moves to complete before returning", "ok");
 
         /**
          * Create a new config directory and load the default configuration.
@@ -172,16 +174,12 @@ public class GcodeDriverTest {
     
     @AfterEach
     public void after() throws Exception {
+        Logger.info("Shutdown");
         /**
-         * TODO: This is cleaner than not shutting it down, but it causes a 3s delay in the test
-         * because the TCP implementation does not handle timeouts correctly. Until that's fixed,
-         * this can be left out to speed up the tests. 
+         * Stop the machine.
          */
-//        /**
-//         * Stop the machine.
-//         */
-//        Machine machine = Configuration.get().getMachine();
-//        machine.setEnabled(false);
+        Machine machine = Configuration.get().getMachine();
+        machine.setEnabled(false);
 
         server.shutdown();
     }


### PR DESCRIPTION
# Description
When a driver had no axes, it would not wait for completion, even unconditional waits. This is fixed here.

As a "stowaway", this also fixes an unnecessary exception in Issues & Solutions if no vacuum actuator is assigned to a nozzle.

# Justification
See user case:
https://groups.google.com/g/openpnp/c/2jx2SCEEQtk/m/GXkBhtYVEAAJ

# Instructions for Use
Applies to `GcodeAsyncDrivers` without any axes, but implementing the (historically named) `MOVE_TO_COMPLETE_COMMAND`, typically implementing `M400`, i.e., a command to wait for pending controller actions to complete. 

Typical use case: When using Actuator **After Actuate** machine coordination, the actuator driver should unconditionally wait for completion, even if it has no axes assigned to it. The user's case was a Feeder _feed_ actuator that the machine should wait for to complete before moving the nozzle down there. 

The same should happen in other cases of unconditional wait for completion, such as after homing the machine, i.e. multi-driver machine will now properly wait for all drivers to complete homing cycles, even those without axes.

# Implementation Details
1. Tested in simulation and unit tests. In fact, the `GcodeDriverTest` server now needed to know the `M400` command, because it was positively used after homing. 
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. Successful `mvn test` before submitting the Pull Request.
