### PR TITLE
Fix/Bugfixes Testing Round

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/driver/ReferenceAdvancedMotionPlanner.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/ReferenceAdvancedMotionPlanner.java
@@ -349,7 +349,7 @@ public class ReferenceAdvancedMotionPlanner extends AbstractMotionPlanner {
         if (allowUncoordinated) {
             if (location0.isInSafeZone()
                     && location1.isInSafeZone()) {
-                // Both locations are in the Save Zone. Add the uncoordinated flags.
+                // Both locations are in the Safe Zone. Add the uncoordinated flags.
                 options |= MotionOption.UncoordinatedMotion.flag()
                         | MotionOption.LimitToSafeZone.flag()
                         | MotionOption.SynchronizeStraighten.flag()

--- a/src/main/java/org/openpnp/machine/reference/solutions/KinematicSolutions.java
+++ b/src/main/java/org/openpnp/machine/reference/solutions/KinematicSolutions.java
@@ -439,9 +439,9 @@ public class KinematicSolutions implements Solutions.Subject {
     protected void dynamicSafeZSolution(Solutions solutions, ReferenceNozzle nozzle, ReferenceNozzle nozzle2, ReferenceControllerAxis rawAxisZ) 
             throws Exception {
         Length [] zoneZ = nozzle.getSafeZZone();
-        Length zone = zoneZ[1].subtract(zoneZ[0]);
         if (nozzle.isEnableDynamicSafeZ() 
                 && zoneZ[0] != null && zoneZ[1] != null) {
+            Length zone = zoneZ[1].subtract(zoneZ[0]);
             LengthConverter lengthConverter = new LengthConverter();
             for (NozzleTip nt : nozzle.getCompatibleNozzleTips()) {
                 if (nt instanceof ReferenceNozzleTip) {

--- a/src/main/java/org/openpnp/machine/reference/solutions/VisionSolutions.java
+++ b/src/main/java/org/openpnp/machine/reference/solutions/VisionSolutions.java
@@ -746,7 +746,7 @@ public class VisionSolutions implements Solutions.Subject {
                             nozzle, 
                             "Safe Z of Nozzle "+nozzle.getName()+" lower than "+qualifier+" fiducial Z.", 
                             "Safe Z of Nozzle "+nozzle.getName()+" is lower than the calibration "+qualifier+" fiducial Z. "
-                                    + "Please change the calibration rig "+qualifier+" height or adjust Save Z.", 
+                                    + "Please change the calibration rig "+qualifier+" height or adjust Safe Z.", 
                             Solutions.Severity.Error,
                             "https://github.com/openpnp/openpnp/wiki/Vision-Solutions#nozzle-offsets"));
                 }
@@ -1580,7 +1580,7 @@ public class VisionSolutions implements Solutions.Subject {
         FiducialVisionSettings visionSettings = fiducialLocator.getInheritedVisionSettings(part);
         if (visionSettings.getUsedFiducialVisionIn().size() == 1 
                 && visionSettings.getUsedFiducialVisionIn().get(0) == part) {
-            // Alreday a special setting on the part. Modify it.
+            // Already a special setting on the part. Modify it.
         }
         else {
             FiducialVisionSettings newSettings = new FiducialVisionSettings();
@@ -1588,9 +1588,10 @@ public class VisionSolutions implements Solutions.Subject {
             newSettings.setName(part.getShortName());
             part.setFiducialVisionSettings(newSettings);
             Configuration.get().addVisionSettings(newSettings);
+            visionSettings = newSettings;
         }
         String xml = IOUtils.toString(ReferenceBottomVision.class
-                .getResource("ReferenceFiducialLocator-CircularSymmetryPipeline.xml"));
+                .getResource("ReferenceFiducialLocator-DefaultPipeline.xml"));
         CvPipeline pipeline = new CvPipeline(xml);
         visionSettings.setPipeline(pipeline);
     }

--- a/src/main/java/org/openpnp/vision/pipeline/stages/DetectCircularSymmetry.java
+++ b/src/main/java/org/openpnp/vision/pipeline/stages/DetectCircularSymmetry.java
@@ -248,6 +248,8 @@ public class DetectCircularSymmetry extends CvStage {
             if (Double.isFinite(diameter)) {
                 minDiameter = (int) Math.round(diameter*(1.0-innerMargin));
                 maxDiameter = (int) Math.round(diameter*(1.0+outerMargin));
+                recordPropertyOverride("minDiameter", minDiameter);
+                recordPropertyOverride("maxDiameter", maxDiameter);
             }
 
             maxDistance = getPossiblePipelinePropertyOverride(maxDistance, pipeline, 


### PR DESCRIPTION
# Description
Some small bug-fixes in the running testing version.

- Bugs in [Issues & Solutions](https://github.com/openpnp/openpnp/wiki/Issues-and-Solutions) when establishing Visual Homing, see #1248, broken by #1318.
- Register the `DetectCircularSymmetry` `minDiameter`/`maxDiameter` property override, see #1387.
- Preventing a caught but unnecessary exception and fixing typos in #1395.

# Justification
Various feed-back and own testing.

# Instructions for Use
Bugfix demonstrated in Visual Homing calibration:

![visual-homing-issues-and-solutions](https://user-images.githubusercontent.com/9963310/162245692-1def5213-c72c-4f4d-a646-9361274993b7.gif)

# Implementation Details
1. Tested in simulation.
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. Successful `mvn test` before submitting the Pull Request.
