### PR TITLE
Fix / No Background Calibration when Calibrating Camera

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/ReferenceNozzleTipCalibration.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceNozzleTipCalibration.java
@@ -589,7 +589,7 @@ public class ReferenceNozzleTipCalibration extends AbstractModelObject {
     @Attribute(required = false)
     private int backgroundWorstValue = 255/2; 
 
-    private List<byte []> backgroundImages;
+    private List<byte []> backgroundImages = new ArrayList<>();
 
     /**
      * TODO Left for backward compatibility. Unused. Can be removed after Feb 7, 2020.
@@ -842,12 +842,13 @@ public class ReferenceNozzleTipCalibration extends AbstractModelObject {
             // go to camera position (now offset-corrected). prevents the user from being irritated if it's not exactly centered
             nozzle.moveTo(camera.getLocation(nozzle).derive(null, null, measureBaseLocation.getZ(), angleStop));
 
-            // Finish the background calibration, if images were successfully collected.  
-            finishBackgroundCalibration(referenceCamera, nozzle);
+            if (!calibrateCamera) {
+                // Finish the background calibration, if images were successfully collected.  
+                finishBackgroundCalibration(referenceCamera, nozzle);
+            }
 
             // after processing the nozzle returns to safe-z
             nozzle.moveToSafeZ();
-            MovableUtils.fireTargetedUserAction(nozzle);
 
             // setting to false in the very end to prevent endless calibration repetitions if calibration was not successful (pipeline not well or similar) and the nozzle is commanded afterwards somewhere else (where the calibration is asked for again ...)
             calibrating = false;


### PR DESCRIPTION
# Description
Background calibration must not be done when calibrating the camera (rather than the nozzle tip). It could result in a null pointer exception.

This also removes an erroneous `MovableUtils.fireTargetedUserAction(nozzle)` call that flickered the camera.

# Justification
User report (in PM):

![Exception](https://user-images.githubusercontent.com/9963310/169485436-92a92213-668d-45ed-af13-06ca6a150beb.png)

# Instructions for Use
No change in usage. See the Wiki:

https://github.com/openpnp/openpnp/wiki/Nozzle-Tip-Background-Calibration

# Implementation Details
1. Tested in simulation.
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. Successful `mvn test` before submitting the Pull Request. 
