### PR TITLE
Feature / Issues & Solutions Dynamic Safe Z and Max. Part Heights

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/solutions/HeadSolutions.java
+++ b/src/main/java/org/openpnp/machine/reference/solutions/HeadSolutions.java
@@ -216,53 +216,7 @@ public class HeadSolutions implements Solutions.Subject {
                         addInconsistentAxisIssue(solutions, camera, hm, Axis.Type.X);
                         addInconsistentAxisIssue(solutions, camera, hm, Axis.Type.Y);
                         if (hm instanceof Nozzle) {
-                            if (hm.getAxisZ() == null) {
-                                solutions.add(new Solutions.PlainIssue(
-                                        hm, 
-                                        "Nozzle "+hm.getName()+" does not have a Z axis assigned.", 
-                                        "Please assign a proper Z axis. You might need to create one first.", 
-                                        Severity.Error,
-                                        "https://github.com/openpnp/openpnp/wiki/Mapping-Axes"));
-                            }
-                            if (hm.getAxisRotation() == null) {
-                                solutions.add(new Solutions.PlainIssue(
-                                        hm, 
-                                        "Nozzle "+hm.getName()+" does not have a Rotation axis assigned.", 
-                                        "Please assign a proper Rotation axis. You might need to create one first.", 
-                                        Severity.Error,
-                                        "https://github.com/openpnp/openpnp/wiki/Mapping-Axes"));
-                            }
-                            if (hm.getAxisZ() != null && hm.getAxisRotation() != null) {
-                                for (Camera camera2 : head.getCameras()) {
-                                    if (camera2.getAxisZ() == hm.getAxisZ()) {
-                                        sameAxisAssignedIssue(solutions, camera2, hm, camera2.getAxisZ(), Axis.Type.Z);
-                                    }
-                                    if (camera2.getAxisRotation() == hm.getAxisRotation()) {
-                                        sameAxisAssignedIssue(solutions, camera2, hm, camera2.getAxisRotation(), Axis.Type.Rotation);
-                                    }
-                                }
-                                for (Nozzle nozzle2 : head.getNozzles()) {
-                                    if (nozzle2 == hm) {
-                                        break;
-                                    }
-                                    if (nozzle2.getAxisZ() == hm.getAxisZ()) {
-                                        solutions.add(new Solutions.PlainIssue(
-                                                head, 
-                                                "Nozzles "+nozzle2.getName()+" and "+hm.getName()+" have the same Z axis assigned.", 
-                                                "Please assign a different Z axis.", 
-                                                Severity.Error,
-                                                "https://github.com/openpnp/openpnp/wiki/Mapping-Axes"));
-                                    }
-                                    if (nozzle2.getAxisRotation() == hm.getAxisRotation()) {
-                                        solutions.add(new Solutions.PlainIssue(
-                                                head, 
-                                                "Nozzles "+nozzle2.getName()+" and "+hm.getName()+" have the same Rotation axis assigned.", 
-                                                "It is OK to share rotation axes. If intentional, just dismiss this issue. Otherwise assign a different Rotation axis.", 
-                                                Severity.Information,
-                                                "https://github.com/openpnp/openpnp/wiki/Mapping-Axes"));
-                                    }
-                                }
-                            }
+                            perNozzleSolutions(solutions, (Nozzle) hm);
                         }
                     }
                 }
@@ -274,6 +228,56 @@ public class HeadSolutions implements Solutions.Subject {
                 if (head.getzProbeActuator() != null) {
                     ActuatorSolutions.findActuatorReadIssues(solutions, head, head.getzProbeActuator(), "Z probe",
                         "https://github.com/openpnp/openpnp/wiki/Z-Probing");
+                }
+            }
+        }
+    }
+
+    protected void perNozzleSolutions(Solutions solutions, Nozzle nozzle) {
+        if (nozzle.getAxisZ() == null) {
+            solutions.add(new Solutions.PlainIssue(
+                    nozzle, 
+                    "Nozzle "+nozzle.getName()+" does not have a Z axis assigned.", 
+                    "Please assign a proper Z axis. You might need to create one first.", 
+                    Severity.Error,
+                    "https://github.com/openpnp/openpnp/wiki/Mapping-Axes"));
+        }
+        if (nozzle.getAxisRotation() == null) {
+            solutions.add(new Solutions.PlainIssue(
+                    nozzle, 
+                    "Nozzle "+nozzle.getName()+" does not have a Rotation axis assigned.", 
+                    "Please assign a proper Rotation axis. You might need to create one first.", 
+                    Severity.Error,
+                    "https://github.com/openpnp/openpnp/wiki/Mapping-Axes"));
+        }
+        if (nozzle.getAxisZ() != null && nozzle.getAxisRotation() != null) {
+            for (Camera camera2 : head.getCameras()) {
+                if (camera2.getAxisZ() == nozzle.getAxisZ()) {
+                    sameAxisAssignedIssue(solutions, camera2, nozzle, camera2.getAxisZ(), Axis.Type.Z);
+                }
+                if (camera2.getAxisRotation() == nozzle.getAxisRotation()) {
+                    sameAxisAssignedIssue(solutions, camera2, nozzle, camera2.getAxisRotation(), Axis.Type.Rotation);
+                }
+            }
+            for (Nozzle nozzle2 : head.getNozzles()) {
+                if (nozzle2 == nozzle) {
+                    break;
+                }
+                if (nozzle2.getAxisZ() == nozzle.getAxisZ()) {
+                    solutions.add(new Solutions.PlainIssue(
+                            nozzle, 
+                            "Nozzles "+nozzle2.getName()+" and "+nozzle.getName()+" have the same Z axis assigned.", 
+                            "Please assign a different Z axis.", 
+                            Severity.Error,
+                            "https://github.com/openpnp/openpnp/wiki/Mapping-Axes"));
+                }
+                if (nozzle2.getAxisRotation() == nozzle.getAxisRotation()) {
+                    solutions.add(new Solutions.PlainIssue(
+                            nozzle, 
+                            "Nozzles "+nozzle2.getName()+" and "+nozzle.getName()+" have the same Rotation axis assigned.", 
+                            "It is OK to share rotation axes. If intentional, just dismiss this issue. Otherwise assign a different Rotation axis.", 
+                            Severity.Information,
+                            "https://github.com/openpnp/openpnp/wiki/Mapping-Axes"));
                 }
             }
         }

--- a/src/main/java/org/openpnp/machine/reference/solutions/KinematicSolutions.java
+++ b/src/main/java/org/openpnp/machine/reference/solutions/KinematicSolutions.java
@@ -469,7 +469,7 @@ public class KinematicSolutions implements Solutions.Subject {
                                     public String getExtendedDescription() {
                                         return "<html>"
                                                 + "<p>With <strong>Dynamic Safe Z</strong> enabled, the nozzle needs a head-room, the so-called Safe Z Zone "
-                                                + "to lift the nozzle higher with taller parts. The maximum expected part height is specificed on the "
+                                                + "to lift the nozzle higher with taller parts. The maximum expected part height is specified on the "
                                                 + "nozzle tip <strong>Max. Part Height</strong>.</p><br/>"
                                                 + "<p>Nozzle "+nozzle.getName()+" with compatible tip "+nt.getName()+" has a <strong>Max. Part Height</strong> of "
                                                 + lengthConverter.convertForward(maxHeight)+" which is larger than the Safe Z Zone of "
@@ -513,7 +513,7 @@ public class KinematicSolutions implements Solutions.Subject {
                                         return "<html>"
                                                 + "<p>With <strong>Dynamic Safe Z</strong> enabled, the nozzles need a head-room, the so-called Safe Z Zone to lift "
                                                 + "the nozzles higher with taller parts. On nozzles with shared Z axes the part heights compete for the same head-room. "
-                                                + "The maximum expected part height is specificed on the nozzle tip <strong>Max. Part Height</strong>.</p><br/>"
+                                                + "The maximum expected part height is specified on the nozzle tip <strong>Max. Part Height</strong>.</p><br/>"
                                                 + "<p>Nozzle "+nozzle.getName()+" with compatible tip "+nt.getName()+" has a <strong>Max. Part Height</strong> of "
                                                 + lengthConverter.convertForward(maxHeight)+", furthermore, nozzle "+nozzle2.getName()+" with compatible tip "
                                                 + nt2.getName()+" has a largest <strong>Max. Part Height</strong> of "+lengthConverter.convertForward(maxHeight2)+", which "

--- a/src/main/java/org/openpnp/machine/reference/solutions/KinematicSolutions.java
+++ b/src/main/java/org/openpnp/machine/reference/solutions/KinematicSolutions.java
@@ -25,8 +25,10 @@ import javax.swing.Icon;
 
 import org.openpnp.gui.MainFrame;
 import org.openpnp.gui.support.Icons;
+import org.openpnp.gui.support.LengthConverter;
 import org.openpnp.machine.reference.ReferenceMachine;
 import org.openpnp.machine.reference.ReferenceNozzle;
+import org.openpnp.machine.reference.ReferenceNozzleTip;
 import org.openpnp.machine.reference.axis.ReferenceCamClockwiseAxis;
 import org.openpnp.machine.reference.axis.ReferenceCamCounterClockwiseAxis;
 import org.openpnp.machine.reference.axis.ReferenceControllerAxis;
@@ -37,6 +39,7 @@ import org.openpnp.model.Location;
 import org.openpnp.model.Solutions;
 import org.openpnp.model.Solutions.Issue;
 import org.openpnp.model.Solutions.Milestone;
+import org.openpnp.model.Solutions.Severity;
 import org.openpnp.model.Solutions.State;
 import org.openpnp.spi.Axis;
 import org.openpnp.spi.Axis.Type;
@@ -44,6 +47,7 @@ import org.openpnp.spi.CoordinateAxis;
 import org.openpnp.spi.Head;
 import org.openpnp.spi.HeadMountable;
 import org.openpnp.spi.Nozzle;
+import org.openpnp.spi.NozzleTip;
 import org.openpnp.spi.base.AbstractHeadMountable;
 import org.pmw.tinylog.Logger;
 
@@ -74,7 +78,7 @@ public class KinematicSolutions implements Solutions.Subject {
                                 "Dynamic Safe Z for "+nozzle.getName()+".", 
                                 "Decide whether "+nozzle.getName()+" has dynamic Safe Z or not.", 
                                 Solutions.Severity.Fundamental,
-                                "https://github.com/openpnp/openpnp/wiki/Setup-and-Calibration%3A-Nozzle-Setup") {
+                                "https://github.com/openpnp/openpnp/wiki/Kinematic-Solutions#dynamic-safe-z") {
                             {
                                 setChoice(oldDynamicSafeZ);
                             }
@@ -164,7 +168,7 @@ public class KinematicSolutions implements Solutions.Subject {
                                                 "Set Safe Z of "+hm.getName()+".", 
                                                 "Jog "+hm.getName()+" over the tallest obstacle and capture.", 
                                                 Solutions.Severity.Fundamental,
-                                                "https://github.com/openpnp/openpnp/wiki/Machine-Axes#kinematic-settings--axis-limits") {
+                                                "https://github.com/openpnp/openpnp/wiki/Kinematic-Solutions#capture-safe-z") {
 
                                             @Override 
                                             public void activate() throws Exception {
@@ -221,6 +225,22 @@ public class KinematicSolutions implements Solutions.Subject {
                                                 super.setState(state);
                                             }
                                         });
+                                    }
+                                    if (hm instanceof ReferenceNozzle) {
+                                        // try to find a shared Z axis nozzle
+                                        ReferenceNozzle sharedZNozzle = null;
+                                        for (Nozzle nozzle2 : head.getNozzles()) {
+                                            if (nozzle2 instanceof ReferenceNozzle 
+                                                    && nozzle2 != hm) {
+                                                ReferenceNozzle refNozzle2 = (ReferenceNozzle) nozzle2;
+                                                if (refNozzle2.isEnableDynamicSafeZ() 
+                                                        && HeadSolutions.getRawAxis(machine, refNozzle2.getAxisZ()) == axisZ) {
+                                                    sharedZNozzle = refNozzle2;
+                                                    break;
+                                                }
+                                            }
+                                        }
+                                        dynamicSafeZSolution(solutions, (ReferenceNozzle)hm, sharedZNozzle, axisZ);
                                     }
                                 }
                                 catch (Exception e) {
@@ -360,7 +380,7 @@ public class KinematicSolutions implements Solutions.Subject {
                                         "Set the "+qualifier+" soft limit of "+controllerAxis.getName()+".", 
                                         "Move axis "+controllerAxis.getName()+" to the "+qualifier+" soft limit and capture.", 
                                         Solutions.Severity.Suggestion,
-                                        "https://github.com/openpnp/openpnp/wiki/Machine-Axes#kinematic-settings--axis-limits") {
+                                        "https://github.com/openpnp/openpnp/wiki/Kinematic-Solutions#capture-soft-limits") {
 
                                     @Override 
                                     public void activate() throws Exception {
@@ -414,4 +434,128 @@ public class KinematicSolutions implements Solutions.Subject {
         }
         return false;
     }
+
+
+    protected void dynamicSafeZSolution(Solutions solutions, ReferenceNozzle nozzle, ReferenceNozzle nozzle2, ReferenceControllerAxis rawAxisZ) 
+            throws Exception {
+        Length [] zoneZ = nozzle.getSafeZZone();
+        Length zone = zoneZ[1].subtract(zoneZ[0]);
+        if (nozzle.isEnableDynamicSafeZ() 
+                && zoneZ[0] != null && zoneZ[1] != null) {
+            LengthConverter lengthConverter = new LengthConverter();
+            for (NozzleTip nt : nozzle.getCompatibleNozzleTips()) {
+                if (nt instanceof ReferenceNozzleTip) {
+                    // Check the maximum part height on a nozzle tip to the Safe Z zone.
+                    Length maxHeight = ((ReferenceNozzleTip) nt).getMaxPartHeight();
+                    Location z0 = new Location(AxesLocation.getUnits(), 
+                            0, 0, nozzle.getSafeZ().convertToUnits(AxesLocation.getUnits()).getValue(), 0);
+                    Location z1 = new Location(AxesLocation.getUnits(), 
+                            0, 0, nozzle.getSafeZ().add(maxHeight).convertToUnits(AxesLocation.getUnits()).getValue(), 0);
+                    AxesLocation az0 = nozzle.toRaw(nozzle.toHeadLocation(z0));
+                    AxesLocation az1 = nozzle.toRaw(nozzle.toHeadLocation(z1));
+                    int signum1 = (int) Math.signum(az0.motionSegmentTo(az1).getCoordinate(rawAxisZ));
+                    AxesLocation az2 = new AxesLocation(rawAxisZ, 
+                            signum1 > 0 ? rawAxisZ.getSafeZoneHigh() : rawAxisZ.getSafeZoneLow());
+                    int signum2 = (int) Math.signum(az1.motionSegmentTo(az2).getCoordinate(rawAxisZ));
+                    if (signum2*signum1 == -1) {
+                        solutions.add(new Solutions.PlainIssue(
+                                nt, 
+                                "Nozzle "+nozzle.getName()+" with tip "+nt.getName()+" Safe Z Zone violation.", 
+                                "With dynamic safe Z, the Max. Part Height of each compatible nozzle tip must be smaller than the axis "+rawAxisZ.getName()+" Safe Z Zone.", 
+                                Severity.Error,
+                                "https://github.com/openpnp/openpnp/wiki/Kinematic-Solutions#dynamic-safe-z-zone") {
+
+                                    @Override
+                                    public String getExtendedDescription() {
+                                        return "<html>"
+                                                + "<p>With <strong>Dynamic Safe Z</strong> enabled, the nozzle needs a head-room, the so-called Safe Z Zone "
+                                                + "to lift the nozzle higher with taller parts. The maximum expected part height is specificed on the "
+                                                + "nozzle tip <strong>Max. Part Height</strong>.</p><br/>"
+                                                + "<p>Nozzle "+nozzle.getName()+" with compatible tip "+nt.getName()+" has a <strong>Max. Part Height</strong> of "
+                                                + lengthConverter.convertForward(maxHeight)+" which is larger than the Safe Z Zone of "
+                                                + lengthConverter.convertForward(zone)+". Note, the safe Z Zone is configured on the "+rawAxisZ.getName()+" axis "
+                                                + "to reach from "+lengthConverter.convertForward(rawAxisZ.getSafeZoneLow())+" to "
+                                                + lengthConverter.convertForward(rawAxisZ.getSafeZoneHigh())+" in (untransformed) coordinates.</p><br/>"
+                                                + "<p>Please either enlarge the Safe Z Zone, by reducing the nozzle "+nozzle.getName()+" Z clearance, or reduce "
+                                                + "the <strong>Max. Part Height</strong> on nozzle tip "+nt.getName()+".</p><br/>"
+                                                + "<p>Reducing Z clearance is best done by revisiting the Safe Z solution for nozzle "+nozzle.getName()+". "
+                                                + "Disable the <strong>Save Zone "+(signum1 > 0 ? "Low" : "High")+"  Enabled</strong> checkbox on axis "+rawAxisZ.getName()+", "
+                                                + "then come back here and press <strong>Find Issues &amp; Solutions</strong>.</p>"
+                                                + "</html>";
+                                    }
+                                    @Override
+                                    public Icon getExtendedIcon() {
+                                        return Icons.safeZDynamic;
+                                    }
+                        });
+                    }
+                    else if (nozzle2 != null) { 
+                        // Check combined nozzle tip max part heights too.
+                        ReferenceNozzleTip nt2 = getCompatibleNozzleTipMaxPartHeight(nozzle2, nt);
+                        if (nt2 != null) {
+                            Length maxHeight2 = nt2.getMaxPartHeight();
+                            Location z3 = new Location(AxesLocation.getUnits(), 
+                                    0, 0, nozzle2.getSafeZ().add(maxHeight2).convertToUnits(AxesLocation.getUnits()).getValue(), 0);
+                            AxesLocation az3 = nozzle2.toRaw(nozzle2.toHeadLocation(z3));
+                            int signum3 = (int) Math.signum(az1.motionSegmentTo(az3).getCoordinate(rawAxisZ));
+                            if (signum3*signum1 == -1) {
+                                solutions.add(new Solutions.PlainIssue(
+                                        nt, 
+                                        "Nozzle "+nozzle.getName()+" with tip "+nt.getName()+" and nozzle "+nozzle2.getName()+" with tip "+nt2.getName()
+                                        +" potential Safe Z Zone violation.", 
+                                        "With dynamic safe Z, the combined Max. Part Heights of compatible nozzle tips must be smaller than the axis "
+                                        +rawAxisZ.getName()+" Safe Z Zone.", 
+                                        Severity.Warning,
+                                        "https://github.com/openpnp/openpnp/wiki/Kinematic-Solutions#dynamic-safe-z-zone") {
+
+                                    @Override
+                                    public String getExtendedDescription() {
+                                        return "<html>"
+                                                + "<p>With <strong>Dynamic Safe Z</strong> enabled, the nozzles need a head-room, the so-called Safe Z Zone to lift "
+                                                + "the nozzles higher with taller parts. On nozzles with shared Z axes the part heights compete for the same head-room. "
+                                                + "The maximum expected part height is specificed on the nozzle tip <strong>Max. Part Height</strong>.</p><br/>"
+                                                + "<p>Nozzle "+nozzle.getName()+" with compatible tip "+nt.getName()+" has a <strong>Max. Part Height</strong> of "
+                                                + lengthConverter.convertForward(maxHeight)+", furthermore, nozzle "+nozzle2.getName()+" with compatible tip "
+                                                + nt2.getName()+" has a largest <strong>Max. Part Height</strong> of "+lengthConverter.convertForward(maxHeight2)+", which "
+                                                + "in combination (and after transformation) is larger than the Safe Z Zone of "+lengthConverter.convertForward(zone)+". "
+                                                + "Note, the safe Z Zone is configured on the "+rawAxisZ.getName()+" axis to reach from "
+                                                + lengthConverter.convertForward(rawAxisZ.getSafeZoneLow())+" to "
+                                                + lengthConverter.convertForward(rawAxisZ.getSafeZoneHigh())+" in (untransformed) coordinates.</p><br/>"
+                                                + "<p>Please either enlarge the Safe Z Zone, by reducing the nozzle "+nozzle.getName()+" and "+nozzle2.getName()
+                                                + " Z clearances, or reduce the <strong>Max. Part Height</strong> on nozzle tips "+nt.getName()+" and "
+                                                + nt2.getName()+".</p><br/>"
+                                                + "<p>Reducing Z clearances is best done by revisiting the Safe Z solutions for nozzles "+nozzle.getName()+" and "
+                                                + nozzle2.getName()+". "
+                                                + "Disable the <strong>Save Zone Low / High Enabled</strong> checkbox on axis "+rawAxisZ.getName()+", "
+                                                + "then come back here and press <strong>Find Issues &amp; Solutions</strong>.</p>"
+                                                + "</html>";
+                                    }
+                                    @Override
+                                    public Icon getExtendedIcon() {
+                                        return Icons.safeZDynamic;
+                                    }
+                                });
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    protected ReferenceNozzleTip getCompatibleNozzleTipMaxPartHeight(ReferenceNozzle nozzle, NozzleTip nt1) {
+        ReferenceNozzleTip ntMax = null;
+        for (NozzleTip nt : nozzle.getCompatibleNozzleTips()) {
+            if (nt instanceof ReferenceNozzleTip
+                    && nt1 != nt) {
+                ReferenceNozzleTip ntRef = (ReferenceNozzleTip) nt;
+                if (ntMax == null 
+                        || ntMax.getMaxPartHeight().compareTo(ntRef.getMaxPartHeight()) < 0) {
+                    ntMax = ntRef;
+                }
+            }
+        }
+        return ntMax;
+    }
+
 }

--- a/src/main/java/org/openpnp/spi/NozzleTip.java
+++ b/src/main/java/org/openpnp/spi/NozzleTip.java
@@ -3,11 +3,12 @@ package org.openpnp.spi;
 import org.openpnp.model.Identifiable;
 import org.openpnp.model.Length;
 import org.openpnp.model.Named;
+import org.openpnp.model.Solutions;
 
 /**
  * A NozzleTip is the physical interface between a Nozzle and a Part.
  */
-public interface NozzleTip extends Identifiable, Named, WizardConfigurable, PropertySheetHolder {
+public interface NozzleTip extends Identifiable, Named, Solutions.Subject, WizardConfigurable, PropertySheetHolder {
     /**
      * @return The outside diameter of the NozzleTip at the lowest ca. 0.75mm. Most nozzle tips seem to have 
      * a cylindrical (i.e. constant diameter) point of about this height. This diameter is used to calculate 


### PR DESCRIPTION
# Description
With **Dynamic Safe Z** enabled, nozzles need a head-room, the so-called Safe Z Zone to lift the nozzles higher with taller parts. Furthermore, on nozzles with shared Z axes the part heights compete for the same head-room. The maximum expected part height is specified on the nozzle tip **Max. Part Height**.

These Issues & Solutions detect when the (combined) **Max. Part Height**(s) on single or shared Z axis nozzles violate the Safe Z Zone head-room.

# Justification
See discussion group:
https://groups.google.com/g/openpnp/c/kQZzXxshQog/m/1kGQF2XYBwAJ

# Instructions for Use
Are provided in the Solutions, and in the [Wiki](https://github.com/openpnp/openpnp/wiki/Kinematic-Solutions), that was already written to accompany the Solutions with links:

![Safe Z Zone Isssue](https://user-images.githubusercontent.com/9963310/162012365-124e356a-ee21-4c82-8f48-dd528169d811.png)

New, more specific Wiki sections and links were also added for existing Dynamic Safe Z and Kinematics solutions.

https://github.com/openpnp/openpnp/wiki/Kinematic-Solutions


# Implementation Details
1. Tested in simulation.
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. There is a minimal change in `org.openpnp.spi.NozzleTip` to include the `Solutions.Subject` interface, so nozzle tips can become I&S subjects.
4. Successful `mvn test` before submitting the Pull Request. 
