### PR TITLE
Fix / Issues & Solutions more Watertight - Round 2

### DIFF
--- a/src/main/java/org/openpnp/gui/FeedersPanel.java
+++ b/src/main/java/org/openpnp/gui/FeedersPanel.java
@@ -705,6 +705,9 @@ public class FeedersPanel extends JPanel implements WizardContainer {
     }
 
     protected static Nozzle getCompatibleNozzleAndTip(Feeder feeder, boolean allowNozzleTipChange) throws Exception {
+        if (feeder.getPart() == null) {
+            throw new Exception("Feeder has not part set.");
+        }
         // Check the nozzle tip package compatibility.
         Nozzle nozzle = MainFrame.get().getMachineControls().getSelectedNozzle();
         org.openpnp.model.Package packag = feeder.getPart().getPackage();

--- a/src/main/java/org/openpnp/gui/processes/CalibrateCameraProcess.java
+++ b/src/main/java/org/openpnp/gui/processes/CalibrateCameraProcess.java
@@ -55,6 +55,7 @@ import org.openpnp.model.Point;
 import org.openpnp.spi.Camera;
 import org.openpnp.spi.HeadMountable;
 import org.openpnp.spi.Nozzle;
+import org.openpnp.spi.Nozzle.RotationMode;
 import org.openpnp.util.CameraWalker;
 import org.openpnp.util.ImageUtils;
 import org.openpnp.util.MovableUtils;
@@ -430,6 +431,14 @@ public abstract class CalibrateCameraProcess {
             protected Void doInBackground() throws Exception {
                 publish("Estimating Units Per Pixel.");
                 try {
+                    if (movable instanceof Nozzle
+                            && ((Nozzle) movable).getRotationMode() == RotationMode.LimitedArticulation
+                            && angleIncrement < 360) {
+                        // Make sure it is compliant with limited articulation.
+                        Location l1 = centralLocation.derive(null, null, null, (double) angleIncrement);
+                        ((Nozzle) movable).prepareForPickAndPlaceArticulation(centralLocation, l1);
+                    }
+
                     cameraWalker.estimateScaling(advCal.getTrialStep(), new Point(pixelsX/2, pixelsY/2));
                 }
                 catch (Exception e) {

--- a/src/main/java/org/openpnp/machine/reference/driver/wizards/AbstractReferenceDriverConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/wizards/AbstractReferenceDriverConfigurationWizard.java
@@ -108,13 +108,7 @@ public class AbstractReferenceDriverConfigurationWizard extends AbstractConfigur
         communicationsType = new JComboBox(CommunicationsType.values());
         communicationsType.addItemListener(new ItemListener() {
             public void itemStateChanged(ItemEvent e) {
-                if (communicationsType.getSelectedItem() == CommunicationsType.serial) {
-                    setPanelEnabled(panelSerial, true);
-                    setPanelEnabled(panelTcp, false);
-                } else {
-                    setPanelEnabled(panelSerial, false);
-                    setPanelEnabled(panelTcp, true);
-                }
+                communicationsTypeChanged();
             }
         });
         
@@ -328,5 +322,17 @@ public class AbstractReferenceDriverConfigurationWizard extends AbstractConfigur
         addWrappedBinding(driver, "port", portTextField, "text", integerConverter);
 
         ComponentDecorators.decorateWithAutoSelect(driverName);
+
+        communicationsTypeChanged();
+    }
+
+    protected void communicationsTypeChanged() {
+        if (communicationsType.getSelectedItem() == CommunicationsType.serial) {
+            setPanelEnabled(panelSerial, true);
+            setPanelEnabled(panelTcp, false);
+        } else {
+            setPanelEnabled(panelSerial, false);
+            setPanelEnabled(panelTcp, true);
+        }
     }
 }

--- a/src/main/java/org/openpnp/machine/reference/solutions/VisionSolutions.java
+++ b/src/main/java/org/openpnp/machine/reference/solutions/VisionSolutions.java
@@ -648,6 +648,9 @@ public class VisionSolutions implements Solutions.Subject {
                             throw new Exception("The nozzle "+defaultNozzle.getName()+" head offsets are not yet set. "
                                     + "You need to perform the \"Nozzle "+defaultNozzle.getName()+" offsets for the primary fiducial\" calibration first.");
                         }
+                        if (referenceNozzleTip == null) {
+                            throw new Exception("The nozzle "+defaultNozzle.getName()+" has no nozzle tip loaded.");
+                        }
 
                         final State oldState = getState();
                         UiUtils.submitUiMachineTask(
@@ -661,10 +664,8 @@ public class VisionSolutions implements Solutions.Subject {
                                     camera.setHeadOffsets(nozzleLocation);
                                     Logger.info("Set camera "+camera.getName()+" offsets to "+headOffsets
                                             +" (previously "+oldCameraOffsets+")");
-                                    if (referenceNozzleTip != null) {
-                                        referenceNozzleTip.getCalibration().setCalibrationTipDiameter(visionDiameter);
-                                        Logger.info("Set nozzle tip "+referenceNozzleTip.getName()+" vision diameter to "+visionDiameter+" (previously "+oldVisionDiameter+")");
-                                    }
+                                    referenceNozzleTip.getCalibration().setCalibrationTipDiameter(visionDiameter);
+                                    Logger.info("Set nozzle tip "+referenceNozzleTip.getName()+" vision diameter to "+visionDiameter+" (previously "+oldVisionDiameter+")");
                                     return true;
                                 },
                                 (result) -> {

--- a/src/main/java/org/openpnp/spi/base/AbstractHeadMountable.java
+++ b/src/main/java/org/openpnp/spi/base/AbstractHeadMountable.java
@@ -252,14 +252,20 @@ public abstract class AbstractHeadMountable extends AbstractModelObject implemen
                 throw new Exception("Effective Safe Z coordinate "+safeZ+" is outside Safe Z Zone.");
             }
             safeZ = safeZ.convertToUnits(l.getUnits());
-            if (safeZ.getValue() > l.getZ() || !isInSafeZZone(l.getLengthZ())) {
-                // Only move if 
-                // a) the new effective Safe Z is higher than current Z, or 
-                // b) the current Z is outside the safe zone.
-                // The second condition must be checked for shared Z with negating transform, where the Safe Z Zone 
-                // is limited on two sides. 
+            if (safeZ.getValue() > l.getZ()) {
+                // Only move if the new effective Safe Z is higher than current Z. 
                 l = l.derive(null, null, safeZ.getValue(), null);
                 moveTo(l, speed);
+            }
+            else if (!isInSafeZZone(l.getLengthZ())) {
+                // Still outside safe Z Zone (above it), for shared Z with negating transform, where the Safe Z Zone 
+                // is limited on two sides. 
+                safeZ = getSafeZZone()[1];
+                if (safeZ != null) {
+                    safeZ = safeZ.convertToUnits(l.getUnits());
+                    l = l.derive(null, null, safeZ.getValue(), null);
+                    moveTo(l, speed);
+                }
             }
         }
     }

--- a/src/main/java/org/openpnp/spi/base/AbstractNozzle.java
+++ b/src/main/java/org/openpnp/spi/base/AbstractNozzle.java
@@ -21,6 +21,7 @@ import org.openpnp.spi.Head;
 import org.openpnp.spi.Nozzle;
 import org.openpnp.spi.NozzleTip;
 import org.openpnp.util.Utils2D;
+import org.pmw.tinylog.Logger;
 import org.simpleframework.xml.Attribute;
 import org.simpleframework.xml.ElementList;
 
@@ -191,6 +192,7 @@ public abstract class AbstractNozzle extends AbstractHeadMountable implements No
         Object oldValue = this.rotationModeOffset;
         this.rotationModeOffset = rotationModeOffset;
         firePropertyChange("rotationModeOffset", oldValue, rotationModeOffset);
+        Logger.trace("Set rotation mode offset: "+rotationModeOffset != null ? rotationModeOffset+"°." : "none.");
         // Note, we do not 
         //  fireMachineHeadActivity(head); 
         // as only the upcoming coordinate changes will really make sense and matter.

--- a/src/main/java/org/openpnp/util/MovableUtils.java
+++ b/src/main/java/org/openpnp/util/MovableUtils.java
@@ -1,5 +1,6 @@
 package org.openpnp.util;
 
+import org.openpnp.model.AxesLocation;
 import org.openpnp.model.Configuration;
 import org.openpnp.model.Length;
 import org.openpnp.model.Location;
@@ -26,8 +27,9 @@ public class MovableUtils {
             throws Exception {
         Head head = hm.getHead();
         Location currentLocationWithNewZ = hm.getLocation().derive(location, false, false, true, false);
-        if (! hm.toRaw(hm.toHeadLocation(location, LocationOption.Quiet), LocationOption.Quiet)
-                .matches(hm.toRaw(hm.toHeadLocation(currentLocationWithNewZ, LocationOption.Quiet), LocationOption.Quiet))) {
+        AxesLocation rawLocation = hm.toRaw(hm.toHeadLocation(location, LocationOption.Quiet), LocationOption.Quiet);
+        AxesLocation rawLocationWithNewZ = hm.toRaw(hm.toHeadLocation(currentLocationWithNewZ, LocationOption.Quiet), LocationOption.Quiet);
+        if (! rawLocation.matches(rawLocationWithNewZ)) {
             // Moves in X, Y or C, move to safe Z needed. 
             head.moveToSafeZ(speed);
             // Determine the exit Safe Z of that hm to optimize the move. In shared axis configurations with a Safe Z Zone


### PR DESCRIPTION
# Description
This is a round-up of bug-fixes and improvements out of testing.

* Error when no nozzle tip loaded in _preliminary_ bottom camera
calibration.
* Disable Advanced Camera Calibration after it fails in the middle.
* Advanced Camera Calibration tool selection in Machine Controls from I&S: bug-fix.
* Limited articulation Rotation Mode support for Advanced Camera
Calibration.
* Log new rotation mode offset being set.
* Communications type visibility initially not established in Driver Wizard: bug-fix.
* Better serial flow control vs. confirmation flow control solutions.
* Optimize Safe Z moving: always move HeadMountables to the _nearer_ limit of the Safe Z Zone:
   ![image](https://user-images.githubusercontent.com/9963310/150399494-5c203901-017e-4868-8e3a-4ab29632ff61.png)
* Feeder no part assigned caught in GUI actions.

# Justification
See these discussions:
https://groups.google.com/g/openpnp/c/MnKQK_Keww8/m/k9q2R3n7AQAJ
See #1360 (ongoing).

# Instructions for Use
No substantial change in use. 

![Screenshot_20220120_172007](https://user-images.githubusercontent.com/9963310/150399063-e6d898f3-fe61-4760-b775-0496c565c600.png)

# Implementation Details
1. Tested in simulation, with user config.
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. Successful `mvn test` before submitting the Pull Request.
