### PR TITLE
Fix / AffineWarp Stage Property Overrides by Region of Interest

### DIFF
--- a/src/main/java/org/openpnp/vision/pipeline/stages/AffineWarp.java
+++ b/src/main/java/org/openpnp/vision/pipeline/stages/AffineWarp.java
@@ -189,12 +189,12 @@ public class AffineWarp extends CvStage {
             RegionOfInterest roi = (RegionOfInterest) pipeline.getProperty(getRegionOfInterestProperty());
             if (roi != null) {
                 // the region of interest is overridden by the pipeline caller
-                x0 = roi.getUpperLeftCorner().getX(); 
-                y0 = roi.getUpperLeftCorner().getY();
-                x1 = roi.getUpperRightCorner().getX(); 
-                y1 = roi.getUpperRightCorner().getY();
-                x2 = roi.getLowerLeftCorner().getX(); 
-                y2 = roi.getLowerLeftCorner().getY();
+                x0 = roi.getUpperLeftCorner().convertToUnits(lengthUnit).getX(); 
+                y0 = roi.getUpperLeftCorner().convertToUnits(lengthUnit).getY();
+                x1 = roi.getUpperRightCorner().convertToUnits(lengthUnit).getX(); 
+                y1 = roi.getUpperRightCorner().convertToUnits(lengthUnit).getY();
+                x2 = roi.getLowerLeftCorner().convertToUnits(lengthUnit).getX(); 
+                y2 = roi.getLowerLeftCorner().convertToUnits(lengthUnit).getY();
                 rectify = roi.isRectify();
                 // Record the fact that these individual stage properties are all overridden.
                 recordPropertyOverride("x0", x0);

--- a/src/main/java/org/openpnp/vision/pipeline/stages/AffineWarp.java
+++ b/src/main/java/org/openpnp/vision/pipeline/stages/AffineWarp.java
@@ -196,6 +196,14 @@ public class AffineWarp extends CvStage {
                 x2 = roi.getLowerLeftCorner().getX(); 
                 y2 = roi.getLowerLeftCorner().getY();
                 rectify = roi.isRectify();
+                // Record the fact that these individual stage properties are all overridden.
+                recordPropertyOverride("x0", x0);
+                recordPropertyOverride("y0", y0);
+                recordPropertyOverride("x1", x1);
+                recordPropertyOverride("y1", y1);
+                recordPropertyOverride("x2", x2);
+                recordPropertyOverride("y2", y2);
+                recordPropertyOverride("rectify", rectify);
             }
         }
 


### PR DESCRIPTION
# Description
In the computer vision pipeline stage `AffineWarp`, record individual stage properties as overridden, when a Region Of Interest (ROI) is given by the pipeline caller, such as with feeder vision with OCR.

This PR also fixes a missing length unit conversion.

# Justification
See user report:
https://groups.google.com/g/openpnp/c/wpHLTbWaZI0/m/_hCGZKusAgAJ

# Instructions for Use
The stage properties will now show as controlled:

![ROI is controlled](https://user-images.githubusercontent.com/9963310/165522669-adf7fe15-8512-4525-9b85-21de9f096358.png)

# Implementation Details
1. Tested in simulation.
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. Successful `mvn test` before submitting the Pull Request. 
