### PR TITLE
Feature/Bottom Vision Nozzle Tip Background Knockout Calibration

### DIFF
--- a/src/main/java/org/openpnp/gui/components/HsvIndicator.java
+++ b/src/main/java/org/openpnp/gui/components/HsvIndicator.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright (C) 2022 <mark@makr.zone>
+ * 
+ * This file is part of OpenPnP.
+ * 
+ * OpenPnP is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * OpenPnP is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License along with OpenPnP. If not, see
+ * <http://www.gnu.org/licenses/>.
+ * 
+ * For more information about OpenPnP visit http://openpnp.org
+ */
+
+package org.openpnp.gui.components;
+
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.image.BufferedImage;
+
+import javax.swing.JComponent;
+
+public class HsvIndicator extends JComponent {
+
+    public HsvIndicator() {
+        super();
+    }
+
+    private int minHue;
+    private int maxHue;
+    private int minSaturation;
+    private int maxSaturation;
+    private int minValue;
+    private int maxValue;
+
+    @Override
+    public Dimension getPreferredSize() {
+        Dimension superDim = super.getPreferredSize();
+        int width = (int)Math.max(superDim.getWidth(), 192);
+        int height = (int)Math.max(superDim.getHeight(), 128); 
+        return new Dimension(width, height);
+    }
+
+    protected void paintComponent(Graphics g) {
+        Graphics2D g2d = (Graphics2D) g;
+        int width = getWidth();
+        int height = getHeight();
+        int diameter = Math.min(width, height);
+        int unit = diameter/5;
+        double radius = diameter/2.0; 
+        BufferedImage image = new BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB);
+        int [] data = new int[width*height];
+        for (int y = 0; y < diameter; y++) {
+            for (int x = 0; x < diameter; x++) {
+                double dx = x - radius;
+                double dy = y - radius;
+                double r = Math.sqrt(dx*dx + dy*dy);
+                if (r < radius) {
+                    double saturation = 255.0*r/radius;
+                    double hue = 255.0*((1.0 + Math.atan2(-dy, dx)/Math.PI/2.0) % 1.0);
+                    double alpha = Math.min(1.0, radius - r);
+                    double dHue = r/64;
+                    double dSat = radius/255;
+                    double included = Math.max(0, Math.min(1.0, Math.min(
+                            dHue*(minHue <= maxHue ? Math.min(hue - minHue, maxHue - hue) : Math.max(hue - minHue, maxHue - hue)),
+                            dSat*Math.min(saturation - minSaturation, maxSaturation - saturation))));
+                    alpha = alpha*(included*0.8 + 0.2);
+                    Color color = makeHsvColor((int)hue, (isEnabled() ? (int)saturation : 0), maxValue, (int) (255*alpha));
+                    data[y*width + x] = color.getRGB();
+                }
+            }
+        }
+        
+        for (int y = 0; y < diameter; y++) {
+            int value = 255 - 255*y/diameter; 
+            int hue = (minHue < maxHue ? (minHue + maxHue)/2 : ((maxHue - minHue)/2) & 0xFF);
+            double dVal = diameter/255.0;
+            double included = Math.max(0, Math.min(1.0, 
+                    dVal*(Math.min(value - minValue, maxValue - value))));
+            double alpha = included*0.8 + 0.2;
+            int x0 = diameter + unit;
+            int x1 = Math.min(diameter + unit*2, width);
+            for (int x = x0; x < x1; x++) {
+                double r = (double)(x - x0)/(x1 - x0);
+                int saturation = isEnabled() && included > 0 ? 
+                        ((int) (r*(maxSaturation - minSaturation) + minSaturation)) : 0;
+                Color color = makeHsvColor(hue, 
+                        saturation, 
+                                value, (int) (255*alpha));
+                data[y*width + x] = color.getRGB();
+            }
+        }
+        image.setRGB(0, 0, width, height, data, 0, width);
+        g2d.drawImage(image, 0, 0, width, height, 0, 0, width, height, null);
+    }
+
+    public int getMinHue() {
+        return minHue;
+    }
+
+    public void setMinHue(int minHue) {
+        this.minHue = minHue;
+        repaint();
+    }
+
+    public int getMaxHue() {
+        return maxHue;
+    }
+
+    public void setMaxHue(int maxHue) {
+        this.maxHue = maxHue;
+        repaint();
+    }
+
+    public int getMinSaturation() {
+        return minSaturation;
+    }
+
+    public void setMinSaturation(int minSaturation) {
+        this.minSaturation = minSaturation;
+        repaint();
+    }
+
+    public int getMaxSaturation() {
+        return maxSaturation;
+    }
+
+    public void setMaxSaturation(int maxSaturation) {
+        this.maxSaturation = maxSaturation;
+        repaint();
+    }
+
+    public int getMinValue() {
+        return minValue;
+    }
+
+    public void setMinValue(int minValue) {
+        this.minValue = minValue;
+        repaint();
+    }
+
+    public int getMaxValue() {
+        return maxValue;
+    }
+
+    public void setMaxValue(int maxValue) {
+        this.maxValue = maxValue;
+        repaint();
+    }
+
+    private Color makeHsvColor(int hue, int saturation, int value, int alpha){
+        double s = saturation/255.0;
+        double v = value/255.0;
+        double h = 360.0*hue/255;
+        double C = s*v;
+        double X = C*(1 - Math.abs(((h/60.0) % 2) - 1.0));
+        double m = v - C;
+        double r, g, b;
+        if (h >= 0 && h < 60){
+            r = C; g = X; b = 0;
+        }
+        else if (h >= 60 && h < 120){
+            r = X; g = C; b = 0;
+        }
+        else if (h >= 120 && h < 180){
+            r = 0; g = C; b = X;
+        }
+        else if (h >= 180 && h < 240){
+            r = 0; g = X; b = C;
+        }
+        else if (h >= 240 && h < 300){
+            r = X; g = 0; b = C;
+        }
+        else{
+            r = C; g = 0; b = X;
+        }
+        int red = (int) ((r+m)*255);
+        int green = (int) ((g+m)*255);
+        int blue = (int) ((b+m)*255);
+        return new Color(red, green, blue, alpha);
+    }
+}

--- a/src/main/java/org/openpnp/gui/components/HsvIndicator.java
+++ b/src/main/java/org/openpnp/gui/components/HsvIndicator.java
@@ -162,27 +162,39 @@ public class HsvIndicator extends JComponent {
         double s = saturation/255.0;
         double v = value/255.0;
         double h = 360.0*hue/255;
-        double C = s*v;
-        double X = C*(1 - Math.abs(((h/60.0) % 2) - 1.0));
-        double m = v - C;
+        double c = s*v;
+        double x = c*(1 - Math.abs(((h/60.0) % 2) - 1.0));
+        double m = v - c;
         double r, g, b;
         if (h >= 0 && h < 60){
-            r = C; g = X; b = 0;
+            r = c; 
+            g = x; 
+            b = 0;
         }
         else if (h >= 60 && h < 120){
-            r = X; g = C; b = 0;
+            r = x; 
+            g = c; 
+            b = 0;
         }
         else if (h >= 120 && h < 180){
-            r = 0; g = C; b = X;
+            r = 0; 
+            g = c; 
+            b = x;
         }
         else if (h >= 180 && h < 240){
-            r = 0; g = X; b = C;
+            r = 0; 
+            g = x; 
+            b = c;
         }
         else if (h >= 240 && h < 300){
-            r = X; g = 0; b = C;
+            r = x; 
+            g = 0; 
+            b = c;
         }
         else{
-            r = C; g = 0; b = X;
+            r = c;
+            g = 0;
+            b = x;
         }
         int red = (int) ((r+m)*255);
         int green = (int) ((g+m)*255);

--- a/src/main/java/org/openpnp/gui/components/HsvIndicator.java
+++ b/src/main/java/org/openpnp/gui/components/HsvIndicator.java
@@ -75,7 +75,7 @@ public class HsvIndicator extends JComponent {
                             dHue*(minHue <= maxHue ? Math.min(hue + 1 - minHue, maxHue + 1 - hue) : Math.max(hue + 1 - minHue, maxHue + 1 - hue)),
                             dSat*Math.min(saturation + 1 - minSaturation, maxSaturation + 1 - saturation))));
                     double includedAlpha = (included*(maxValue - minValue) + minValue)/255;
-                    Color color = makeHsvColor((int)hue, (isEnabled() ? (int)saturation : 0), (int) (255*includedAlpha), (int) (255*alpha));
+                    Color color = getHsvColor((int)hue, (isEnabled() ? (int)saturation : 0), (int) (255*includedAlpha), (int) (255*alpha));
                     data[y*width + x] = color.getRGB();
                 }
             }
@@ -92,9 +92,9 @@ public class HsvIndicator extends JComponent {
             int x1 = Math.min(diameter + unit*2, width);
             for (int x = x0; x < x1; x++) {
                 double r = (double)(x - x0)/(x1 - x0);
-                int saturation =  monochrome ? 0 : isEnabled() && included > 0 ? 
+                int saturation =  monochrome ? 0 : isEnabled() && included > 0 ?
                         ((int) (r*(maxSaturation - minSaturation) + minSaturation)) : 0;
-                Color color = makeHsvColor(hue, 
+                Color color = getHsvColor(hue, 
                         saturation, 
                         value, (int) (255*alpha));
                 data[y*width + x] = color.getRGB();
@@ -158,47 +158,9 @@ public class HsvIndicator extends JComponent {
         repaint();
     }
 
-    private Color makeHsvColor(int hue, int saturation, int value, int alpha){
-        double s = saturation/255.0;
-        double v = value/255.0;
-        double h = 360.0*hue/255;
-        double c = s*v;
-        double x = c*(1 - Math.abs(((h/60.0) % 2) - 1.0));
-        double m = v - c;
-        double r, g, b;
-        if (h >= 0 && h < 60){
-            r = c; 
-            g = x; 
-            b = 0;
-        }
-        else if (h >= 60 && h < 120){
-            r = x; 
-            g = c; 
-            b = 0;
-        }
-        else if (h >= 120 && h < 180){
-            r = 0; 
-            g = c; 
-            b = x;
-        }
-        else if (h >= 180 && h < 240){
-            r = 0; 
-            g = x; 
-            b = c;
-        }
-        else if (h >= 240 && h < 300){
-            r = x; 
-            g = 0; 
-            b = c;
-        }
-        else{
-            r = c;
-            g = 0;
-            b = x;
-        }
-        int red = (int) ((r+m)*255);
-        int green = (int) ((g+m)*255);
-        int blue = (int) ((b+m)*255);
-        return new Color(red, green, blue, alpha);
+    private static Color getHsvColor(int hue, int saturation, int value, int alpha){
+        Color rgb = Color.getHSBColor(hue/255.0f, saturation/255.0f, value/255.0f);
+        // Add alpha.
+        return new Color(rgb.getRed(), rgb.getGreen(), rgb.getBlue(), alpha);
     }
 }

--- a/src/main/java/org/openpnp/machine/reference/ReferenceNozzleTipCalibration.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceNozzleTipCalibration.java
@@ -3,8 +3,6 @@ package org.openpnp.machine.reference;
 import java.awt.Color;
 import java.awt.geom.AffineTransform;
 import java.awt.image.BufferedImage;
-import java.io.File;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -18,7 +16,6 @@ import org.opencv.core.KeyPoint;
 import org.opencv.core.Mat;
 import org.opencv.core.RotatedRect;
 import org.opencv.core.Size;
-import org.opencv.imgcodecs.Imgcodecs;
 import org.opencv.imgproc.Imgproc;
 import org.openpnp.gui.MainFrame;
 import org.openpnp.model.AbstractModelObject;
@@ -654,6 +651,9 @@ public class ReferenceNozzleTipCalibration extends AbstractModelObject {
             throw new Exception("Nozzle to nozzle tip mismatch.");
         }
 
+        if (nozzle.getPart()!= null) {
+            throw new Exception("Cannot calibrate nozzle tip with part on nozzle "+nozzle.getName()+".");
+        }
         // Make sure to set start and end rotation to the limits.
         double [] rotationModeLimits = nozzle.getRotationModeLimits();
         angleStart = rotationModeLimits[0];
@@ -992,13 +992,13 @@ public class ReferenceNozzleTipCalibration extends AbstractModelObject {
             int kernelSize = ((int)getMinimumDetailSize()
                     .divide(camera.getUnitsPerPixel().getLengthX()))|1;
             Imgproc.GaussianBlur(image, image, new Size(kernelSize, kernelSize), 0);
-            try {
-                File file = Configuration.get()
-                        .createResourceFile(getClass(), "background", ".jpg");
-                Imgcodecs.imwrite(file.getAbsolutePath(), image);
-            }
-            catch (IOException e) {
-            }
+//            try {
+//                File file = Configuration.get()
+//                        .createResourceFile(getClass(), "background", ".jpg");
+//                Imgcodecs.imwrite(file.getAbsolutePath(), image);
+//            }
+//            catch (IOException e) {
+//            }
             if (getBackgroundCalibrationMethod() == BackgroundCalibrationMethod.BrightnessAndKeyColor) {
                 Imgproc.cvtColor(image, image, FluentCv.ColorCode.Bgr2HsvFull.getCode());
                 backgroundImages.add(image);

--- a/src/main/java/org/openpnp/machine/reference/ReferenceNozzleTipCalibration.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceNozzleTipCalibration.java
@@ -535,16 +535,25 @@ public class ReferenceNozzleTipCalibration extends AbstractModelObject {
     private int backgroundMaxHue; 
 
     @Attribute(required = false)
+    private int backgroundTolHue = 8; 
+
+    @Attribute(required = false)
     private int backgroundMinSaturation; 
 
     @Attribute(required = false)
     private int backgroundMaxSaturation; 
 
     @Attribute(required = false)
+    private int backgroundTolSaturation = 8; 
+
+    @Attribute(required = false)
     private int backgroundMinValue; 
 
     @Attribute(required = false)
     private int backgroundMaxValue; 
+
+    @Attribute(required = false)
+    private int backgroundTolValue = 8; 
 
     @Attribute(required = false)
     private String backgroundDiagnostics; 
@@ -1530,7 +1539,9 @@ public class ReferenceNozzleTipCalibration extends AbstractModelObject {
     }
 
     public void setMinimumDetailSize(Length minimumDetailSize) {
+        Object oldValue = this.minimumDetailSize;
         this.minimumDetailSize = minimumDetailSize;
+        firePropertyChange("minimumDetailSize", oldValue, minimumDetailSize);
     }
 
     public int getBackgroundMinHue() {
@@ -1553,6 +1564,16 @@ public class ReferenceNozzleTipCalibration extends AbstractModelObject {
         firePropertyChange("backgroundMaxHue", oldValue, backgroundMaxHue);
     }
 
+    public int getBackgroundTolHue() {
+        return backgroundTolHue;
+    }
+
+    public void setBackgroundTolHue(int backgroundTolHue) {
+        Object oldValue = this.backgroundTolHue;
+        this.backgroundTolHue = backgroundTolHue;
+        firePropertyChange("backgroundTolHue", oldValue, backgroundTolHue);
+    }
+
     public int getBackgroundMinSaturation() {
         return backgroundMinSaturation;
     }
@@ -1573,6 +1594,17 @@ public class ReferenceNozzleTipCalibration extends AbstractModelObject {
         firePropertyChange("backgroundMaxSaturation", oldValue, backgroundMaxSaturation);
     }
 
+
+    public int getBackgroundTolSaturation() {
+        return backgroundTolSaturation;
+    }
+
+    public void setBackgroundTolSaturation(int backgroundTolSaturation) {
+        Object oldValue = this.backgroundTolSaturation;
+        this.backgroundTolSaturation = backgroundTolSaturation;
+        firePropertyChange("backgroundTolSaturation", oldValue, backgroundTolSaturation);
+    }
+
     public int getBackgroundMinValue() {
         return backgroundMinValue;
     }
@@ -1591,6 +1623,16 @@ public class ReferenceNozzleTipCalibration extends AbstractModelObject {
         Object oldValue = this.backgroundMaxValue;
         this.backgroundMaxValue = backgroundMaxValue;
         firePropertyChange("backgroundMaxValue", oldValue, backgroundMaxValue);
+    }
+
+    public int getBackgroundTolValue() {
+        return backgroundTolValue;
+    }
+
+    public void setBackgroundTolValue(int backgroundTolValue) {
+        Object oldValue = this.backgroundTolValue;
+        this.backgroundTolValue = backgroundTolValue;
+        firePropertyChange("backgroundTolValue", oldValue, backgroundTolValue);
     }
 
     public String getBackgroundDiagnostics() {

--- a/src/main/java/org/openpnp/machine/reference/camera/SimulatedUpCamera.java
+++ b/src/main/java/org/openpnp/machine/reference/camera/SimulatedUpCamera.java
@@ -78,7 +78,7 @@ public class SimulatedUpCamera extends ReferenceCamera {
         }
         BufferedImage image = new BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB);
         Graphics2D g = (Graphics2D) image.getGraphics();
-        g.setColor(Color.black);
+        g.setColor(new Color(32, 32, 32));
         g.fillRect(0, 0, width, height);
         AffineTransform tx = g.getTransform();
         // invert the image in Y so that Y+ is up
@@ -160,6 +160,7 @@ public class SimulatedUpCamera extends ReferenceCamera {
 
         // Create a nozzle shape
         if (fillShape(g, new Ellipse2D.Double(-0.5, -0.5, 1, 1), new Color(0, 220, 0), unitsPerPixel, offsets, false)) {
+            fillShape(g, new Ellipse2D.Double(-0.1, -0.1, 0.2, 0.2), new Color(32, 32, 32), unitsPerPixel, offsets, false);
             if (frame != null) {
                 blurObjectIntoView(gView, frame, nozzle, l);
 

--- a/src/main/java/org/openpnp/machine/reference/vision/ReferenceBottomVision.java
+++ b/src/main/java/org/openpnp/machine/reference/vision/ReferenceBottomVision.java
@@ -118,6 +118,9 @@ public class ReferenceBottomVision extends AbstractPartAlignment {
     }
 
     public Location getCameraLocationAtPartHeight(Part part, Camera camera, Nozzle nozzle, double angle) throws Exception {
+        if (part == null) {
+            throw new Exception("There is no part on nozzle "+nozzle.getName()+".");
+        }
         if (part.isPartHeightUnknown()) {
             if (camera.getFocusProvider() != null
                     && nozzle.getNozzleTip() instanceof ReferenceNozzleTip) {
@@ -409,6 +412,8 @@ public class ReferenceBottomVision extends AbstractPartAlignment {
             if (calibration != null 
                     && calibration.getBackgroundCalibrationMethod() != BackgroundCalibrationMethod.None) {
                 pipeline.setProperty("BlurGaussian.kernelSize", calibration.getMinimumDetailSize());
+                pipeline.setProperty("FilterContours.minArea", calibration.getMinimumDetailSize()
+                        .multiply(calibration.getMinimumDetailSize()));
                 pipeline.setProperty("MaskHsv.hueMin", calibration.getBackgroundMinHue());
                 pipeline.setProperty("MaskHsv.hueMax", calibration.getBackgroundMaxHue());
                 pipeline.setProperty("MaskHsv.saturationMin", calibration.getBackgroundMinSaturation());

--- a/src/main/java/org/openpnp/machine/reference/vision/wizards/BottomVisionSettingsConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/vision/wizards/BottomVisionSettingsConfigurationWizard.java
@@ -413,7 +413,7 @@ public class BottomVisionSettingsConfigurationWizard extends AbstractConfigurati
         CvPipeline pipeline = visionSettings.getCvPipeline();
         Camera camera = VisionUtils.getBottomVisionCamera();
         Nozzle nozzle = MainFrame.get().getMachineControls().getSelectedNozzle();
-        ReferenceBottomVision.preparePipeline(pipeline, camera, nozzle);
+        ReferenceBottomVision.preparePipeline(pipeline, camera, nozzle, visionSettings);
         // Nominal position of the part over camera center
         double angle = new DoubleConverter(Configuration.get().getLengthDisplayFormat())
                 .convertReverse(testAlignmentAngle.getText());

--- a/src/main/java/org/openpnp/machine/reference/vision/wizards/BottomVisionSettingsConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/vision/wizards/BottomVisionSettingsConfigurationWizard.java
@@ -414,10 +414,21 @@ public class BottomVisionSettingsConfigurationWizard extends AbstractConfigurati
         Camera camera = VisionUtils.getBottomVisionCamera();
         Nozzle nozzle = MainFrame.get().getMachineControls().getSelectedNozzle();
         ReferenceBottomVision.preparePipeline(pipeline, camera, nozzle);
+        // Nominal position of the part over camera center
+        double angle = new DoubleConverter(Configuration.get().getLengthDisplayFormat())
+                .convertReverse(testAlignmentAngle.getText());
+        Location alignmentLocation = bottomVision.getCameraLocationAtPartHeight(nozzle.getPart(), 
+                camera,
+                nozzle, angle);
 
-        CvPipelineEditor editor = new CvPipelineEditor(pipeline);
-        JDialog dialog = new CvPipelineEditorDialog(MainFrame.get(), "Bottom Vision Pipeline", editor);
-        dialog.setVisible(true);
+        UiUtils.confirmMoveToLocationAndAct(getTopLevelAncestor(), 
+                "move nozzle "+nozzle.getName()+" to the camera alignment location before editing the pipeline", 
+                nozzle, 
+                alignmentLocation, true, () -> {
+                    CvPipelineEditor editor = new CvPipelineEditor(pipeline);
+                    JDialog dialog = new CvPipelineEditorDialog(MainFrame.get(), "Bottom Vision Pipeline", editor);
+                    dialog.setVisible(true);
+                });
     }
 
     private void testAlignment(boolean centerAfterTest) throws Exception {

--- a/src/main/java/org/openpnp/machine/reference/vision/wizards/BottomVisionSettingsConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/vision/wizards/BottomVisionSettingsConfigurationWizard.java
@@ -32,6 +32,7 @@ import org.openpnp.model.Location;
 import org.openpnp.model.Package;
 import org.openpnp.model.Part;
 import org.openpnp.model.PartSettingsHolder;
+import org.openpnp.spi.Camera;
 import org.openpnp.spi.Nozzle;
 import org.openpnp.spi.PartAlignment;
 import org.openpnp.util.UiUtils;
@@ -410,8 +411,9 @@ public class BottomVisionSettingsConfigurationWizard extends AbstractConfigurati
 
     private void editPipeline() throws Exception {
         CvPipeline pipeline = visionSettings.getCvPipeline();
-        pipeline.setProperty("camera", VisionUtils.getBottomVisionCamera());
-        pipeline.setProperty("nozzle", MainFrame.get().getMachineControls().getSelectedNozzle());
+        Camera camera = VisionUtils.getBottomVisionCamera();
+        Nozzle nozzle = MainFrame.get().getMachineControls().getSelectedNozzle();
+        ReferenceBottomVision.preparePipeline(pipeline, camera, nozzle);
 
         CvPipelineEditor editor = new CvPipelineEditor(pipeline);
         JDialog dialog = new CvPipelineEditorDialog(MainFrame.get(), "Bottom Vision Pipeline", editor);

--- a/src/main/java/org/openpnp/machine/reference/wizards/ReferenceNozzleTipCalibrationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/wizards/ReferenceNozzleTipCalibrationWizard.java
@@ -19,6 +19,7 @@
 
 package org.openpnp.machine.reference.wizards;
 
+import java.awt.Component;
 import java.awt.FlowLayout;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
@@ -36,12 +37,10 @@ import javax.swing.JPanel;
 import javax.swing.JTextField;
 import javax.swing.border.TitledBorder;
 
-import org.jdesktop.beansbinding.AutoBinding;
 import org.jdesktop.beansbinding.AutoBinding.UpdateStrategy;
-import org.jdesktop.beansbinding.BeanProperty;
-import org.jdesktop.beansbinding.Bindings;
 import org.openpnp.gui.MainFrame;
 import org.openpnp.gui.components.ComponentDecorators;
+import org.openpnp.gui.components.HsvIndicator;
 import org.openpnp.gui.support.AbstractConfigurationWizard;
 import org.openpnp.gui.support.Icons;
 import org.openpnp.gui.support.IntegerConverter;
@@ -50,6 +49,7 @@ import org.openpnp.machine.reference.ReferenceCamera;
 import org.openpnp.machine.reference.ReferenceNozzle;
 import org.openpnp.machine.reference.ReferenceNozzleTip;
 import org.openpnp.machine.reference.ReferenceNozzleTipCalibration;
+import org.openpnp.machine.reference.ReferenceNozzleTipCalibration.BackgroundCalibrationMethod;
 import org.openpnp.machine.reference.ReferenceNozzleTipCalibration.RecalibrationTrigger;
 import org.openpnp.model.Configuration;
 import org.openpnp.model.Location;
@@ -88,6 +88,8 @@ public class ReferenceNozzleTipCalibrationWizard extends AbstractConfigurationWi
     private JLabel lblCalibrationStatus;
     private JCheckBox calibrationEnabledCheckbox;
 
+    private JPanel panelBackground;
+
 
     public ReferenceNozzleTipCalibrationWizard(ReferenceNozzleTip nozzleTip) {
         this.nozzleTip = nozzleTip;
@@ -96,7 +98,7 @@ public class ReferenceNozzleTipCalibrationWizard extends AbstractConfigurationWi
 
 
         panelCalibration = new JPanel();
-        panelCalibration.setBorder(new TitledBorder(null, "Calibration",
+        panelCalibration.setBorder(new TitledBorder(null, "Nozzle Tip Calibration",
                 TitledBorder.LEADING, TitledBorder.TOP, null, null));
         contentPanel.add(panelCalibration);
         panelCalibration.setLayout(new FormLayout(new ColumnSpec[] {
@@ -129,6 +131,11 @@ public class ReferenceNozzleTipCalibrationWizard extends AbstractConfigurationWi
                 FormSpecs.DEFAULT_ROWSPEC,}));
 
         calibrationEnabledCheckbox = new JCheckBox("Enable?");
+        calibrationEnabledCheckbox.addItemListener(new ItemListener() {
+            public void itemStateChanged(ItemEvent arg0) {
+                adaptDialog();
+            }
+        });
         panelCalibration.add(calibrationEnabledCheckbox, "2, 2, right, default");
 
 
@@ -283,7 +290,97 @@ public class ReferenceNozzleTipCalibrationWizard extends AbstractConfigurationWi
             }
         }
 
-        initDataBindings();
+        panelBackground = new JPanel();
+        panelBackground.setBorder(new TitledBorder(null, "Background Calibration",
+                TitledBorder.LEADING, TitledBorder.TOP, null, null));
+        contentPanel.add(panelBackground);
+        panelBackground.setLayout(new FormLayout(new ColumnSpec[] {
+                FormSpecs.RELATED_GAP_COLSPEC,
+                ColumnSpec.decode("max(70dlu;default)"),
+                FormSpecs.RELATED_GAP_COLSPEC,
+                FormSpecs.DEFAULT_COLSPEC,
+                FormSpecs.RELATED_GAP_COLSPEC,
+                ColumnSpec.decode("max(70dlu;default)"),
+                FormSpecs.RELATED_GAP_COLSPEC,
+                ColumnSpec.decode("max(96dlu;default)"),},
+            new RowSpec[] {
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                RowSpec.decode("max(50dlu;default)"),}));
+        
+        lblMethod = new JLabel("Method");
+        panelBackground.add(lblMethod, "2, 2, right, default");
+        
+        backgroundCalibrationMethod = new JComboBox(BackgroundCalibrationMethod.values());
+        backgroundCalibrationMethod.addItemListener(new ItemListener() {
+            public void itemStateChanged(ItemEvent arg0) {
+                adaptDialog();
+            }
+        });
+        panelBackground.add(backgroundCalibrationMethod, "4, 2, fill, default");
+        
+        lblDetailSize = new JLabel("Minimum Detail Size");
+        lblDetailSize.setToolTipText("<html>\n<p>Specify the size of the smallest details in the image that are considered a<br/>\nmeaningfull part of the shape to be detected.<br/>\nSmaller specks and artifacts, such as image noise, textures, markings, or dirt on<br/>\nobjects, are considered irrelevant for image processing, which means that<br/>\nfilters can be applied to suppress them in the image. </p> \n</html>");
+        panelBackground.add(lblDetailSize, "2, 4, right, default");
+        
+        minimumDetailSize = new JTextField();
+        panelBackground.add(minimumDetailSize, "4, 4, fill, default");
+        minimumDetailSize.setColumns(10);
+        
+        lblBrightnessMin = new JLabel("Brightness Min");
+        panelBackground.add(lblBrightnessMin, "2, 6, right, default");
+        
+        backgroundMinValue = new JTextField();
+        panelBackground.add(backgroundMinValue, "4, 6, fill, default");
+        backgroundMinValue.setColumns(10);
+        
+        lblBrightnessMax = new JLabel("Brightness Max");
+        panelBackground.add(lblBrightnessMax, "6, 6, right, default");
+        
+        backgroundMaxValue = new JTextField();
+        panelBackground.add(backgroundMaxValue, "8, 6, fill, default");
+        backgroundMaxValue.setColumns(10);
+        
+        lblHueMin = new JLabel("Hue Min");
+        panelBackground.add(lblHueMin, "2, 8, right, default");
+        
+        backgroundMinHue = new JTextField();
+        panelBackground.add(backgroundMinHue, "4, 8, fill, default");
+        backgroundMinHue.setColumns(10);
+        
+        lblHueMax = new JLabel("Hue Max");
+        panelBackground.add(lblHueMax, "6, 8, right, default");
+        
+        backgroundMaxHue = new JTextField();
+        panelBackground.add(backgroundMaxHue, "8, 8, fill, default");
+        backgroundMaxHue.setColumns(10);
+        
+        lblSaturationMin = new JLabel("Saturation Min");
+        panelBackground.add(lblSaturationMin, "2, 10, right, default");
+        
+        backgroundMinSaturation = new JTextField();
+        panelBackground.add(backgroundMinSaturation, "4, 10, fill, default");
+        backgroundMinSaturation.setColumns(10);
+        
+        lblSaturationMax = new JLabel("Saturation Max");
+        panelBackground.add(lblSaturationMax, "6, 10, right, default");
+        
+        backgroundMaxSaturation = new JTextField();
+        panelBackground.add(backgroundMaxSaturation, "8, 10, fill, default");
+        backgroundMaxSaturation.setColumns(10);
+        
+        hsvIndicator = new HsvIndicator();
+        panelBackground.add(hsvIndicator, "4, 12, 5, 1");
+        
         adaptDialog();
     }
 
@@ -293,6 +390,29 @@ public class ReferenceNozzleTipCalibrationWizard extends AbstractConfigurationWi
                 || recalibration == ReferenceNozzleTipCalibration.RecalibrationTrigger.NozzleTipChange);
         lblFailHoming.setVisible(calibratesOnHoming);
         failHoming.setVisible(calibratesOnHoming);
+        
+        boolean enabled = calibrationEnabledCheckbox.isSelected();
+        for (Component comp : panelCalibration.getComponents()) {
+            if (comp != calibrationEnabledCheckbox) { 
+                comp.setEnabled(enabled); 
+            }
+        }
+        BackgroundCalibrationMethod method = (BackgroundCalibrationMethod) backgroundCalibrationMethod.getSelectedItem();
+        for (Component comp : panelBackground.getComponents()) {
+            if (comp == backgroundCalibrationMethod 
+                    || comp == lblMethod) { 
+                comp.setEnabled(enabled); 
+            }
+            else if (comp == backgroundMinValue || comp == backgroundMaxValue
+                    || comp == minimumDetailSize
+                    || comp == lblBrightnessMin || comp == lblBrightnessMax
+                    || comp == lblDetailSize) {
+                comp.setEnabled(enabled && (method != BackgroundCalibrationMethod.None)); 
+            }
+            else {
+                comp.setEnabled(enabled && (method == BackgroundCalibrationMethod.BrightnessAndKeyColor)); 
+            }
+        }
     }
 
     @SuppressWarnings("serial")
@@ -328,6 +448,24 @@ public class ReferenceNozzleTipCalibrationWizard extends AbstractConfigurationWi
     private JTextField calibrationTipDiameter;
     private JLabel lblFailHoming;
     private JCheckBox failHoming;
+    private JLabel lblMethod;
+    private JComboBox backgroundCalibrationMethod;
+    private JLabel lblDetailSize;
+    private JTextField minimumDetailSize;
+    private JLabel lblBrightnessMin;
+    private JTextField backgroundMinValue;
+    private JLabel lblHueMin;
+    private JLabel lblHueMax;
+    private JTextField backgroundMinHue;
+    private JTextField backgroundMaxHue;
+    private JLabel lblSaturationMin;
+    private JLabel lblSaturationMax;
+    private JTextField backgroundMinSaturation;
+    private JTextField backgroundMaxSaturation;
+    private JLabel lblBrightnessMax;
+    private JTextField backgroundMaxValue;
+    private HsvIndicator hsvIndicator;
+    private JPanel panel_2;
 
     public static ReferenceNozzle getUiCalibrationNozzle(ReferenceNozzleTip nozzleTip) throws Exception {
         ReferenceNozzle refNozzle; 
@@ -404,7 +542,7 @@ public class ReferenceNozzleTipCalibrationWizard extends AbstractConfigurationWi
                 nozzle, 
                 moveToLocation, true, () -> {
                     CvPipeline pipeline = calibration
-                            .getPipeline(camera, moveToLocation);
+                            .getPipeline(camera, nozzle, moveToLocation);
                     CvPipelineEditor editor = new CvPipelineEditor(pipeline);
                     JDialog dialog = new CvPipelineEditorDialog(MainFrame.get(), "Calibration Pipeline", editor);
                     dialog.setVisible(true);
@@ -449,10 +587,37 @@ public class ReferenceNozzleTipCalibrationWizard extends AbstractConfigurationWi
                 recalibrationCb, "selectedItem");
         
         bind(UpdateStrategy.READ, this, "calibrationStatus", lblCalibrationStatus, "text");
-        
+
+        addWrappedBinding(nozzleTip.getCalibration(), "backgroundCalibrationMethod",
+                backgroundCalibrationMethod, "selectedItem");
+
+        addWrappedBinding(nozzleTip.getCalibration(), "minimumDetailSize", minimumDetailSize,
+                "text", lengthConverter);
+
+        addWrappedBinding(nozzleTip.getCalibration(), "backgroundMinValue", backgroundMinValue,
+                "text", intConverter);
+        addWrappedBinding(nozzleTip.getCalibration(), "backgroundMaxValue", backgroundMaxValue,
+                "text", intConverter);
+        addWrappedBinding(nozzleTip.getCalibration(), "backgroundMinSaturation", backgroundMinSaturation,
+                "text", intConverter);
+        addWrappedBinding(nozzleTip.getCalibration(), "backgroundMaxSaturation", backgroundMaxSaturation,
+                "text", intConverter);
+        addWrappedBinding(nozzleTip.getCalibration(), "backgroundMinHue", backgroundMinHue,
+                "text", intConverter);
+        addWrappedBinding(nozzleTip.getCalibration(), "backgroundMaxHue", backgroundMaxHue,
+                "text", intConverter);
+
+        bind(UpdateStrategy.READ, nozzleTip.getCalibration(), "backgroundMinHue", hsvIndicator, "minHue");
+        bind(UpdateStrategy.READ, nozzleTip.getCalibration(), "backgroundMaxHue", hsvIndicator, "maxHue");
+        bind(UpdateStrategy.READ, nozzleTip.getCalibration(), "backgroundMinSaturation", hsvIndicator, "minSaturation");
+        bind(UpdateStrategy.READ, nozzleTip.getCalibration(), "backgroundMaxSaturation", hsvIndicator, "maxSaturation");
+        bind(UpdateStrategy.READ, nozzleTip.getCalibration(), "backgroundMinValue", hsvIndicator, "minValue");
+        bind(UpdateStrategy.READ, nozzleTip.getCalibration(), "backgroundMaxValue", hsvIndicator, "maxValue");
+
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(offsetThresholdTf);
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(calibrationZOffsetTf);
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(calibrationTipDiameter);
+        ComponentDecorators.decorateWithAutoSelectAndLengthConversion(minimumDetailSize);
 
         try {
             Camera camera = VisionUtils.getBottomVisionCamera();
@@ -465,47 +630,5 @@ public class ReferenceNozzleTipCalibrationWizard extends AbstractConfigurationWi
         catch (Exception e1) {
             Logger.warn(e1);
         }
-    }
-    protected void initDataBindings() {
-        BeanProperty<JCheckBox, Boolean> jCheckBoxBeanProperty = BeanProperty.create("selected");
-        BeanProperty<JButton, Boolean> jButtonBeanProperty = BeanProperty.create("enabled");
-        AutoBinding<JCheckBox, Boolean, JButton, Boolean> autoBinding = Bindings.createAutoBinding(UpdateStrategy.READ, calibrationEnabledCheckbox, jCheckBoxBeanProperty, btnCalibrate, jButtonBeanProperty);
-        autoBinding.bind();
-        //
-        AutoBinding<JCheckBox, Boolean, JButton, Boolean> autoBinding_1 = Bindings.createAutoBinding(UpdateStrategy.READ, calibrationEnabledCheckbox, jCheckBoxBeanProperty, btnReset, jButtonBeanProperty);
-        autoBinding_1.bind();
-        //
-        AutoBinding<JCheckBox, Boolean, JButton, Boolean> autoBinding_10 = Bindings.createAutoBinding(UpdateStrategy.READ, calibrationEnabledCheckbox, jCheckBoxBeanProperty, btnCalibrateCamera, jButtonBeanProperty);
-        autoBinding_10.bind();
-        //
-        BeanProperty<JTextField, Boolean> jTextFieldBeanProperty = BeanProperty.create("enabled");
-        AutoBinding<JCheckBox, Boolean, JTextField, Boolean> autoBinding_3 = Bindings.createAutoBinding(UpdateStrategy.READ, calibrationEnabledCheckbox, jCheckBoxBeanProperty, angleIncrementsTf, jTextFieldBeanProperty);
-        autoBinding_3.bind();
-        //
-        AutoBinding<JCheckBox, Boolean, JTextField, Boolean> autoBinding_6 = Bindings.createAutoBinding(UpdateStrategy.READ, calibrationEnabledCheckbox, jCheckBoxBeanProperty, offsetThresholdTf, jTextFieldBeanProperty);
-        autoBinding_6.bind();
-        //
-        AutoBinding<JCheckBox, Boolean, JTextField, Boolean> autoBinding_7 = Bindings.createAutoBinding(UpdateStrategy.READ, calibrationEnabledCheckbox, jCheckBoxBeanProperty, calibrationZOffsetTf, jTextFieldBeanProperty);
-        autoBinding_7.bind();
-        //
-        AutoBinding<JCheckBox, Boolean, JTextField, Boolean> autoBinding_8 = Bindings.createAutoBinding(UpdateStrategy.READ, calibrationEnabledCheckbox, jCheckBoxBeanProperty, allowMisdetectsTf, jTextFieldBeanProperty);
-        autoBinding_8.bind();
-        //
-        AutoBinding<JCheckBox, Boolean, JButton, Boolean> autoBinding_4 = Bindings.createAutoBinding(UpdateStrategy.READ, calibrationEnabledCheckbox, jCheckBoxBeanProperty, btnEditPipeline, jButtonBeanProperty);
-        autoBinding_4.bind();
-        //
-        AutoBinding<JCheckBox, Boolean, JButton, Boolean> autoBinding_5 = Bindings.createAutoBinding(UpdateStrategy.READ, calibrationEnabledCheckbox, jCheckBoxBeanProperty, btnResetPipeline, jButtonBeanProperty);
-        autoBinding_5.bind();
-        //
-        BeanProperty<JComboBox, Boolean> jComboBoxBeanProperty = BeanProperty.create("enabled");
-        AutoBinding<JCheckBox, Boolean, JComboBox, Boolean> autoBinding_9 = Bindings.createAutoBinding(UpdateStrategy.READ, calibrationEnabledCheckbox, jCheckBoxBeanProperty, recalibrationCb, jComboBoxBeanProperty);
-        autoBinding_9.bind();
-        //
-        AutoBinding<JCheckBox, Boolean, JTextField, Boolean> autoBinding_2 = Bindings.createAutoBinding(UpdateStrategy.READ, calibrationEnabledCheckbox, jCheckBoxBeanProperty, calibrationTipDiameter, jTextFieldBeanProperty);
-        autoBinding_2.bind();
-        //
-        BeanProperty<JCheckBox, Boolean> jCheckBoxBeanProperty_1 = BeanProperty.create("enabled");
-        AutoBinding<JCheckBox, Boolean, JCheckBox, Boolean> autoBinding_11 = Bindings.createAutoBinding(UpdateStrategy.READ, calibrationEnabledCheckbox, jCheckBoxBeanProperty, failHoming, jCheckBoxBeanProperty_1);
-        autoBinding_11.bind();
     }
 }

--- a/src/main/java/org/openpnp/machine/reference/wizards/ReferenceNozzleTipCalibrationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/wizards/ReferenceNozzleTipCalibrationWizard.java
@@ -20,7 +20,6 @@
 package org.openpnp.machine.reference.wizards;
 
 import java.awt.Component;
-import java.awt.FlowLayout;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.ItemEvent;
@@ -85,10 +84,12 @@ public class ReferenceNozzleTipCalibrationWizard extends AbstractConfigurationWi
     private JButton btnCalibrate;
     private JButton btnReset;
     private JLabel lblCalibrationInfo;
-    private JLabel lblCalibrationStatus;
+    private JLabel calibrationStatus;
     private JCheckBox calibrationEnabledCheckbox;
 
     private JPanel panelBackground;
+
+    private JPanel panelTop;
 
 
     public ReferenceNozzleTipCalibrationWizard(ReferenceNozzleTip nozzleTip) {
@@ -96,6 +97,68 @@ public class ReferenceNozzleTipCalibrationWizard extends AbstractConfigurationWi
 
         CellConstraints cc = new CellConstraints();
 
+        panelTop = new JPanel();
+        panelTop.setBorder(new TitledBorder(null, "Calibration",
+                TitledBorder.LEADING, TitledBorder.TOP, null, null));
+        contentPanel.add(panelTop);
+        panelTop.setLayout(new FormLayout(new ColumnSpec[] {
+                FormSpecs.RELATED_GAP_COLSPEC,
+                ColumnSpec.decode("max(70dlu;default)"),
+                FormSpecs.RELATED_GAP_COLSPEC,
+                ColumnSpec.decode("max(50dlu;default)"),
+                FormSpecs.RELATED_GAP_COLSPEC,
+                ColumnSpec.decode("max(50dlu;default)"),
+                FormSpecs.RELATED_GAP_COLSPEC,
+                ColumnSpec.decode("max(96dlu;default)"),
+                FormSpecs.UNRELATED_GAP_COLSPEC,
+                FormSpecs.DEFAULT_COLSPEC,},
+                new RowSpec[] {
+                        FormSpecs.RELATED_GAP_ROWSPEC,
+                        FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC,
+                        FormSpecs.DEFAULT_ROWSPEC,}));
+
+        calibrationEnabledCheckbox = new JCheckBox("Enable?");
+        panelTop.add(calibrationEnabledCheckbox, "2, 2, right, default");
+
+
+        buttonCenterTool = new JButton(positionToolAction);
+        panelTop.add(buttonCenterTool, "4, 2, fill, default");
+        buttonCenterTool.setHideActionText(true);
+
+        lblCalibrate = new JLabel("Calibration");
+        panelTop.add(lblCalibrate, "2, 4, right, default");
+
+        btnCalibrate = new JButton("Calibrate");
+        panelTop.add(btnCalibrate, "4, 4");
+
+        btnReset = new JButton("Reset");
+        panelTop.add(btnReset, "6, 4");
+
+        btnCalibrateCamera = new JButton("Calibrate Camera Position and Rotation");
+        panelTop.add(btnCalibrateCamera, "8, 4");
+        btnCalibrateCamera.setToolTipText("<html>\r\nCalibrate the bottom vision camera position and rotation <br />\r\naccording to a pattern of measured nozzle positions.\r\n</html>");
+        btnCalibrateCamera.addActionListener(new ActionListener() {
+            public void actionPerformed(ActionEvent e) {
+                calibrateCamera();
+            }
+        });
+        btnReset.addActionListener(new ActionListener() {
+            public void actionPerformed(ActionEvent e) {
+                nozzleTip.getCalibration()
+                .resetAll();
+            }
+        });
+        btnCalibrate.addActionListener(new ActionListener() {
+            public void actionPerformed(ActionEvent e) {
+                calibrate();
+            }
+        });
+        calibrationEnabledCheckbox.addItemListener(new ItemListener() {
+            public void itemStateChanged(ItemEvent arg0) {
+                adaptDialog();
+            }
+        });
 
         panelCalibration = new JPanel();
         panelCalibration.setBorder(new TitledBorder(null, "Nozzle Tip Calibration",
@@ -109,7 +172,7 @@ public class ReferenceNozzleTipCalibrationWizard extends AbstractConfigurationWi
                 FormSpecs.RELATED_GAP_COLSPEC,
                 FormSpecs.DEFAULT_COLSPEC,
                 FormSpecs.RELATED_GAP_COLSPEC,
-                ColumnSpec.decode("max(96dlu;default)"),
+                FormSpecs.DEFAULT_COLSPEC,
                 FormSpecs.UNRELATED_GAP_COLSPEC,
                 FormSpecs.DEFAULT_COLSPEC,},
             new RowSpec[] {
@@ -126,110 +189,56 @@ public class ReferenceNozzleTipCalibrationWizard extends AbstractConfigurationWi
                 FormSpecs.RELATED_GAP_ROWSPEC,
                 FormSpecs.DEFAULT_ROWSPEC,
                 FormSpecs.RELATED_GAP_ROWSPEC,
-                FormSpecs.DEFAULT_ROWSPEC,
-                FormSpecs.RELATED_GAP_ROWSPEC,
                 FormSpecs.DEFAULT_ROWSPEC,}));
-
-        calibrationEnabledCheckbox = new JCheckBox("Enable?");
-        calibrationEnabledCheckbox.addItemListener(new ItemListener() {
-            public void itemStateChanged(ItemEvent arg0) {
-                adaptDialog();
-            }
-        });
-        panelCalibration.add(calibrationEnabledCheckbox, "2, 2, right, default");
-
-
-        buttonCenterTool = new JButton(positionToolAction);
-        buttonCenterTool.setHideActionText(true);
-        panelCalibration.add(buttonCenterTool, "4, 2, left, default");
 
 
         lblCalibrationInfo = new JLabel("Status");
-        panelCalibration.add(lblCalibrationInfo, "2, 4, right, default");
+        panelCalibration.add(lblCalibrationInfo, "2, 2, right, default");
 
-        lblCalibrationStatus = new JLabel(getCalibrationStatus());
-        panelCalibration.add(lblCalibrationStatus, "4, 4, 3, 1, left, default");
-
-        lblCalibrate = new JLabel("Calibration");
-        panelCalibration.add(lblCalibrate, "2, 6, right, default");
-
-        panel_1 = new JPanel();
-        panel_1.setBorder(null);
-        FlowLayout flowLayout_1 = (FlowLayout) panel_1.getLayout();
-        flowLayout_1.setHgap(0);
-        flowLayout_1.setVgap(0);
-        panelCalibration.add(panel_1, "4, 6, left, fill");
-
-        btnCalibrate = new JButton("Calibrate");
-        panel_1.add(btnCalibrate);
-
-
-        btnReset = new JButton("Reset");
-        panel_1.add(btnReset);
-        btnReset.addActionListener(new ActionListener() {
-            public void actionPerformed(ActionEvent e) {
-                nozzleTip.getCalibration()
-                    .resetAll();
-            }
-        });
-        btnCalibrate.addActionListener(new ActionListener() {
-            public void actionPerformed(ActionEvent e) {
-                calibrate();
-            }
-        });
-
-
-
-        btnCalibrateCamera = new JButton("Calibrate Camera Position and Rotation");
-        btnCalibrateCamera.setToolTipText("<html>\r\nCalibrate the bottom vision camera position and rotation <br />\r\naccording to a pattern of measured nozzle positions.\r\n</html>");
-        panelCalibration.add(btnCalibrateCamera, "6, 6, 3, 1");
-        btnCalibrateCamera.addActionListener(new ActionListener() {
-            public void actionPerformed(ActionEvent e) {
-                calibrateCamera();
-            }
-        });
+        calibrationStatus = new JLabel(getCalibrationStatus());
+        panelCalibration.add(calibrationStatus, "4, 2, 3, 1, left, default");
 
         lblAngleIncrements = new JLabel("Circle Divisions");
-        panelCalibration.add(lblAngleIncrements, "2, 8, right, default");
+        panelCalibration.add(lblAngleIncrements, "2, 4, right, default");
 
         angleIncrementsTf = new JTextField();
-        panelCalibration.add(angleIncrementsTf, "4, 8, left, default");
+        panelCalibration.add(angleIncrementsTf, "4, 4, fill, default");
         angleIncrementsTf.setColumns(3);
 
         lblAllowMisdectects = new JLabel("Allowed Misdectects");
         lblAllowMisdectects.setToolTipText("Number of missed detections tolerated before a calibration fails.");
-        panelCalibration.add(lblAllowMisdectects, "6, 8, right, default");
+        panelCalibration.add(lblAllowMisdectects, "6, 4, right, default");
 
         allowMisdetectsTf = new JTextField();
-        panelCalibration.add(allowMisdetectsTf, "8, 8, left, default");
+        panelCalibration.add(allowMisdetectsTf, "8, 4, fill, default");
         allowMisdetectsTf.setColumns(3);
 
         lblOffsetThreshold = new JLabel("Offset Threshold");
-        panelCalibration.add(lblOffsetThreshold, "2, 10, right, default");
+        panelCalibration.add(lblOffsetThreshold, "2, 6, right, default");
 
         offsetThresholdTf = new JTextField();
-        panelCalibration.add(offsetThresholdTf, "4, 10, left, default");
+        panelCalibration.add(offsetThresholdTf, "4, 6, left, default");
         offsetThresholdTf.setColumns(10);
 
         lblCalibrationZOffset = new JLabel("Calibration Z Offset");
         lblCalibrationZOffset.setToolTipText("<html>\r\n<p>\r\nWhen the vision-detected feature of a nozzle is higher up on the nozzle tip <br />\r\nit is recommended to shift the focus plane with the \"Z Offset\".\r\n</p>\r\n<p>If a nozzle tip is named \"unloaded\" it is used as a stand-in for calibration<br />\r\nof the bare nozzle tip holder. Again the \"Z Offset\" can be used to calibrate at the <br />\r\nproper focal plane. \r\n</p>\r\n</html>");
-        panelCalibration.add(lblCalibrationZOffset, "6, 10, right, default");
+        panelCalibration.add(lblCalibrationZOffset, "6, 6, right, default");
 
         calibrationZOffsetTf = new JTextField();
-        panelCalibration.add(calibrationZOffsetTf, "8, 10, left, default");
+        panelCalibration.add(calibrationZOffsetTf, "8, 6, fill, default");
         calibrationZOffsetTf.setColumns(10);
-        
+
         lblNozzleTipDiameter = new JLabel("Vision Diameter");
         lblNozzleTipDiameter.setToolTipText("<html>\r\nDiameter of the feature/edge that should be detected in calibration vision.<br/>\r\nOnly used with pipelines that have a DetectCircularSymmetry stage.\r\n</html>");
-        panelCalibration.add(lblNozzleTipDiameter, "2, 12, right, default");
-        
+        panelCalibration.add(lblNozzleTipDiameter, "2, 8, right, default");
+
         calibrationTipDiameter = new JTextField();
-        panelCalibration.add(calibrationTipDiameter, "4, 12, left, default");
+        panelCalibration.add(calibrationTipDiameter, "4, 8, left, default");
         calibrationTipDiameter.setColumns(10);
 
         lblRecalibration = new JLabel("Automatic Recalibration");
         lblRecalibration.setToolTipText("<html>\r\n<p>Determines when a recalibration is automatically executed:</p>\r\n<p><ul><li>On each nozzle tip change.</li>\r\n<li>On each nozzle tip change but only in Jobs.</li>\r\n<li>On machine homing and when first loaded. </li></ul></p>\r\n<p>Manual with stored calibration (only recommended for machines <br /> \r\nwith C axis homing).</p>\r\n</html>");
-        panelCalibration.add(lblRecalibration, "2, 14, right, default");
+        panelCalibration.add(lblRecalibration, "2, 10, right, default");
 
         recalibrationCb = new JComboBox(ReferenceNozzleTipCalibration.RecalibrationTrigger.values());
         recalibrationCb.addItemListener(new ItemListener() {
@@ -237,41 +246,36 @@ public class ReferenceNozzleTipCalibrationWizard extends AbstractConfigurationWi
                 adaptDialog();
             }
         });
-        panelCalibration.add(recalibrationCb, "4, 14, left, default");
-
-        lblFailHoming = new JLabel("Fail Homing?");
-        lblFailHoming.setToolTipText(
-                "When the calibration fails during homing, also fail the homing cycle.");
-        panelCalibration.add(lblFailHoming, "6, 14, right, default");
+        panelCalibration.add(recalibrationCb, "4, 10, 3, 1, fill, default");
+                
+                        lblFailHoming = new JLabel("Fail Homing?");
+                        lblFailHoming.setToolTipText(
+                                "When the calibration fails during homing, also fail the homing cycle.");
+                        panelCalibration.add(lblFailHoming, "2, 12, right, default");
+                
+                        failHoming = new JCheckBox("");
+                        panelCalibration.add(failHoming, "4, 12");
         
-        failHoming = new JCheckBox("");
-        panelCalibration.add(failHoming, "8, 14");
-
-        lblNewLabel = new JLabel("Pipeline");
-        panelCalibration.add(lblNewLabel, "2, 16, right, default");
-
-        panel = new JPanel();
-        FlowLayout flowLayout = (FlowLayout) panel.getLayout();
-        flowLayout.setVgap(0);
-        panelCalibration.add(panel, "4, 16, fill, default");
-
-        btnEditPipeline = new JButton("Edit");
-        panel.add(btnEditPipeline);
-
-        btnResetPipeline = new JButton("Reset");
-        panel.add(btnResetPipeline);
-        btnResetPipeline.addActionListener(new ActionListener() {
-            public void actionPerformed(ActionEvent e) {
-                resetCalibrationPipeline();
-            }
-        });
-        btnEditPipeline.addActionListener(new ActionListener() {
-            public void actionPerformed(ActionEvent e) {
-                UiUtils.messageBoxOnException(() -> {
-                    editCalibrationPipeline();
-                });
-            }
-        });
+                lblNewLabel = new JLabel("Pipeline");
+                panelCalibration.add(lblNewLabel, "2, 14, right, default");
+                
+                        btnEditPipeline = new JButton("Edit");
+                        panelCalibration.add(btnEditPipeline, "4, 14");
+                        
+                                btnResetPipeline = new JButton("Reset");
+                                panelCalibration.add(btnResetPipeline, "6, 14");
+                                btnResetPipeline.addActionListener(new ActionListener() {
+                                    public void actionPerformed(ActionEvent e) {
+                                        resetCalibrationPipeline();
+                                    }
+                                });
+                        btnEditPipeline.addActionListener(new ActionListener() {
+                            public void actionPerformed(ActionEvent e) {
+                                UiUtils.messageBoxOnException(() -> {
+                                    editCalibrationPipeline();
+                                });
+                            }
+                        });
 
         nozzleTip.getCalibration().addPropertyChangeListener("calibrationInformation", e -> {
             firePropertyChange("calibrationStatus", null, null);;
@@ -302,7 +306,9 @@ public class ReferenceNozzleTipCalibrationWizard extends AbstractConfigurationWi
                 FormSpecs.RELATED_GAP_COLSPEC,
                 ColumnSpec.decode("max(70dlu;default)"),
                 FormSpecs.RELATED_GAP_COLSPEC,
-                ColumnSpec.decode("max(96dlu;default)"),},
+                FormSpecs.DEFAULT_COLSPEC,
+                FormSpecs.RELATED_GAP_COLSPEC,
+                ColumnSpec.decode("default:grow"),},
             new RowSpec[] {
                 FormSpecs.RELATED_GAP_ROWSPEC,
                 FormSpecs.DEFAULT_ROWSPEC,
@@ -316,71 +322,77 @@ public class ReferenceNozzleTipCalibrationWizard extends AbstractConfigurationWi
                 FormSpecs.DEFAULT_ROWSPEC,
                 FormSpecs.RELATED_GAP_ROWSPEC,
                 RowSpec.decode("max(50dlu;default)"),}));
-        
+
         lblMethod = new JLabel("Method");
         panelBackground.add(lblMethod, "2, 2, right, default");
-        
+
         backgroundCalibrationMethod = new JComboBox(BackgroundCalibrationMethod.values());
         backgroundCalibrationMethod.addItemListener(new ItemListener() {
             public void itemStateChanged(ItemEvent arg0) {
                 adaptDialog();
             }
         });
-        panelBackground.add(backgroundCalibrationMethod, "4, 2, fill, default");
+        panelBackground.add(backgroundCalibrationMethod, "4, 2, 3, 1, fill, default");
         
+        lblBlowup = new JLabel(" ");
+        panelBackground.add(lblBlowup, "10, 2");
+
         lblDetailSize = new JLabel("Minimum Detail Size");
         lblDetailSize.setToolTipText("<html>\n<p>Specify the size of the smallest details in the image that are considered a<br/>\nmeaningfull part of the shape to be detected.<br/>\nSmaller specks and artifacts, such as image noise, textures, markings, or dirt on<br/>\nobjects, are considered irrelevant for image processing, which means that<br/>\nfilters can be applied to suppress them in the image. </p> \n</html>");
         panelBackground.add(lblDetailSize, "2, 4, right, default");
-        
+
         minimumDetailSize = new JTextField();
         panelBackground.add(minimumDetailSize, "4, 4, fill, default");
         minimumDetailSize.setColumns(10);
-        
+
         lblBrightnessMin = new JLabel("Brightness Min");
         panelBackground.add(lblBrightnessMin, "2, 6, right, default");
-        
+
         backgroundMinValue = new JTextField();
         panelBackground.add(backgroundMinValue, "4, 6, fill, default");
         backgroundMinValue.setColumns(10);
-        
+
         lblBrightnessMax = new JLabel("Brightness Max");
         panelBackground.add(lblBrightnessMax, "6, 6, right, default");
-        
+
         backgroundMaxValue = new JTextField();
         panelBackground.add(backgroundMaxValue, "8, 6, fill, default");
         backgroundMaxValue.setColumns(10);
-        
+
         lblHueMin = new JLabel("Hue Min");
         panelBackground.add(lblHueMin, "2, 8, right, default");
-        
+
         backgroundMinHue = new JTextField();
         panelBackground.add(backgroundMinHue, "4, 8, fill, default");
         backgroundMinHue.setColumns(10);
-        
+
         lblHueMax = new JLabel("Hue Max");
         panelBackground.add(lblHueMax, "6, 8, right, default");
-        
+
         backgroundMaxHue = new JTextField();
         panelBackground.add(backgroundMaxHue, "8, 8, fill, default");
         backgroundMaxHue.setColumns(10);
-        
+
         lblSaturationMin = new JLabel("Saturation Min");
         panelBackground.add(lblSaturationMin, "2, 10, right, default");
-        
+
         backgroundMinSaturation = new JTextField();
         panelBackground.add(backgroundMinSaturation, "4, 10, fill, default");
         backgroundMinSaturation.setColumns(10);
-        
+
         lblSaturationMax = new JLabel("Saturation Max");
         panelBackground.add(lblSaturationMax, "6, 10, right, default");
-        
+
         backgroundMaxSaturation = new JTextField();
         panelBackground.add(backgroundMaxSaturation, "8, 10, fill, default");
         backgroundMaxSaturation.setColumns(10);
-        
+
         hsvIndicator = new HsvIndicator();
-        panelBackground.add(hsvIndicator, "4, 12, 5, 1");
-        
+        panelBackground.add(hsvIndicator, "4, 12, 3, 1");
+
+        backgroundDiagnostics = new JLabel("No diagnostics yet.");
+        panelBackground.add(backgroundDiagnostics, "8, 12, 3, 1");
+
         adaptDialog();
     }
 
@@ -390,12 +402,15 @@ public class ReferenceNozzleTipCalibrationWizard extends AbstractConfigurationWi
                 || recalibration == ReferenceNozzleTipCalibration.RecalibrationTrigger.NozzleTipChange);
         lblFailHoming.setVisible(calibratesOnHoming);
         failHoming.setVisible(calibratesOnHoming);
-        
+
         boolean enabled = calibrationEnabledCheckbox.isSelected();
-        for (Component comp : panelCalibration.getComponents()) {
+        for (Component comp : panelTop.getComponents()) {
             if (comp != calibrationEnabledCheckbox) { 
                 comp.setEnabled(enabled); 
             }
+        }
+        for (Component comp : panelCalibration.getComponents()) {
+            comp.setEnabled(enabled); 
         }
         BackgroundCalibrationMethod method = (BackgroundCalibrationMethod) backgroundCalibrationMethod.getSelectedItem();
         for (Component comp : panelBackground.getComponents()) {
@@ -406,7 +421,9 @@ public class ReferenceNozzleTipCalibrationWizard extends AbstractConfigurationWi
             else if (comp == backgroundMinValue || comp == backgroundMaxValue
                     || comp == minimumDetailSize
                     || comp == lblBrightnessMin || comp == lblBrightnessMax
-                    || comp == lblDetailSize) {
+                    || comp == lblDetailSize
+                    || comp == hsvIndicator
+                    || comp == backgroundDiagnostics) {
                 comp.setEnabled(enabled && (method != BackgroundCalibrationMethod.None)); 
             }
             else {
@@ -435,8 +452,6 @@ public class ReferenceNozzleTipCalibrationWizard extends AbstractConfigurationWi
     };
     private JLabel lblNewLabel;
     private JLabel lblCalibrate;
-    private JPanel panel;
-    private JPanel panel_1;
     private JLabel lblAllowMisdectects;
     private JTextField allowMisdetectsTf;
     private JLabel lblCalibrationZOffset;
@@ -466,6 +481,8 @@ public class ReferenceNozzleTipCalibrationWizard extends AbstractConfigurationWi
     private JTextField backgroundMaxValue;
     private HsvIndicator hsvIndicator;
     private JPanel panel_2;
+    private JLabel backgroundDiagnostics;
+    private JLabel lblBlowup;
 
     public static ReferenceNozzle getUiCalibrationNozzle(ReferenceNozzleTip nozzleTip) throws Exception {
         ReferenceNozzle refNozzle; 
@@ -550,6 +567,7 @@ public class ReferenceNozzleTipCalibrationWizard extends AbstractConfigurationWi
     }
 
     private void calibrate() {
+        applyAction.actionPerformed(null);
         UiUtils.submitUiMachineTask(() -> {
             nozzleTip.getCalibration()
                 .calibrate(getUiCalibrationNozzle(nozzleTip));
@@ -557,6 +575,7 @@ public class ReferenceNozzleTipCalibrationWizard extends AbstractConfigurationWi
     }
 
     private void calibrateCamera() {
+        applyAction.actionPerformed(null);
         UiUtils.submitUiMachineTask(() -> {
             nozzleTip.getCalibration()
                 .calibrateCamera(getUiCalibrationNozzle(nozzleTip));
@@ -585,8 +604,8 @@ public class ReferenceNozzleTipCalibrationWizard extends AbstractConfigurationWi
 
         addWrappedBinding(nozzleTip.getCalibration(), "recalibrationTrigger",
                 recalibrationCb, "selectedItem");
-        
-        bind(UpdateStrategy.READ, this, "calibrationStatus", lblCalibrationStatus, "text");
+
+        bind(UpdateStrategy.READ, this, "calibrationStatus", calibrationStatus, "text");
 
         addWrappedBinding(nozzleTip.getCalibration(), "backgroundCalibrationMethod",
                 backgroundCalibrationMethod, "selectedItem");
@@ -614,6 +633,14 @@ public class ReferenceNozzleTipCalibrationWizard extends AbstractConfigurationWi
         bind(UpdateStrategy.READ, nozzleTip.getCalibration(), "backgroundMinValue", hsvIndicator, "minValue");
         bind(UpdateStrategy.READ, nozzleTip.getCalibration(), "backgroundMaxValue", hsvIndicator, "maxValue");
 
+        bind(UpdateStrategy.READ, nozzleTip.getCalibration(), "backgroundDiagnostics", backgroundDiagnostics, "text");
+
+        ComponentDecorators.decorateWithAutoSelect(backgroundMinValue);
+        ComponentDecorators.decorateWithAutoSelect(backgroundMaxValue);
+        ComponentDecorators.decorateWithAutoSelect(backgroundMinSaturation);
+        ComponentDecorators.decorateWithAutoSelect(backgroundMaxSaturation);
+        ComponentDecorators.decorateWithAutoSelect(backgroundMinHue);
+        ComponentDecorators.decorateWithAutoSelect(backgroundMaxHue);
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(offsetThresholdTf);
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(calibrationZOffsetTf);
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(calibrationTipDiameter);

--- a/src/main/java/org/openpnp/machine/reference/wizards/ReferenceNozzleTipConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/wizards/ReferenceNozzleTipConfigurationWizard.java
@@ -190,7 +190,7 @@ public class ReferenceNozzleTipConfigurationWizard extends AbstractConfiguration
 
         lblMaxPartDiameter = new JLabel("Max. Part Diameter");
         lblMaxPartDiameter.setToolTipText(
-                "Maximum diameter/diagonal of parts picked with this nozzle tip. ");
+                "<html>\nMaximum diameter/diagonal of parts picked with this nozzle tip, <br/>\nincluding tolerances.\n</html>\n");
         panelPartDimensions.add(lblMaxPartDiameter, "2, 2, right, default");
 
         maxPartDiameter = new JTextField();

--- a/src/main/java/org/openpnp/util/VisionUtils.java
+++ b/src/main/java/org/openpnp/util/VisionUtils.java
@@ -1,5 +1,6 @@
 package org.openpnp.util;
 
+import java.awt.Color;
 import java.awt.image.BufferedImage;
 import java.util.Collections;
 import java.util.Comparator;
@@ -274,6 +275,32 @@ public class VisionUtils {
                 histogram[0][r]++;
                 histogram[1][g]++;
                 histogram[2][b]++;
+            }
+        }
+        return histogram;
+    }
+
+    /**
+     * Compute an RGB histogram over the provided image.
+     * 
+     * @param image
+     * @return the histogram as long[channel][value] with channel 0=Red 1=Green 2=Blue and value 0...255.
+     */
+    public static long[][] computeImageHistogramHsv(BufferedImage image) {
+        long[][] histogram = new long[3][256];
+        for (int y = 0; y < image.getHeight(); y++) {
+            for (int x = 0; x < image.getWidth(); x++) {
+                int rgb = image.getRGB(x, y);
+                int r = (rgb >> 16) & 0xff;
+                int g = (rgb >> 8) & 0xff;
+                int b = (rgb >> 0) & 0xff;
+                float[] hsb = Color.RGBtoHSB(r, g, b, null);
+                int h = (int)(hsb[0]*255.999);
+                int s = (int)(hsb[1]*255.999);
+                int v = (int)(hsb[2]*255.999);
+                histogram[0][h]++;
+                histogram[1][s]++;
+                histogram[2][v]++;
             }
         }
         return histogram;

--- a/src/main/java/org/openpnp/vision/pipeline/CvPipeline.java
+++ b/src/main/java/org/openpnp/vision/pipeline/CvPipeline.java
@@ -1,5 +1,6 @@
 package org.openpnp.vision.pipeline;
 
+import java.awt.image.BufferedImage;
 import java.io.IOException;
 import java.io.StringReader;
 import java.io.StringWriter;
@@ -64,6 +65,8 @@ public class CvPipeline implements AutoCloseable {
     private ColorSpace workingColorSpace;
     
     private long totalProcessingTimeNs;
+
+    private BufferedImage lastCapturedImage;
     
     public CvPipeline() {
         
@@ -405,5 +408,13 @@ public class CvPipeline implements AutoCloseable {
         AnnotationStrategy strategy = new AnnotationStrategy();
         Serializer serializer = new Persister(strategy, format);
         return serializer;
+    }
+
+    public BufferedImage getLastCapturedImage() {
+        return lastCapturedImage;
+    }
+
+    public void setLastCapturedImage(BufferedImage lastCapturedImage) {
+        this.lastCapturedImage = lastCapturedImage;
     }
 }

--- a/src/main/java/org/openpnp/vision/pipeline/stages/BlurGaussian.java
+++ b/src/main/java/org/openpnp/vision/pipeline/stages/BlurGaussian.java
@@ -3,6 +3,7 @@ package org.openpnp.vision.pipeline.stages;
 import org.opencv.core.Mat;
 import org.opencv.core.Size;
 import org.opencv.imgproc.Imgproc;
+import org.openpnp.model.Length;
 import org.openpnp.vision.pipeline.CvPipeline;
 import org.openpnp.vision.pipeline.CvStage;
 import org.openpnp.vision.pipeline.Property;
@@ -15,6 +16,10 @@ public class BlurGaussian extends CvStage {
     @Property(description="Width and height of the blurring kernel. Should be and odd number greater than or equal to 3")
     private int kernelSize = 3;
 
+    @Attribute(required = false)
+    @Property(description = "Name of the property controlled by OpenPnP. Use \"BlurGaussian\" for bottom vision background removal blur.")
+    private String propertyName = "BlurGaussian";
+
     public int getKernelSize() {
         return kernelSize;
     }
@@ -24,8 +29,18 @@ public class BlurGaussian extends CvStage {
         this.kernelSize = this.kernelSize < 3 ? 3 : this.kernelSize;
     }
 
+    public String getPropertyName() {
+        return propertyName;
+    }
+
+    public void setPropertyName(String propertyName) {
+        this.propertyName = propertyName;
+    }
+
     @Override
     public Result process(CvPipeline pipeline) throws Exception {
+        int kernelSize = getPossiblePipelinePropertyOverride(this.kernelSize, pipeline, propertyName+".kernelSize",
+                Double.class, Length.class)|1;
         Mat mat = pipeline.getWorkingImage();
         Imgproc.GaussianBlur(mat, mat, new Size(kernelSize, kernelSize), 0);
         return null;

--- a/src/main/java/org/openpnp/vision/pipeline/stages/BlurGaussian.java
+++ b/src/main/java/org/openpnp/vision/pipeline/stages/BlurGaussian.java
@@ -17,7 +17,7 @@ public class BlurGaussian extends CvStage {
     private int kernelSize = 3;
 
     @Attribute(required = false)
-    @Property(description = "Name of the property controlled by OpenPnP. Use \"BlurGaussian\" for bottom vision background removal blur.")
+    @Property(description = "Name of the property through which OpenPnP controls this stage. Use \"BlurGaussian\" for standard control.")
     private String propertyName = "BlurGaussian";
 
     public int getKernelSize() {

--- a/src/main/java/org/openpnp/vision/pipeline/stages/CreateFootprintTemplateImage.java
+++ b/src/main/java/org/openpnp/vision/pipeline/stages/CreateFootprintTemplateImage.java
@@ -4,9 +4,7 @@ import java.awt.Color;
 import java.awt.image.BufferedImage;
 
 import org.openpnp.model.Footprint;
-import org.openpnp.model.Part;
 import org.openpnp.spi.Camera;
-import org.openpnp.spi.Nozzle;
 import org.openpnp.util.OpenCvUtils;
 import org.openpnp.vision.FluentCv.ColorSpace;
 import org.openpnp.vision.pipeline.CvPipeline;
@@ -95,12 +93,6 @@ public class CreateFootprintTemplateImage extends CvStage {
     public Result process(CvPipeline pipeline) throws Exception {
         Camera camera = (Camera) pipeline.getProperty("camera");
         Footprint footprint = (Footprint) pipeline.getProperty("footprint");
-        if (footprint == null && pipeline.getProperty("nozzle") != null) {
-            Nozzle nozzle = (Nozzle)pipeline.getProperty("nozzle");
-            if (nozzle.getPart() != null) {
-                footprint = nozzle.getPart().getPackage().getFootprint();
-            }
-        }
 
         if (camera == null) {
             throw new Exception("Property \"camera\" is required.");

--- a/src/main/java/org/openpnp/vision/pipeline/stages/FilterContours.java
+++ b/src/main/java/org/openpnp/vision/pipeline/stages/FilterContours.java
@@ -5,8 +5,10 @@ import java.util.List;
 
 import org.opencv.core.MatOfPoint;
 import org.opencv.imgproc.Imgproc;
+import org.openpnp.model.Area;
 import org.openpnp.vision.pipeline.CvPipeline;
 import org.openpnp.vision.pipeline.CvStage;
+import org.openpnp.vision.pipeline.Property;
 import org.simpleframework.xml.Attribute;
 
 /**
@@ -17,11 +19,17 @@ public class FilterContours extends CvStage {
     private String contoursStageName = null;
     
     @Attribute
+    @Property(description = "Minimum area of the contour, or -1 if no minimum limit is wanted.")
     private double minArea = -1;
     
     @Attribute
+    @Property(description = "Maximum area of the contour, or -1 if no maximum limit is wanted.")
     private double maxArea = -1;
-    
+
+    @Attribute(required = false)
+    @Property(description = "Name of the property through which OpenPnP controls this stage. Use \"FilterContours\" for standard control.")
+    private String propertyName = "FilterContours";
+
     public String getContoursStageName() {
         return contoursStageName;
     }
@@ -55,6 +63,10 @@ public class FilterContours extends CvStage {
         if (result.model == null) {
             return null;
         }
+        double minArea = getPossiblePipelinePropertyOverride(this.minArea, pipeline, propertyName+".minArea",
+                Double.class, Area.class);
+        double maxArea = getPossiblePipelinePropertyOverride(this.maxArea, pipeline, propertyName+".maxArea",
+                Double.class, Area.class);
         List<MatOfPoint> contours = result.getExpectedListModel(MatOfPoint.class, null);
         List<MatOfPoint> results = new ArrayList<MatOfPoint>();
         for (MatOfPoint contour : contours) {

--- a/src/main/java/org/openpnp/vision/pipeline/stages/ImageCapture.java
+++ b/src/main/java/org/openpnp/vision/pipeline/stages/ImageCapture.java
@@ -86,6 +86,9 @@ public class ImageCapture extends CvStage {
             camera.actuateLightBeforeCapture((defaultLight ? null : getLight()));
             try {
                 BufferedImage bufferedImage = (settleFirst ? camera.settleAndCapture() : camera.capture()); 
+                // Remember the last captured image. This specifically records the native camera image, 
+                // i.e. it does not apply averaging (we want an unaltered raw image for analysis purposes).
+                pipeline.setLastCapturedImage(bufferedImage);
                 Mat image = OpenCvUtils.toMat(bufferedImage);
                 if (count <= 1) { 
                     return new Result(image, ColorSpace.Bgr);

--- a/src/main/java/org/openpnp/vision/pipeline/stages/ImageRead.java
+++ b/src/main/java/org/openpnp/vision/pipeline/stages/ImageRead.java
@@ -1,9 +1,11 @@
 package org.openpnp.vision.pipeline.stages;
 
+import java.awt.image.BufferedImage;
 import java.io.File;
 
 import org.opencv.core.Mat;
 import org.opencv.imgcodecs.Imgcodecs;
+import org.openpnp.util.OpenCvUtils;
 import org.openpnp.vision.FluentCv.ColorSpace;
 import org.openpnp.vision.pipeline.CvPipeline;
 import org.openpnp.vision.pipeline.CvStage;
@@ -24,6 +26,10 @@ public class ImageRead extends CvStage {
     @Property(description="The color space of the image.  Use to select the color space that the original image had when it was written.  Note that this does not change any of the numerical values that represent the image but rather their interpretation when the image is displayed in the pipeline editor.")
     private ColorSpace colorSpace = ColorSpace.Bgr;
     
+    @Attribute(required=false)
+    @Property(description="Handle the loaded image as if captured by the camera.")
+    private boolean handleAsCaptured = false;
+
     public File getFile() {
         return file;
     }
@@ -40,6 +46,14 @@ public class ImageRead extends CvStage {
         this.colorSpace = colorSpace;
     }
 
+    public boolean isHandleAsCaptured() {
+        return handleAsCaptured;
+    }
+
+    public void setHandleAsCaptured(boolean handleAsCaptured) {
+        this.handleAsCaptured = handleAsCaptured;
+    }
+
     @Override
     public Result process(CvPipeline pipeline) throws Exception {
         if (!file.exists()) {
@@ -48,6 +62,10 @@ public class ImageRead extends CvStage {
         Mat image = Imgcodecs.imread(file.getAbsolutePath());
         if (image.channels() == 1) {
             colorSpace = ColorSpace.Gray;
+        }
+        if (handleAsCaptured) {
+            BufferedImage bufferedImage = OpenCvUtils.toBufferedImage(image);
+            pipeline.setLastCapturedImage(bufferedImage);
         }
         return new Result(image, colorSpace);
     }

--- a/src/main/java/org/openpnp/vision/pipeline/stages/MaskCircle.java
+++ b/src/main/java/org/openpnp/vision/pipeline/stages/MaskCircle.java
@@ -15,13 +15,18 @@ import org.openpnp.vision.pipeline.CvStage;
 import org.openpnp.vision.pipeline.Property;
 import org.openpnp.vision.pipeline.Stage;
 import org.simpleframework.xml.Attribute;
+import org.simpleframework.xml.core.Commit;
 
 @Stage(description="Mask everything in the working image outside of a circle centered at the center of the image with the specified diameter.")
 public class MaskCircle extends CvStage {
     @Attribute
     @Property(description="The diameter of the circle to mask. Use a negative value to invert the mask.")
     private int diameter = 100;
-    
+
+    @Attribute(required = false)
+    @Property(description = "Name of the property through which OpenPnP controls this stage. Use \"MaskCircle\" for standard control.")
+    private String propertyName = "MaskCircle";
+
     public int getDiameter() {
         return diameter;
     }
@@ -29,7 +34,24 @@ public class MaskCircle extends CvStage {
     public void setDiameter(int diameter) {
         this.diameter = diameter;
     }
-    
+
+    public String getPropertyName() {
+        return propertyName;
+    }
+
+    public void setPropertyName(String propertyName) {
+        this.propertyName = propertyName;
+    }
+
+    @Commit
+    void commit() {
+        if (diameter == 0) {
+            // MaskCircle with diameter 0 is traditionally used to paint the image black, 
+            // no control by propertName wanted. 
+            propertyName = "";
+        }
+    }
+
     @Override
     public Result process(CvPipeline pipeline) throws Exception {
         Mat mat = pipeline.getWorkingImage();
@@ -43,10 +65,10 @@ public class MaskCircle extends CvStage {
         int diameter = this.diameter;
         Point center = new Point(mat.cols()*0.5, mat.rows()*0.5);
         
-        diameter = getPossiblePipelinePropertyOverride(diameter, pipeline, "MaskCircle.diameter", 
+        diameter = getPossiblePipelinePropertyOverride(diameter, pipeline, propertyName+".diameter", 
                 Double.class, Integer.class, Length.class);
         
-        center = getPossiblePipelinePropertyOverride(center, pipeline, "MaskCircle.center", 
+        center = getPossiblePipelinePropertyOverride(center, pipeline, propertyName+".center", 
                 Point.class, org.openpnp.model.Point.class, Location.class);
 
         Imgproc.circle(mask, center,  Math.abs(diameter) / 2, 

--- a/src/main/java/org/openpnp/vision/pipeline/stages/MaskHsv.java
+++ b/src/main/java/org/openpnp/vision/pipeline/stages/MaskHsv.java
@@ -63,7 +63,7 @@ public class MaskHsv extends CvStage {
     private boolean binaryMask = false;
 
     @Attribute(required = false)
-    @Property(description = "Name of the property controlled by OpenPnP. Use \"MaskHsv\" for bottom vision background removal.")
+    @Property(description = "Name of the property through which OpenPnP controls this stage. Use \"MaskHsv\" for standard control.")
     private String propertyName = "MaskHsv";
 
     public Boolean getAuto() {


### PR DESCRIPTION
# Description

## Problem 

The Bottom Vision pipeline almost never works out of the box, users need to tweak the properties of select stages to make them work with their camera and their machine. Firstly, it is difficult to understand why a part detection does not work, and where in the pipeline the problem happens. Root causes may often be obscured and happen many stages before the visibly bad result is exposed. Secondly, once the proper stage is identified, it is often difficult to adjust its properties. Stages and individual properties are completely generic, and (often very academically) abstracted from their actual tasks, which is a good thing from a math and software design perspective, but a bad thing for them to be understood by OpenPnP users, in the context of the actual pipeline use case. 

One of the more complex to understand and tune stages is the `MaskHSV` stage, to detect and "knock out" the green Juki nozzle from bottom vision image (this works like a film-maker's [green-screen](https://en.wikipedia.org/wiki/Chroma_key)). Users tend to just "try & error", which often leads to just haphazardly working pipelines, i.e. the pipeline may momentarily work with one part or package, but not with the next. This leads to a large and hard to maintain number of pipelines, and tedious job setup. Even for users with prior computer vision knowledge, the required effort is considerable.

Furthermore, even slight changes in conditions (such as ambient light, slight differences in nozzle tips) will often break these pipelines, leading to errors in jobs, and _more_ work tweaking the many pipelines.

## Solution

This Pull-Request aims to solve this problem, by automatically (and repeatedly) calibrating the background with empty nozzle tip during the [Nozzle Tip Calibration](https://github.com/openpnp/openpnp/wiki/Nozzle-Tip-Calibration-Setup). Note: this is just **one** puzzle piece towards a tuning-free bottom vision (other PRs are in work). 

## Calibration Operating Principle

The new Background Calibration reuses the images that are already captured by the Nozzle Tip Calibration, so no extra machine time and motion is needed to obtain them. It analyzes these background images for the **Key Color** (Chroma Key) of the Juki (or similar) nozzle tip. Any dominant, vivid color is automatically detected and a likely bounding box computed in the [HSV Color Model](https://en.wikipedia.org/wiki/HSL_and_HSV). 

Furthermore, a cutoff brightness is determined where the non-color-keyed parts of the background must all be darker. This indicates the minimum brightness applicable typically in a `Threshold` stage (the subject of an upcoming PR). 

The background calibration automatically blots out the center piece in the calibration image, where the nozzle tip was detected. This will eliminate any shiny elements that are typically present (needles, scraped off points etc.). OpenPnP assumes this center part to be always covered by the picked part, i.e. there is no need to include its color in the background calibration, or these shiny elements treated as a problem (see Trouble Shooting). The blotted-out disc has a size of **Vision Diameter** + 2 x **Minimum Detail Size** (see Configuration).

The resulting calibration is also validated, and if the detected quality is not good, diagnostic guidance and visual feed-back is provided for users to remedy the situation (see section Trouble Shooting below).

## Calibration Pipeline Control

If the Background Calibration is enabled, the following is controlled in the bottom vision pipeline:

1. The `BlurGaussian` `kernelSize` property is controlled by a new **Minimum Detail Size** field, where the user can enter a length (in system units) that indicates the smallest sensible size of a feature on a part (such as the dimension of a pad, pin, ball of a package). The GaussianBlur is configured accordingly, to suppress image noise, dirt, texture etc. that is not relevant for detection. This is also applied to the Background Calibration itself, to get the same `MaskHSV` input data as the pipeline.
2. The `MaskCircle` `diameter` property is controlled by the already existing **Max. Part Diameter** field on the Nozzle tip. Peripheral background content that might disrupt the vision operation is masked out. This is also applied to the Background Calibration itself, to get the same `MaskHSV` input data as the pipeline.
3. The `MaskHSV` `hueMin`, `hueMax`, `saturationMin`,  `saturationMax`, `valueMin` and `valueMax` properties are all controlled by the Background Calibration bounding box.  

# Justification
See the Description above, and countless user support cases in the discussion group. 

# Instructions for Use

## Configuration
There is a new Background Calibration section on the Calibration tab: 

![Screenshot_20220219_154325](https://user-images.githubusercontent.com/9963310/154806475-db1c38d9-7be9-44f7-8bd4-86e06fbdcba4.png)

**Method** controls the Background Calibration:

![Screenshot_20220219_160944](https://user-images.githubusercontent.com/9963310/154806671-75d40a06-bd88-42d1-b309-517f283cc75a.png)

- **None** switches Background Calibration off. The pipeline is no longer controlled, i.e. the user can edit the properties in the Pipeline Editor. 
- **Brightness** only determines the cutoff brightness of the nozzle tip and background, no key color is assumed to be present. 
- **BrightnessAndKeyColor** determines both the nozzle tip key color, and the remaining background cutoff brightness. 

**Minimum Detail Size** (in system units) configures the smallest valid detail of a part to be detected in bottom vision, such as the smallest dimension of a pad, pin, ball of a package. All smaller image details like image noise, textures, dirt etc. are considered irrelevant for detection. The **Minimum Detail Size** controls a blurring filter to suppress these artifacts.

**Minimum** and **Maximum** columns in the **Hue** (base color), **Saturation**, **Value** (Brightness) [HSV color model](https://en.wikipedia.org/wiki/HSL_and_HSV) indicate the calibrated bounding box of the key color (if enabled). 

The HSV color model can be illustrated like this (Wikipedia):

![image](https://user-images.githubusercontent.com/9963310/154807032-f8de9cd1-daf9-4de3-8fb2-02884266c4e7.png)

**Tolerance** can be used for each channel, to expand the detected bounding box. This provides robustness against changing ambient lighting, shadows cast by the picked parts, etc. Note: practical tolerance values are yet to be determined in testing. The tolerance is applied to both sides of the channel bounds, except for Saturation Maximum, and Value Minimum which are both  left unlimited in the bottom vision `MaskHSV` stage. OpenPnP assumes both darker and more vivid (greener) pixels are always part of the background, even if they were not detected, or cut off in the calibration. 

## Application

The Background Calibration data is then used to automatically parametrize the bottom vision operation. If the Background Calibration **Method** is not **None**, the relevant stage properties in the pipeline are fully controlled. If the background was successfully calibrated, the knockout should now be perfect:

![nozzle-tip-background-knockout](https://user-images.githubusercontent.com/9963310/154805842-e565ec69-a890-4757-963c-2ffe603cdf3f.gif)

As the Nozzle Tip Calibration is typically renewed at least whenever the machine was homed, or even with each nozzle tip change, the calibration data should be adaptive to changing ambient light and other conditions. A manual recalibration can also always be triggered, if needed.

Furthermore, any (color) differences between nozzle tips are also implicitly handled. This is important, when packages are compatible with multiple such nozzle tips. The pipeline (with is part/package dependent, but not nozzle tip dependent), can therefore dynamically react to these differences, through the calibration control. 

## Trouble Shooting

The calibration provides diagnostic feed-back regarding the quality of the background. A text describes the problem(s) and provides rough guidance as to how the problem can be remedied. Furthermore, the button **Show Problems** can be pressed to display the problematic image portions in the camera preview:

![nozzle-tip-background-diagnostics](https://user-images.githubusercontent.com/9963310/154807616-560c3710-6de2-4c44-ae6e-52625f0b4041.gif)

Credits: Nozzle tip images by Jan, with thanks!

# Implementation Details
1. Tested in simulation with real user images. 
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. Successful `mvn test` before submitting the Pull Request.
