### PR TITLE
Fix / Visual Homing with Advanced Camera Calibration

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/ReferenceHead.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceHead.java
@@ -38,6 +38,7 @@ import org.openpnp.model.Part;
 import org.openpnp.model.Solutions;
 import org.openpnp.spi.Axis;
 import org.openpnp.spi.HeadMountable;
+import org.openpnp.spi.Locatable.LocationOption;
 import org.openpnp.spi.PropertySheetHolder;
 import org.openpnp.spi.base.AbstractHead;
 import org.pmw.tinylog.Logger;
@@ -88,6 +89,14 @@ public class ReferenceHead extends AbstractHead {
                     // Use bare X, Y homing coordinates (legacy mode).
                     axesHomingLocation =  new AxesLocation(machine, 
                             (axis) -> (axis.getHomeCoordinate())); 
+                    // For best legacy support, we suppress the camera calibration head offsets, but we do not
+                    // suppress the head offsets in general. Whether it was a bug or a feature to not account for the 
+                    // head offsets, can be left open. 
+                    Location cameraHomingLocation = hm.toHeadMountableLocation(hm.toTransformed(axesHomingLocation), 
+                            LocationOption.SuppressCameraCalibration);
+                    // Having the legacy camera location, we can derive the axesHomingLocation, this time accounting 
+                    // for the camera calibration head offsets.
+                    axesHomingLocation = hm.toRaw(hm.toHeadLocation(cameraHomingLocation));
                 }
                 // Just take the X and Y axes.
                 axesHomingLocation = axesHomingLocation.byType(Axis.Type.X, Axis.Type.Y); 

--- a/src/main/java/org/openpnp/machine/reference/SimulationModeMachine.java
+++ b/src/main/java/org/openpnp/machine/reference/SimulationModeMachine.java
@@ -34,7 +34,6 @@ import org.openpnp.machine.reference.camera.ImageCamera;
 import org.openpnp.machine.reference.driver.GcodeDriver;
 import org.openpnp.machine.reference.driver.NullDriver;
 import org.openpnp.machine.reference.driver.ReferenceDriverCommunications;
-import org.openpnp.machine.reference.driver.SimulatedCommunications;
 import org.openpnp.machine.reference.feeder.BlindsFeeder;
 import org.openpnp.machine.reference.feeder.ReferenceStripFeeder;
 import org.openpnp.machine.reference.wizards.SimulationModeMachineConfigurationWizard;
@@ -400,7 +399,8 @@ public class SimulationModeMachine extends ReferenceMachine {
     public static Location getSimulatedPhysicalLocation(HeadMountable hm, Looking looking) {
         // Use ideal location as a default, used in case this fails (not a place to throw).
         Location location = hm.getLocation().convertToUnits(AxesLocation.getUnits());
-        if (Configuration.get().getMachine() == null) {
+        Machine plainMachine = Configuration.get().getMachine();
+        if (plainMachine == null) {
             // Uninitialized (Unit Test). 
             return location;
         }
@@ -408,12 +408,17 @@ public class SimulationModeMachine extends ReferenceMachine {
         SimulationModeMachine machine = getSimulationModeMachine();
         if (machine == null || machine.getSimulationMode() == SimulationMode.Off) {
             // Not a simulation machine. Just take the momentary nominal location.
-            if (Configuration.get().getMachine() instanceof ReferenceMachine) {
+            if (plainMachine instanceof ReferenceMachine) {
                 double cameraTime = NanosecondTime.getRuntimeSeconds();
-                Motion momentary = ((ReferenceMachine)Configuration.get()
-                        .getMachine()).getMotionPlanner()
+                Motion momentary = ((ReferenceMachine)plainMachine).getMotionPlanner()
                         .getMomentaryMotion(cameraTime);
                 AxesLocation axesLocation = momentary.getMomentaryLocation(cameraTime - momentary.getPlannedTime0());
+                try {
+                    axesLocation = applyHomingOffsets(plainMachine, axesLocation, hm.getMappedAxes(plainMachine), looking);
+                }
+                catch (Exception e) {
+                    //Logger.trace(e);
+                }
                 location = hm.toTransformed(axesLocation);
                 location = hm.toHeadMountableLocation(location, 
                         LocationOption.SuppressCameraCalibration);
@@ -430,25 +435,7 @@ public class SimulationModeMachine extends ReferenceMachine {
                 double cameraTime = NanosecondTime.getRuntimeSeconds() - lag;
                 AxesLocation axesLocation = getMomentaryVector(machine, cameraTime, (m, time) -> m.getMomentaryLocation(time));
                 AxesLocation mappedAxes = hm.getMappedAxes(machine);
-                if (looking == Looking.Down) {
-                    // This is a down-looking camera, apply the homing error. 
-                    for (Driver driver : mappedAxes.getAxesDrivers(machine)) {
-                        if (driver instanceof NullDriver) {
-                            AxesLocation homingOffsets = ((NullDriver)driver).getHomingOffsets();
-                            // Apply homing offset
-                            axesLocation = axesLocation.subtract(homingOffsets);
-                        }
-                        else if (driver instanceof GcodeDriver) {
-                            ReferenceDriverCommunications comms = ((GcodeDriver) driver).getCommunications();
-                            if (comms instanceof SimulatedCommunications) {
-                                GcodeServer server = ((SimulatedCommunications) comms).getGcodeServer();
-                                AxesLocation homingOffsets = server.getHomingOffsets();
-                                // Apply homing offset
-                                axesLocation = axesLocation.subtract(homingOffsets);
-                            }
-                        }
-                    }
-                }
+                axesLocation = applyHomingOffsets(machine, axesLocation, mappedAxes, looking);
                 if (machine.getSimulationMode().isDynamicallyImperfectMachine()) {
                     // Add vibrations
                     double amplitude = machine.getSimulatedVibrationAmplitude();
@@ -528,6 +515,30 @@ public class SimulationModeMachine extends ReferenceMachine {
         return location;
     }
 
+    protected static AxesLocation applyHomingOffsets(Machine machine,
+            AxesLocation axesLocation, AxesLocation mappedAxes, Looking looking) throws Exception {
+        if (looking == Looking.Down) {
+            // This is a down-looking camera, apply the homing error. 
+            for (Driver driver : mappedAxes.getAxesDrivers(machine)) {
+                if (driver instanceof NullDriver) {
+                    AxesLocation homingOffsets = ((NullDriver)driver).getHomingOffsets();
+                    // Apply homing offset
+                    axesLocation = axesLocation.subtract(homingOffsets);
+                }
+                else if (driver instanceof GcodeDriver) {
+                    ReferenceDriverCommunications comms = ((GcodeDriver) driver).getCommunications();
+                    GcodeServer server = comms.getGcodeServer();
+                    if (server != null) {
+                        AxesLocation homingOffsets = server.getHomingOffsets();
+                        // Apply homing offset
+                        axesLocation = axesLocation.subtract(homingOffsets);
+                    }
+                }
+            }
+        }
+        return axesLocation;
+    }
+
     public static AxesLocation getMomentaryVector(SimulationModeMachine machine,
             double cameraTime, BiFunction<Motion, Double, AxesLocation> function) throws Exception {
         // First take it from the motion planner.
@@ -538,8 +549,8 @@ public class SimulationModeMachine extends ReferenceMachine {
         for (Driver driver : machine.getDrivers()) {
             if (driver instanceof GcodeDriver) {
                 ReferenceDriverCommunications comms = ((GcodeDriver) driver).getCommunications();
-                if (comms instanceof SimulatedCommunications) {
-                    GcodeServer server = ((SimulatedCommunications) comms).getGcodeServer();
+                GcodeServer server = comms.getGcodeServer();
+                if (server != null) {
                     momentary = server
                             .getMomentaryMotion(cameraTime);
                     AxesLocation driverLocation = function.apply(momentary, cameraTime - momentary.getPlannedTime0());

--- a/src/main/java/org/openpnp/machine/reference/driver/ReferenceDriverCommunications.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/ReferenceDriverCommunications.java
@@ -22,6 +22,7 @@ package org.openpnp.machine.reference.driver;
 import java.io.IOException;
 import java.util.concurrent.TimeoutException;
 
+import org.openpnp.util.GcodeServer;
 import org.simpleframework.xml.Attribute;
 
 /**
@@ -114,5 +115,8 @@ public abstract class ReferenceDriverCommunications {
     
     public LineEndingType getLineEndingType() {
         return lineEndingType;
+    }
+    public GcodeServer getGcodeServer() {
+        return null;
     }
 }

--- a/src/main/java/org/openpnp/machine/reference/driver/SimulatedCommunications.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/SimulatedCommunications.java
@@ -10,6 +10,7 @@ import java.util.concurrent.TimeoutException;
 
 import org.openpnp.spi.Driver;
 import org.openpnp.util.GcodeServer;
+import org.pmw.tinylog.Logger;
 
 /**
  * A base class for basic TCP based Drivers. Includes functions for connecting,
@@ -47,11 +48,19 @@ public class SimulatedCommunications extends ReferenceDriverCommunications {
         return "simulated: "+(gcodeServer == null ? "off" : "port "+gcodeServer.getListenerPort());
     }
 
-    public GcodeServer getGcodeServer() throws Exception {
+    @Override
+    public GcodeServer getGcodeServer() {
         if (gcodeServer == null) {
-            gcodeServer = new GcodeServer();
+            try {
+                gcodeServer = new GcodeServer();
+            }
+            catch (Exception e) {
+                Logger.warn(e);
+            }
         }
-        gcodeServer.setDriver(driver);
+        if (gcodeServer != null) {
+            gcodeServer.setDriver(driver);
+        }
         return gcodeServer;
     }
 

--- a/src/main/java/org/openpnp/machine/reference/driver/TcpCommunications.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/TcpCommunications.java
@@ -8,7 +8,6 @@ import java.net.Socket;
 import java.net.SocketTimeoutException;
 import java.util.concurrent.TimeoutException;
 
-import org.openpnp.machine.reference.driver.ReferenceDriverCommunications.LineEndingType;
 import org.openpnp.util.GcodeServer;
 import org.simpleframework.xml.Attribute;
 
@@ -106,6 +105,10 @@ public class TcpCommunications extends ReferenceDriverCommunications {
     public void setDriver(AbstractReferenceDriver driver) {
         this.driver = driver;
     }
-    
+
+    @Override
+    public GcodeServer getGcodeServer() {
+        return gcodeServer;
+    }
 }
 


### PR DESCRIPTION
# Description
Visual Homing with the legacy **ResetToHomeLocation** option did not properly account for the Advanced Camera Calibration. 

The camera should be at nominal homing coordinates when above the homing fiducial, i.e. after visual homing. This was not the case, when the camera had non-zero head offsets, as these are "traditionally" not accounted for in calculating the homing coordinates, when legacy **ResetToHomeLocation** is used. By introducing the Advanced Camera Calibration, we now have dynamic head offsets on the camera that _should_ be accounted for.

For best legacy support, this fix does not alter the existing behavior, i.e. static head offsets are still not accounted for. 

This PR also contains a fix for the `ImageCamera` not showing `G92` adjusted physical locations accurately, e.g. after Visual Homing, when using a regular `ReferenceMachine` and not a `SimulationModeMachine`. This bug has popped up in testing this PR.

# Justification
See the user case:
https://groups.google.com/g/openpnp/c/_BqWBSMAdt8/m/wOPtFJlWBAAJ

Thanks to @tonyluken for finding the culprit! 

# Instructions for Use
See the wiki:
https://github.com/openpnp/openpnp/wiki/Visual-Homing#setting-up-visual-homing

# Implementation Details
1. While the **ResetToFiducialLocation** Visual Homing was retested, the relevant **ResetToHomeLocation** can only be truly tested on a machine with legacy config and the corresponding _preexisting_ physical setup. Testing will be followed up ASAP, or this PR reverted. 
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. Successful `mvn test` before submitting the Pull Request. 
