### PR TITLE
Fix / Add Property Control to SimpleOcr Stage

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/feeder/BlindsFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/BlindsFeeder.java
@@ -456,15 +456,15 @@ public class BlindsFeeder extends ReferenceFeeder {
     private void setupOcr(Camera camera, CvPipeline pipeline, OcrAction ocrAction) {
         if (ocrAction != OcrAction.None) {
             pipeline.setProperty("regionOfInterest", getOcrRegion(camera));
-            pipeline.setProperty("fontName", getOcrFontName());
-            pipeline.setProperty("fontSizePt", getOcrFontSizePt());
-            pipeline.setProperty("alphabet", OcrUtils.getConsolidatedPartsAlphabet(null, "\\"));
+            pipeline.setProperty("SimpleOcr.fontName", getOcrFontName());
+            pipeline.setProperty("SimpleOcr.fontSizePt", getOcrFontSizePt());
+            pipeline.setProperty("SimpleOcr.alphabet", OcrUtils.getConsolidatedPartsAlphabet(null, "\\"));
         }
         else {
             pipeline.setProperty("regionOfInterest", null);
-            pipeline.setProperty("fontName", null);
-            pipeline.setProperty("fontSizePt", null);
-            pipeline.setProperty("alphabet", ""); // empty alphabet switches OCR off
+            pipeline.setProperty("SimpleOcr.fontName", null);
+            pipeline.setProperty("SimpleOcr.fontSizePt", null);
+            pipeline.setProperty("SimpleOcr.alphabet", ""); // empty alphabet switches OCR off
         }
     }
 

--- a/src/main/java/org/openpnp/machine/reference/feeder/ReferencePushPullFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/ReferencePushPullFeeder.java
@@ -1206,9 +1206,9 @@ public class ReferencePushPullFeeder extends ReferenceFeeder {
 
     protected void setupOcr(Camera camera, CvPipeline pipeline, Location hole1, Location hole2, Location pickLocation) {
         pipeline.setProperty("regionOfInterest", getOcrRegion());
-        pipeline.setProperty("fontName", getOcrFontName());
-        pipeline.setProperty("fontSizePt", getOcrFontSizePt());
-        pipeline.setProperty("alphabet", OcrUtils.getConsolidatedPartsAlphabet(null, "\\"));
+        pipeline.setProperty("SimpleOcr.fontName", getOcrFontName());
+        pipeline.setProperty("SimpleOcr.fontSizePt", getOcrFontSizePt());
+        pipeline.setProperty("SimpleOcr.alphabet", OcrUtils.getConsolidatedPartsAlphabet(null, "\\"));
     }
 
     protected void setupOcr(Camera camera, CvPipeline pipeline) {
@@ -1217,9 +1217,9 @@ public class ReferencePushPullFeeder extends ReferenceFeeder {
 
     protected void disableOcr(Camera camera, CvPipeline pipeline) {
         pipeline.setProperty("regionOfInterest", null);
-        pipeline.setProperty("fontName", null);
-        pipeline.setProperty("fontSizePt", null);
-        pipeline.setProperty("alphabet", ""); // empty alphabet switches OCR off
+        pipeline.setProperty("SimpleOcr.fontName", null);
+        pipeline.setProperty("SimpleOcr.fontSizePt", null);
+        pipeline.setProperty("SimpleOcr.alphabet", ""); // empty alphabet switches OCR off
     }
 
     public CvPipeline getCvPipeline(Camera camera, boolean clone, boolean performOcr, boolean autoSetup) {

--- a/src/main/java/org/openpnp/vision/pipeline/stages/SimpleOcr.java
+++ b/src/main/java/org/openpnp/vision/pipeline/stages/SimpleOcr.java
@@ -117,6 +117,12 @@ public class SimpleOcr extends CvStage {
     @Property(description = "Write debug images and messages. Will slow down operation.")
     private boolean debug;
 
+    @Attribute(required = false)
+    @Property(description = "Property name as controlled by the vision operation using this pipeline.<br/>"
+            + "If set, these will override the properties configured here.")
+    private String propertyName = "SimpleOcr";
+
+
     public String getAlphabet() {
         return alphabet;
     }
@@ -179,6 +185,14 @@ public class SimpleOcr extends CvStage {
 
     public void setDebug(boolean debug) {
         this.debug = debug;
+    }
+
+    public String getPropertyName() {
+        return propertyName;
+    }
+
+    public void setPropertyName(String propertyName) {
+        this.propertyName = propertyName;
     }
 
     protected static class CharacterMatch extends TemplateMatch {
@@ -252,19 +266,15 @@ public class SimpleOcr extends CvStage {
             throw new Exception("Property \"camera\" is required.");
         }
 
-        String alphabet = (String)pipeline.getProperty("alphabet");
-        if (alphabet == null) {
-            alphabet = getAlphabet();
-        }
+        String alphabet = getPossiblePipelinePropertyOverride(this.alphabet, pipeline, 
+                propertyName + ".alphabet");
         if (alphabet == null || alphabet.isEmpty()) {
             // Note: a given empty alphabet is also the signal to conditionally disable the stage
             // from the calling OpenPnP vision code.
             return null;
         }
-        String fontName = (String)pipeline.getProperty("fontName");
-        if (fontName == null) {
-            fontName = getFontName();
-        }
+        String fontName = getPossiblePipelinePropertyOverride(this.fontName, pipeline, 
+                propertyName + ".fontName");
         if (fontName == null || fontName.isEmpty()) {
             return null;
         }
@@ -273,10 +283,8 @@ public class SimpleOcr extends CvStage {
             return decodeBarcode(pipeline);
         }
 
-        Double fontSizePt = (Double)pipeline.getProperty("fontSizePt");
-        if (fontSizePt == null) {
-            fontSizePt = getFontSizePt();
-        }
+        Double fontSizePt =  getPossiblePipelinePropertyOverride(this.fontSizePt, pipeline, 
+                propertyName + ".fontSizePt");
         if (fontSizePt == null || fontSizePt == 0.0) {
             return null;
         }


### PR DESCRIPTION
# Description
Computer vision pipeline stage `SimpleOcr`: 

- Add `getPossiblePipelinePropertyOverride()` handling of properties. 
- Add `propertyName`.

# Justification
Missing property control indication.

# Instructions for Use
The control is now indicated:
![grafik](https://user-images.githubusercontent.com/9963310/165536092-d80b38b1-1667-44ac-bf6b-70c02ad7f105.png)


# Implementation Details
1. Tested in simulation.
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. Successful `mvn test` before submitting the Pull Request. 
