### PR TITLE
Fix / Rotation Axis Default Limits -180° .. 180°, and Rotation Mode

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/driver/AbstractMotionPlanner.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/AbstractMotionPlanner.java
@@ -616,22 +616,25 @@ public abstract class AbstractMotionPlanner extends AbstractModelObject implemen
         Location location = hm.toTransformed(axesLocation);
         location = hm.toHeadMountableLocation(location);
         double limitedRotation = location.getRotation();
-        double limit0 = -180;
-        double limit1 = 180;
-        if (axis.isSoftLimitLowEnabled()) {
-            AxesLocation axesLimit = axesLocation
-                    .put(new AxesLocation(axis, axis.getSoftLimitLow()));
-            Location limit = hm.toTransformed(axesLimit, LocationOption.Quiet);
-            limit = hm.toHeadMountableLocation(limit, LocationOption.Quiet);
-            limit0 = limit.getRotation();
-        }
-        if (axis.isSoftLimitHighEnabled()) {
-            AxesLocation axesLimit = axesLocation
-                    .put(new AxesLocation(axis, axis.getSoftLimitHigh()));
-            Location limit = hm.toTransformed(axesLimit, LocationOption.Quiet);
-            limit = hm.toHeadMountableLocation(limit, LocationOption.Quiet);
-            limit1 = limit.getRotation();
-        }
+        // Lower limit.
+        AxesLocation axesLimitLow = axesLocation
+                .put(new AxesLocation(axis, 
+                        (axis.isSoftLimitLowEnabled() 
+                                ? axis.getSoftLimitLow() 
+                                : new Length(-180, AxesLocation.getUnits()))));
+        Location limitLow = hm.toTransformed(axesLimitLow, LocationOption.Quiet);
+        limitLow = hm.toHeadMountableLocation(limitLow, LocationOption.Quiet);
+        double limit0 = limitLow.getRotation();
+        // Higher limit.
+        AxesLocation axesLimitHigh = axesLocation
+                .put(new AxesLocation(axis, 
+                        (axis.isSoftLimitHighEnabled() 
+                                ? axis.getSoftLimitHigh() 
+                                : new Length(180, AxesLocation.getUnits()))));
+        Location limitHigh = hm.toTransformed(axesLimitHigh, LocationOption.Quiet);
+        limitHigh = hm.toHeadMountableLocation(limitHigh, LocationOption.Quiet);
+        double limit1 = limitHigh.getRotation();
+        // Swap if necessary.
         if (limit0 > limit1) {
             // Transformation must have negated the coordinates.
             double swap = limit0;

--- a/src/main/java/org/openpnp/spi/base/AbstractNozzle.java
+++ b/src/main/java/org/openpnp/spi/base/AbstractNozzle.java
@@ -12,6 +12,7 @@ import org.openpnp.gui.support.Icons;
 import org.openpnp.machine.reference.axis.ReferenceControllerAxis;
 import org.openpnp.model.AxesLocation;
 import org.openpnp.model.Configuration;
+import org.openpnp.model.Length;
 import org.openpnp.model.Location;
 import org.openpnp.model.Part;
 import org.openpnp.spi.Axis;
@@ -114,20 +115,24 @@ public abstract class AbstractNozzle extends AbstractHeadMountable implements No
         if (coordinateAxis instanceof ReferenceControllerAxis) {
             ReferenceControllerAxis refAxis = (ReferenceControllerAxis) coordinateAxis;
             if (refAxis.isLimitRotation()) {
-                if (refAxis.isSoftLimitLowEnabled()) {
-                    AxesLocation axesLimit = getMappedAxes(getMachine())
-                            .put(new AxesLocation(refAxis, refAxis.getSoftLimitLow()));
-                    Location limit = toTransformed(axesLimit, LocationOption.Quiet);
-                    limit = toHeadMountableLocation(limit, LocationOption.Quiet);
-                    limit0 = limit.getRotation();
-                }
-                if (refAxis.isSoftLimitHighEnabled()) {
-                    AxesLocation axesLimit = getMappedAxes(getMachine())
-                            .put(new AxesLocation(refAxis, refAxis.getSoftLimitHigh()));
-                    Location limit = toTransformed(axesLimit, LocationOption.Quiet);
-                    limit = toHeadMountableLocation(limit, LocationOption.Quiet);
-                    limit1 = limit.getRotation();
-                }
+                // Lower limit.
+                AxesLocation axesLimitLow = getMappedAxes(getMachine())
+                        .put(new AxesLocation(refAxis, 
+                                (refAxis.isSoftLimitLowEnabled() 
+                                        ? refAxis.getSoftLimitLow() 
+                                        : new Length(-180, AxesLocation.getUnits()))));
+                Location limitLow = toTransformed(axesLimitLow, LocationOption.Quiet);
+                limitLow = toHeadMountableLocation(limitLow, LocationOption.Quiet);
+                limit0 = limitLow.getRotation();
+                // Higher limit.
+                AxesLocation axesLimitHigh = getMappedAxes(getMachine())
+                        .put(new AxesLocation(refAxis, 
+                                (refAxis.isSoftLimitHighEnabled() 
+                                        ? refAxis.getSoftLimitHigh() 
+                                        : new Length(180, AxesLocation.getUnits()))));
+                Location limitHigh = toTransformed(axesLimitHigh, LocationOption.Quiet);
+                limitHigh = toHeadMountableLocation(limitHigh, LocationOption.Quiet);
+                limit1 = limitHigh.getRotation();
             }
         }
         if (limit0 <= limit1) {
@@ -192,7 +197,7 @@ public abstract class AbstractNozzle extends AbstractHeadMountable implements No
         Object oldValue = this.rotationModeOffset;
         this.rotationModeOffset = rotationModeOffset;
         firePropertyChange("rotationModeOffset", oldValue, rotationModeOffset);
-        Logger.trace("Set rotation mode offset: "+rotationModeOffset != null ? rotationModeOffset+"°." : "none.");
+        Logger.trace("Set rotation mode offset: "+(rotationModeOffset != null ? rotationModeOffset+"°." : "none."));
         // Note, we do not 
         //  fireMachineHeadActivity(head); 
         // as only the upcoming coordinate changes will really make sense and matter.


### PR DESCRIPTION
# Description
Rotation axes default limits -180° .. 180° were not properly calculated when a Rotation Mode offset was applied. Instead of taking raw axis coordinates, it took nozzle coordinates, i.e. potentially shifted by the Rotation Mode offset.

![image](https://user-images.githubusercontent.com/9963310/151865601-1e0cbf12-9a6e-4803-9a15-442013d8541f.png)

This PR fixes it.

A small logging error was also fixed.

# Justification
See user report:
https://groups.google.com/g/openpnp/c/bXTsbYdW4dU/m/0aw54eugAgAJ

# Instructions for Use
See 
https://github.com/openpnp/openpnp/wiki/Nozzle-Rotation-Mode

Note: when using transformed rotation axis, i.e. with raw coordinates that are not degrees, the default limits of -180° .. 180° might now be non-sensical:
https://github.com/openpnp/openpnp/wiki/Nozzle-Rotation-Mode#rotational-axis-transformations

This case might "accidentally" have worked before, as defaults were (mistakenly) taken from _transformed_ nozzle coordinates. For transformed axes, always use _specific_ soft limits instead:
https://github.com/openpnp/openpnp/wiki/Nozzle-Rotation-Mode#rotational-axis-limits

# Implementation Details
1. Tested in simulation with the Rotation Mode machine config from #1309. Running the full test job at limited articulation.
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. Successful `mvn test` before submitting the Pull Request. 
