### PR TITLE
Feature / Introduce Job-Interrupting Exceptions - Manual Nozzle Tip Changing

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/ReferenceNozzle.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceNozzle.java
@@ -37,6 +37,7 @@ import org.openpnp.spi.Camera.Looking;
 import org.openpnp.spi.CoordinateAxis;
 import org.openpnp.spi.Feeder;
 import org.openpnp.spi.HeadMountable;
+import org.openpnp.spi.JobProcessor.JobProcessorException;
 import org.openpnp.spi.MotionPlanner.CompletionType;
 import org.openpnp.spi.Nozzle;
 import org.openpnp.spi.NozzleTip;
@@ -699,7 +700,9 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
                     this.nozzleTip.getCalibration().reset(this);
                 }
                 waitForCompletion(CompletionType.WaitForStillstand);
-                throw new Exception("Manual NozzleTip "+nt.getName()+" load on Nozzle "+getName()+" required!");
+                throw new JobProcessorException(this, 
+                        "Manual NozzleTip "+nt.getName()+" load on Nozzle "+getName()+" required!", 
+                        true);
             }
         }
 
@@ -792,7 +795,9 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
 
         if (!changerEnabled) {
             waitForCompletion(CompletionType.WaitForStillstand);
-            throw new Exception("Manual NozzleTip "+nt.getName()+" unload from Nozzle "+getName()+" required!");
+            throw new JobProcessorException(this, 
+                    "Manual NozzleTip "+nt.getName()+" unload from Nozzle "+getName()+" required!", 
+                    true);
         }
 
         ensureZCalibrated(true);

--- a/src/main/java/org/openpnp/machine/reference/ReferencePnpJobProcessor.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferencePnpJobProcessor.java
@@ -1095,7 +1095,7 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
                         df.format(dtSec), 
                         df.format(totalPartsPlaced / (dtSec / 3600.0)));
 
-                Logger.info("Errored Placements:");
+                Logger.info("Errored Placements: "+erroredPlacements.size());
                 for (JobPlacement jobPlacement : erroredPlacements) {
                     Logger.info("{}: {}", jobPlacement, jobPlacement.getError().getMessage());
                 }
@@ -1204,6 +1204,9 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
                     case Alert:
                         throw e;
                     case Defer:
+                        if (e.isInterrupting()) {
+                            throw e;
+                        }
                         plannedPlacement.jobPlacement.setError(e);
                         return this;
                     default:

--- a/src/main/java/org/openpnp/spi/JobProcessor.java
+++ b/src/main/java/org/openpnp/spi/JobProcessor.java
@@ -22,8 +22,9 @@ public interface JobProcessor extends PropertySheetHolder, WizardConfigurable {
     
     public class JobProcessorException extends Exception {
         private static final long serialVersionUID = 1L;
-        
+
         private final Object source;
+        private boolean interrupting = false;
 
         private static String getThrowableMessage(Throwable throwable) {
             if (throwable.getMessage() != null) {
@@ -40,15 +41,28 @@ public interface JobProcessor extends PropertySheetHolder, WizardConfigurable {
         public JobProcessorException(Object source, Throwable throwable) {
             super(getThrowableMessage(throwable), throwable);
             this.source = source;
+            if (throwable instanceof JobProcessorException) {
+                this.interrupting = ((JobProcessorException) throwable).isInterrupting();
+            }
         }
 
         public JobProcessorException(Object source, String message) {
             super(message);
             this.source = source;
         }
-        
+
+        public JobProcessorException(Object source, String message, boolean interrupting) {
+            super(message);
+            this.source = source;
+            this.interrupting = interrupting;
+        }
+
         public Object getSource() {
             return source;
+        }
+
+        public boolean isInterrupting() {
+            return interrupting;
         }
     }
 }


### PR DESCRIPTION
# Description
This PR introduces Job-interrupting Exceptions. These are propagated even if the placement has **Defer** error handling. 

# Justification
Some exceptions, such as those prompting for manual nozzle tip changing must not be deferred. 

See also the user case:
![image](https://user-images.githubusercontent.com/9963310/164709439-4c4a5f61-cc11-4720-ac36-e349e1cc6f1d.png)

https://groups.google.com/g/openpnp/c/uvRoayOn3fo/m/Kmwgio7LAQAJ

# Instructions for Use
To reproduce the problem 

- create a Job
- set placements to **Defer**
- disable automatic nozzle tip changing
- make sure wrong/no nozzle tips are loaded
- start the job

In the previous version, this would silently skip the exception prompting for manual nozzle tip change, continuing the job with the (physically) wrong nozzle tip.

Now it should interrupt the Job and prompt for manual nozzle tip change with the usual message box.

# Implementation Details
1. Tested in simulation.
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. Adds the `interrupting` property to `JobProcessorException`.
5. Successful `mvn test` before submitting the Pull Request.
