### PR TITLE
Fixes to the Advanced Camera Calibration.

### DIFF
--- a/src/main/java/org/openpnp/gui/processes/CalibrateCameraProcess.java
+++ b/src/main/java/org/openpnp/gui/processes/CalibrateCameraProcess.java
@@ -440,7 +440,6 @@ public abstract class CalibrateCameraProcess {
      */
     private boolean estimateUnitsPerPixelAction() {
         Logger.trace("Entering estimateUnitsPerPixelAction");
-        ((ReferenceCamera) camera).setAutoVisible(savedAutoVisible);
         
         //Capture the movable's coordinate as the approximate center of the camera's field-of-view
         centralLocation = movable.getLocation().convertToUnits(LengthUnit.Millimeters).
@@ -763,10 +762,7 @@ public abstract class CalibrateCameraProcess {
                 }
                 // Note, automatic only available when location set. 
                 if (automatic) {
-                    setInstructionsAndProceedAction("If necessary, use the jog controls on the Machine Controls panel to jog the camera so that the calibration fiducial at Z = %s is approximately centered in the green circle.  Click Next when ready to proceed.", 
-                            ()->requestOperatorToAdjustDiameterAction(),
-                            calibrationLocations.get(calibrationHeightIndex).getLengthZ().toString()); 
-//                    requestOperatorToAdjustDiameterAction();
+                    requestOperatorToAdjustDiameterAction();
                     return true;
                 }
             }
@@ -973,13 +969,6 @@ public abstract class CalibrateCameraProcess {
         //Mask off everything that is not near the expected location
         pipeline.setProperty("MaskCircle.center", expectedPoint);
         pipeline.setProperty("DetectCircularSymmetry.center", expectedPoint);
-        
-        //Restrict the mask diameter so as to not extend beyond the edge of  the image
-        maskDiameter = 2*(int)Math.min(expectedPoint.getX(), 
-                Math.min(pixelsX-expectedPoint.getX(),
-                Math.min(expectedPoint.getY(),
-                Math.min(pixelsY-expectedPoint.getY(), maskDiameter/2))));
-        
         pipeline.setProperty("MaskCircle.diameter", maskDiameter);
         pipeline.setProperty("DetectCircularSymmetry.maxDistance", maskDiameter/2.0);
 

--- a/src/main/java/org/openpnp/machine/reference/camera/calibration/AdvancedCalibration.java
+++ b/src/main/java/org/openpnp/machine/reference/camera/calibration/AdvancedCalibration.java
@@ -53,7 +53,8 @@ public class AdvancedCalibration extends LensCalibrationParams {
     // tangential distortion correction by default.
     // Moving to version 1.3 - version 1.2 accidentally disabled all distortion correction by 
     // default rather than only tangential distortion correction.
-    private static final Double LATEST_VERSION = 1.3;
+    // Moving to version 1.4 - increase the testPatternFillFraction. 
+    private static final Double LATEST_VERSION = 1.4;
     
     @Attribute(required = false)
     private boolean overridingOldTransformsAndDistortionCorrectionSettings = false;
@@ -122,7 +123,7 @@ public class AdvancedCalibration extends LensCalibrationParams {
     private int desiredRadialLinesPerTestPattern = 32;
     
     @Attribute(required = false)
-    private double testPatternFillFraction = 0.90;
+    private double testPatternFillFraction = 0.98;
     
     @Attribute(required = false)
     private double walkingLoopGain = 0.50;
@@ -277,6 +278,11 @@ public class AdvancedCalibration extends LensCalibrationParams {
             //Fix version 1.2 where the initial values of these two were accidentally swapped
             disableDistortionCorrection = false;
             disableTangentialDistortionCorrection = true;
+        }
+        if (version <= 1.3) {
+            // Allow for a larger fill fraction, thanks to better circular symmetry detection,
+            // including even cropped circles. 
+            testPatternFillFraction = 0.98;
         }
     }
     


### PR DESCRIPTION
# Description
Fixes to the Advanced Camera Calibration.

1. Automatic progression to the second Z level restored. 
2. Coverage of calibration increased from 90% to 98%.
3. Restriction of search radius removed. The circular symmetry detection can work with cropped search areas, since #1242.
4. For some reason, the **Auto Camera View** mode was switched off by Advanced Camera Calibration. This was removed. 

# Justification
## Automatic Calibration from issues & Solutions
In automatic mode, as employed by Issues & Solutions, the calibration would still require the user to press "Next" to go to the second Z level. The change introducing this was probably an unintended left-over from a debugging session. This PR restores the original code.

## Coverage of Search
Changing the coverage from 90% to 98% increases the precision. See the results.

Before:
![Before](https://user-images.githubusercontent.com/9963310/169604583-5768f467-5f9b-41bc-bf3c-15ae2d83e8eb.png)

After:
![After](https://user-images.githubusercontent.com/9963310/169604599-53d048af-4967-4f13-9180-c552333aac9d.png)

The precision was increased by approx. √2.

## Search Diameter
The Advanced Camera Calibration would no longer work with strong distortion (such as in simulation), the search diameter would be so constrained at the edge that the fiducial was no longer found. Restricting the search radius is no longer necessary due to #1242.

# Instructions for Use
No change in usage.

# Implementation Details
1. Tested in simulation.
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
5. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
6. Successful `mvn test` before submitting the Pull Request. 
