### PR TITLE
Feature / Move all HeadMountables on Head to Safe Z when Park Z is pressed

### DIFF
--- a/src/main/java/org/openpnp/gui/JogControlsPanel.java
+++ b/src/main/java/org/openpnp/gui/JogControlsPanel.java
@@ -586,13 +586,17 @@ public class JogControlsPanel extends JPanel {
         public void actionPerformed(ActionEvent arg0) {
             UiUtils.submitUiMachineTask(() -> {
                 HeadMountable hm = machineControlsPanel.getSelectedTool();
-                // Note, we don't just moveToSafeZ(), because this will just sit still, if we're anywhere in the Safe Z Zone.
+                // Note, we don't just moveToSafeZ(), because this will just sit still, if we're already in the Safe Z Zone.
                 // instead we explicitly move to the Safe Z coordinate i.e. the lower bound of the Safe Z Zone, applicable
                 // for this hm.
                 Location location = hm.getLocation();
                 Length safeZLength = hm.getSafeZ();
                 double safeZ = (safeZLength != null ? safeZLength.convertToUnits(location.getUnits()).getValue() : Double.NaN);
                 location = location.derive(null, null, safeZ, null);
+                if (Configuration.get().getMachine().isSafeZPark()) {
+                    // All other head-mountables must also be moved to safe Z.
+                    hm.getHead().moveToSafeZ();
+                }
                 hm.moveTo(location);
                 MovableUtils.fireTargetedUserAction(hm);
             });

--- a/src/main/java/org/openpnp/machine/reference/ReferenceMachine.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceMachine.java
@@ -129,6 +129,9 @@ public class ReferenceMachine extends AbstractMachine {
     @Attribute(required = false)
     private boolean autoToolSelect = true;
 
+    @Attribute(required = false)
+    private boolean safeZPark = true;
+
     @Element(required = false)
     private Solutions solutions = new Solutions();
 
@@ -263,6 +266,17 @@ public class ReferenceMachine extends AbstractMachine {
         Object oldValue = this.autoToolSelect;
         this.autoToolSelect = autoToolSelect;
         firePropertyChange("autoToolSelect", oldValue, autoToolSelect);
+    }
+
+    @Override
+    public boolean isSafeZPark() {
+        return safeZPark;
+    }
+
+    public void setSafeZPark(boolean safeZPark) {
+        Object oldValue = this.safeZPark;
+        this.safeZPark = safeZPark;
+        firePropertyChange("safeZPark", oldValue, safeZPark);
     }
 
     @Override

--- a/src/main/java/org/openpnp/machine/reference/wizards/ReferenceMachineConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/wizards/ReferenceMachineConfigurationWizard.java
@@ -37,6 +37,7 @@ public class ReferenceMachineConfigurationWizard extends AbstractConfigurationWi
     private JComboBox motionPlannerClass;
     private boolean reloadWizard;
     private JCheckBox autoToolSelect;
+    private JCheckBox safeZPark;
 
     public ReferenceMachineConfigurationWizard(ReferenceMachine machine) {
         this.machine = machine;
@@ -58,6 +59,8 @@ public class ReferenceMachineConfigurationWizard extends AbstractConfigurationWi
                 FormSpecs.RELATED_GAP_ROWSPEC,
                 FormSpecs.DEFAULT_ROWSPEC,
                 FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
                 FormSpecs.DEFAULT_ROWSPEC,}));
         
         JLabel lblHomeAfterEnabled = new JLabel("Home after enabled?");
@@ -72,13 +75,20 @@ public class ReferenceMachineConfigurationWizard extends AbstractConfigurationWi
         autoToolSelect = new JCheckBox("");
         panelGeneral.add(autoToolSelect, "4, 4");
         
+        JLabel lblParkAllAtSafeZ = new JLabel("Park all at Safe Z?");
+        lblParkAllAtSafeZ.setToolTipText("When the Z Park button is pressed, move all tools mounted on the same head to safe Z.");
+        panelGeneral.add(lblParkAllAtSafeZ, "2, 6, right, default");
+        
+        safeZPark = new JCheckBox("");
+        panelGeneral.add(safeZPark, "4, 6");
+        
         JLabel lblMotionPlanning = new JLabel("Motion Planning");
-        panelGeneral.add(lblMotionPlanning, "2, 6, right, default");
+        panelGeneral.add(lblMotionPlanning, "2, 8, right, default");
         
         Object[] classNames = machine.getCompatibleMotionPlannerClasses().stream()
         .map(c -> c.getSimpleName()).toArray();
         motionPlannerClass = new JComboBox(classNames);
-        panelGeneral.add(motionPlannerClass, "4, 6, fill, default");
+        panelGeneral.add(motionPlannerClass, "4, 8, fill, default");
         
                 JPanel panelLocations = new JPanel();
         panelLocations.setBorder(new TitledBorder(null, "Locations", TitledBorder.LEADING,
@@ -142,6 +152,7 @@ public class ReferenceMachineConfigurationWizard extends AbstractConfigurationWi
 
         addWrappedBinding(machine, "homeAfterEnabled", checkBoxHomeAfterEnabled, "selected");
         addWrappedBinding(machine, "autoToolSelect", autoToolSelect, "selected");
+        addWrappedBinding(machine, "safeZPark", safeZPark, "selected");
 
         motionPlannerClassName = machine.getMotionPlanner().getClass().getSimpleName();
         addWrappedBinding(this, "motionPlannerClassName", motionPlannerClass, "selectedItem");

--- a/src/main/java/org/openpnp/spi/Machine.java
+++ b/src/main/java/org/openpnp/spi/Machine.java
@@ -356,4 +356,9 @@ public interface Machine extends WizardConfigurable, PropertySheetHolder, Closea
      * @return True if the tool in machine controls should be auto-selected based on targeted user action.
      */
     public boolean isAutoToolSelect();
+
+    /**
+     * @return True if the Z Park button should move all other HeadMountables to Safe Z. 
+     */
+    public boolean isSafeZPark();
 }


### PR DESCRIPTION
# Description
Adds an option to move all HeadMountables on the same Head to Safe Z when Park Z is pressed.
# Justification
See discussion here (second item):
https://groups.google.com/g/openpnp/c/_BqWBSMAdt8/m/adpLhMQxEAAJ

# Instructions for Use
Enabled the **Park all at Safe Z?** option on the Machine:

![image](https://user-images.githubusercontent.com/9963310/147965494-a6c753ae-0956-416d-b2f6-b55ffda1358d.png)

Use the Z Park button 

![image](https://user-images.githubusercontent.com/9963310/147965564-8ace7264-c015-4e7e-9124-01ff8ce49211.png)


# Implementation Details
1. Tested in simulation.
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. New `Machine.isSafeZPark()` in  `org.openpnp.spi` package.
4. Successful `mvn test` before submitting the Pull Request.
