### PR TITLE
Disable tangential distortion correction by default

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/camera/calibration/AdvancedCalibration.java
+++ b/src/main/java/org/openpnp/machine/reference/camera/calibration/AdvancedCalibration.java
@@ -47,6 +47,12 @@ import org.simpleframework.xml.core.Commit;
 import org.simpleframework.xml.core.Persist;
 
 public class AdvancedCalibration extends LensCalibrationParams {
+    // Prior to version 1.2, no explicit version attribute existed. Version 1.0 (implicit) was the
+    // initial release of AdvancedCalibration, version 1.1 (implicit) added attributes to disable 
+    // distortion and tilt corrections but were all enabled by default, and version 1.2 disabled
+    // tangential distortion correction by default
+    private static final Double LATEST_VERSION = 1.2;
+    
     @Attribute(required = false)
     private boolean overridingOldTransformsAndDistortionCorrectionSettings = false;
     
@@ -150,10 +156,13 @@ public class AdvancedCalibration extends LensCalibrationParams {
     private boolean disableTiltCorrection = false;
     
     @Attribute(required = false)
-    private boolean disableDistortionCorrection = false;
+    private boolean disableDistortionCorrection = true;
     
     @Attribute(required = false)
     private boolean disableTangentialDistortionCorrection = false;
+    
+    @Attribute(required = false)
+    private Double version;
 
     
     private Mat virtualCameraMatrix = Mat.eye(3, 3, CvType.CV_64FC1);
@@ -255,6 +264,13 @@ public class AdvancedCalibration extends LensCalibrationParams {
         else {
             outlierPointList = new ArrayList<Integer>();
         }
+        
+        //Prior versions didn't have an explicit version number. This fixes any machine.xml
+        //files that may have been updated with the prior version that had enabled tangential
+        //distortion correction by default.  We now want to change it to be disabled by default.
+        if (version == null) {
+            disableTangentialDistortionCorrection = true;
+        }
     }
     
     @Persist
@@ -274,6 +290,10 @@ public class AdvancedCalibration extends LensCalibrationParams {
         else {
             outlierPoints = new Integer[0];
         }
+        
+        //Update to the latest version number.  We need to do this here so that newly instantiated 
+        //cameras will have a version number when they are written to the machine.xml file.
+        version = LATEST_VERSION;
     }
 
     /**


### PR DESCRIPTION
# Description
This is a follow on to PR #1401 - this change disables tangential distortion correction by default

# Justification
Testing has shown that camera calibration performs better with tangential distortion correction disabled. 

# Instructions for Use
For new camera calibrations, no special action is required as this will be applied by default.

For cameras that had previously been calibrated, they can either be fully recalibrated, or the collection step can be skipped and the change applied by navigating to each camera in the Machine setup tree, selecting the Advanced Calibration tab, enabling the "Skip New Collection and Reprocess Prior Collection" check box, and then clicking the "Start Calibration" button.

Note - in the off chance that someone wants to re-enable tangential distortion correction, they can manually do so by editing their machine.xml file and changing the attribute disable-tangential-distortion-correction to the value of "false".

# Implementation Details
1. How did you test the change? **Started OpenPnP, saved the configuration, and then examined the machine.xml file to verify that all cameras had disable-tangential-distortion-correction set to "true".  Also verified that if it is manually changed back to "false", the value is retained.**
2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)? **Yes.**
3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing. **No changes were made to those packages.**
4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted.  **All maven tests were run and passed.**
