### PR TITLE
Initialized camera and distortion matrices

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/camera/calibration/LensCalibrationParams.java
+++ b/src/main/java/org/openpnp/machine/reference/camera/calibration/LensCalibrationParams.java
@@ -19,9 +19,11 @@
 
 package org.openpnp.machine.reference.camera.calibration;
 
+import org.opencv.core.Core;
 import org.opencv.core.CvType;
 import org.opencv.core.Mat;
 import org.openpnp.model.AbstractModelObject;
+import org.pmw.tinylog.Logger;
 import org.simpleframework.xml.Attribute;
 import org.simpleframework.xml.Element;
 import org.simpleframework.xml.core.Commit;
@@ -37,17 +39,17 @@ public class LensCalibrationParams extends AbstractModelObject {
     @Element(name = "distortionCoefficients", required = false)
     private double[] distortionCoefficientsArr = new double[5];
 
-    protected Mat cameraMatrix = new Mat(3, 3, CvType.CV_64FC1);
-    protected Mat distortionCoefficients = new Mat(5, 1, CvType.CV_64FC1);
+    protected Mat cameraMatrix = Mat.zeros(3, 3, CvType.CV_64FC1);
+    protected Mat distortionCoefficients = Mat.zeros(5, 1, CvType.CV_64FC1);
 
     @Commit void commit() {
         cameraMatrix.put(0, 0, cameraMatrixArr);
         distortionCoefficients.put(0, 0, distortionCoefficientsArr);
-        /*if (!Core.checkRange(distortionCoefficients, true, -10e6, +10e6)) {
+        if (!Core.checkRange(distortionCoefficients, true, -10e6, +10e6)) {
             Logger.warn("distortionCoefficients = " + distortionCoefficients.dump());
             Logger.warn("Distortion Coefficients have extreme values - resetting all to zero");
             distortionCoefficients.put(0, 0, new double[5] );
-        }*/
+        }
     }
 
     @Persist void persist() {


### PR DESCRIPTION
# Description
Explicitly initialize the cameraMatrix and distortionCoefficients matrices to prevent unnecessary warning messages during Maven tests..

# Justification
Eliminates unnecessary warning messages during Maven test so there are fewer things to sort through.

# Instructions for Use
No special instructions for the user.

# Implementation Details
1. How did you test the change? **Ran Maven tests several times and observed no warnings due to uninitialized memory.**
2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)? **Yes.**
3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing. **No changes.**
4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted. **Maven tests were run and all passed.**
