### PR TITLE
pom: Target Java17 and add add-opens flags to tests and launchers

### DIFF
--- a/openpnp.bat
+++ b/openpnp.bat
@@ -2,7 +2,7 @@
 
 set archi=%PROCESSOR_ARCHITECTURE%
 
-if not x%archi:86=%==x%archi% java -jar target\openpnp-gui-0.0.1-alpha-SNAPSHOT.jar
-if not x%archi:64=%==x%archi% java -jar target\openpnp-gui-0.0.1-alpha-SNAPSHOT.jar
+if not x%archi:86=%==x%archi% java --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.desktop/java.awt=ALL-UNNAMED -jar target\openpnp-gui-0.0.1-alpha-SNAPSHOT.jar
+if not x%archi:64=%==x%archi% java --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.desktop/java.awt=ALL-UNNAMED -jar target\openpnp-gui-0.0.1-alpha-SNAPSHOT.jar
 
 

--- a/openpnp.sh
+++ b/openpnp.sh
@@ -15,9 +15,9 @@ esac
 
 case "$platform" in
 	mac)
-		java -Xdock:name=OpenPnP -jar $rootdir/target/openpnp-gui-0.0.1-alpha-SNAPSHOT.jar
+		java -Xdock:name=OpenPnP --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.desktop/java.awt=ALL-UNNAMED -jar $rootdir/target/openpnp-gui-0.0.1-alpha-SNAPSHOT.jar
 	;;
 	linux)
-		java $1 -jar $rootdir/target/openpnp-gui-0.0.1-alpha-SNAPSHOT.jar
+		java $1 --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.desktop/java.awt=ALL-UNNAMED -jar $rootdir/target/openpnp-gui-0.0.1-alpha-SNAPSHOT.jar
 	;;
 esac

--- a/pom.xml
+++ b/pom.xml
@@ -264,8 +264,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.1</version>
 				<configuration>
-					<source>1.8</source>
-					<target>1.8</target>
+					<source>17</source>
+					<target>17</target>
 					<mainClass>org.openpnp.app.Main</mainClass>
 					<excludes>
 						<!-- <exclude>**/zippy/**</exclude> -->
@@ -404,7 +404,7 @@
 				<artifactId>maven-surefire-plugin</artifactId>
 				<version>2.22.2</version>
 				<configuration>
-					<argLine>-Xmx512m</argLine>
+					<argLine>-Xmx512m --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.desktop/java.awt=ALL-UNNAMED</argLine>
 				</configuration>
 			</plugin>
 


### PR DESCRIPTION
# Description
Update target compiler to Java 17. Add --add-opens flags to surefire test launcher and openpnp batch scripts to allow internal access to java.lang and java.awt.

# Justification
This should allow developer use of Java 17. Further work may be needed on prebuilt packages.

# Instructions for Use
N/A for the user, other than allowing Java 17 to be used.

# Implementation Details
1. How did you test the change? Maven tests pass. On my machine started, ran homing, closed. Machine.xml survived.
2. Did you follow the coding style? N/A for pom/scripts
3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages... N/A
4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted.
mvn tests completed using default java...
openjdk 17.0.3 2022-04-19
OpenJDK Runtime Environment (build 17.0.3+3)
OpenJDK 64-Bit Server VM (build 17.0.3+3, mixed mode)

## Breaks GH CI pipelines?
GitHub emailed saying all the CI runs failed with an invalid target version. Seems they don't like "17" though it is the correct version afaik for Java 17. Should this be passed in from the build environment somehow? None of the CI pipelines use 17.