### PR TITLE
Fix/Issues & Solutions Axes Handling, Firmware Detection

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/driver/GcodeAsyncDriver.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/GcodeAsyncDriver.java
@@ -26,8 +26,6 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 
 import org.openpnp.gui.support.PropertySheetWizardAdapter;
-import org.openpnp.machine.reference.ReferenceHeadMountable;
-import org.openpnp.machine.reference.ReferenceMachine;
 import org.openpnp.machine.reference.driver.wizards.GcodeAsyncDriverSettings;
 import org.openpnp.model.Length;
 import org.openpnp.model.LengthUnit;
@@ -314,6 +312,10 @@ public class GcodeAsyncDriver extends GcodeDriver {
 
         Logger.debug("{} commandQueue.offer({}, {})...", getCommunications().getConnectionName(), command, timeout);
         command = preProcessCommand(command);
+        if (command.isEmpty()) {
+            Logger.debug("{} empty command after pre process", getCommunications().getConnectionName());
+            return;
+        }
         CommandLine commandLine = new CommandLine(command, timeout);
         commandQueue.offer(commandLine, writerQueueTimeout, TimeUnit.MILLISECONDS);
     }

--- a/src/main/java/org/openpnp/machine/reference/driver/GcodeDriver.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/GcodeDriver.java
@@ -1394,8 +1394,6 @@ public class GcodeDriver extends AbstractReferenceDriver implements Named {
         return false;
     }
 
-
-
     @Override
     public PropertySheet[] getPropertySheets() {
         return new PropertySheet[] {
@@ -1526,6 +1524,23 @@ public class GcodeDriver extends AbstractReferenceDriver implements Named {
         this.reportedAxes = reportedAxes;
         firePropertyChange("reportedAxes", oldValue, reportedAxes);
         firePropertyChange("firmwareConfiguration", null, getFirmwareConfiguration());
+    }
+
+    public List<String> getReportedAxesLetters() {
+        List<String> reportedLetters = new ArrayList<>();
+        if (getReportedAxes() == null) {
+            return reportedLetters;
+        }
+        Pattern p = Pattern.compile("(?<letter>[A-Z]):-?\\d+.\\d+");
+        Matcher m = p.matcher(getReportedAxes());
+        while (m.find()) {
+            String letter = m.group("letter");
+            if (!reportedLetters.contains(letter) // No duplicates.
+                    && (!letter.equals("E") || reportedLetters.contains("A"))) { // Not E, if solo.
+                reportedLetters.add(letter);
+            }
+        }
+        return reportedLetters;
     }
 
     public String getConfiguredAxes() {

--- a/src/main/java/org/openpnp/machine/reference/driver/GcodeDriver.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/GcodeDriver.java
@@ -1058,7 +1058,8 @@ public class GcodeDriver extends AbstractReferenceDriver implements Named {
 
         Logger.debug("[{}] >> {}, {}", getCommunications().getConnectionName(), command, timeout);
         command = preProcessCommand(command);
-        if (command == "") {
+        if (command.isEmpty()) {
+            Logger.debug("{} empty command after pre process", getCommunications().getConnectionName());
             return;
         }
 

--- a/src/main/java/org/openpnp/machine/reference/solutions/GcodeDriverSolutions.java
+++ b/src/main/java/org/openpnp/machine/reference/solutions/GcodeDriverSolutions.java
@@ -257,13 +257,13 @@ public class GcodeDriverSolutions implements Solutions.Subject {
                                 gcodeDriver.getFirmwareProperty("FIRMWARE_VERSION", "").contains("chmt-")?
                                         FirmwareType.SmoothiewareChmt : FirmwareType.Smoothieware;
                     firmwareAxesCount = Integer.valueOf(gcodeDriver.getFirmwareProperty("X-AXES", "0"));
-                    firmwarePrimaryAxesCount = Integer.valueOf(gcodeDriver.getFirmwareProperty("X-PAXES", "3"));
                     if (firmware == FirmwareType.SmoothiewareChmt) {
-                        // OK. Take PAXES == 5 if missing (legacy make)
+                        // OK, CHMT STM32 Smoothieware board. Take PAXES == 5 if missing (legacy build).
                         firmwarePrimaryAxesCount = Integer.valueOf(gcodeDriver.getFirmwareProperty("X-PAXES", "5"));
                     }
-                    else if (firmwarePrimaryAxesCount == firmwareAxesCount) {
-                        // OK.
+                    else if (gcodeDriver.getFirmwareProperty("X-SOURCE_CODE_URL", "").contains("best-for-pnp")) {
+                        // OK, regular Smoothieboard with pnp firmware.
+                        firmwarePrimaryAxesCount = Integer.valueOf(gcodeDriver.getFirmwareProperty("X-PAXES", "3"));
                     }
                     else {
                         solutions.add(new Solutions.PlainIssue(
@@ -271,6 +271,15 @@ public class GcodeDriverSolutions implements Solutions.Subject {
                                 "There is a better Smoothieware firmware available. "+gcodeDriver.getDetectedFirmware(), 
                                 "Please upgrade to the special PnP version. See info link.", 
                                 Severity.Error, 
+                                "https://github.com/openpnp/openpnp/wiki/Motion-Controller-Firmwares#smoothieware"));
+                    }
+                    if (firmwarePrimaryAxesCount != null 
+                            && firmwarePrimaryAxesCount != firmwareAxesCount) {
+                        solutions.add(new Solutions.PlainIssue(
+                                gcodeDriver, 
+                                "Smoothieware firmware should be made with the PAXIS="+firmwareAxesCount+" option.", 
+                                "Download an up-to-date firmware built for OpenPnP, or if you build the firmware yourself, please use the `make AXIS="+firmwareAxesCount+" PAXIS="+firmwareAxesCount+"` command. See info link.", 
+                                Severity.Warning, 
                                 "https://github.com/openpnp/openpnp/wiki/Motion-Controller-Firmwares#smoothieware"));
                     }
                 }


### PR DESCRIPTION
# Description
Another round-up of bugs and issues that popped up during the testing round.

1. For CHMT machines: the Smoothieware STM32 port (legacy) `PAXIS` build option is now implied and properly handled.
2. Regular Smoothieboard detection improved. Now looking for the "best-for-pnp" tag in the `M115` `X-SOURCE_CODE_URL` property, instead of just relying on the `X-PAXES` property.
3. If `PAXIS` is not reported via `M115` `X-PAXES` property, or if it is reported smaller than `X-AXES`, then Issues & Solutions will remind the user to get or build a better firmware.
3. Issues & Solutions now takes `M114` reported axes as the valid axis letters on the controller. If the reported axes are not (yet) available, it falls back to offer all the standard letters.  
4. Only the valid axis letters are then checked against, and offered in the axis letter assignment issues: 

   ![image](https://user-images.githubusercontent.com/9963310/151693565-3e848b73-9519-4ae0-acd2-9e1f340a82d6.png)

5. Only the valid axis letters are used to propose the `POSITION_REPORT_REGEX`, notably in the order of being reported. Controllers not reporting axes in canonical order are now supported.
4. Axes are now properly handled, if `3 < PAXIS  < AXIS`, i.e. if some, but not all the extra axes are handled as primary/linear. The proper Issues & Solutions warnings are generated, if the **Switch Linear <-> Rotational** checkbox is not set on these (partial) axes. 

# Justification
See the ongoing discussion in the user group.
https://groups.google.com/g/openpnp/c/RT9uaZO82w0/m/4JhuT1omAQAJ

# Instructions for Use
Issues & Solutions contains any changed instructions.

# Implementation Details
1. Tested with the user configuration, and against GcodeServer.
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. Successful `mvn test` before submitting the Pull Request.
