### PR TITLE
Feature / Configurable parkAfterHomed and unsafeZRoamingDistance Options

### DIFF
--- a/src/main/java/org/openpnp/gui/MachineControlsPanel.java
+++ b/src/main/java/org/openpnp/gui/MachineControlsPanel.java
@@ -53,6 +53,7 @@ import org.openpnp.gui.support.MessageBoxes;
 import org.openpnp.gui.support.NozzleItem;
 import org.openpnp.machine.reference.axis.ReferenceVirtualAxis;
 import org.openpnp.model.Configuration;
+import org.openpnp.model.Length;
 import org.openpnp.model.LengthUnit;
 import org.openpnp.model.Location;
 import org.openpnp.spi.Actuator;
@@ -77,7 +78,6 @@ public class MachineControlsPanel extends JPanel {
     private final Configuration configuration;
     private final JobPanel jobPanel;
 
-    private static final double VIRTUAL_Z_MAX_UNSAFE_ROAMING_MM = 10;
     private static final String PREF_JOG_CONTROLS_EXPANDED =
             "MachineControlsPanel.jogControlsExpanded"; //$NON-NLS-1$
     private static final boolean PREF_JOG_CONTROLS_EXPANDED_DEF = true;
@@ -436,8 +436,8 @@ public class MachineControlsPanel extends JPanel {
                 else {
                     // Jogging the same selected tool. Apply auto-Safe Z.
                     if (hm.getAxisZ() instanceof ReferenceVirtualAxis) {
-                        double distance = lastUserActionLocation.getLinearDistanceTo(hm.getLocation());
-                        if (distance > VIRTUAL_Z_MAX_UNSAFE_ROAMING_MM) {
+                        Length distance = lastUserActionLocation.getLinearLengthTo(hm.getLocation());
+                        if (distance.compareTo(machine.getUnsafeZRoamingDistance()) > 0) {
                             // Distance is too large to retain virtual Z. Make it safe.
                             Logger.debug(hm.getName()+" exceeded roaming distance at non-safe Z, going to safe Z. "
                                     + "Last user action at "+lastUserActionLocation+" roamed to "+hm.getLocation()+" distance "+distance+"mm.");

--- a/src/main/java/org/openpnp/machine/reference/ReferenceMachine.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceMachine.java
@@ -88,6 +88,8 @@ import org.openpnp.machine.reference.vision.ReferenceBottomVision;
 import org.openpnp.machine.reference.vision.ReferenceFiducialLocator;
 import org.openpnp.machine.reference.wizards.ReferenceMachineConfigurationWizard;
 import org.openpnp.model.Configuration;
+import org.openpnp.model.Length;
+import org.openpnp.model.LengthUnit;
 import org.openpnp.model.Solutions;
 import org.openpnp.model.Solutions.Milestone;
 import org.openpnp.spi.Actuator;
@@ -107,6 +109,7 @@ import org.openpnp.spi.base.AbstractDriver;
 import org.openpnp.spi.base.AbstractMachine;
 import org.openpnp.spi.base.SimplePropertySheetHolder;
 import org.openpnp.util.Collect;
+import org.openpnp.util.MovableUtils;
 import org.pmw.tinylog.Logger;
 import org.simpleframework.xml.Attribute;
 import org.simpleframework.xml.Element;
@@ -130,11 +133,17 @@ public class ReferenceMachine extends AbstractMachine {
     @Element(required = false)
     private boolean homeAfterEnabled = false;
 
+    @Element(required = false)
+    private boolean parkAfterHomed = false;
+
     @Attribute(required = false)
     private boolean autoToolSelect = true;
 
     @Attribute(required = false)
     private boolean safeZPark = true;
+
+    @Element(required = false)
+    private Length unsafeZRoamingDistance = new Length(10, LengthUnit.Millimeters);
 
     @Element(required = false)
     private Solutions solutions = new Solutions();
@@ -281,6 +290,26 @@ public class ReferenceMachine extends AbstractMachine {
         Object oldValue = this.safeZPark;
         this.safeZPark = safeZPark;
         firePropertyChange("safeZPark", oldValue, safeZPark);
+    }
+
+    @Override
+    public boolean isParkAfterHomed() {
+        return parkAfterHomed;
+    }
+
+    public void setParkAfterHomed(boolean parkAfterHomed) {
+        this.parkAfterHomed = parkAfterHomed;
+    }
+
+    @Override
+    public Length getUnsafeZRoamingDistance() {
+        return unsafeZRoamingDistance;
+    }
+
+    public void setUnsafeZRoamingDistance(Length unsafeZRoamingDistance) {
+        Object oldValue = this.unsafeZRoamingDistance;
+        this.unsafeZRoamingDistance = unsafeZRoamingDistance;
+        firePropertyChange("safeRoamingDistance", oldValue, unsafeZRoamingDistance);
     }
 
     @Override
@@ -450,7 +479,13 @@ public class ReferenceMachine extends AbstractMachine {
         Configuration.get().getScripting().on("Machine.AfterHoming", null);
 
         // if homing went well, set machine homed-flag true
-        this.setHomed(true);     
+        this.setHomed(true);
+        
+        if (isParkAfterHomed()) {
+            for (Head head : getHeads()) {
+                MovableUtils.park(head);
+            }
+        }
     }
 
     @Override

--- a/src/main/java/org/openpnp/machine/reference/wizards/ReferenceMachineConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/wizards/ReferenceMachineConfigurationWizard.java
@@ -38,6 +38,8 @@ public class ReferenceMachineConfigurationWizard extends AbstractConfigurationWi
     private boolean reloadWizard;
     private JCheckBox autoToolSelect;
     private JCheckBox safeZPark;
+    private JTextField unsafeZRoamingDistance;
+    private JCheckBox parkAfterHomed;
 
     public ReferenceMachineConfigurationWizard(ReferenceMachine machine) {
         this.machine = machine;
@@ -48,10 +50,20 @@ public class ReferenceMachineConfigurationWizard extends AbstractConfigurationWi
                 TitledBorder.TOP, null, null));
         panelGeneral.setLayout(new FormLayout(new ColumnSpec[] {
                 FormSpecs.RELATED_GAP_COLSPEC,
+                ColumnSpec.decode("max(70dlu;default)"),
+                FormSpecs.RELATED_GAP_COLSPEC,
                 FormSpecs.DEFAULT_COLSPEC,
                 FormSpecs.RELATED_GAP_COLSPEC,
                 FormSpecs.DEFAULT_COLSPEC,},
             new RowSpec[] {
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
                 FormSpecs.RELATED_GAP_ROWSPEC,
                 FormSpecs.DEFAULT_ROWSPEC,
                 FormSpecs.RELATED_GAP_ROWSPEC,
@@ -69,11 +81,11 @@ public class ReferenceMachineConfigurationWizard extends AbstractConfigurationWi
         checkBoxHomeAfterEnabled = new JCheckBox("");
         panelGeneral.add(checkBoxHomeAfterEnabled, "4, 2");
         
-        JLabel lblAutoToolSelect = new JLabel("Auto tool select?");
-        panelGeneral.add(lblAutoToolSelect, "2, 4, right, default");
+        JLabel lblParkAfterHomed = new JLabel("Park after homed?");
+        panelGeneral.add(lblParkAfterHomed, "2, 4, right, default");
         
-        autoToolSelect = new JCheckBox("");
-        panelGeneral.add(autoToolSelect, "4, 4");
+        parkAfterHomed = new JCheckBox("");
+        panelGeneral.add(parkAfterHomed, "4, 4");
         
         JLabel lblParkAllAtSafeZ = new JLabel("Park all at Safe Z?");
         lblParkAllAtSafeZ.setToolTipText("When the Z Park button is pressed, move all tools mounted on the same head to safe Z.");
@@ -82,27 +94,50 @@ public class ReferenceMachineConfigurationWizard extends AbstractConfigurationWi
         safeZPark = new JCheckBox("");
         panelGeneral.add(safeZPark, "4, 6");
         
+        JLabel lblAutoToolSelect = new JLabel("Auto tool select?");
+        panelGeneral.add(lblAutoToolSelect, "2, 10, right, default");
+        
+        autoToolSelect = new JCheckBox("");
+        panelGeneral.add(autoToolSelect, "4, 10");
+        
+        JLabel lblNewLabel = new JLabel("Unsafe Z Roaming");
+        lblNewLabel.setToolTipText("<html>Maximum allowable roaming distance at unsafe Z.<br/><br/>\r\nVirtual Z axes (typically on cameras) are invisible, therefore it can easily be overlooked<br/>\r\nthat you are at unsafe Z. When you later press the <strong>Move tool to camera location</strong><br/>\r\nbutton, an unexpected Z down-move will result, potentially crashing the tool.<br/>\r\nThe maximum allowable roaming distance at unsafe Z therefore limits the jogging area<br/>\r\nwithin which an unsafe virtual Z is kept, it should be enough to fine-adjust a captured<br/>\r\nlocation. Jogging further away will automatically move the virtual axis to Safe Z.\r\n</html>");
+        panelGeneral.add(lblNewLabel, "2, 12, right, default");
+        
+        unsafeZRoamingDistance = new JTextField();
+        panelGeneral.add(unsafeZRoamingDistance, "4, 12, fill, default");
+        unsafeZRoamingDistance.setColumns(10);
+        
         JLabel lblMotionPlanning = new JLabel("Motion Planning");
-        panelGeneral.add(lblMotionPlanning, "2, 8, right, default");
+        panelGeneral.add(lblMotionPlanning, "2, 16, right, default");
         
         Object[] classNames = machine.getCompatibleMotionPlannerClasses().stream()
         .map(c -> c.getSimpleName()).toArray();
         motionPlannerClass = new JComboBox(classNames);
-        panelGeneral.add(motionPlannerClass, "4, 8, fill, default");
+        panelGeneral.add(motionPlannerClass, "4, 16, fill, default");
         
                 JPanel panelLocations = new JPanel();
         panelLocations.setBorder(new TitledBorder(null, "Locations", TitledBorder.LEADING,
                 TitledBorder.TOP, null, null));
         contentPanel.add(panelLocations);
-        panelLocations.setLayout(new FormLayout(
-                new ColumnSpec[] {FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,
-                        FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,
-                        FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,
-                        FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,
-                        FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,
-                        FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,},
-                new RowSpec[] {FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
-                        FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,}));
+        panelLocations.setLayout(new FormLayout(new ColumnSpec[] {
+                FormSpecs.RELATED_GAP_COLSPEC,
+                ColumnSpec.decode("max(70dlu;default)"),
+                FormSpecs.RELATED_GAP_COLSPEC,
+                FormSpecs.DEFAULT_COLSPEC,
+                FormSpecs.RELATED_GAP_COLSPEC,
+                FormSpecs.DEFAULT_COLSPEC,
+                FormSpecs.RELATED_GAP_COLSPEC,
+                FormSpecs.DEFAULT_COLSPEC,
+                FormSpecs.RELATED_GAP_COLSPEC,
+                FormSpecs.DEFAULT_COLSPEC,
+                FormSpecs.RELATED_GAP_COLSPEC,
+                FormSpecs.DEFAULT_COLSPEC,},
+            new RowSpec[] {
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,}));
         
                 JLabel lblX = new JLabel("X");
         panelLocations.add(lblX, "4, 2");
@@ -151,8 +186,10 @@ public class ReferenceMachineConfigurationWizard extends AbstractConfigurationWi
         LengthConverter lengthConverter = new LengthConverter();
 
         addWrappedBinding(machine, "homeAfterEnabled", checkBoxHomeAfterEnabled, "selected");
+        addWrappedBinding(machine, "parkAfterHomed", parkAfterHomed, "selected");
         addWrappedBinding(machine, "autoToolSelect", autoToolSelect, "selected");
         addWrappedBinding(machine, "safeZPark", safeZPark, "selected");
+        addWrappedBinding(machine, "unsafeZRoamingDistance", unsafeZRoamingDistance, "text", lengthConverter);
 
         motionPlannerClassName = machine.getMotionPlanner().getClass().getSimpleName();
         addWrappedBinding(this, "motionPlannerClassName", motionPlannerClass, "selectedItem");
@@ -163,7 +200,8 @@ public class ReferenceMachineConfigurationWizard extends AbstractConfigurationWi
         addWrappedBinding(discardLocation, "lengthY", discardYTf, "text", lengthConverter);
         addWrappedBinding(discardLocation, "lengthZ", discardZTf, "text", lengthConverter);
         addWrappedBinding(discardLocation, "rotation", discardCTf, "text", doubleConverter);
-        
+
+        ComponentDecorators.decorateWithAutoSelectAndLengthConversion(unsafeZRoamingDistance);
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(discardXTf);
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(discardYTf);
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(discardZTf);

--- a/src/main/java/org/openpnp/spi/Machine.java
+++ b/src/main/java/org/openpnp/spi/Machine.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Future;
 
+import org.openpnp.model.Length;
 import org.openpnp.model.Location;
 import org.openpnp.model.Solutions;
 
@@ -361,4 +362,22 @@ public interface Machine extends WizardConfigurable, PropertySheetHolder, Closea
      * @return True if the Z Park button should move all other HeadMountables to Safe Z. 
      */
     public boolean isSafeZPark();
+    
+    /**
+     * @return True if the machine heads should be parked after the machine was homed.
+     */
+    public boolean isParkAfterHomed();
+    
+    /**
+     * 
+     * Virtual Z axes (typically on cameras) are invisible, therefore it can easily be overlooked 
+     * by users that it is at unsafe Z. When they later press the Move tool to camera location button, 
+     * an unexpected Z down-move will result, potentially crashing the tool. 
+     * The maximum allowable roaming distance at unsafe Z therefore limits the jogging area 
+     * within which an unsafe virtual Z is kept. It should be enough to fine-adjust a captured
+     * location, but jogging further away will automatically move the virtual axis to Safe Z.
+     * 
+     * @return Maximum allowable roaming distance at unsafe Z. 
+     */
+    public Length getUnsafeZRoamingDistance();
 }


### PR DESCRIPTION
# Description
Adds to minor goodies to machine control.

- Option to park heads after the machine was homed.
- Configurable unsafe Z roaming distance for head-mountables (typically cameras) with Virtual Z axes.

## Park Heads after Machine Homed
The option to park heads after the machine was homed was a user suggestion.

## Unsafe Z Roaming Distance
Virtual Z axes (typically on cameras) are invisible, therefore it can easily be overlooked by users that they might be at unsafe Z. When they later press the **Move tool to camera location** button, an unexpected Z down-move will result, potentially crashing the tool. 

The maximum allowable roaming distance at unsafe Z therefore limits the jogging area within which an unsafe virtual Z is kept. It should be enough to fine-adjust a captured location, but jogging further away will automatically move the virtual axis to Safe Z.

This functionality was already present before, but with a hard-coded 10 mm distance (`VIRTUAL_Z_MAX_UNSAFE_ROAMING_MM`).

# Justification
See these discussions:
https://groups.google.com/g/openpnp/c/0xHtBdzVeTE/m/fV3VQa2vAwAJ
https://groups.google.com/g/openpnp/c/qF52tfyxRr8/m/NgqOMrTSAwAJ

# Instructions for Use
Use the **Park after homed?** and the **Unsafe Z Roaming** fields on the machine:

![grafik](https://user-images.githubusercontent.com/9963310/152964814-7eeba725-2dcf-45c2-a391-9312ce240565.png)

More about Virtual Axes:
https://github.com/openpnp/openpnp/wiki/Machine-Axes#referencevirtualaxis

And particularly how they are used for 3D Units per Pixel:
https://github.com/openpnp/openpnp/wiki/3D-Units-per-Pixel

# Implementation Details
1. Tested in simulation
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. Introduces `org.openpnp.spi.Machine.isParkAfterHomed()` and `org.openpnp.spi.Machine.getUnsafeZRoamingDistance()`.
4. Successful `mvn test` before submitting the Pull Request.
