### PR TITLE
Fix/Issues & Solutions Advanced Camera Calibration, Axis Handling

### DIFF
--- a/src/main/java/org/openpnp/gui/IssuesAndSolutionsPanel.java
+++ b/src/main/java/org/openpnp/gui/IssuesAndSolutionsPanel.java
@@ -344,7 +344,6 @@ public class IssuesAndSolutionsPanel extends JPanel {
             if (issue.getUri() != null) {
                 needInfo = true;
             }
-
         }
         acceptSolutionAction.setEnabled(needAccept && issues.size() == 1);
         dismissSolutionAction.setEnabled(needDismiss);
@@ -352,6 +351,9 @@ public class IssuesAndSolutionsPanel extends JPanel {
         infoAction.setEnabled(needInfo);
         if (issuePanel != null) {
             issuePane.remove(issuePanel);
+            issuePanel.setVisible(false);
+            issuePanel = null;
+            issuePane.revalidate();
         }
         if (issues.size() == 1) {
             issuePanel = new IssuePanel(issues.get(0), machine);

--- a/src/main/java/org/openpnp/gui/components/IssuePanel.java
+++ b/src/main/java/org/openpnp/gui/components/IssuePanel.java
@@ -251,9 +251,6 @@ public class IssuePanel extends JPanel {
                     textField.setEnabled(issue.getState() == Solutions.State.Open);
                     panel.add(subPanel, "4, "+(formRow*2)+",fill, fill");
                     if (stringProperty.getSuggestions() != null) {
-//                        lbl = new JLabel("Suggestions");
-//                        lbl.setToolTipText(property.getToolTip());
-//                        panel.add(lbl, "2, "+(formRow*2)+", right, default");
                         JPanel suggestPanel = new JPanel();
                         suggestPanel.setLayout(new BorderLayout());
                         JLabel lbl2 = new JLabel("Templates: ");

--- a/src/main/java/org/openpnp/machine/reference/driver/GcodeDriver.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/GcodeDriver.java
@@ -1576,6 +1576,7 @@ public class GcodeDriver extends AbstractReferenceDriver implements Named {
         }
 
         try {
+            Logger.debug("Detecting firmware and position reporting, please ignore any errors and warnings.");
             sendCommand("M115");
             String firmware = receiveSingleResponse("^.*FIRMWARE.*");
             if (firmware != null) {
@@ -1608,6 +1609,7 @@ public class GcodeDriver extends AbstractReferenceDriver implements Named {
             else {
                 setReportedAxes("");
             }
+            Logger.debug("End detecting firmware and position reporting.");
         }
         finally {
             if (!wasConnected) {

--- a/src/main/java/org/openpnp/machine/reference/solutions/VisionSolutions.java
+++ b/src/main/java/org/openpnp/machine/reference/solutions/VisionSolutions.java
@@ -65,6 +65,8 @@ import org.openpnp.spi.Camera;
 import org.openpnp.spi.Head;
 import org.openpnp.spi.HeadMountable;
 import org.openpnp.spi.Nozzle;
+import org.openpnp.spi.Nozzle.RotationMode;
+import org.openpnp.spi.base.AbstractCamera;
 import org.openpnp.spi.base.AbstractHead.VisualHomingMethod;
 import org.openpnp.util.LogUtils;
 import org.openpnp.util.MovableUtils;
@@ -122,6 +124,11 @@ public class VisionSolutions implements Solutions.Subject {
     @Attribute(required = false)
     private double zeroKnowledgeDisplacementMm = 1;
     /**
+     * The required minimum offset between primary and secondary calibration fiducial Z.
+     */
+    @Attribute(required = false)
+    private double fiducialsMinimumZOffsetMm = 2;
+    /**
      * How to perform one-sided backlash compensation, before we know anything about the machine. 
      * Note, due to this having evolved, these are no longer backlash offsets in the classic sense, instead they 
      * give a "final approach vector". Hence the negative sign, to be as compatible as possible with backlash 
@@ -139,7 +146,7 @@ public class VisionSolutions implements Solutions.Subject {
     private double fiducialMargin = 1.1;
 
     @Attribute(required = false)
-    private int zeroKnowledgeRunoutCompensationShots = 6;
+    private int zeroKnowledgeRunoutCompensationShots = 2;
 
     @Attribute(required = false)
     private double zeroKnowledgeAutoFocusDepthMm = 2.0;
@@ -161,6 +168,7 @@ public class VisionSolutions implements Solutions.Subject {
     }
 
     private ReferenceMachine machine;
+    private BufferedImage retainedImage;
 
     @Override
     public void findIssues(Solutions solutions) {
@@ -285,26 +293,34 @@ public class VisionSolutions implements Solutions.Subject {
                                 @Override
                                 public void actionPerformed(ActionEvent e) {
                                     new Thread(() -> {
-                                        double bestScore = 0.0;
-                                        for (double diameter = 10; diameter <= maxDiameter; diameter = diameter*Math.sqrt(fiducialMargin) + 1) {
+                                        UiUtils.messageBoxOnException(() -> {
                                             try {
-                                                ScoreRange scoreRange = new ScoreRange();
-                                                Circle result = getSubjectPixelLocation(camera, null, new Circle(0, 0, (int)diameter), 0.05, "Diameter "+(int)diameter+" px - Score {score} ", scoreRange);
-                                                if (bestScore < scoreRange.finalScore) {
-                                                    bestScore = scoreRange.finalScore;
-                                                    featureDiameter = (int) Math.round(result.getDiameter());
+                                                retainedImage = camera.lightSettleAndCapture();
+                                                double bestScore = 0.0;
+                                                for (double diameter = 10; diameter <= maxDiameter; diameter = diameter*Math.sqrt(fiducialMargin) + 1) {
+                                                    try {
+                                                        ScoreRange scoreRange = new ScoreRange();
+                                                        Circle result = getSubjectPixelLocation(camera, null, new Circle(0, 0, (int)diameter), 0.05, "Diameter "+(int)diameter+" px - Score {score} ", scoreRange);
+                                                        if (bestScore < scoreRange.finalScore) {
+                                                            bestScore = scoreRange.finalScore;
+                                                            featureDiameter = (int) Math.round(result.getDiameter());
+                                                        }
+                                                    }
+                                                    catch (Exception e1) {
+                                                        continue;
+                                                    }
+                                                }
+                                                // Preview best diameter again.
+                                                try {
+                                                    getSubjectPixelLocation(camera, null, new Circle(0, 0, (int)featureDiameter), 0.05, "Best Diameter "+(int)featureDiameter+" px", null);
+                                                }
+                                                catch (Exception e1) {
                                                 }
                                             }
-                                            catch (Exception e1) {
-                                                continue;
+                                            finally {
+                                                retainedImage = null;
                                             }
-                                        }
-                                        // Preview best diameter again.
-                                        try {
-                                            getSubjectPixelLocation(camera, null, new Circle(0, 0, (int)featureDiameter), 0.05, "Best Diameter "+(int)featureDiameter+" px", null);
-                                        }
-                                        catch (Exception e1) {
-                                        }
+                                        });
                                         MainFrame.get().getIssuesAndSolutionsTab().solutionChanged();
                                     }).start();
                                 }
@@ -360,8 +376,8 @@ public class VisionSolutions implements Solutions.Subject {
 
                 @Override
                 public boolean isForcedUnsolved() {
-                    // When the camera is not at all calibrated. Always show this as unsolved.
-                    return camera.getUnitsPerPixelPrimary().getX() <= 0.0 || camera.getUnitsPerPixelPrimary().getY() <= 0.0;
+                    // Always show this as unsolved, if data is missing/invalid.
+                    return !isSolvedPrimaryXY(head);
                 }
 
                 @Override
@@ -438,6 +454,12 @@ public class VisionSolutions implements Solutions.Subject {
                             + "Zoom the camera using the scroll-wheel.</p><br/>"
                             + "<p>Then press Accept to capture the position.</p>"
                             + "</html>";
+                }
+
+                @Override
+                public boolean isForcedUnsolved() {
+                    // Always show this as unsolved, if data is missing/invalid.
+                    return !isSolvedSecondaryXY(head);
                 }
 
                 @Override
@@ -614,8 +636,9 @@ public class VisionSolutions implements Solutions.Subject {
 
                 @Override
                 public boolean isForcedUnsolved() {
-                    // When the camera is not at all calibrated. Always show this as unsolved.
-                    return camera.getUnitsPerPixelPrimary().getX() <= 0.0 || camera.getUnitsPerPixelPrimary().getY() <= 0.0;
+                    // When the camera is not at all calibrated, always show this as unsolved.
+                    return !camera.getLocation().isInitialized()
+                            || camera.getUnitsPerPixelPrimary().getX() <= 0.0 || camera.getUnitsPerPixelPrimary().getY() <= 0.0;
                 }
 
                 @Override
@@ -673,18 +696,47 @@ public class VisionSolutions implements Solutions.Subject {
 
     private void perNozzleSolutions(Solutions solutions, ReferenceHead head, ReferenceCamera defaultCamera, Nozzle defaultNozzle, ReferenceNozzle nozzle) {
         if (isSolvedPrimaryXY(head) 
-                && (isSolvedPrimaryZ(head) || defaultNozzle == nozzle)) {
+                && (isSolvedPrimaryZ(head) || defaultNozzle == nozzle)
+                && nozzle.getSafeZ() != null) {
             final Location oldPrimaryFiducialLocation = head.getCalibrationPrimaryFiducialLocation();
             final Location oldSecondaryFiducialLocation = head.getCalibrationSecondaryFiducialLocation();
             final Location oldPrimaryUpp = defaultCamera.getUnitsPerPixelPrimary();
             final Location oldSecondaryUpp = defaultCamera.getUnitsPerPixelSecondary();
-            
+
             final Location oldNozzleOffsets = nozzle.getHeadOffsets();
             final Length oldPrimaryZ = defaultCamera.getCameraPrimaryZ();
             final Length oldSecondaryZ = defaultCamera.getCameraSecondaryZ();
             final boolean oldEnabled3D = defaultCamera.isEnableUnitsPerPixel3D();
+
+            if (defaultNozzle == nozzle
+                    && oldPrimaryFiducialLocation.getLengthZ().isInitialized()
+                    && oldSecondaryFiducialLocation.getLengthZ().isInitialized()
+                    && Math.abs(oldPrimaryFiducialLocation.getLengthZ()
+                            .subtract(oldSecondaryFiducialLocation.getLengthZ())
+                            .convertToUnits(LengthUnit.Millimeters).getValue()) < fiducialsMinimumZOffsetMm) {
+                solutions.add(new Solutions.PlainIssue(
+                        head, 
+                        "Primary/secondary calibration fiducial Z too close together.", 
+                        "Head "+head.getName()+" primary and secondary calibration fiducial Z coordinates must be at least "
+                                +fiducialsMinimumZOffsetMm+"\u00A0mm apart.", 
+                                Solutions.Severity.Error,
+                        "https://github.com/openpnp/openpnp/wiki/Vision-Solutions#nozzle-offsets"));
+            }
+
             for (boolean primary : (nozzle == defaultNozzle && isSolvedSecondaryXY(head)) ? new boolean [] {true, false} : new boolean [] {true} ) {
                 String qualifier = primary ? "primary" : "secondary";
+                Location oldLocation = primary ? oldPrimaryFiducialLocation : oldSecondaryFiducialLocation;
+                if (defaultNozzle == nozzle
+                        && oldLocation.getLengthZ().isInitialized()
+                        && oldLocation.getLengthZ().compareTo(nozzle.getSafeZ()) >= 0) {
+                    solutions.add(new Solutions.PlainIssue(
+                            nozzle, 
+                            "Safe Z of Nozzle "+nozzle.getName()+" lower than "+qualifier+" fiducial Z.", 
+                            "Safe Z of Nozzle "+nozzle.getName()+" is lower than the calibration "+qualifier+" fiducial Z. "
+                                    + "Please change the calibration rig "+qualifier+" height or adjust Save Z.", 
+                            Solutions.Severity.Error,
+                            "https://github.com/openpnp/openpnp/wiki/Vision-Solutions#nozzle-offsets"));
+                }
                 solutions.add(new Solutions.Issue(
                         nozzle, 
                         "Nozzle "+nozzle.getName()+" offsets for the "+qualifier+" fiducial.", 
@@ -707,14 +759,32 @@ public class VisionSolutions implements Solutions.Subject {
                                             "<p>This will also equalize Z of nozzle "+nozzle.getName()+" to Z of the default nozzle "+defaultNozzle.getName()+".</p><br/>")
                                 + "<p>Jog nozzle " + nozzle.getName()
                                 + " over the "+qualifier+" fiducial. Lower the nozzle tip down until it touches the fiducial.</p><br/>"
+                                        + "<p><strong style=\"color:red;\">CAUTION:</strong> this is a very important Z coordinate, please capture it with care.</p><br/>"
                                 + "<p>Then press Accept to capture the nozzle head offsets.</p>"
                                 + "</html>";
+                    }
+
+                    @Override
+                    public boolean isForcedUnsolved() {
+                        // Always show this as unsolved, if data is missing/invalid.
+                        if (nozzle == defaultNozzle) {
+                            if (primary) {
+                                if (!defaultCamera.getDefaultZ().equals(head.getCalibrationPrimaryFiducialLocation().getLengthZ())) {
+                                    return true;
+                                }
+                            }
+                            return !(primary ? isSolvedPrimaryZ(head) : isSolvedSecondaryZ(head));
+                        }
+                        return false;
                     }
 
                     @Override
                     public void setState(Solutions.State state) throws Exception {
                         if (state == State.Solved) {
                             // Check pre-conditions.
+                            if (nozzle.getSafeZ() == null) {
+                                throw new Exception("The nozzle "+nozzle.getName()+" Z axis Safe Z Zone must be set first.");
+                            }
                             if (! isSolvedPrimaryXY(head)) {
                                 throw new Exception("The head "+head.getName()+" primary fiducial location X and Y must be set first.");
                             }
@@ -738,6 +808,16 @@ public class VisionSolutions implements Solutions.Subject {
                                         Location nozzleLocation = nozzle.getLocation();
                                         if (nozzle == defaultNozzle) {
                                             // This is the reference nozzle, set the Z of the fiducial.
+                                            if (nozzle.getSafeZ().compareTo(nozzleLocation.getLengthZ()) <= 0) {
+                                                throw new Exception("The calibration "+qualifier+" fidcuial Z must be lower than Safe Z.");
+                                            }
+                                            else if (!primary
+                                                    && Math.abs(head.getCalibrationPrimaryFiducialLocation().getLengthZ()
+                                                    .subtract(nozzleLocation.getLengthZ())
+                                                    .convertToUnits(LengthUnit.Millimeters).getValue()) < fiducialsMinimumZOffsetMm) {
+                                                throw new Exception("Primary and secondary calibration fidcuial Z must be more than "
+                                                        +fiducialsMinimumZOffsetMm+"\u00A0mm apart.");
+                                            }
                                             if (primary) {
                                                 head.setCalibrationPrimaryFiducialLocation(head.getCalibrationPrimaryFiducialLocation()
                                                         .derive(nozzleLocation, false, false, true, false));
@@ -1227,7 +1307,8 @@ public class VisionSolutions implements Solutions.Subject {
         if (scoreRange == null) {
             scoreRange = new ScoreRange();
         }
-        BufferedImage bufferedImage = camera.lightSettleAndCapture();
+        BufferedImage bufferedImage = (retainedImage != null ?
+                retainedImage : camera.lightSettleAndCapture());
         Mat image = OpenCvUtils.toMat(bufferedImage);
         try {
             int subjectAreaDiameter = (int) (Math.min(image.cols(), image.rows())
@@ -1252,7 +1333,20 @@ public class VisionSolutions implements Solutions.Subject {
                 double y = 0;
                 int n = 0;
                 int da = 360/zeroKnowledgeRunoutCompensationShots;
-                for (int angle = -180+da/2; angle < 180; angle += da) {
+                int angle0 = 0;
+                int angle1 = 360-da;
+                if (movable instanceof Nozzle
+                        && ((Nozzle) movable).getRotationMode() == RotationMode.LimitedArticulation) {
+                    // Make sure it is compliant.
+                    zeroKnowledgeRunoutCompensationShots = Math.min(zeroKnowledgeRunoutCompensationShots, 2);
+                    da = 360/zeroKnowledgeRunoutCompensationShots;
+                    angle0 = 0;
+                    angle1 = 360-da;
+                    Location l0 = l.derive(new Location(l.getUnits(), 0, 0, 0, angle0), false, false, false, true);
+                    Location l1 = l.derive(new Location(l.getUnits(), 0, 0, 0, angle1), false, false, false, true);
+                    ((Nozzle) movable).prepareForPickAndPlaceArticulation(l0, l1);
+                }
+                for (int angle = angle0; angle <= angle1; angle += da) {
                     l = l.derive(new Location(l.getUnits(), 0, 0, 0, angle), false, false, false, true);
                     movable.moveTo(l);
                     bufferedImage = camera.lightSettleAndCapture();
@@ -1353,24 +1447,61 @@ public class VisionSolutions implements Solutions.Subject {
     }
 
     public boolean isSolvedPrimaryXY(ReferenceHead head) {
+        AbstractCamera camera;
+        try {
+            camera = (AbstractCamera) head.getDefaultCamera();
+        }
+        catch (Exception e) {
+            return false;
+        }
+        if (camera.getUnitsPerPixelPrimary().getX() <= 0.0 || camera.getUnitsPerPixelPrimary().getY() <= 0.0) {
+            return false;
+        }
         Location fiducialLocation = head.getCalibrationPrimaryFiducialLocation();
         return fiducialLocation.getLengthX().isInitialized()
-               && fiducialLocation.getLengthY().isInitialized();
+               && fiducialLocation.getLengthY().isInitialized()
+               && head.getCalibrationPrimaryFiducialDiameter().isInitialized();
     }
 
     public boolean isSolvedPrimaryZ(ReferenceHead head) {
+        Nozzle nozzle;
+        try {
+            nozzle = head.getDefaultNozzle();
+        }
+        catch (Exception e) {
+            return false;
+        }
         Location fiducialLocation = head.getCalibrationPrimaryFiducialLocation();
+        if (nozzle.getSafeZ() == null || nozzle.getSafeZ().compareTo(fiducialLocation.getLengthZ()) <= 0) {
+            return false; // Cannot be lower than Safe Z.
+        }
         return fiducialLocation.getLengthZ().isInitialized();
     }
 
     public boolean isSolvedSecondaryXY(ReferenceHead head) {
         Location fiducialLocation = head.getCalibrationSecondaryFiducialLocation();
         return fiducialLocation.getLengthX().isInitialized()
-               && fiducialLocation.getLengthY().isInitialized();
+               && fiducialLocation.getLengthY().isInitialized()
+               && head.getCalibrationSecondaryFiducialDiameter().isInitialized();
     }
 
     public boolean isSolvedSecondaryZ(ReferenceHead head) {
+        Nozzle nozzle;
+        try {
+            nozzle = head.getDefaultNozzle();
+        }
+        catch (Exception e) {
+            return false;
+        }
         Location fiducialLocation = head.getCalibrationSecondaryFiducialLocation();
+        if (nozzle.getSafeZ() == null || nozzle.getSafeZ().compareTo(fiducialLocation.getLengthZ()) <= 0) {
+            return false; // Cannot be lower than Safe Z.
+        }
+        else if (Math.abs(head.getCalibrationPrimaryFiducialLocation().getLengthZ()
+                .subtract(fiducialLocation.getLengthZ())
+                .convertToUnits(LengthUnit.Millimeters).getValue()) < fiducialsMinimumZOffsetMm) {
+            return false; // Primary/secondary fiducial Z must be sufficiently different.
+        }
         return fiducialLocation.getLengthZ().isInitialized();
     }
 


### PR DESCRIPTION
# Description
According to feedback from the testing, improves Issues & Solutions to validate more preconditions, automatically re-open solutions and add Z and Rotation axes solutions.

1. Reject any calibration fiducial Z above Safe Z.
2. Reject secondary calibration fiducial, if Z is less that 2mm different from primary (min offset can be set in `machine.xml`).
3. For all solutions using fiducials, also check that the fiducial diameter is set (it was only looking at X, Y coordinates before). A user might have tried to capture fiducials manually, and forgot the diameter. Solutions will not be offered in this case.
4. For all solutions using the primary fiducial, also check that camera UPP are set. A user might have tried to capture fiducials manually, but not set the UPP. Solutions will not be offered in this case.
5. For all solutions using fiducials, re-check (1) and (2). A user might have lowered Safe Z in the mean-time, or manually fiddled with fiducial coordinates. Solutions will not be offered in this case.
6. For the Advanced Camera Calibration, check the above preconditions (for the down-looking camera) or check camera location and UPP (for the up-looking camera). Solutions will not be offered in this case.
7. Re-open fiducial/preliminary camera calibration solutions automatically, when any of the above is not (no longer) OK.
8. Issues & Solutions error when Safe Z Zone is invalid (lower > higher).
9. Caution users to do the calibration fiducial Z capture carefully.
10. Provide better warning when doing Advanced Camera Calibration for the bottom camera: nozzle must not collide when moving across whole view area.
11. Issues & Solutions error when a Z or Rotation axis is shared with a Nozzle. Solution unassigns axis from camera. 
12. Issues & Solutions solution to assign existing or create new Virtual Z and Rotation Axes to camera.

# Justification
See the discussion group about Advanced Camera Calibration.
https://groups.google.com/g/openpnp/c/LfUO3tQs5HE/m/7tTVnlW7AgAJ
https://groups.google.com/g/openpnp/c/dBg7txMB0R0/m/96I6ccEHBgAJ
https://groups.google.com/g/openpnp/c/XLuQGxR_r4Q/m/e-_HhL-oBQAJ

# Instructions for Use
Issues & Solutions will reject invalid Z on calibration fiducials when trying to capture. This will also catch the case where the user forgets to lower Z to capture (which seems to happen, according to testing):

![Screenshot_20220115_122628](https://user-images.githubusercontent.com/9963310/149677003-4198559e-a55b-4553-9f2b-976695670e29.png)
![Screenshot_20220115_123215](https://user-images.githubusercontent.com/9963310/149677021-eb5ca2ee-fac2-430a-9252-495a61bf863e.png)

Issues & Solutions will report _existing_ invalid configurations, either because it was done before the above-mentioned validation, or because fiducial Z and/or Safe Z were changed manually. Note, it will also automatically re-open the solution to reacquire good settings (see the first line in the screen shot):

![Screenshot_20220115_134223](https://user-images.githubusercontent.com/9963310/149677020-ece84f8d-4850-45cd-9bb4-4599f9fdb099.png)
![Screenshot_20220115_181337](https://user-images.githubusercontent.com/9963310/149677019-a09196a7-b4c7-41e9-997c-0b844d5edee8.png)

Wrong camera Z and Rotation axes will be reported:

![image](https://user-images.githubusercontent.com/9963310/149677237-da500269-89fa-4810-9339-8354e2cb98ee.png)

Missing camera Virtual Axes can now be automatically created an assigned:

![image](https://user-images.githubusercontent.com/9963310/149677263-2814b41f-42eb-4405-9ff3-d39668b81306.png)


# Implementation Details
1. Tested with user's configuration.
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. Successful `mvn test` before submitting the Pull Request.
