### PR TITLE
Fix / Allow For Pick Angle Tolerance Under Limited Articulation.

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/driver/AbstractMotionPlanner.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/AbstractMotionPlanner.java
@@ -662,8 +662,9 @@ public abstract class AbstractMotionPlanner extends AbstractModelObject implemen
                 throw new Exception("Axis "+axis.getName()+" with limited articulation must not have Wrap Around option set.");
             }
             else {
-                throw new Exception("Axis "+axis.getName()+" with limited articulation cannot rotate to "+
-                        limitedAxesLocation.getCoordinate(axis)+" ("+hm.getName()+" to "+location.getRotation()+"°)");
+                throw new Exception("Axis "+axis.getName()+" with limited articulation "+
+                        axesLimitLow.getCoordinate(axis)+".."+axesLimitHigh.getCoordinate(axis)+" cannot rotate to "+
+                        limitedAxesLocation.getCoordinate(axis)+" (transformed "+hm.getName()+" to "+location.getRotation()+"°)");
             }
         }
         return limitedAxesLocation;


### PR DESCRIPTION
# Description
Some feeders (e.g. `ReferenceStripFeeder`) use vision to determine the precise pick location **and angle**. Under [limited articulation Rotation Mode](https://github.com/openpnp/openpnp/wiki/Nozzle-Rotation-Mode) we need to _predict_ not only the needed pick-to-place articulation but also the added tolerance on both the pick and the alignment/placement side. This PR adds the tolerance  on the pick side to allow for feeder vision pick angle adjustment. Such a tolerance was previously already present on the alignment (bottom vision) side.

![Limited Articulation](https://user-images.githubusercontent.com/9963310/164706672-8a5fd3af-e07f-468c-ae15-a40889a41d41.png)

In the unlikely event that this is required, the expected maximum tolerances can now be configured in the `machine.xml` file. If the machine articulation is sufficient, the pick-to-place articulation plus the tolerances on both sides are centered. If the machine articulation is not sufficient, tolerances are proportionally "squeezed". 

The PR also makes the limited articulation violation error message more verbose, stating the limited range.

# Justification
The pick would fail for `ReferenceStripFeeder` when the pick-to-place articulation is near the articulation limit, and feeder vision determines a pick angle that is _away_ from the pick-to-place articulation.

# Instructions for Use
No change.

See the Wiki:
https://github.com/openpnp/openpnp/wiki/Nozzle-Rotation-Mode

# Implementation Details
1. Tested in simulation (that's where I noticed it in the first place, when working on a different topic)
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. Successful `mvn test` before submitting the Pull Request. 
