### PR TITLE
 Remove serial port read timeout. Close port before reader thread join. (resubmit)

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/driver/GcodeDriver.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/GcodeDriver.java
@@ -1284,7 +1284,6 @@ public class GcodeDriver extends AbstractReferenceDriver implements Named {
                 }
                 catch (IOException e) {
                     if (disconnectRequested) {
-                        Logger.trace(e, "Read error while disconnecting");
                         return;
                     }
                     else {

--- a/src/main/java/org/openpnp/machine/reference/driver/GcodeDriver.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/GcodeDriver.java
@@ -991,14 +991,14 @@ public class GcodeDriver extends AbstractReferenceDriver implements Named {
         disconnectRequested = true;
         connected = false;
 
-        disconnectThreads();
-
         try {
             getCommunications().disconnect();
         }
         catch (Exception e) {
             Logger.error(e, "disconnect()");
         }
+
+        disconnectThreads();
 
         closeGcodeLogger();
     }

--- a/src/main/java/org/openpnp/machine/reference/driver/GcodeDriver.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/GcodeDriver.java
@@ -1284,6 +1284,7 @@ public class GcodeDriver extends AbstractReferenceDriver implements Named {
                 }
                 catch (IOException e) {
                     if (disconnectRequested) {
+                        Logger.trace("Read error while disconnecting (normal)");
                         return;
                     }
                     else {

--- a/src/main/java/org/openpnp/machine/reference/driver/SerialPortCommunications.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/SerialPortCommunications.java
@@ -1,11 +1,8 @@
 package org.openpnp.machine.reference.driver;
 
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.concurrent.TimeoutException;
-import java.util.regex.Pattern;
 
 import org.simpleframework.xml.Attribute;
 

--- a/src/main/java/org/openpnp/machine/reference/driver/SerialPortCommunications.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/SerialPortCommunications.java
@@ -107,7 +107,7 @@ public class SerialPortCommunications extends ReferenceDriverCommunications {
             serialPort.setRTS();
         }
         serialPort.setComPortTimeouts(
-                SerialPort.TIMEOUT_READ_SEMI_BLOCKING | SerialPort.TIMEOUT_WRITE_BLOCKING, 500, 0);
+                SerialPort.TIMEOUT_READ_SEMI_BLOCKING | SerialPort.TIMEOUT_WRITE_BLOCKING, 0, 0);
     }
 
     public synchronized void disconnect() throws Exception {


### PR DESCRIPTION
# Description
Avoid loss of characters due to serial port read timeouts causing a partially read line to be discarded.

# Justification
As discussed in #1235 and rebased onto test branch as mentioned in #1377.

# Instructions for Use
N/A

# Implementation Details
1. How did you test the change? Be descriptive. Untested code will not be accepted.
Only tested with maven built in tests. I've no serial comms to check this.

2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)?
Yes
3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing.
N/A
4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted.
Tests passed.