### PR TITLE
Fix/Feeder Bugs in Testing Round

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/feeder/ReferencePushPullFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/ReferencePushPullFeeder.java
@@ -2401,8 +2401,13 @@ public class ReferencePushPullFeeder extends ReferenceFeeder {
                 setVisionOffset(feature.calibratedVisionOffset);
             }
             if (ocrPass) {
-                Logger.trace("got OCR text "+feature.detectedOcrModel.getText());
-                triggerOcrAction(feature.detectedOcrModel, ocrAction, ocrStop, report);
+                if (feature.detectedOcrModel == null) {
+                    Logger.warn("Feeder "+getName()+" OCR operation expected, but no \"OCR\" stage result obtained from pipeline.");
+                }
+                else {
+                    Logger.trace("got OCR text "+feature.detectedOcrModel.getText());
+                    triggerOcrAction(feature.detectedOcrModel, ocrAction, ocrStop, report);
+                }
             }
             // is it good enough? Compare with running offset.
             if (error.convertToUnits(LengthUnit.Millimeters).getValue() < calibrateToleranceMm) {


### PR DESCRIPTION
# Description
- ReferencePushPullFeeder: More robustness against OCR failure during Auto-Setup.
- RapidFeeder: Remove a numerical instability in the QR scanning loop (old bug).

# Justification
User feed-back:

- https://github.com/openpnp/openpnp/pull/1409#issuecomment-1121579824
- https://groups.google.com/g/openpnp/c/14Eoeqr2pvM/m/ak__R_OQBQAJ

# Instructions for Use
No changes.

# Implementation Details
1. Can only be tested on user side. 
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. Successful `mvn test` before submitting the Pull Request.
