### PR TITLE
Feature/Parts Table Placement and Feeder Counts

### DIFF
--- a/src/main/java/org/openpnp/gui/tablemodel/PartsTableModel.java
+++ b/src/main/java/org/openpnp/gui/tablemodel/PartsTableModel.java
@@ -36,9 +36,9 @@ import org.openpnp.model.Part;
 @SuppressWarnings("serial")
 public class PartsTableModel extends AbstractObjectTableModel implements PropertyChangeListener {
     private String[] columnNames =
-            new String[] {"ID", "Description", "Height", "Package", "Speed %", "BottomVision", "FiducialVision"};
+            new String[] {"ID", "Description", "Height", "Package", "Speed %", "BottomVision", "FiducialVision", "Placements", "Feeders"};
     private Class[] columnTypes = new Class[] {String.class, String.class, LengthCellValue.class,
-            Package.class, String.class, BottomVisionSettings.class, FiducialVisionSettings.class};
+            Package.class, String.class, BottomVisionSettings.class, FiducialVisionSettings.class, Integer.class, Integer.class};
     private List<Part> parts;
     private PercentConverter percentConverter = new PercentConverter();
 
@@ -67,7 +67,7 @@ public class PartsTableModel extends AbstractObjectTableModel implements Propert
 
     @Override
     public boolean isCellEditable(int rowIndex, int columnIndex) {
-        return columnIndex != 0;
+        return columnIndex >= 1 && columnIndex <= 6;
     }
 
     @Override
@@ -137,6 +137,10 @@ public class PartsTableModel extends AbstractObjectTableModel implements Propert
                 return part.getBottomVisionSettings();
             case 6:
                 return part.getFiducialVisionSettings();
+            case 7:
+                return part.getPlacementCount();
+            case 8:
+                return part.getAssignedFeeders();
             default:
                 return null;
         }

--- a/src/main/java/org/openpnp/model/Part.java
+++ b/src/main/java/org/openpnp/model/Part.java
@@ -21,6 +21,7 @@ package org.openpnp.model;
 
 import org.openpnp.ConfigurationListener;
 import org.openpnp.machine.reference.vision.AbstractPartSettingsHolder;
+import org.openpnp.spi.Feeder;
 import org.simpleframework.xml.Attribute;
 import org.simpleframework.xml.core.Persist;
 
@@ -150,5 +151,37 @@ public class Part extends AbstractPartSettingsHolder {
 
     public boolean isPartHeightUnknown() {
         return getHeight().getValue() <= 0.0;
+    }
+
+    public int getPlacementCount() {
+        int n = 0;
+        for (Board board : Configuration.get().getBoards()) {
+            for (Placement placement : board.getPlacements()) {
+                if (placement.getPart() == this) {
+                    n++;
+                }
+            }
+        }
+        return n;
+    }
+
+    public void setPlacementCount(int placementCount) {
+        // Pseudo-setter just used to fire the property change (no matter what is passed).
+        firePropertyChange("placementCount", null, getPlacementCount());
+    }
+
+    public int getAssignedFeeders() {
+        int n = 0;
+        for (Feeder feeder : Configuration.get().getMachine().getFeeders()) {
+            if (feeder.getPart() == this) {
+                n++;
+            }
+        }
+        return n;
+    }
+
+    public void setAssignedFeeders(int assignedFeeders) {
+        // Pseudo-setter just used to fire the property change (no matter what is passed).
+        firePropertyChange("assignedFeeders", null, getAssignedFeeders());
     }
 }

--- a/src/main/java/org/openpnp/model/Placement.java
+++ b/src/main/java/org/openpnp/model/Placement.java
@@ -122,6 +122,13 @@ public class Placement extends AbstractModelObject implements Identifiable {
         Part oldValue = this.part;
         this.part = part;
         firePropertyChange("part", oldValue, part);
+        // Also notify the old/new part that the placement count has changed.
+        if (oldValue != null) {
+            oldValue.setPlacementCount(-1);
+        }
+        if (part != null) {
+            part.setPlacementCount(+1);
+        }
     }
 
     public String getId() {

--- a/src/main/java/org/openpnp/spi/base/AbstractFeeder.java
+++ b/src/main/java/org/openpnp/spi/base/AbstractFeeder.java
@@ -92,7 +92,7 @@ public abstract class AbstractFeeder extends AbstractModelObject implements Feed
 
     @Override
     public void setPart(Part part) {
-        Object oldValue = this.part;
+        Part oldValue = this.part;
         this.part = part;
         firePropertyChange("part", oldValue, part);
         if (part != null) {
@@ -100,6 +100,13 @@ public abstract class AbstractFeeder extends AbstractModelObject implements Feed
         }
         else {
             this.partId = "";
+        }
+        // Also notify the old/new part that the feeder count has changed.
+        if (oldValue != null) {
+            oldValue.setAssignedFeeders(-1);
+        }
+        if (part != null) {
+            part.setAssignedFeeders(+1);
         }
     }
 


### PR DESCRIPTION
# Description
This adds **Placements** and **Feeders** counts to the **Parts** table.

# Justification
Users can quickly see how many parts are going to be required for one Job. The table can also be cleverly sorted by these columns to help provisioning feeders.

# Instructions for Use
The **Placements** count is automatically computed and updated whenever placements are added/changed. Note, the full count is used, regardless of enabled/disabled boards, and regardless of enabled/disabled or already placed placements.

The **Feeders** count is automatically computed and updated whenever parts are assigned/unassigned on feeders. Note, the full count is used, regardless of enabled/disabled feeders. 

For feeder provisioning, first click twice on the **Placements** column header to sort descending and then click on the  **Feeders** column header to sort ascending. This will show all parts requiring additional feeders at the top, starting with those that require the most parts:

![Screenshot_20220506_114720](https://user-images.githubusercontent.com/9963310/167109245-78669cde-2ddb-438b-be95-3840eb2bfca6.png)

# Implementation Details
1. Tested in simulation.
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. Changes `org.openpnp.model.Part` to add the counts as (pseudo) properties.
4. Successful `mvn test` before submitting the Pull Request.
