### PR TITLE
Fix / Trying to get rid of the Issues & Solutions Tab Race

### DIFF
--- a/src/main/java/org/openpnp/gui/IssuesAndSolutionsPanel.java
+++ b/src/main/java/org/openpnp/gui/IssuesAndSolutionsPanel.java
@@ -232,7 +232,7 @@ public class IssuesAndSolutionsPanel extends JPanel {
                             return;
                         }
 
-                        selectionActions();
+                        solutionChanged();
                     }
                 });
                 table.getColumnModel().getColumn(0).setPreferredWidth(150);
@@ -256,7 +256,7 @@ public class IssuesAndSolutionsPanel extends JPanel {
                         new java.util.TimerTask() {
                             @Override
                             public void run() {
-                                findIssuesAndSolutions(); 
+                                SwingUtilities.invokeLater(()->findIssuesAndSolutions()); 
                             }
                         },
                         5000
@@ -580,8 +580,8 @@ public class IssuesAndSolutionsPanel extends JPanel {
      * Rebuild the UI as needed, when solutions have changed state, perhaps asynchronously.
      */
     public void solutionChanged() {
+        dirty = true;
         SwingUtilities.invokeLater(() -> {
-            dirty = true;
             notifySolutionsChanged();
         });
     }


### PR DESCRIPTION
# Description
There was a race/bug drawing/layouting the Issues & Solutions tab in a corrupted way. This is related to the initial automatic execution of **Find Issues & Solutions** when OpenPnP starts up.   

![image](https://user-images.githubusercontent.com/9963310/152529133-bc79ace1-53fc-4fbd-b03d-9cd2da6f3789.png)
(Screenshot by Duncan)

This PR further decouples the initial automatic execution of **Find Issues & Solutions**, and subsequent solutions change and selection change notifications. This is after reading that a `TimerTask`, contrary to my expectations, does not run on the GUI event dispatching thread (as `SwingUtilities.invokeLater()` would). 

Everything is now done asynchronously. Only one notification is followed up, even if several have been registered. Note, I already attempted to implement that idea before, but there was a bug, setting the `dirty` flag asynchronously, instead of synchronously, defying the whole purpose. 🙄

# Justification
See the user report, and own experience:
https://groups.google.com/g/openpnp/c/Qk1Yxswmy-E/m/SbkM7d-3AgAJ

# Instructions for Use
No change.

# Implementation Details
1. Tested on Linux/Kubuntu. Could no longer reproduce the issue, while this was relatively easy before (no guarantees, though). 
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. Does not apply in `mvn test`.
