### PR TITLE
Cope with M115 response properties, illegally containing a colon char…

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/driver/GcodeDriver.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/GcodeDriver.java
@@ -1645,7 +1645,18 @@ public class GcodeDriver extends AbstractReferenceDriver implements Named {
                 String value;
                 int pos = matcher.end();
                 if (matcher.find()) {
-                    value = detectedFirmware.substring(pos, matcher.start()-1);
+                    if (matcher.start() <= pos) {
+                        // Likely an illegal value with ':' in it, like an URL.
+                        if (matcher.find()) {
+                            value = detectedFirmware.substring(pos, matcher.start()-1);
+                        }
+                        else {
+                            value = detectedFirmware.substring(pos);
+                        }
+                    }
+                    else {
+                        value = detectedFirmware.substring(pos, matcher.start()-1);
+                    }
                 }
                 else {
                     value = detectedFirmware.substring(pos);


### PR DESCRIPTION


# Description
Cope with `M115` response properties, that illegally contain a colon character. Some firmwares  report URLs with plain colon, when in fact they should encode it using `%3A`.

# Justification
Avoid a strange error message box and malfunction in the `GcodeDriver`, `GcodeDriverSolutions`.

# Instructions for Use
No change. 

# Implementation Details
1. Tested with user `machine.xml` containing such a `M115` response. 
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. Successful `mvn test` before submitting the Pull Request.
