### PR TITLE
Feature/Pipeline Panel Copy&Paste

### DIFF
--- a/src/main/java/org/openpnp/gui/components/PipelinePanel.java
+++ b/src/main/java/org/openpnp/gui/components/PipelinePanel.java
@@ -182,8 +182,9 @@ public abstract class PipelinePanel extends JPanel {
                         @Override
                         public void pipelineChanged() {
                             super.pipelineChanged();
-                            // We need to make sure, the settings is recognized as a change, otherwise 
-                            // somehow the firePropertyChange() will not be propagated. 
+                            // We need to make sure, the settings is recognized as a "deep" change, otherwise 
+                            // somehow the firePropertyChange() will not be propagated. So toggle to null first.
+                            setPipeline(null);
                             setPipeline(pipeline);
                         }
                     };
@@ -296,6 +297,7 @@ public abstract class PipelinePanel extends JPanel {
     private void rebuildUi() {
         removeAll();
         invokation++;
+        //Logger.trace("rebuild "+this.hashCode()+" invokation "+invokation);
         JPanel panel = this;
         List<CvAbstractParameterStage> parameterStages = getPipeline() != null ? 
                 getPipeline().getParameterStages() : new ArrayList<>();
@@ -345,7 +347,7 @@ public abstract class PipelinePanel extends JPanel {
 
         int formRow = 2;
         for (CvAbstractParameterStage parameter : parameterStages) {
-            //org.pmw.tinylog.Logger.trace("rebuild "+stage.getParameterName()+" invokation "+invokation);
+            //Logger.trace("    rebuild "+parameter.getParameterName()+" invokation "+invokation);
             if (parameter instanceof CvAbstractScalarParameterStage) {
                 CvAbstractScalarParameterStage scalarParameter = (CvAbstractScalarParameterStage) parameter;
                 try {

--- a/src/main/java/org/openpnp/machine/reference/vision/wizards/BottomVisionSettingsConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/vision/wizards/BottomVisionSettingsConfigurationWizard.java
@@ -197,7 +197,15 @@ public class BottomVisionSettingsConfigurationWizard extends AbstractConfigurati
                         JOptionPane.YES_NO_OPTION, JOptionPane.WARNING_MESSAGE);
                 if (result == JOptionPane.YES_OPTION) {
                     ReferenceBottomVision bottomVision = ReferenceBottomVision.getDefault();
-                    visionSettings.setValues(bottomVision.getBottomVisionSettings());
+                    if (bottomVision.getBottomVisionSettings() == visionSettings) {
+                        // Already the default. Set stock.
+                        BottomVisionSettings stockVisionSettings = (BottomVisionSettings) Configuration.get()
+                                .getVisionSettings(AbstractVisionSettings.STOCK_BOTTOM_ID);
+                        visionSettings.setValues(stockVisionSettings);
+                    }
+                    else {
+                        visionSettings.setValues(bottomVision.getBottomVisionSettings());
+                    }
                 }
             });
         });

--- a/src/main/java/org/openpnp/machine/reference/vision/wizards/FiducialVisionSettingsConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/vision/wizards/FiducialVisionSettingsConfigurationWizard.java
@@ -174,7 +174,15 @@ public class FiducialVisionSettingsConfigurationWizard extends AbstractConfigura
                         JOptionPane.YES_NO_OPTION, JOptionPane.WARNING_MESSAGE);
                 if (result == JOptionPane.YES_OPTION) {
                     ReferenceFiducialLocator fiducialVision = ReferenceFiducialLocator.getDefault();
-                    visionSettings.setValues(fiducialVision.getFiducialVisionSettings());
+                    if (fiducialVision.getFiducialVisionSettings() == visionSettings) {
+                        // Already the default. Set stock.
+                        FiducialVisionSettings stockVisionSettings = (FiducialVisionSettings) Configuration.get()
+                                .getVisionSettings(AbstractVisionSettings.STOCK_FIDUCIAL_ID);
+                        visionSettings.setValues(stockVisionSettings);
+                    }
+                    else {
+                        visionSettings.setValues(fiducialVision.getFiducialVisionSettings());
+                    }
                 }
             });
         });


### PR DESCRIPTION
# Description
Exposes the Copy & Paste actions directly on the Pipeline Panel. 

![Pipeline Copy & Paste](https://user-images.githubusercontent.com/9963310/155850099-9133af45-b0ff-452a-8db1-746971c1decc.png)

This PR also contains two related bug-fixes:

- The Pipeline Parameter UI is now always refreshed properly. 
- The **Reset to Default** button in Bottom Vision Settings, and Fiducial Vision Settings Wizards will now reset the Default settings to Stock settings, instead to itself (no effect).

# Justification
The last reason to enter the Pipeline Editor (where the Copy & Paste actions are present) is removed. 

This also allows one to copy the stock pipeline, despite it being read-only. The Pipeline Editor is disabled when read-only, so the Copy function was not reachable before.

![Stock pipeline copy](https://user-images.githubusercontent.com/9963310/155850071-018b769e-8f22-481b-8288-a6f0f50d51a0.png)

# Instructions for Use
Copy the pipeline in one setting, go to another setting, paste the pipeline. 

# Implementation Details
1. Tested in simulation.
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. Successful `mvn test` before submitting the Pull Request.
