### PR TITLE
Fix the ACTUATOR_READ_REGEX template, hide the Position & Rotation bu…

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/camera/calibration/LensCalibrationParams.java
+++ b/src/main/java/org/openpnp/machine/reference/camera/calibration/LensCalibrationParams.java
@@ -19,11 +19,9 @@
 
 package org.openpnp.machine.reference.camera.calibration;
 
-import org.opencv.core.Core;
 import org.opencv.core.CvType;
 import org.opencv.core.Mat;
 import org.openpnp.model.AbstractModelObject;
-import org.pmw.tinylog.Logger;
 import org.simpleframework.xml.Attribute;
 import org.simpleframework.xml.Element;
 import org.simpleframework.xml.core.Commit;
@@ -45,11 +43,11 @@ public class LensCalibrationParams extends AbstractModelObject {
     @Commit void commit() {
         cameraMatrix.put(0, 0, cameraMatrixArr);
         distortionCoefficients.put(0, 0, distortionCoefficientsArr);
-        if (!Core.checkRange(distortionCoefficients, true, -10e6, +10e6)) {
+        /*if (!Core.checkRange(distortionCoefficients, true, -10e6, +10e6)) {
             Logger.warn("distortionCoefficients = " + distortionCoefficients.dump());
             Logger.warn("Distortion Coefficients have extreme values - resetting all to zero");
             distortionCoefficients.put(0, 0, new double[5] );
-        }
+        }*/
     }
 
     @Persist void persist() {

--- a/src/main/java/org/openpnp/machine/reference/solutions/ActuatorSolutions.java
+++ b/src/main/java/org/openpnp/machine/reference/solutions/ActuatorSolutions.java
@@ -89,8 +89,8 @@ public class ActuatorSolutions implements Solutions.Subject {
         HashMap<CommandType, String []> suggestions = new HashMap<>();
         suggestions.put(CommandType.ACTUATOR_READ_COMMAND, new String[] { "M105 ; read inputs" });
         suggestions.put(CommandType.ACTUATOR_READ_REGEX, new String[] { 
-                "*\u2753:(?<Value>-?\\d+).*",
-                "*\u2753:(?<Value>-?\\d+\\.\\d+).*" 
+                ".*\u2753:(?<Value>-?\\d+).*",
+                ".*\u2753:(?<Value>-?\\d+\\.\\d+).*" 
         });
         new ActuatorSolutions(actuator).findActuatorIssues(solutions, holder, qualifier, 
                 new CommandType[] { CommandType.ACTUATOR_READ_COMMAND, CommandType.ACTUATOR_READ_REGEX }, suggestions, 

--- a/src/main/java/org/openpnp/machine/reference/wizards/ReferenceNozzleTipCalibrationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/wizards/ReferenceNozzleTipCalibrationWizard.java
@@ -46,6 +46,7 @@ import org.openpnp.gui.support.AbstractConfigurationWizard;
 import org.openpnp.gui.support.Icons;
 import org.openpnp.gui.support.IntegerConverter;
 import org.openpnp.gui.support.LengthConverter;
+import org.openpnp.machine.reference.ReferenceCamera;
 import org.openpnp.machine.reference.ReferenceNozzle;
 import org.openpnp.machine.reference.ReferenceNozzleTip;
 import org.openpnp.machine.reference.ReferenceNozzleTipCalibration;
@@ -62,6 +63,7 @@ import org.openpnp.util.VisionUtils;
 import org.openpnp.vision.pipeline.CvPipeline;
 import org.openpnp.vision.pipeline.ui.CvPipelineEditor;
 import org.openpnp.vision.pipeline.ui.CvPipelineEditorDialog;
+import org.pmw.tinylog.Logger;
 
 import com.jgoodies.forms.layout.CellConstraints;
 import com.jgoodies.forms.layout.ColumnSpec;
@@ -451,6 +453,18 @@ public class ReferenceNozzleTipCalibrationWizard extends AbstractConfigurationWi
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(offsetThresholdTf);
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(calibrationZOffsetTf);
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(calibrationTipDiameter);
+
+        try {
+            Camera camera = VisionUtils.getBottomVisionCamera();
+            if (camera instanceof ReferenceCamera) {
+                if (((ReferenceCamera) camera).getAdvancedCalibration().isOverridingOldTransformsAndDistortionCorrectionSettings()) {
+                    btnCalibrateCamera.setVisible(false);
+                }
+            }
+        }
+        catch (Exception e1) {
+            Logger.warn(e1);
+        }
     }
     protected void initDataBindings() {
         BeanProperty<JCheckBox, Boolean> jCheckBoxBeanProperty = BeanProperty.create("selected");

--- a/src/test/java/CvStageTest.java
+++ b/src/test/java/CvStageTest.java
@@ -17,9 +17,14 @@
  * For more information about OpenPnP visit http://openpnp.org
  */
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.File;
+
 import org.junit.jupiter.api.Test;
 import org.openpnp.model.Area;
 import org.openpnp.model.AreaUnit;
+import org.openpnp.model.Configuration;
 import org.openpnp.model.Length;
 import org.openpnp.model.LengthUnit;
 import org.openpnp.model.Location;
@@ -27,7 +32,7 @@ import org.openpnp.spi.Camera;
 import org.openpnp.vision.pipeline.CvPipeline;
 import org.openpnp.vision.pipeline.CvStage;
 
-import static org.junit.jupiter.api.Assertions.*;
+import com.google.common.io.Files;
 
 
 public class CvStageTest {
@@ -51,6 +56,13 @@ public class CvStageTest {
 	 */
     @Test
     public void testPipelinePropertyOverrides() throws Exception {
+        File workingDirectory = Files.createTempDir();
+        workingDirectory = new File(workingDirectory, ".openpnp");
+        System.out.println("Configuration directory: " + workingDirectory);
+
+        Configuration.initialize(workingDirectory);
+        Configuration.get().load();
+
         Camera camera = new VisionUtilsTest.TestCamera();
         
         String propName = "propName";


### PR DESCRIPTION
# Description
A small bug-fixing PR for the testing round.

- Fix the `ACTUATOR_READ_REGEX` template.
- Hide the Camera Position & Rotation button in the nozzle tip calibration (superseded by Advanced Camera Calibration)
 
# Justification
Feedback from the testing round.

# Instructions for Use
No change.

# Implementation Details
1. Tested in simulation (only config).
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. Successful  `mvn test` before submitting the Pull Request.
