### PR TITLE
Feature/ReferencePushPullFeeder uses Actuator Rotation Axis for Peeling

### DIFF
--- a/src/main/java/org/openpnp/gui/components/LocationButtonsPanel.java
+++ b/src/main/java/org/openpnp/gui/components/LocationButtonsPanel.java
@@ -69,6 +69,7 @@ public class LocationButtonsPanel extends JPanel {
     private JButton buttonCenterCamera;
 
     private Location baseLocation;
+    private boolean baseLocationVectorial;
     private boolean contactProbeReference;
 
     public LocationButtonsPanel(JTextField textFieldX, JTextField textFieldY, JTextField textFieldZ,
@@ -116,6 +117,14 @@ public class LocationButtonsPanel extends JPanel {
 
     public void setBaseLocation(Location baseLocation) {
         this.baseLocation = baseLocation;
+    }
+
+    public boolean isBaseLocationVectorial() {
+        return baseLocationVectorial;
+    }
+
+    public void setBaseLocationVectorial(boolean baseLocationVectorial) {
+        this.baseLocationVectorial = baseLocationVectorial;
     }
 
     @Override
@@ -262,7 +271,9 @@ public class LocationButtonsPanel extends JPanel {
                         }
                         if (baseLocation != null) {
                             l = l.subtractWithRotation(baseLocation);
-                            l = l.rotateXy(-baseLocation.getRotation());
+                            if (!isBaseLocationVectorial()) {
+                                l = l.rotateXy(-baseLocation.getRotation());
+                            }
                         }
                         final Location lf = l;
                         SwingUtilities.invokeAndWait(() -> {
@@ -289,7 +300,9 @@ public class LocationButtonsPanel extends JPanel {
                         Location l = getTool().getLocation();
                         if (baseLocation != null) {
                             l = l.subtractWithRotation(baseLocation);
-                            l = l.rotateXy(-baseLocation.getRotation());
+                            if (!isBaseLocationVectorial()) {
+                                l = l.rotateXy(-baseLocation.getRotation());
+                            }
                         }
                         final Location lf = l;
                         SwingUtilities.invokeAndWait(() -> {
@@ -317,7 +330,9 @@ public class LocationButtonsPanel extends JPanel {
                         Location l = actuator.getLocation();
                         if (baseLocation != null) {
                             l = l.subtractWithRotation(baseLocation);
-                            l = l.rotateXy(-baseLocation.getRotation());
+                            if (!isBaseLocationVectorial()) {
+                                l = l.rotateXy(-baseLocation.getRotation());
+                            }
                         }
                         final Location lf = l;
                         SwingUtilities.invokeAndWait(() -> {
@@ -342,7 +357,9 @@ public class LocationButtonsPanel extends JPanel {
                         Camera camera = getCamera();
                         Location location = getParsedLocation();
                         if (baseLocation != null) {
-                            location = location.rotateXy(baseLocation.getRotation());
+                            if (!isBaseLocationVectorial()) {
+                                location = location.rotateXy(baseLocation.getRotation());
+                            }
                             location = location.addWithRotation(baseLocation);
                         }
                         MovableUtils.moveToLocationAtSafeZ(camera, location);
@@ -367,7 +384,9 @@ public class LocationButtonsPanel extends JPanel {
                 HeadMountable tool = getTool();
                 Location location = getParsedLocation();
                 if (baseLocation != null) {
-                    location = location.rotateXy(baseLocation.getRotation());
+                    if (!isBaseLocationVectorial()) {
+                        location = location.rotateXy(baseLocation.getRotation());
+                    }
                     location = location.addWithRotation(baseLocation);
                 }
                 MovableUtils.moveToLocationAtSafeZ(tool, location);
@@ -389,7 +408,9 @@ public class LocationButtonsPanel extends JPanel {
                 HeadMountable tool = getTool();
                 Location location = getParsedLocation();
                 if (baseLocation != null) {
-                    location = location.rotateXy(baseLocation.getRotation());
+                    if (!isBaseLocationVectorial()) {
+                        location = location.rotateXy(baseLocation.getRotation());
+                    }
                     location = location.addWithRotation(baseLocation);
                 }
                 tool.moveTo(location);
@@ -461,7 +482,9 @@ public class LocationButtonsPanel extends JPanel {
                 Actuator actuator = getActuator();
                 Location location = getParsedLocation();
                 if (baseLocation != null) {
-                    location = location.rotateXy(baseLocation.getRotation());
+                    if (!isBaseLocationVectorial()) {
+                        location = location.rotateXy(baseLocation.getRotation());
+                    }
                     location = location.addWithRotation(baseLocation);
                 }
                 MovableUtils.moveToLocationAtSafeZ(actuator, location);
@@ -483,7 +506,9 @@ public class LocationButtonsPanel extends JPanel {
                 Actuator actuator = getActuator();
                 Location location = getParsedLocation();
                 if (baseLocation != null) {
-                    location = location.rotateXy(baseLocation.getRotation());
+                    if (!isBaseLocationVectorial()) {
+                        location = location.rotateXy(baseLocation.getRotation());
+                    }
                     location = location.addWithRotation(baseLocation);
                 }
                 actuator.moveTo(location);

--- a/src/main/java/org/openpnp/machine/reference/feeder/wizards/ReferencePushPullMotionConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/wizards/ReferencePushPullMotionConfigurationWizard.java
@@ -22,11 +22,17 @@
 package org.openpnp.machine.reference.feeder.wizards;
 
 import java.awt.GraphicsEnvironment;
+import java.awt.event.ActionEvent;
+import java.awt.event.ItemEvent;
+import java.awt.event.ItemListener;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import javax.swing.AbstractAction;
+import javax.swing.Action;
 import javax.swing.BoxLayout;
+import javax.swing.JButton;
 import javax.swing.JCheckBox;
 import javax.swing.JComboBox;
 import javax.swing.JLabel;
@@ -41,6 +47,7 @@ import org.openpnp.gui.components.LocationButtonsPanel;
 import org.openpnp.gui.support.AbstractConfigurationWizard;
 import org.openpnp.gui.support.ActuatorsComboBoxModel;
 import org.openpnp.gui.support.DoubleConverter;
+import org.openpnp.gui.support.Icons;
 import org.openpnp.gui.support.IntegerConverter;
 import org.openpnp.gui.support.LengthConverter;
 import org.openpnp.gui.support.LongConverter;
@@ -48,6 +55,7 @@ import org.openpnp.gui.support.MutableLocationProxy;
 import org.openpnp.gui.support.NamedConverter;
 import org.openpnp.machine.reference.feeder.ReferencePushPullFeeder;
 import org.openpnp.model.Configuration;
+import org.openpnp.model.Location;
 import org.openpnp.spi.Actuator;
 import org.openpnp.spi.Head;
 import org.pmw.tinylog.Logger;
@@ -125,6 +133,7 @@ extends AbstractConfigurationWizard {
     private JTextField textFieldFeedMid3C;
     private JTextField textFieldFeedEndC;
     private JCheckBox additiveRotation;
+    private JButton btnRotationBase;
 
     public ReferencePushPullMotionConfigurationWizard(ReferencePushPullFeeder feeder) {
         super();
@@ -162,37 +171,33 @@ extends AbstractConfigurationWizard {
                 ColumnSpec.decode("max(100dlu;default)"),
                 FormSpecs.RELATED_GAP_COLSPEC,
                 ColumnSpec.decode("left:max(100dlu;default):grow"),},
-                new RowSpec[] {
-                        FormSpecs.RELATED_GAP_ROWSPEC,
-                        FormSpecs.DEFAULT_ROWSPEC,
-                        FormSpecs.RELATED_GAP_ROWSPEC,
-                        FormSpecs.DEFAULT_ROWSPEC,
-                        FormSpecs.RELATED_GAP_ROWSPEC,
-                        FormSpecs.DEFAULT_ROWSPEC,
-                        FormSpecs.RELATED_GAP_ROWSPEC,
-                        FormSpecs.DEFAULT_ROWSPEC,
-                        FormSpecs.RELATED_GAP_ROWSPEC,
-                        FormSpecs.DEFAULT_ROWSPEC,
-                        FormSpecs.RELATED_GAP_ROWSPEC,
-                        FormSpecs.DEFAULT_ROWSPEC,
-                        FormSpecs.RELATED_GAP_ROWSPEC,
-                        FormSpecs.DEFAULT_ROWSPEC,
-                        FormSpecs.RELATED_GAP_ROWSPEC,
-                        FormSpecs.DEFAULT_ROWSPEC,
-                        FormSpecs.RELATED_GAP_ROWSPEC,
-                        FormSpecs.DEFAULT_ROWSPEC,
-                        FormSpecs.RELATED_GAP_ROWSPEC,
-                        FormSpecs.DEFAULT_ROWSPEC,
-                        FormSpecs.RELATED_GAP_ROWSPEC,
-                        FormSpecs.DEFAULT_ROWSPEC,
-                        FormSpecs.RELATED_GAP_ROWSPEC,
-                        FormSpecs.DEFAULT_ROWSPEC,
-                        FormSpecs.RELATED_GAP_ROWSPEC,
-                        FormSpecs.DEFAULT_ROWSPEC,
-                        FormSpecs.RELATED_GAP_ROWSPEC,
-                        FormSpecs.DEFAULT_ROWSPEC,
-                        FormSpecs.RELATED_GAP_ROWSPEC,
-                        RowSpec.decode("default:grow"),}));
+            new RowSpec[] {
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                RowSpec.decode("default:grow"),}));
 
         Head head = null;
         try {
@@ -207,9 +212,17 @@ extends AbstractConfigurationWizard {
         panelPushPull.add(lblActuatorId, "2, 2, right, default");
 
         actuator = new JComboBox();
+        actuator.addItemListener(new ItemListener() {
+            public void itemStateChanged(ItemEvent e) {
+                applyBaseLocations();
+            }
+        });
         panelPushPull.add(actuator, "4, 2, 3, 1");
         actuator.setMaximumRowCount(15);
         actuator.setModel(new ActuatorsComboBoxModel(head));
+        
+                lblRotation = new JLabel("Rotation");
+                panelPushPull.add(lblRotation, "10, 2, center, default");
 
 
         lblPeelOffActuatorId = new JLabel("Auxiliary Actuator");
@@ -220,261 +233,271 @@ extends AbstractConfigurationWizard {
         panelPushPull.add(actuator2, "4, 4, 3, 1");
         actuator2.setMaximumRowCount(15);
         actuator2.setModel(new ActuatorsComboBoxModel(head));
+        
+                additiveRotation = new JCheckBox("Additive");
+                additiveRotation.addItemListener(new ItemListener() {
+                    public void itemStateChanged(ItemEvent arg0) {
+                        applyBaseLocations();
+                    }
+                });
+                additiveRotation.setToolTipText("<html>Before the feed is performed, the current coordinate of the Rotation axis is taken.<br/>\nRotations stated below are then added to that base angle.<br/>\nThis is typically used for peeling axes, creating a continuous cover tape spool wind-up.\n</html>");
+                panelPushPull.add(additiveRotation, "10, 4, center, default");
 
         JLabel lblX = new JLabel("X");
-        panelPushPull.add(lblX, "4, 8, center, default");
+        panelPushPull.add(lblX, "4, 6, center, default");
 
         JLabel lblY = new JLabel("Y");
-        panelPushPull.add(lblY, "6, 8, center, default");
+        panelPushPull.add(lblY, "6, 6, center, default");
 
         JLabel lblZ = new JLabel("Z");
-        panelPushPull.add(lblZ, "8, 8, center, default");
-
-        lblRotation = new JLabel("Rotation");
-        panelPushPull.add(lblRotation, "10, 8, center, default");
+        panelPushPull.add(lblZ, "8, 6, center, default");
+        
+                btnRotationBase = new JButton(actionRotationBase);
+                panelPushPull.add(btnRotationBase, "10, 6, fill, default");
 
         lblPush = new JLabel("↓");
         lblPush.setToolTipText("Locations that are included when pushing.");
-        panelPushPull.add(lblPush, "12, 8, center, default");
+        panelPushPull.add(lblPush, "12, 6, center, default");
 
         lblMulti = new JLabel("↑↓");
         lblMulti.setToolTipText("<html>Locations that are included, when actuating multiple times.<br/>\r\nThe combination with the push ↓ and pull ↑ switch is taken.</html>");
-        panelPushPull.add(lblMulti, "14, 8, 3, 1, center, default");
+        panelPushPull.add(lblMulti, "14, 6, 3, 1, center, default");
 
         lblPull = new JLabel("↑");
         lblPull.setToolTipText("Locations that are included when pulling.");
-        panelPushPull.add(lblPull, "18, 8, center, default");
-
-        additiveRotation = new JCheckBox("Additive");
-        additiveRotation.setToolTipText("<html>Before the feed is performed, the current coordinate of the Rotation axis is taken.<br/>\nRotations stated below are then added to that base angle.<br/>\nThis is typically used for peeling axes, creating a continuous cover tape spool wind-up.\n</html>");
-        panelPushPull.add(additiveRotation, "10, 10, center, default");
+        panelPushPull.add(lblPull, "18, 6, center, default");
 
         JLabel lblFeedStartLocation = new JLabel("Start Location");
-        panelPushPull.add(lblFeedStartLocation, "2, 12, right, default");
+        panelPushPull.add(lblFeedStartLocation, "2, 8, right, default");
 
         textFieldFeedStartX = new JTextField();
-        panelPushPull.add(textFieldFeedStartX, "4, 12");
+        panelPushPull.add(textFieldFeedStartX, "4, 8");
         textFieldFeedStartX.setColumns(8);
 
         textFieldFeedStartY = new JTextField();
-        panelPushPull.add(textFieldFeedStartY, "6, 12");
+        panelPushPull.add(textFieldFeedStartY, "6, 8");
         textFieldFeedStartY.setColumns(8);
 
         textFieldFeedStartZ = new JTextField();
-        panelPushPull.add(textFieldFeedStartZ, "8, 12");
+        panelPushPull.add(textFieldFeedStartZ, "8, 8");
         textFieldFeedStartZ.setColumns(8);
 
         textFieldFeedStartC = new JTextField();
-        panelPushPull.add(textFieldFeedStartC, "10, 12, fill, default");
+        panelPushPull.add(textFieldFeedStartC, "10, 8, fill, default");
         textFieldFeedStartC.setColumns(8);
 
         chckbxMulti0 = new JCheckBox("");
         chckbxMulti0.setToolTipText("Include the Start Location in multi-actuating motion (if the pull switch is also set).");
         chckbxMulti0.setSelected(true);
-        panelPushPull.add(chckbxMulti0, "14, 12, 3, 1, center, default");
+        panelPushPull.add(chckbxMulti0, "14, 8, 3, 1, center, default");
 
         chckbxPull0 = new JCheckBox("");
         chckbxPull0.setToolTipText("Go to the Start Location when pulling.");
         chckbxPull0.setSelected(true);
-        panelPushPull.add(chckbxPull0, "18, 12, center, default");
+        panelPushPull.add(chckbxPull0, "18, 8, center, default");
 
         locationButtonsPanelFeedStart = new LocationButtonsPanel(textFieldFeedStartX,
-                textFieldFeedStartY, textFieldFeedStartZ, null);
+                textFieldFeedStartY, textFieldFeedStartZ, textFieldFeedStartC);
         locationButtonsPanelFeedStart.setShowPositionToolNoSafeZ(true);
-        panelPushPull.add(locationButtonsPanelFeedStart, "20, 12, fill, default");
+        locationButtonsPanelFeedStart.setBaseLocationVectorial(true);
+        panelPushPull.add(locationButtonsPanelFeedStart, "20, 8, fill, default");
 
         lblFeedSpeed0_1 = new JLabel("Speed ↕");
-        panelPushPull.add(lblFeedSpeed0_1, "10, 14, right, default");
+        panelPushPull.add(lblFeedSpeed0_1, "10, 10, right, default");
 
         textFieldFeedPush1 = new JTextField();
-        panelPushPull.add(textFieldFeedPush1, "12, 14, 3, 1");
+        panelPushPull.add(textFieldFeedPush1, "12, 10, 3, 1");
         textFieldFeedPush1.setColumns(10);
 
         textFieldFeedPull0 = new JTextField();
-        panelPushPull.add(textFieldFeedPull0, "16, 14, 3, 1");
+        panelPushPull.add(textFieldFeedPull0, "16, 10, 3, 1");
         textFieldFeedPull0.setColumns(10);
 
         lblFeedMid1Location = new JLabel("Mid 1 Location");
-        panelPushPull.add(lblFeedMid1Location, "2, 16, right, default");
+        panelPushPull.add(lblFeedMid1Location, "2, 12, right, default");
 
         textFieldFeedMid1X = new JTextField();
-        panelPushPull.add(textFieldFeedMid1X, "4, 16");
+        panelPushPull.add(textFieldFeedMid1X, "4, 12");
         textFieldFeedMid1X.setColumns(10);
 
         textFieldFeedMid1Y = new JTextField();
-        panelPushPull.add(textFieldFeedMid1Y, "6, 16");
+        panelPushPull.add(textFieldFeedMid1Y, "6, 12");
         textFieldFeedMid1Y.setColumns(10);
 
         textFieldFeedMid1Z = new JTextField();
-        panelPushPull.add(textFieldFeedMid1Z, "8, 16");
+        panelPushPull.add(textFieldFeedMid1Z, "8, 12");
         textFieldFeedMid1Z.setColumns(10);
 
         textFieldFeedMid1C = new JTextField();
-        panelPushPull.add(textFieldFeedMid1C, "10, 16, fill, default");
+        panelPushPull.add(textFieldFeedMid1C, "10, 12, fill, default");
         textFieldFeedMid1C.setColumns(8);
 
         chckbxPush1 = new JCheckBox("");
         chckbxPush1.setToolTipText("Go to the Mid 1 Location when pushing.");
         chckbxPush1.setSelected(true);
-        panelPushPull.add(chckbxPush1, "12, 16, center, default");
+        panelPushPull.add(chckbxPush1, "12, 12, center, default");
 
         chckbxMulti1 = new JCheckBox("");
         chckbxMulti1.setToolTipText("Include the Mid 1 Location in multi-actuation motion (if the push/pull switch is also set).");
         chckbxMulti1.setSelected(true);
-        panelPushPull.add(chckbxMulti1, "14, 16, 3, 1, center, default");
+        panelPushPull.add(chckbxMulti1, "14, 12, 3, 1, center, default");
 
         chckbxPull1 = new JCheckBox("");
         chckbxPull1.setToolTipText("Go to the Mid 1 Location when pulling.");
         chckbxPull1.setSelected(true);
-        panelPushPull.add(chckbxPull1, "18, 16, center, default");
+        panelPushPull.add(chckbxPull1, "18, 12, center, default");
 
-        locationButtonsPanelFeedMid1 = new LocationButtonsPanel(textFieldFeedMid1X, textFieldFeedMid1Y, textFieldFeedMid1Z, (JTextField) null);
+        locationButtonsPanelFeedMid1 = new LocationButtonsPanel(textFieldFeedMid1X, textFieldFeedMid1Y, textFieldFeedMid1Z, textFieldFeedMid1C);
         locationButtonsPanelFeedMid1.setShowPositionToolNoSafeZ(true);
-        panelPushPull.add(locationButtonsPanelFeedMid1, "20, 16, fill, default");
+        locationButtonsPanelFeedMid1.setBaseLocationVectorial(true);
+        panelPushPull.add(locationButtonsPanelFeedMid1, "20, 12, fill, default");
 
         lblFeedSpeed1_2 = new JLabel("Speed ↕");
-        panelPushPull.add(lblFeedSpeed1_2, "10, 18, right, default");
+        panelPushPull.add(lblFeedSpeed1_2, "10, 14, right, default");
 
         textFieldFeedPush2 = new JTextField();
-        panelPushPull.add(textFieldFeedPush2, "12, 18, 3, 1");
+        panelPushPull.add(textFieldFeedPush2, "12, 14, 3, 1");
         textFieldFeedPush2.setColumns(10);
 
         textFieldFeedPull1 = new JTextField();
         textFieldFeedPull1.setColumns(10);
-        panelPushPull.add(textFieldFeedPull1, "16, 18, 3, 1");
+        panelPushPull.add(textFieldFeedPull1, "16, 14, 3, 1");
 
         lblFeedMid2Location = new JLabel("Mid 2 Location");
-        panelPushPull.add(lblFeedMid2Location, "2, 20, right, default");
+        panelPushPull.add(lblFeedMid2Location, "2, 16, right, default");
 
         textFieldFeedMid2X = new JTextField();
-        panelPushPull.add(textFieldFeedMid2X, "4, 20");
+        panelPushPull.add(textFieldFeedMid2X, "4, 16");
         textFieldFeedMid2X.setColumns(10);
 
         textFieldFeedMid2Y = new JTextField();
-        panelPushPull.add(textFieldFeedMid2Y, "6, 20");
+        panelPushPull.add(textFieldFeedMid2Y, "6, 16");
         textFieldFeedMid2Y.setColumns(10);
 
         textFieldFeedMid2Z = new JTextField();
-        panelPushPull.add(textFieldFeedMid2Z, "8, 20");
+        panelPushPull.add(textFieldFeedMid2Z, "8, 16");
         textFieldFeedMid2Z.setColumns(10);
 
         textFieldFeedMid2C = new JTextField();
-        panelPushPull.add(textFieldFeedMid2C, "10, 20, fill, default");
+        panelPushPull.add(textFieldFeedMid2C, "10, 16, fill, default");
         textFieldFeedMid2C.setColumns(8);
 
         chckbxPush2 = new JCheckBox("");
         chckbxPush2.setToolTipText("Go to the Mid 2 Location when pushing.");
         chckbxPush2.setSelected(true);
-        panelPushPull.add(chckbxPush2, "12, 20, center, default");
+        panelPushPull.add(chckbxPush2, "12, 16, center, default");
 
         chckbxMulti2 = new JCheckBox("");
         chckbxMulti2.setToolTipText("Include the Mid 2 Location in multi-actuation motion (if the push/pull switch is also set).");
         chckbxMulti2.setSelected(true);
-        panelPushPull.add(chckbxMulti2, "14, 20, 3, 1, center, default");
+        panelPushPull.add(chckbxMulti2, "14, 16, 3, 1, center, default");
 
         chckbxPull2 = new JCheckBox("");
         chckbxPull2.setToolTipText("Go to the Mid 2 Location when pulling.");
         chckbxPull2.setSelected(true);
-        panelPushPull.add(chckbxPull2, "18, 20, center, default");
+        panelPushPull.add(chckbxPull2, "18, 16, center, default");
 
-        locationButtonsPanelFeedMid2 = new LocationButtonsPanel(textFieldFeedMid2X, textFieldFeedMid2Y, textFieldFeedMid2Z, (JTextField) null);
+        locationButtonsPanelFeedMid2 = new LocationButtonsPanel(textFieldFeedMid2X, textFieldFeedMid2Y, textFieldFeedMid2Z, textFieldFeedMid2C);
         locationButtonsPanelFeedMid2.setShowPositionToolNoSafeZ(true);
-        panelPushPull.add(locationButtonsPanelFeedMid2, "20, 20, fill, default");
+        locationButtonsPanelFeedMid2.setBaseLocationVectorial(true);
+        panelPushPull.add(locationButtonsPanelFeedMid2, "20, 16, fill, default");
 
         lblFeedSpeed2_3 = new JLabel("Speed ↕");
-        panelPushPull.add(lblFeedSpeed2_3, "10, 22, right, default");
+        panelPushPull.add(lblFeedSpeed2_3, "10, 18, right, default");
 
         textFieldFeedPush3 = new JTextField();
-        panelPushPull.add(textFieldFeedPush3, "12, 22, 3, 1");
+        panelPushPull.add(textFieldFeedPush3, "12, 18, 3, 1");
         textFieldFeedPush3.setColumns(10);
 
         textFieldFeedPull2 = new JTextField();
         textFieldFeedPull2.setColumns(10);
-        panelPushPull.add(textFieldFeedPull2, "16, 22, 3, 1");
+        panelPushPull.add(textFieldFeedPull2, "16, 18, 3, 1");
 
         lblFeedMid3Location = new JLabel("Mid 3 Location");
-        panelPushPull.add(lblFeedMid3Location, "2, 24, right, default");
+        panelPushPull.add(lblFeedMid3Location, "2, 20, right, default");
 
         textFieldFeedMid3X = new JTextField();
-        panelPushPull.add(textFieldFeedMid3X, "4, 24");
+        panelPushPull.add(textFieldFeedMid3X, "4, 20");
         textFieldFeedMid3X.setColumns(10);
 
         textFieldFeedMid3Y = new JTextField();
-        panelPushPull.add(textFieldFeedMid3Y, "6, 24");
+        panelPushPull.add(textFieldFeedMid3Y, "6, 20");
         textFieldFeedMid3Y.setColumns(10);
 
         textFieldFeedMid3Z = new JTextField();
-        panelPushPull.add(textFieldFeedMid3Z, "8, 24, fill, default");
+        panelPushPull.add(textFieldFeedMid3Z, "8, 20, fill, default");
         textFieldFeedMid3Z.setColumns(10);
 
         textFieldFeedMid3C = new JTextField();
         textFieldFeedMid3C.setText("");
-        panelPushPull.add(textFieldFeedMid3C, "10, 24, fill, default");
+        panelPushPull.add(textFieldFeedMid3C, "10, 20, fill, default");
         textFieldFeedMid3C.setColumns(8);
 
         chckbxPush3 = new JCheckBox("");
         chckbxPush3.setToolTipText("Go to the Mid 3 Location when pushing.");
         chckbxPush3.setSelected(true);
-        panelPushPull.add(chckbxPush3, "12, 24, center, default");
+        panelPushPull.add(chckbxPush3, "12, 20, center, default");
 
         chckbxMulti3 = new JCheckBox("");
         chckbxMulti3.setToolTipText("Include the Mid 3 Location in multi-actuation motion (if the push/pull switch is also set).");
         chckbxMulti3.setSelected(true);
-        panelPushPull.add(chckbxMulti3, "14, 24, 3, 1, center, default");
+        panelPushPull.add(chckbxMulti3, "14, 20, 3, 1, center, default");
 
         chckbxPull3 = new JCheckBox("");
         chckbxPull3.setToolTipText("Go to the Mid 3 Location when pulling.");
         chckbxPull3.setSelected(true);
-        panelPushPull.add(chckbxPull3, "18, 24, center, default");
+        panelPushPull.add(chckbxPull3, "18, 20, center, default");
 
-        locationButtonsPanelFeedMid3 = new LocationButtonsPanel(textFieldFeedMid3X, textFieldFeedMid3Y, textFieldFeedMid3Z, (JTextField) null);
+        locationButtonsPanelFeedMid3 = new LocationButtonsPanel(textFieldFeedMid3X, textFieldFeedMid3Y, textFieldFeedMid3Z, textFieldFeedMid3C);
         locationButtonsPanelFeedMid3.setShowPositionToolNoSafeZ(true);
-        panelPushPull.add(locationButtonsPanelFeedMid3, "20, 24, fill, default");
+        locationButtonsPanelFeedMid3.setBaseLocationVectorial(true);
+        panelPushPull.add(locationButtonsPanelFeedMid3, "20, 20, fill, default");
 
         lblFeedSpeed3_4 = new JLabel("Speed ↕");
-        panelPushPull.add(lblFeedSpeed3_4, "10, 26, right, default");
+        panelPushPull.add(lblFeedSpeed3_4, "10, 22, right, default");
 
         textFieldFeedPush4 = new JTextField();
-        panelPushPull.add(textFieldFeedPush4, "12, 26, 3, 1");
+        panelPushPull.add(textFieldFeedPush4, "12, 22, 3, 1");
         textFieldFeedPush4.setColumns(10);
 
         textFieldFeedPull3 = new JTextField();
         textFieldFeedPull3.setColumns(10);
-        panelPushPull.add(textFieldFeedPull3, "16, 26, 3, 1");
+        panelPushPull.add(textFieldFeedPull3, "16, 22, 3, 1");
 
         JLabel lblFeedEndLocation = new JLabel("End Location");
-        panelPushPull.add(lblFeedEndLocation, "2, 28, right, default");
+        panelPushPull.add(lblFeedEndLocation, "2, 24, right, default");
 
         textFieldFeedEndX = new JTextField();
-        panelPushPull.add(textFieldFeedEndX, "4, 28");
+        panelPushPull.add(textFieldFeedEndX, "4, 24");
         textFieldFeedEndX.setColumns(8);
 
         textFieldFeedEndY = new JTextField();
-        panelPushPull.add(textFieldFeedEndY, "6, 28");
+        panelPushPull.add(textFieldFeedEndY, "6, 24");
         textFieldFeedEndY.setColumns(8);
 
         textFieldFeedEndZ = new JTextField();
-        panelPushPull.add(textFieldFeedEndZ, "8, 28");
+        panelPushPull.add(textFieldFeedEndZ, "8, 24");
         textFieldFeedEndZ.setColumns(8);
 
         textFieldFeedEndC = new JTextField();
-        panelPushPull.add(textFieldFeedEndC, "10, 28, fill, default");
+        panelPushPull.add(textFieldFeedEndC, "10, 24, fill, default");
         textFieldFeedEndC.setColumns(8);
 
         chckbxPushEnd = new JCheckBox("");
         chckbxPushEnd.setToolTipText("Go to the End Location when pushing.");
         chckbxPushEnd.setSelected(true);
-        panelPushPull.add(chckbxPushEnd, "12, 28, center, default");
+        panelPushPull.add(chckbxPushEnd, "12, 24, center, default");
 
         chckbxMultiEnd = new JCheckBox("");
         chckbxMultiEnd.setToolTipText("Include the End Location in multi-actuation motion (if the push switch is also set).");
         chckbxMultiEnd.setSelected(true);
-        panelPushPull.add(chckbxMultiEnd, "14, 28, 3, 1, center, default");
+        panelPushPull.add(chckbxMultiEnd, "14, 24, 3, 1, center, default");
 
         locationButtonsPanelFeedEnd = new LocationButtonsPanel(textFieldFeedEndX, textFieldFeedEndY,
-                textFieldFeedEndZ, null);
+                textFieldFeedEndZ, textFieldFeedEndC);
         locationButtonsPanelFeedEnd.setShowPositionToolNoSafeZ(true);
-        panelPushPull.add(locationButtonsPanelFeedEnd, "20, 28, fill, default");
+        locationButtonsPanelFeedEnd.setBaseLocationVectorial(true);
+        panelPushPull.add(locationButtonsPanelFeedEnd, "20, 24, fill, default");
 
         // Compose a font list of the system, the one currently selected, even if the system does not know it (yet), and the empty selection 
         List<String> systemFontList = Arrays.asList(GraphicsEnvironment.getLocalGraphicsEnvironment()
@@ -620,5 +643,44 @@ extends AbstractConfigurationWizard {
         bind(UpdateStrategy.READ, actuator, "selectedItem", locationButtonsPanelFeedMid2, "actuatorName");
         bind(UpdateStrategy.READ, actuator, "selectedItem", locationButtonsPanelFeedMid3, "actuatorName");
         bind(UpdateStrategy.READ, actuator, "selectedItem", locationButtonsPanelFeedEnd, "actuatorName");
+
+        applyBaseLocations();
     }
+
+    private void applyBaseLocations() {
+        boolean additive = additiveRotation.isSelected();
+        Location baseLocation = null;
+        if (additive) {
+            Head head = null;
+            Actuator feedActuator = null;
+            try {
+                head = Configuration.get().getMachine().getDefaultHead();
+                feedActuator = head.getActuatorByName((String) actuator.getSelectedItem());
+                // Take the rotation from the actuator.
+                baseLocation = feedActuator.getLocation().multiply(0, 0, 0, 1);
+            }
+            catch (Exception e) {
+                Logger.error(e, "Cannot determine base location of actuator.");
+            }
+        }
+        locationButtonsPanelFeedStart.setBaseLocation(baseLocation);
+        locationButtonsPanelFeedMid1.setBaseLocation(baseLocation);
+        locationButtonsPanelFeedMid2.setBaseLocation(baseLocation);
+        locationButtonsPanelFeedMid3.setBaseLocation(baseLocation);
+        locationButtonsPanelFeedEnd.setBaseLocation(baseLocation);
+        actionRotationBase.setEnabled(additive);
+    }
+    private final Action actionRotationBase = new AbstractAction() {
+        {
+            putValue(SMALL_ICON, Icons.axisRotation);
+            putValue(NAME, "= 0°");
+            putValue(SHORT_DESCRIPTION, "<html>"
+                    + "Reset the current rotation axis to <strong>additive 0°</strong> for subsequent<br/>"
+                    + "capturing/positioning using the location buttons."
+                    + "</html>");
+        }
+        public void actionPerformed(ActionEvent e) {
+            applyBaseLocations();
+        }
+    };
 }

--- a/src/main/java/org/openpnp/machine/reference/feeder/wizards/ReferencePushPullMotionConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/wizards/ReferencePushPullMotionConfigurationWizard.java
@@ -21,7 +21,6 @@
 
 package org.openpnp.machine.reference.feeder.wizards;
 
-import java.awt.Color;
 import java.awt.GraphicsEnvironment;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -46,8 +45,10 @@ import org.openpnp.gui.support.IntegerConverter;
 import org.openpnp.gui.support.LengthConverter;
 import org.openpnp.gui.support.LongConverter;
 import org.openpnp.gui.support.MutableLocationProxy;
+import org.openpnp.gui.support.NamedConverter;
 import org.openpnp.machine.reference.feeder.ReferencePushPullFeeder;
 import org.openpnp.model.Configuration;
+import org.openpnp.spi.Actuator;
 import org.openpnp.spi.Head;
 import org.pmw.tinylog.Logger;
 
@@ -80,9 +81,9 @@ extends AbstractConfigurationWizard {
     private JTextField textFieldFeedMid3Y;
     private JTextField textFieldFeedMid3Z;
     private JLabel lblActuatorId;
-    private JComboBox comboBoxFeedActuator;
+    private JComboBox actuator;
     private JLabel lblPeelOffActuatorId;
-    private JComboBox comboBoxPeelOffActuator;
+    private JComboBox actuator2;
     private JPanel panelLocations;
     private JPanel panelPushPull;
     private LocationButtonsPanel locationButtonsPanelFeedStart;
@@ -117,6 +118,13 @@ extends AbstractConfigurationWizard {
     private JCheckBox chckbxPull1;
     private JCheckBox chckbxPull2;
     private JCheckBox chckbxPull3;
+    private JLabel lblRotation;
+    private JTextField textFieldFeedStartC;
+    private JTextField textFieldFeedMid1C;
+    private JTextField textFieldFeedMid2C;
+    private JTextField textFieldFeedMid3C;
+    private JTextField textFieldFeedEndC;
+    private JCheckBox additiveRotation;
 
     public ReferencePushPullMotionConfigurationWizard(ReferencePushPullFeeder feeder) {
         super();
@@ -133,23 +141,25 @@ extends AbstractConfigurationWizard {
         panelPushPull.setBorder(new TitledBorder(UIManager.getBorder("TitledBorder.border"), "Push-Pull Settings", TitledBorder.LEADING, TitledBorder.TOP, null));
         panelPushPull.setLayout(new FormLayout(new ColumnSpec[] {
                 FormSpecs.RELATED_GAP_COLSPEC,
-                ColumnSpec.decode("default:grow"),
-                FormSpecs.RELATED_GAP_COLSPEC,
-                ColumnSpec.decode("default:grow"),
-                FormSpecs.RELATED_GAP_COLSPEC,
-                ColumnSpec.decode("default:grow"),
-                FormSpecs.RELATED_GAP_COLSPEC,
-                ColumnSpec.decode("default:grow"),
-                FormSpecs.RELATED_GAP_COLSPEC,
-                ColumnSpec.decode("default:grow"),
+                ColumnSpec.decode("max(70dlu;default)"),
                 FormSpecs.RELATED_GAP_COLSPEC,
                 FormSpecs.DEFAULT_COLSPEC,
                 FormSpecs.RELATED_GAP_COLSPEC,
                 FormSpecs.DEFAULT_COLSPEC,
                 FormSpecs.RELATED_GAP_COLSPEC,
-                ColumnSpec.decode("default:grow"),
+                FormSpecs.DEFAULT_COLSPEC,
                 FormSpecs.RELATED_GAP_COLSPEC,
-                ColumnSpec.decode("max(100dlu;default):grow"),
+                FormSpecs.DEFAULT_COLSPEC,
+                FormSpecs.RELATED_GAP_COLSPEC,
+                ColumnSpec.decode("max(20dlu;default)"),
+                FormSpecs.RELATED_GAP_COLSPEC,
+                ColumnSpec.decode("max(10dlu;default)"),
+                FormSpecs.RELATED_GAP_COLSPEC,
+                ColumnSpec.decode("max(10dlu;default)"),
+                FormSpecs.RELATED_GAP_COLSPEC,
+                ColumnSpec.decode("max(20dlu;default)"),
+                FormSpecs.RELATED_GAP_COLSPEC,
+                ColumnSpec.decode("max(100dlu;default)"),
                 FormSpecs.RELATED_GAP_COLSPEC,
                 ColumnSpec.decode("left:max(100dlu;default):grow"),},
                 new RowSpec[] {
@@ -180,10 +190,9 @@ extends AbstractConfigurationWizard {
                         FormSpecs.RELATED_GAP_ROWSPEC,
                         FormSpecs.DEFAULT_ROWSPEC,
                         FormSpecs.RELATED_GAP_ROWSPEC,
+                        FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC,
                         RowSpec.decode("default:grow"),}));
-
-        lblActuatorId = new JLabel("Actuator");
-        panelPushPull.add(lblActuatorId, "2, 4, right, default");
 
         Head head = null;
         try {
@@ -193,243 +202,279 @@ extends AbstractConfigurationWizard {
             Logger.error(e, "Cannot determine default head of machine.");
         }
 
-        comboBoxFeedActuator = new JComboBox();
-        panelPushPull.add(comboBoxFeedActuator, "4, 4");
-        comboBoxFeedActuator.setModel(new ActuatorsComboBoxModel(head));
+        lblActuatorId = new JLabel("Feed Actuator");
+        lblActuatorId.setToolTipText("Actuator for feed signal and for motion");
+        panelPushPull.add(lblActuatorId, "2, 2, right, default");
 
-        lblPeelOffActuatorId = new JLabel("Peel Off Actuator");
-        panelPushPull.add(lblPeelOffActuatorId, "6, 4, right, default");
+        actuator = new JComboBox();
+        panelPushPull.add(actuator, "4, 2, 3, 1");
+        actuator.setMaximumRowCount(15);
+        actuator.setModel(new ActuatorsComboBoxModel(head));
 
-        comboBoxPeelOffActuator = new JComboBox();
-        panelPushPull.add(comboBoxPeelOffActuator, "8, 4");
-        comboBoxPeelOffActuator.setModel(new ActuatorsComboBoxModel(head));
+
+        lblPeelOffActuatorId = new JLabel("Auxiliary Actuator");
+        lblPeelOffActuatorId.setToolTipText("Actuator for auxiliary purpose (e.g. peeling).");
+        panelPushPull.add(lblPeelOffActuatorId, "2, 4, right, default");
+
+        actuator2 = new JComboBox();
+        panelPushPull.add(actuator2, "4, 4, 3, 1");
+        actuator2.setMaximumRowCount(15);
+        actuator2.setModel(new ActuatorsComboBoxModel(head));
 
         JLabel lblX = new JLabel("X");
-        panelPushPull.add(lblX, "4, 8");
+        panelPushPull.add(lblX, "4, 8, center, default");
 
         JLabel lblY = new JLabel("Y");
-        panelPushPull.add(lblY, "6, 8");
+        panelPushPull.add(lblY, "6, 8, center, default");
 
         JLabel lblZ = new JLabel("Z");
-        panelPushPull.add(lblZ, "8, 8");
+        panelPushPull.add(lblZ, "8, 8, center, default");
+
+        lblRotation = new JLabel("Rotation");
+        panelPushPull.add(lblRotation, "10, 8, center, default");
 
         lblPush = new JLabel("↓");
         lblPush.setToolTipText("Locations that are included when pushing.");
-        panelPushPull.add(lblPush, "10, 8, center, default");
+        panelPushPull.add(lblPush, "12, 8, center, default");
 
         lblMulti = new JLabel("↑↓");
         lblMulti.setToolTipText("<html>Locations that are included, when actuating multiple times.<br/>\r\nThe combination with the push ↓ and pull ↑ switch is taken.</html>");
-        panelPushPull.add(lblMulti, "12, 8, 3, 1, center, default");
+        panelPushPull.add(lblMulti, "14, 8, 3, 1, center, default");
 
         lblPull = new JLabel("↑");
         lblPull.setToolTipText("Locations that are included when pulling.");
-        panelPushPull.add(lblPull, "16, 8, center, default");
+        panelPushPull.add(lblPull, "18, 8, center, default");
+
+        additiveRotation = new JCheckBox("Additive");
+        additiveRotation.setToolTipText("<html>Before the feed is performed, the current coordinate of the Rotation axis is taken.<br/>\nRotations stated below are then added to that base angle.<br/>\nThis is typically used for peeling axes, creating a continuous cover tape spool wind-up.\n</html>");
+        panelPushPull.add(additiveRotation, "10, 10, center, default");
 
         JLabel lblFeedStartLocation = new JLabel("Start Location");
-        panelPushPull.add(lblFeedStartLocation, "2, 10, right, default");
+        panelPushPull.add(lblFeedStartLocation, "2, 12, right, default");
 
         textFieldFeedStartX = new JTextField();
-        panelPushPull.add(textFieldFeedStartX, "4, 10");
+        panelPushPull.add(textFieldFeedStartX, "4, 12");
         textFieldFeedStartX.setColumns(8);
 
         textFieldFeedStartY = new JTextField();
-        panelPushPull.add(textFieldFeedStartY, "6, 10");
+        panelPushPull.add(textFieldFeedStartY, "6, 12");
         textFieldFeedStartY.setColumns(8);
 
         textFieldFeedStartZ = new JTextField();
-        panelPushPull.add(textFieldFeedStartZ, "8, 10");
+        panelPushPull.add(textFieldFeedStartZ, "8, 12");
         textFieldFeedStartZ.setColumns(8);
+
+        textFieldFeedStartC = new JTextField();
+        panelPushPull.add(textFieldFeedStartC, "10, 12, fill, default");
+        textFieldFeedStartC.setColumns(8);
 
         chckbxMulti0 = new JCheckBox("");
         chckbxMulti0.setToolTipText("Include the Start Location in multi-actuating motion (if the pull switch is also set).");
         chckbxMulti0.setSelected(true);
-        panelPushPull.add(chckbxMulti0, "12, 10, 3, 1, center, default");
+        panelPushPull.add(chckbxMulti0, "14, 12, 3, 1, center, default");
 
         chckbxPull0 = new JCheckBox("");
         chckbxPull0.setToolTipText("Go to the Start Location when pulling.");
         chckbxPull0.setSelected(true);
-        panelPushPull.add(chckbxPull0, "16, 10, center, default");
+        panelPushPull.add(chckbxPull0, "18, 12, center, default");
 
         locationButtonsPanelFeedStart = new LocationButtonsPanel(textFieldFeedStartX,
                 textFieldFeedStartY, textFieldFeedStartZ, null);
         locationButtonsPanelFeedStart.setShowPositionToolNoSafeZ(true);
-        panelPushPull.add(locationButtonsPanelFeedStart, "18, 10, 3, 1, fill, default");
+        panelPushPull.add(locationButtonsPanelFeedStart, "20, 12, fill, default");
 
         lblFeedSpeed0_1 = new JLabel("Speed ↕");
-        panelPushPull.add(lblFeedSpeed0_1, "8, 12, right, default");
+        panelPushPull.add(lblFeedSpeed0_1, "10, 14, right, default");
 
         textFieldFeedPush1 = new JTextField();
-        panelPushPull.add(textFieldFeedPush1, "10, 12, 3, 1");
-        textFieldFeedPush1.setColumns(5);
+        panelPushPull.add(textFieldFeedPush1, "12, 14, 3, 1");
+        textFieldFeedPush1.setColumns(10);
 
         textFieldFeedPull0 = new JTextField();
-        panelPushPull.add(textFieldFeedPull0, "14, 12, 3, 1");
+        panelPushPull.add(textFieldFeedPull0, "16, 14, 3, 1");
         textFieldFeedPull0.setColumns(10);
 
         lblFeedMid1Location = new JLabel("Mid 1 Location");
-        panelPushPull.add(lblFeedMid1Location, "2, 14, right, default");
+        panelPushPull.add(lblFeedMid1Location, "2, 16, right, default");
 
         textFieldFeedMid1X = new JTextField();
-        panelPushPull.add(textFieldFeedMid1X, "4, 14");
+        panelPushPull.add(textFieldFeedMid1X, "4, 16");
         textFieldFeedMid1X.setColumns(10);
 
         textFieldFeedMid1Y = new JTextField();
-        panelPushPull.add(textFieldFeedMid1Y, "6, 14");
+        panelPushPull.add(textFieldFeedMid1Y, "6, 16");
         textFieldFeedMid1Y.setColumns(10);
 
         textFieldFeedMid1Z = new JTextField();
-        panelPushPull.add(textFieldFeedMid1Z, "8, 14");
+        panelPushPull.add(textFieldFeedMid1Z, "8, 16");
         textFieldFeedMid1Z.setColumns(10);
+
+        textFieldFeedMid1C = new JTextField();
+        panelPushPull.add(textFieldFeedMid1C, "10, 16, fill, default");
+        textFieldFeedMid1C.setColumns(8);
 
         chckbxPush1 = new JCheckBox("");
         chckbxPush1.setToolTipText("Go to the Mid 1 Location when pushing.");
         chckbxPush1.setSelected(true);
-        panelPushPull.add(chckbxPush1, "10, 14, center, default");
+        panelPushPull.add(chckbxPush1, "12, 16, center, default");
 
         chckbxMulti1 = new JCheckBox("");
         chckbxMulti1.setToolTipText("Include the Mid 1 Location in multi-actuation motion (if the push/pull switch is also set).");
         chckbxMulti1.setSelected(true);
-        panelPushPull.add(chckbxMulti1, "12, 14, 3, 1, center, default");
+        panelPushPull.add(chckbxMulti1, "14, 16, 3, 1, center, default");
 
         chckbxPull1 = new JCheckBox("");
         chckbxPull1.setToolTipText("Go to the Mid 1 Location when pulling.");
         chckbxPull1.setSelected(true);
-        panelPushPull.add(chckbxPull1, "16, 14, center, default");
+        panelPushPull.add(chckbxPull1, "18, 16, center, default");
 
         locationButtonsPanelFeedMid1 = new LocationButtonsPanel(textFieldFeedMid1X, textFieldFeedMid1Y, textFieldFeedMid1Z, (JTextField) null);
         locationButtonsPanelFeedMid1.setShowPositionToolNoSafeZ(true);
-        panelPushPull.add(locationButtonsPanelFeedMid1, "18, 14, 3, 1, fill, default");
+        panelPushPull.add(locationButtonsPanelFeedMid1, "20, 16, fill, default");
 
         lblFeedSpeed1_2 = new JLabel("Speed ↕");
-        panelPushPull.add(lblFeedSpeed1_2, "8, 16, right, default");
+        panelPushPull.add(lblFeedSpeed1_2, "10, 18, right, default");
 
         textFieldFeedPush2 = new JTextField();
-        panelPushPull.add(textFieldFeedPush2, "10, 16, 3, 1");
+        panelPushPull.add(textFieldFeedPush2, "12, 18, 3, 1");
         textFieldFeedPush2.setColumns(10);
 
         textFieldFeedPull1 = new JTextField();
         textFieldFeedPull1.setColumns(10);
-        panelPushPull.add(textFieldFeedPull1, "14, 16, 3, 1");
+        panelPushPull.add(textFieldFeedPull1, "16, 18, 3, 1");
 
         lblFeedMid2Location = new JLabel("Mid 2 Location");
-        panelPushPull.add(lblFeedMid2Location, "2, 18, right, default");
+        panelPushPull.add(lblFeedMid2Location, "2, 20, right, default");
 
         textFieldFeedMid2X = new JTextField();
-        panelPushPull.add(textFieldFeedMid2X, "4, 18");
+        panelPushPull.add(textFieldFeedMid2X, "4, 20");
         textFieldFeedMid2X.setColumns(10);
 
         textFieldFeedMid2Y = new JTextField();
-        panelPushPull.add(textFieldFeedMid2Y, "6, 18");
+        panelPushPull.add(textFieldFeedMid2Y, "6, 20");
         textFieldFeedMid2Y.setColumns(10);
 
         textFieldFeedMid2Z = new JTextField();
-        panelPushPull.add(textFieldFeedMid2Z, "8, 18");
+        panelPushPull.add(textFieldFeedMid2Z, "8, 20");
         textFieldFeedMid2Z.setColumns(10);
+
+        textFieldFeedMid2C = new JTextField();
+        panelPushPull.add(textFieldFeedMid2C, "10, 20, fill, default");
+        textFieldFeedMid2C.setColumns(8);
 
         chckbxPush2 = new JCheckBox("");
         chckbxPush2.setToolTipText("Go to the Mid 2 Location when pushing.");
         chckbxPush2.setSelected(true);
-        panelPushPull.add(chckbxPush2, "10, 18, center, default");
+        panelPushPull.add(chckbxPush2, "12, 20, center, default");
 
         chckbxMulti2 = new JCheckBox("");
         chckbxMulti2.setToolTipText("Include the Mid 2 Location in multi-actuation motion (if the push/pull switch is also set).");
         chckbxMulti2.setSelected(true);
-        panelPushPull.add(chckbxMulti2, "12, 18, 3, 1, center, default");
+        panelPushPull.add(chckbxMulti2, "14, 20, 3, 1, center, default");
 
         chckbxPull2 = new JCheckBox("");
         chckbxPull2.setToolTipText("Go to the Mid 2 Location when pulling.");
         chckbxPull2.setSelected(true);
-        panelPushPull.add(chckbxPull2, "16, 18, center, default");
+        panelPushPull.add(chckbxPull2, "18, 20, center, default");
 
         locationButtonsPanelFeedMid2 = new LocationButtonsPanel(textFieldFeedMid2X, textFieldFeedMid2Y, textFieldFeedMid2Z, (JTextField) null);
         locationButtonsPanelFeedMid2.setShowPositionToolNoSafeZ(true);
-        panelPushPull.add(locationButtonsPanelFeedMid2, "18, 18, 3, 1, fill, default");
+        panelPushPull.add(locationButtonsPanelFeedMid2, "20, 20, fill, default");
 
         lblFeedSpeed2_3 = new JLabel("Speed ↕");
-        panelPushPull.add(lblFeedSpeed2_3, "8, 20, right, default");
+        panelPushPull.add(lblFeedSpeed2_3, "10, 22, right, default");
 
         textFieldFeedPush3 = new JTextField();
-        panelPushPull.add(textFieldFeedPush3, "10, 20, 3, 1");
+        panelPushPull.add(textFieldFeedPush3, "12, 22, 3, 1");
         textFieldFeedPush3.setColumns(10);
 
         textFieldFeedPull2 = new JTextField();
         textFieldFeedPull2.setColumns(10);
-        panelPushPull.add(textFieldFeedPull2, "14, 20, 3, 1");
+        panelPushPull.add(textFieldFeedPull2, "16, 22, 3, 1");
 
         lblFeedMid3Location = new JLabel("Mid 3 Location");
-        panelPushPull.add(lblFeedMid3Location, "2, 22, right, default");
+        panelPushPull.add(lblFeedMid3Location, "2, 24, right, default");
 
         textFieldFeedMid3X = new JTextField();
-        panelPushPull.add(textFieldFeedMid3X, "4, 22");
+        panelPushPull.add(textFieldFeedMid3X, "4, 24");
         textFieldFeedMid3X.setColumns(10);
 
         textFieldFeedMid3Y = new JTextField();
-        panelPushPull.add(textFieldFeedMid3Y, "6, 22");
+        panelPushPull.add(textFieldFeedMid3Y, "6, 24");
         textFieldFeedMid3Y.setColumns(10);
 
         textFieldFeedMid3Z = new JTextField();
-        panelPushPull.add(textFieldFeedMid3Z, "8, 22, fill, default");
+        panelPushPull.add(textFieldFeedMid3Z, "8, 24, fill, default");
         textFieldFeedMid3Z.setColumns(10);
+
+        textFieldFeedMid3C = new JTextField();
+        textFieldFeedMid3C.setText("");
+        panelPushPull.add(textFieldFeedMid3C, "10, 24, fill, default");
+        textFieldFeedMid3C.setColumns(8);
 
         chckbxPush3 = new JCheckBox("");
         chckbxPush3.setToolTipText("Go to the Mid 3 Location when pushing.");
         chckbxPush3.setSelected(true);
-        panelPushPull.add(chckbxPush3, "10, 22, center, default");
+        panelPushPull.add(chckbxPush3, "12, 24, center, default");
 
         chckbxMulti3 = new JCheckBox("");
         chckbxMulti3.setToolTipText("Include the Mid 3 Location in multi-actuation motion (if the push/pull switch is also set).");
         chckbxMulti3.setSelected(true);
-        panelPushPull.add(chckbxMulti3, "12, 22, 3, 1, center, default");
+        panelPushPull.add(chckbxMulti3, "14, 24, 3, 1, center, default");
 
         chckbxPull3 = new JCheckBox("");
         chckbxPull3.setToolTipText("Go to the Mid 3 Location when pulling.");
         chckbxPull3.setSelected(true);
-        panelPushPull.add(chckbxPull3, "16, 22, center, default");
+        panelPushPull.add(chckbxPull3, "18, 24, center, default");
 
         locationButtonsPanelFeedMid3 = new LocationButtonsPanel(textFieldFeedMid3X, textFieldFeedMid3Y, textFieldFeedMid3Z, (JTextField) null);
         locationButtonsPanelFeedMid3.setShowPositionToolNoSafeZ(true);
-        panelPushPull.add(locationButtonsPanelFeedMid3, "18, 22, 3, 1, fill, default");
+        panelPushPull.add(locationButtonsPanelFeedMid3, "20, 24, fill, default");
 
         lblFeedSpeed3_4 = new JLabel("Speed ↕");
-        panelPushPull.add(lblFeedSpeed3_4, "8, 24, right, default");
+        panelPushPull.add(lblFeedSpeed3_4, "10, 26, right, default");
 
         textFieldFeedPush4 = new JTextField();
-        panelPushPull.add(textFieldFeedPush4, "10, 24, 3, 1");
+        panelPushPull.add(textFieldFeedPush4, "12, 26, 3, 1");
         textFieldFeedPush4.setColumns(10);
 
         textFieldFeedPull3 = new JTextField();
         textFieldFeedPull3.setColumns(10);
-        panelPushPull.add(textFieldFeedPull3, "14, 24, 3, 1");
+        panelPushPull.add(textFieldFeedPull3, "16, 26, 3, 1");
 
         JLabel lblFeedEndLocation = new JLabel("End Location");
-        panelPushPull.add(lblFeedEndLocation, "2, 26, right, default");
+        panelPushPull.add(lblFeedEndLocation, "2, 28, right, default");
 
         textFieldFeedEndX = new JTextField();
-        panelPushPull.add(textFieldFeedEndX, "4, 26");
+        panelPushPull.add(textFieldFeedEndX, "4, 28");
         textFieldFeedEndX.setColumns(8);
 
         textFieldFeedEndY = new JTextField();
-        panelPushPull.add(textFieldFeedEndY, "6, 26");
+        panelPushPull.add(textFieldFeedEndY, "6, 28");
         textFieldFeedEndY.setColumns(8);
 
         textFieldFeedEndZ = new JTextField();
-        panelPushPull.add(textFieldFeedEndZ, "8, 26");
+        panelPushPull.add(textFieldFeedEndZ, "8, 28");
         textFieldFeedEndZ.setColumns(8);
+
+        textFieldFeedEndC = new JTextField();
+        panelPushPull.add(textFieldFeedEndC, "10, 28, fill, default");
+        textFieldFeedEndC.setColumns(8);
 
         chckbxPushEnd = new JCheckBox("");
         chckbxPushEnd.setToolTipText("Go to the End Location when pushing.");
         chckbxPushEnd.setSelected(true);
-        panelPushPull.add(chckbxPushEnd, "10, 26, center, default");
+        panelPushPull.add(chckbxPushEnd, "12, 28, center, default");
 
         chckbxMultiEnd = new JCheckBox("");
         chckbxMultiEnd.setToolTipText("Include the End Location in multi-actuation motion (if the push switch is also set).");
         chckbxMultiEnd.setSelected(true);
-        panelPushPull.add(chckbxMultiEnd, "12, 26, 3, 1, center, default");
+        panelPushPull.add(chckbxMultiEnd, "14, 28, 3, 1, center, default");
 
         locationButtonsPanelFeedEnd = new LocationButtonsPanel(textFieldFeedEndX, textFieldFeedEndY,
                 textFieldFeedEndZ, null);
         locationButtonsPanelFeedEnd.setShowPositionToolNoSafeZ(true);
-        panelPushPull.add(locationButtonsPanelFeedEnd, "18, 26, 3, 1, fill, default");
+        panelPushPull.add(locationButtonsPanelFeedEnd, "20, 28, fill, default");
 
         // Compose a font list of the system, the one currently selected, even if the system does not know it (yet), and the empty selection 
         List<String> systemFontList = Arrays.asList(GraphicsEnvironment.getLocalGraphicsEnvironment()
@@ -442,7 +487,6 @@ extends AbstractConfigurationWizard {
         fontList.addAll(systemFontList);
 
         contentPanel.add(panelFields);
-        initDataBindings();
     }
 
     @Override
@@ -452,9 +496,17 @@ extends AbstractConfigurationWizard {
         LongConverter longConverter = new LongConverter();
         DoubleConverter doubleConverter =
                 new DoubleConverter(Configuration.get().getLengthDisplayFormat());
+        Head head = null;
+        try {
+            head = Configuration.get().getMachine().getDefaultHead();
+        }
+        catch (Exception e) {
+            Logger.error(e, "Cannot determine default head of machine.");
+        }
+        NamedConverter<Actuator> actuatorConverter = (new NamedConverter<>(head.getActuators()));
 
-        addWrappedBinding(feeder, "actuatorName", comboBoxFeedActuator, "selectedItem");
-        addWrappedBinding(feeder, "peelOffActuatorName", comboBoxPeelOffActuator, "selectedItem");
+        addWrappedBinding(feeder, "actuator", actuator, "selectedItem", actuatorConverter);
+        addWrappedBinding(feeder, "actuator2", actuator2, "selectedItem", actuatorConverter);
 
         addWrappedBinding(feeder, "feedSpeedPush1", textFieldFeedPush1, "text", doubleConverter);
         addWrappedBinding(feeder, "feedSpeedPush2", textFieldFeedPush2, "text", doubleConverter);
@@ -481,6 +533,8 @@ extends AbstractConfigurationWizard {
         addWrappedBinding(feeder, "includedPull2", chckbxPull2, "selected");
         addWrappedBinding(feeder, "includedPull3", chckbxPull3, "selected");
 
+        addWrappedBinding(feeder, "additiveRotation", additiveRotation, "selected");
+
         MutableLocationProxy feedStartLocation = new MutableLocationProxy();
         bind(UpdateStrategy.READ_WRITE, feeder, "feedStartLocation", feedStartLocation, "location");
         addWrappedBinding(feedStartLocation, "lengthX", textFieldFeedStartX, "text",
@@ -489,6 +543,8 @@ extends AbstractConfigurationWizard {
                 lengthConverter);
         addWrappedBinding(feedStartLocation, "lengthZ", textFieldFeedStartZ, "text",
                 lengthConverter);
+        addWrappedBinding(feedStartLocation, "rotation", textFieldFeedStartC, "text",
+                doubleConverter);
 
         MutableLocationProxy feedMid1Location = new MutableLocationProxy();
         bind(UpdateStrategy.READ_WRITE, feeder, "feedMid1Location", feedMid1Location, "location");
@@ -498,6 +554,8 @@ extends AbstractConfigurationWizard {
                 lengthConverter);
         addWrappedBinding(feedMid1Location, "lengthZ", textFieldFeedMid1Z, "text",
                 lengthConverter);
+        addWrappedBinding(feedMid1Location, "rotation", textFieldFeedMid1C, "text",
+                doubleConverter);
 
         MutableLocationProxy feedMid2Location = new MutableLocationProxy();
         bind(UpdateStrategy.READ_WRITE, feeder, "feedMid2Location", feedMid2Location, "location");
@@ -507,6 +565,8 @@ extends AbstractConfigurationWizard {
                 lengthConverter);
         addWrappedBinding(feedMid2Location, "lengthZ", textFieldFeedMid2Z, "text",
                 lengthConverter);
+        addWrappedBinding(feedMid2Location, "rotation", textFieldFeedMid2C, "text",
+                doubleConverter);
 
         MutableLocationProxy feedMid3Location = new MutableLocationProxy();
         bind(UpdateStrategy.READ_WRITE, feeder, "feedMid3Location", feedMid3Location, "location");
@@ -516,12 +576,15 @@ extends AbstractConfigurationWizard {
                 lengthConverter);
         addWrappedBinding(feedMid3Location, "lengthZ", textFieldFeedMid3Z, "text",
                 lengthConverter);
+        addWrappedBinding(feedMid3Location, "rotation", textFieldFeedMid3C, "text",
+                doubleConverter);
 
         MutableLocationProxy feedEndLocation = new MutableLocationProxy();
         bind(UpdateStrategy.READ_WRITE, feeder, "feedEndLocation", feedEndLocation, "location");
         addWrappedBinding(feedEndLocation, "lengthX", textFieldFeedEndX, "text", lengthConverter);
         addWrappedBinding(feedEndLocation, "lengthY", textFieldFeedEndY, "text", lengthConverter);
         addWrappedBinding(feedEndLocation, "lengthZ", textFieldFeedEndZ, "text", lengthConverter);
+        addWrappedBinding(feedEndLocation, "rotation", textFieldFeedEndC, "text", doubleConverter);
 
         ComponentDecorators.decorateWithAutoSelect(textFieldFeedPush1);
         ComponentDecorators.decorateWithAutoSelect(textFieldFeedPush2);
@@ -534,26 +597,28 @@ extends AbstractConfigurationWizard {
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldFeedStartX);
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldFeedStartY);
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldFeedStartZ);
+        ComponentDecorators.decorateWithAutoSelect(textFieldFeedStartC);
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldFeedMid1X);
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldFeedMid1Y);
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldFeedMid1Z);
+        ComponentDecorators.decorateWithAutoSelect(textFieldFeedMid1C);
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldFeedMid2X);
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldFeedMid2Y);
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldFeedMid2Z);
+        ComponentDecorators.decorateWithAutoSelect(textFieldFeedMid2C);
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldFeedMid3X);
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldFeedMid3Y);
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldFeedMid3Z);
+        ComponentDecorators.decorateWithAutoSelect(textFieldFeedMid3C);
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldFeedEndX);
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldFeedEndY);
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldFeedEndZ);
+        ComponentDecorators.decorateWithAutoSelect(textFieldFeedEndC);
 
-        bind(UpdateStrategy.READ, feeder, "actuatorName", locationButtonsPanelFeedStart, "actuatorName");
-        bind(UpdateStrategy.READ, feeder, "actuatorName", locationButtonsPanelFeedMid1, "actuatorName");
-        bind(UpdateStrategy.READ, feeder, "actuatorName", locationButtonsPanelFeedMid2, "actuatorName");
-        bind(UpdateStrategy.READ, feeder, "actuatorName", locationButtonsPanelFeedMid3, "actuatorName");
-        bind(UpdateStrategy.READ, feeder, "actuatorName", locationButtonsPanelFeedEnd, "actuatorName");
-    }
-
-    protected void initDataBindings() {
+        bind(UpdateStrategy.READ, actuator, "selectedItem", locationButtonsPanelFeedStart, "actuatorName");
+        bind(UpdateStrategy.READ, actuator, "selectedItem", locationButtonsPanelFeedMid1, "actuatorName");
+        bind(UpdateStrategy.READ, actuator, "selectedItem", locationButtonsPanelFeedMid2, "actuatorName");
+        bind(UpdateStrategy.READ, actuator, "selectedItem", locationButtonsPanelFeedMid3, "actuatorName");
+        bind(UpdateStrategy.READ, actuator, "selectedItem", locationButtonsPanelFeedEnd, "actuatorName");
     }
 }

--- a/src/main/java/org/openpnp/machine/reference/solutions/AxisSolutions.java
+++ b/src/main/java/org/openpnp/machine/reference/solutions/AxisSolutions.java
@@ -41,6 +41,7 @@ import org.openpnp.model.Solutions.Subject;
 import org.openpnp.spi.Axis;
 import org.openpnp.spi.Axis.Type;
 import org.openpnp.spi.Machine;
+import org.openpnp.spi.Nozzle;
 import org.openpnp.spi.Nozzle.RotationMode;
 import org.openpnp.spi.PartAlignment;
 import org.openpnp.spi.base.AbstractControllerAxis;
@@ -236,36 +237,39 @@ public class AxisSolutions implements Solutions.Subject {
                     }
                 }
                 if (isUnlimitedArticulation) {
-                    if (!axis.isWrapAroundRotation()) {
-                        solutions.add(new Solutions.Issue(
-                                axis, 
-                                "Rotation can be optimized by wrapping-around the shorter way. Best combined with Limit ±180°.", 
-                                "Enable Wrap Around.", 
-                                Severity.Suggestion,
-                                "https://github.com/openpnp/openpnp/wiki/Machine-Axes#controller-settings-rotational-axis") {
+                    if (axis.getDefaultHeadMountable() instanceof Nozzle) {
+                        // Axis is used on nozzle, suggest some optimizations.
+                        if (!axis.isWrapAroundRotation()) {
+                            solutions.add(new Solutions.Issue(
+                                    axis, 
+                                    "Rotation can be optimized by wrapping-around the shorter way. Best combined with Limit ±180°.", 
+                                    "Enable Wrap Around.", 
+                                    Severity.Suggestion,
+                                    "https://github.com/openpnp/openpnp/wiki/Machine-Axes#controller-settings-rotational-axis") {
 
-                            @Override
-                            public void setState(Solutions.State state) throws Exception {
-                                axis.setWrapAroundRotation((state == Solutions.State.Solved));
-                                super.setState(state);
-                            }
-                        });
-                    }
-                    if (!axis.isLimitRotation()) {
-                        solutions.add(new Solutions.Issue(
-                                axis, 
-                                "Rotation can be optimized by limiting angles to ±180°. "
-                                        + "Best combined with Wrap Around.", 
-                                        "Enable Limit to Range.", 
-                                        Severity.Suggestion,
-                                "https://github.com/openpnp/openpnp/wiki/Machine-Axes#controller-settings-rotational-axis") {
+                                @Override
+                                public void setState(Solutions.State state) throws Exception {
+                                    axis.setWrapAroundRotation((state == Solutions.State.Solved));
+                                    super.setState(state);
+                                }
+                            });
+                        }
+                        if (!axis.isLimitRotation()) {
+                            solutions.add(new Solutions.Issue(
+                                    axis, 
+                                    "Rotation can be optimized by limiting angles to ±180°. "
+                                            + "Best combined with Wrap Around.", 
+                                            "Enable Limit to Range.", 
+                                            Severity.Suggestion,
+                                    "https://github.com/openpnp/openpnp/wiki/Machine-Axes#controller-settings-rotational-axis") {
 
-                            @Override
-                            public void setState(Solutions.State state) throws Exception {
-                                axis.setLimitRotation((state == Solutions.State.Solved));
-                                super.setState(state);
-                            }
-                        });
+                                @Override
+                                public void setState(Solutions.State state) throws Exception {
+                                    axis.setLimitRotation((state == Solutions.State.Solved));
+                                    super.setState(state);
+                                }
+                            });
+                        }
                     }
                 }
                 else {


### PR DESCRIPTION
# Description

- Use the Rotation axis on a `ReferencePushPullFeeder` actuator motion locations, to be used for _coordinated_ peeling.
- Support additive rotation for continuous peeling spool wind-up.
- Change Issues & Solutions to only suggest wrap-around and +/-180° limiting on nozzle rotation axes (it would be wrong for peeler rotation axes).
- Actuators are now always referenced by Object from the `ReferencePushPullFeeder`, reference by name only for XML persistence.

# Justification
See the conversation here:
https://groups.google.com/g/openpnp/c/pd2hQ1cq2dw/m/FOcm83PLAgAJ

# Instructions for Use

## Coordinated Peeling

Cover tape peeling can be done using motion that is coordinated with the push-pull articulation, as needed for drag feeders etc. This allows for an elaborate and coordinated motion pattern. Furthermore, it performs the peeling motion _in parallel_ with the other feeding articulation, potentially saving time. 

## Peeler Axis
Create a rotation axis for the peeler. Make sure to _disable_ the **Limit to Range** and **Wrap Around** options, as we want contonuous wind-up of the peeled-off cover tape:

![Rotation Axis](https://user-images.githubusercontent.com/9963310/158563357-84e92d16-36d0-4ecb-a56a-63e8c6f3701e.png)

Assign the created axis to the push-pull actuator:

![Assign to Actuator](https://user-images.githubusercontent.com/9963310/158563736-3c94a813-d7ef-43c6-bf0e-9a9ce76aa34d.png)

## Configure Coordinated Peeling
On the `ReferencePushPullFeeder` use the new **Rotation** column to configure the peeling coordinates. For a typical configuration, you cannot use bidirectional motion, i.e. be sure to disable all the ↑↓ and ↑ column check-boxes. 

For typical control, the **Additive** switch needs to be enabled, so the peeling motion is _additive/relative_ to the starting point. The starting point is the peeler axis coordinate, right before the feed actuation. Note that for multi-actuation/multi-feed, the additive behavior is _for each_ actuation.

The **= 0°** button can be used to reset the starting point to the current peeler axis coordinate. After pressing it, you can use the capture and positioning buttons to get and test the _additive/relative_ locations of the push-pull motion, _including_ the peel.

![Push-pull motion with Rotation](https://user-images.githubusercontent.com/9963310/158595210-0505cb15-ffbc-4aea-8645-ce34407202a2.png)

# Implementation Details
1. Tested in simulation. 
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. Successful `mvn test` before submitting the Pull Request. 
