### PR TITLE
Feature / ReferencePushPullFeeder Better Motion Coordinate Handling

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/feeder/wizards/ReferencePushPullMotionConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/wizards/ReferencePushPullMotionConfigurationWizard.java
@@ -655,9 +655,12 @@ extends AbstractConfigurationWizard {
             Actuator feedActuator = null;
             try {
                 head = Configuration.get().getMachine().getDefaultHead();
-                feedActuator = head.getActuatorByName((String) actuator.getSelectedItem());
-                // Take the rotation from the actuator.
-                baseLocation = feedActuator.getLocation().multiply(0, 0, 0, 1);
+                String actuatorName = (String) actuator.getSelectedItem();
+                if (actuatorName != null && !actuatorName.isEmpty()) {
+                    feedActuator = head.getActuatorByName(actuatorName);
+                    // Take the rotation from the actuator.
+                    baseLocation = feedActuator.getLocation().multiply(0, 0, 0, 1);
+                }
             }
             catch (Exception e) {
                 Logger.error(e, "Cannot determine base location of actuator.");


### PR DESCRIPTION
# Description

- Allow switching off the application of vision calibration to the  X/Y coordinates of the push-pull motion locations.
- Reset the peeler/rotation axis coordinate instead of just using additive math.
- Handle resetting properly, even if there is multi-actuation needed. 
- Bugfix: Avoid an exception in the GUI if no actuator is assigned to the feeder yet.

# Justification
Testing round of #1390. 

See the discussion here:
https://groups.google.com/g/openpnp/c/wpHLTbWaZI0/m/39Lx57wCAwAJ

# Instructions for Use

Use the new **Vision Calibrate?** checkboxes under the **X** and **Y** columns:

![Vision Calibrate X, Y](https://user-images.githubusercontent.com/9963310/159045634-fd7ff079-0e69-4fde-b36d-1bfbddca30bd.png)

Some feeders need multi-actuation, for instance if the part pitch in the tape is larger than the maximum tape feed that can be done by the mechanical motion. To enable multi-actuation _together_ with additive rotation, see the screenshot above, for how to configure the ↑↓ and ↑ column check-boxes.

See the Wiki for more instructions:
https://github.com/openpnp/openpnp/wiki/ReferencePushPullFeeder#coordinated-peeling

# Implementation Details
1. Tested in simulation.
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. Successful `mvn test` before submitting the Pull Request. 
