### PR TITLE
Fix/PadExtents

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/vision/ReferenceBottomVision.java
+++ b/src/main/java/org/openpnp/machine/reference/vision/ReferenceBottomVision.java
@@ -1,6 +1,6 @@
 package org.openpnp.machine.reference.vision;
 
-import java.awt.Rectangle;
+import java.awt.geom.Rectangle2D;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -318,7 +318,7 @@ public class ReferenceBottomVision extends AbstractPartAlignment {
                 checkHeight = footprint.getBodyHeight();
                 break;
             case PadExtents:
-                Rectangle bounds = footprint.getPadsShape().getBounds();
+                Rectangle2D bounds = footprint.getPadsShape().getBounds2D();
                 checkWidth = bounds.getWidth();
                 checkHeight = bounds.getHeight();
                 break;


### PR DESCRIPTION
# Description
Fixes a bug in the Bottom Vision Check Size feature, when using the PadExtents option: 

![image](https://user-images.githubusercontent.com/9963310/151230137-9fe7e6de-7630-4e42-bdc9-605d603f9cc0.png)

For some reasons, Java `getBounds()` will not return a bounding rectangle that is guaranteed to be minimal. Typically, a larger rectangle that somehow bounds the shape can be returned. Instead you need to use `getBounds2D()`.

# Justification
See the user case:
https://groups.google.com/g/openpnp/c/V6fCVaSwyZ4/m/dRdX6Ka_AAAJ

# Instructions for Use
No change. 

# Implementation Details
1. User tested the change, and `mvn test`.
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. Successful `mvn test` before submitting the Pull Request.
