### PR TITLE
Fix / Remove Races in Machine Enabling and Disabling 

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/driver/AbstractReferenceDriver.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/AbstractReferenceDriver.java
@@ -166,6 +166,7 @@ public abstract class AbstractReferenceDriver extends AbstractDriver {
         firePropertyChange("connectionKeepAlive", oldValue, connectionKeepAlive);
     }
 
+    @Override
     public boolean isSyncInitialLocation() {
         return syncInitialLocation;
     }

--- a/src/main/java/org/openpnp/machine/reference/driver/GcodeDriver.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/GcodeDriver.java
@@ -1300,6 +1300,9 @@ public class GcodeDriver extends AbstractReferenceDriver implements Named {
                 responseQueue.offer(line);
             }
             Logger.trace("[{}] disconnectRequested, bye-bye.", getCommunications().getConnectionName());
+            if (connected) {
+                connected = false;
+            }
         }
     }
 

--- a/src/main/java/org/openpnp/machine/reference/driver/NullDriver.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/NullDriver.java
@@ -295,4 +295,10 @@ public class NullDriver extends AbstractDriver {
             });
         }
     }
+
+
+    @Override
+    public boolean isSyncInitialLocation() {
+        return false;
+    }
 }

--- a/src/main/java/org/openpnp/machine/reference/driver/SimulatedCommunications.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/SimulatedCommunications.java
@@ -36,10 +36,12 @@ public class SimulatedCommunications extends ReferenceDriverCommunications {
             clientSocket.close();
             input.close();
             output.close();
-            gcodeServer.shutdown();
             input = null;
             output = null;
             clientSocket = null;
+        }
+        if (gcodeServer != null) {
+            gcodeServer.shutdown();
             gcodeServer = null;
         }
     }

--- a/src/main/java/org/openpnp/spi/Driver.java
+++ b/src/main/java/org/openpnp/spi/Driver.java
@@ -93,6 +93,11 @@ import org.openpnp.spi.MotionPlanner.CompletionType;
     public AxesLocation getReportedLocation(long timeout) throws Exception;
 
     /**
+     * @return true if the driver should synchronize its initial position after enabling.
+     */
+    boolean isSyncInitialLocation();
+
+    /**
      * @return true if a motion is still assumed to be pending, i.e. waitForCompletion() has not yet been called.  
      * 
      */

--- a/src/main/java/org/openpnp/util/UiUtils.java
+++ b/src/main/java/org/openpnp/util/UiUtils.java
@@ -64,6 +64,7 @@ public class UiUtils {
         MessageBoxes.errorBox(MainFrame.get(), "Error", t);
     }
 
+
     /**
      * Functional version of Machine.submit which guarantees that the the onSuccess and onFailure
      * handlers will be run on the Swing event thread.
@@ -75,6 +76,21 @@ public class UiUtils {
      */
     public static <T> Future<T> submitUiMachineTask(final Callable<T> callable,
             final Consumer<T> onSuccess, final Consumer<Throwable> onFailure) {
+        return submitUiMachineTask(callable, onSuccess, onFailure, false);
+    }
+
+    /**
+     * Functional version of Machine.submit which guarantees that the the onSuccess and onFailure
+     * handlers will be run on the Swing event thread. Includes the ignoreEnabled argument.
+     * 
+     * @param callable
+     * @param onSuccess
+     * @param onFailure
+     * @param ignoreEnabled
+     * @return
+     */
+    public static <T> Future<T> submitUiMachineTask(final Callable<T> callable,
+            final Consumer<T> onSuccess, final Consumer<Throwable> onFailure, boolean ignoreEnabled) {
         return Configuration.get().getMachine().submit(callable, new FutureCallback<T>() {
             @Override
             public void onSuccess(T result) {
@@ -95,7 +111,7 @@ public class UiUtils {
                     e.printStackTrace();
                 }
             }
-        });
+        }, ignoreEnabled);
     }
 
     /**

--- a/src/test/java/SampleJobTest.java
+++ b/src/test/java/SampleJobTest.java
@@ -125,7 +125,7 @@ public class SampleJobTest {
                 //spin
             };
             return null;
-        });
+        }, false, 10000);
         // camera.stopContinuousCapture(encoder);
         // encoder.finish();
     }

--- a/src/test/java/org/openpnp/machine/reference/driver/test/TestDriver.java
+++ b/src/test/java/org/openpnp/machine/reference/driver/test/TestDriver.java
@@ -201,6 +201,11 @@ public class TestDriver extends AbstractDriver implements Driver {
         public double getMinimumVelocity() {
             return 0;
         }
+
+        @Override
+        public boolean isSyncInitialLocation() {
+            return false;
+        }
    }
 
     @Override
@@ -266,6 +271,11 @@ public class TestDriver extends AbstractDriver implements Driver {
 
     @Override
     public boolean isMotionPending() {
+        return false;
+    }
+
+    @Override
+    public boolean isSyncInitialLocation() {
         return false;
     }
 }


### PR DESCRIPTION
# Description
Machine enabling/disabling has been handled outside the regular Machine task threading framework. The reason ([as stated in comments in code](https://github.com/markmaker/openpnp/blob/32f227c6b9fbe0fbe82ee07d5f21362718ce4d72/src/main/java/org/openpnp/gui/MachineControlsPanel.java#L288-L289)) was that disabling should act as sort of Emergency Stop, i.e. be _immediately_ effective, even if machine tasks are still running and/or pending in the queue. By tearing down the driver connections, any pending tasks would be _indirectly_ killed through IO exceptions. 

![Not aus](https://user-images.githubusercontent.com/9963310/168637326-572e2401-c9e4-4744-9276-f9872ebe9ecb.png)
_(Wikimedia)_

When machine enabling/disabling was later expanded to include automatic machine homing and [setting/initializing Actuators automatically in the **Enabled**/**Disabled** machine state change](https://github.com/openpnp/openpnp/wiki/Setup-and-Calibration%3A-Actuators#actuator-machine-states), this resulted in race conditions, as the generated machine tasks would then overlap with the special enable/disable thread and the command sequences sent there.

This PR refactors machine enabling/disabling to work inside the regular machine task threading framework whenever possible. Only when an Emergency Stop condition is detected will it actually perform as such. In this emergency case, some of the machine state change (disabled) actuations might not work (as before). This is now reported as error messages. 

## Changes

- Move most of the enable/disable functionality from the Machine Controls to the Machine object, this includes:
- Reading the initial machine position after enabling (as a result, `org.openpnp.spi.Driver.isSyncInitialLocation()` had to be moved to the spi).
- Automatic machine state change actuation.
- Automatic homing after enabling (and therefore everything that can be triggered by homing).
- The `org.openpnp.util.UiUtils.submitUiMachineTask(Callable<Object>, Consumer<Object>, Consumer<Throwable>, boolean)` had to be added, to expose the `ignoreEnabled` boolean to allow running the enable task in the _disabled_ machine.
- The unit test `SampleJobTest` that is using explicit `machine.setEnable()` and subsequent machine tasks had to be adapted.
- Simulation machine `GcodeServer` connection tear-down had to be made more robust, so a machine can be re-enabled after emergency stop.

# Justification
Users reported race conditions:
https://groups.google.com/g/desktop-pick-and-place/c/xrl44HcTpHQ/m/0Cn7HVAUAwAJ

# Instructions for Use
When the machine is enabled, or when an _idle_ machine is disabled, the enable/disable task is now run in a regular machine task.

Only when a busy machine is disabled, will the old method be used. In this case, the disable task is run in a separate thread and will tear down the connections, _indirectly_ killing running/pending tasks. 

# Implementation Details
1. Tested in simulation, using mutliple simulated `GcodeServer` connections/drivers.
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. The `org.openpnp.spi.Driver.isSyncInitialLocation()` had to be moved to the spi, and implemented in all `Driver` classes.
4.Successful `mvn test` before submitting the Pull Request. 
