### PR TITLE
Fix / Better Error Message When Max. Pick Tolerance Violated.

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/vision/ReferenceBottomVision.java
+++ b/src/main/java/org/openpnp/machine/reference/vision/ReferenceBottomVision.java
@@ -303,12 +303,14 @@ public class ReferenceBottomVision extends AbstractPartAlignment {
 
     protected void offsetsCheck(Part part, Nozzle nozzle, Location offsets) throws Exception {
         if (nozzle.getNozzleTip() instanceof ReferenceNozzleTip) {
+            ReferenceNozzleTip nt = (ReferenceNozzleTip) nozzle.getNozzleTip();
             Length offsetsLength = offsets.getLinearLengthTo(Location.origin);
-            Length maxPickTolerance = ((ReferenceNozzleTip) nozzle.getNozzleTip()).getMaxPickTolerance();
+            Length maxPickTolerance = nt.getMaxPickTolerance();
             if (offsetsLength.compareTo(maxPickTolerance) > 0) {
                 LengthConverter lengthConverter = new LengthConverter(); 
                 throw new Exception("Part "+part.getId()+" bottom vision offsets length "+lengthConverter.convertForward(offsetsLength)
-                +" larger than allowed "+lengthConverter.convertForward(maxPickTolerance));
+                +" larger than the allowed Max. Pick Tolerance "+lengthConverter.convertForward(maxPickTolerance)+" set on nozzle tip "
+                + nt.getName()+".");
             }
         }
     }


### PR DESCRIPTION
# Description
This just improves the error message, when the Max. Pick Tolerance is violated in bottom vision. It now points to the **Max. Pick Tolerance** setting on the nozzle tip.

![image](https://user-images.githubusercontent.com/9963310/163726442-b13f470f-f412-48ec-a495-50f8597bf258.png)


# Justification
See user feedback:
https://groups.google.com/g/openpnp/c/lGikHtY5lh8/m/eADrPxEhDAAJ

# Instructions for Use
No change.

Background, see Wiki:
https://github.com/openpnp/openpnp/wiki/DetectRectlinearSymmetry#nozzle-tip-configuration

# Implementation Details
1. Tested in simulation.
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. Successful `mvn test` before submitting the Pull Request. 
