### PR TITLE
Fix / Races in GitHubActions - UiUtils.showError() - SimulatedCommunications

### DIFF
--- a/src/main/java/org/openpnp/gui/processes/CalibrateCameraProcess.java
+++ b/src/main/java/org/openpnp/gui/processes/CalibrateCameraProcess.java
@@ -45,7 +45,6 @@ import org.opencv.core.Size;
 import org.openpnp.gui.MainFrame;
 import org.openpnp.gui.components.CameraView;
 import org.openpnp.gui.components.CameraViewFilter;
-import org.openpnp.gui.support.MessageBoxes;
 import org.openpnp.machine.reference.ReferenceCamera;
 import org.openpnp.machine.reference.ReferenceMachine;
 import org.openpnp.machine.reference.ReferenceNozzleTip;
@@ -64,6 +63,7 @@ import org.openpnp.util.CameraWalker;
 import org.openpnp.util.ImageUtils;
 import org.openpnp.util.MovableUtils;
 import org.openpnp.util.OpenCvUtils;
+import org.openpnp.util.UiUtils;
 import org.openpnp.util.UiUtils.Thrunnable;
 import org.openpnp.util.VisionUtils;
 import org.openpnp.vision.pipeline.CvPipeline;
@@ -268,7 +268,7 @@ public abstract class CalibrateCameraProcess {
                     });
                 }
                 catch (Exception ex) {
-                    MessageBoxes.errorBox(MainFrame.get(), "Error", ex);
+                    UiUtils.showError(ex);
                     cleanUpWhenCancelled();
                 }
                 // Note, automatic is only available if the moveLocation is already set.
@@ -511,7 +511,7 @@ public abstract class CalibrateCameraProcess {
                 
                 if (!cameraWalker.isReadyToWalk()) {
                     if (!isCancelled()) {
-                        MessageBoxes.errorBox(MainFrame.get(), "Error", "Could not estimate units per pixel - calibration aborting.");
+                        UiUtils.showError(new Exception("Could not estimate units per pixel - calibration aborting."));
                     }
                     cleanUpWhenCancelled();
                     return;
@@ -592,7 +592,7 @@ public abstract class CalibrateCameraProcess {
                         });
                     }
                     catch (Exception ex) {
-                        MessageBoxes.errorBox(MainFrame.get(), "Error", ex);
+                        UiUtils.showError(ex);
                         cleanUpWhenCancelled();
                     }
                     
@@ -678,7 +678,7 @@ public abstract class CalibrateCameraProcess {
                 }
                 
                 if (errorCount > props.maxErrorCount) {
-                    MessageBoxes.errorBox(MainFrame.get(), "Error", "Too many misdetects - retry and verify fiducial/nozzle tip detection." );
+                    UiUtils.showError(new Exception("Too many misdetects - retry and verify fiducial/nozzle tip detection."));
                     cleanUpWhenCancelled();
                     return;
                 }
@@ -722,7 +722,7 @@ public abstract class CalibrateCameraProcess {
                             new Size(pixelsX, pixelsY), mirrored, apparentMotionDirection);
                     }
                     catch (Exception ex) {
-                        MessageBoxes.errorBox(MainFrame.get(), "Error", ex);
+                        UiUtils.showError(ex);
                     }
                     finally {
                         cleanUpWhenDone();
@@ -767,7 +767,7 @@ public abstract class CalibrateCameraProcess {
                     });
                 }
                 catch (Exception ex) {
-                    MessageBoxes.errorBox(MainFrame.get(), "Error", ex);
+                    UiUtils.showError(ex);
                     cleanUpWhenCancelled();
                 }
                 // Note, automatic only available when location set. 
@@ -793,7 +793,7 @@ public abstract class CalibrateCameraProcess {
                 });
             }
             catch (Exception ex) {
-                MessageBoxes.errorBox(MainFrame.get(), "Error", ex);
+                UiUtils.showError(ex);
                 cleanUpWhenCancelled();
             }
             
@@ -826,7 +826,7 @@ public abstract class CalibrateCameraProcess {
                 });
             }
             catch (Exception ex) {
-                MessageBoxes.errorBox(MainFrame.get(), "Error", ex);
+                UiUtils.showError(ex);
                 cleanUpWhenCancelled();
             }
             // Note, automatic only available when location set. 
@@ -876,7 +876,7 @@ public abstract class CalibrateCameraProcess {
             });
         }
         catch (Exception ex) {
-            MessageBoxes.errorBox(MainFrame.get(), "Error", ex);
+            UiUtils.showError(ex);
             cleanUpWhenCancelled();
         }
         
@@ -1151,7 +1151,7 @@ public abstract class CalibrateCameraProcess {
                     tempAction.thrun();
                 }
                 catch (Exception ex) {
-                    MessageBoxes.errorBox(MainFrame.get(), "Error", ex);
+                    UiUtils.showError(ex);
                     cleanUpWhenCancelled();
                 }
             }

--- a/src/main/java/org/openpnp/machine/reference/ReferenceMachine.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceMachine.java
@@ -111,7 +111,6 @@ import org.openpnp.spi.base.AbstractMachine;
 import org.openpnp.spi.base.SimplePropertySheetHolder;
 import org.openpnp.util.Collect;
 import org.openpnp.util.MovableUtils;
-import org.openpnp.util.UiUtils;
 import org.pmw.tinylog.Logger;
 import org.simpleframework.xml.Attribute;
 import org.simpleframework.xml.Element;
@@ -223,8 +222,8 @@ public class ReferenceMachine extends AbstractMachine {
                     // position to the initial reported location (see Driver.isSyncInitialLocation()).
                     getMotionPlanner().waitForCompletion(null, CompletionType.WaitForStillstand);
                 }
-                if (getHomeAfterEnabled()) {
-                    UiUtils.submitUiMachineTask(() -> home());
+                if (getHomeAfterEnabled() && isTask(Thread.currentThread())) {
+                    home();
                 }
             }
             catch (Exception e) {

--- a/src/main/java/org/openpnp/machine/reference/driver/GcodeDriver.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/GcodeDriver.java
@@ -358,10 +358,10 @@ public class GcodeDriver extends AbstractReferenceDriver implements Named {
         getCommunications().connect();
         connected = false;
 
+        connectThreads();
+
         // Wait a bit while the controller starts up
         Thread.sleep(connectWaitTimeMilliseconds);
-
-        connectThreads();
 
         // Consume any startup messages
         try {

--- a/src/main/java/org/openpnp/machine/reference/driver/ReferenceDriverCommunications.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/ReferenceDriverCommunications.java
@@ -56,7 +56,7 @@ public abstract class ReferenceDriverCommunications {
 
     abstract public String getConnectionName();
 
-    abstract public void writeBytes(byte[] data) throws IOException;
+    abstract protected void writeBytes(byte[] data) throws IOException;
 
     abstract public int read() throws TimeoutException, IOException;
 
@@ -86,7 +86,7 @@ public abstract class ReferenceDriverCommunications {
      * @throws TimeoutException
      * @throws IOException
      */
-    public String readUntil(String characters) throws TimeoutException, IOException {
+    protected String readUntil(String characters) throws TimeoutException, IOException {
         StringBuffer line = new StringBuffer();
         while (true) {
             int ch = read();
@@ -108,14 +108,15 @@ public abstract class ReferenceDriverCommunications {
         byte[] b = new byte[] { (byte) d };
         writeBytes(b);
     }
-    
+
     public void setLineEndingType(LineEndingType lineEndingType) {
         this.lineEndingType = lineEndingType;
     }
-    
+
     public LineEndingType getLineEndingType() {
         return lineEndingType;
     }
+
     public GcodeServer getGcodeServer() {
         return null;
     }

--- a/src/main/java/org/openpnp/machine/reference/driver/SerialPortCommunications.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/SerialPortCommunications.java
@@ -133,9 +133,16 @@ public class SerialPortCommunications extends ReferenceDriverCommunications {
         return portNames.toArray(new String[] {});
     }
 
+    @Override
     public int read() throws TimeoutException, IOException {
         byte[] b = new byte[1];
-        int l = serialPort.readBytes(b, 1);
+        int l;
+        try {
+            l = serialPort.readBytes(b, 1);
+        }
+        catch (NullPointerException e) {
+            throw new IOException("Trying to read from a unconnected serial.");
+        }
         if (l == -1) {
             throw new IOException("Read error.");
         }
@@ -145,6 +152,7 @@ public class SerialPortCommunications extends ReferenceDriverCommunications {
         return b[0];
     }
 
+    @Override
     public void writeBytes(byte[] data) throws IOException {
         int l = serialPort.writeBytes(data, data.length);
         if (l == -1) {
@@ -153,6 +161,7 @@ public class SerialPortCommunications extends ReferenceDriverCommunications {
     }
 
 
+    @Override
     public String getConnectionName() {
         return "serial://" + portName;
     }

--- a/src/main/java/org/openpnp/machine/reference/driver/SimulatedCommunications.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/SimulatedCommunications.java
@@ -26,6 +26,17 @@ public class SimulatedCommunications extends ReferenceDriverCommunications {
 
     public synchronized void connect() throws Exception {
         disconnect();
+        if (gcodeServer == null) {
+            try {
+                gcodeServer = new GcodeServer();
+            }
+            catch (Exception e) {
+                Logger.warn(e);
+            }
+        }
+        if (gcodeServer != null) {
+            gcodeServer.setDriver(driver);
+        }
         clientSocket = new Socket("localhost", getGcodeServer().getListenerPort());
         input = new BufferedReader(new InputStreamReader(clientSocket.getInputStream()));
         output = new DataOutputStream(clientSocket.getOutputStream());
@@ -52,17 +63,6 @@ public class SimulatedCommunications extends ReferenceDriverCommunications {
 
     @Override
     public GcodeServer getGcodeServer() {
-        if (gcodeServer == null) {
-            try {
-                gcodeServer = new GcodeServer();
-            }
-            catch (Exception e) {
-                Logger.warn(e);
-            }
-        }
-        if (gcodeServer != null) {
-            gcodeServer.setDriver(driver);
-        }
         return gcodeServer;
     }
 

--- a/src/main/java/org/openpnp/machine/reference/driver/SimulatedCommunications.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/SimulatedCommunications.java
@@ -24,6 +24,7 @@ public class SimulatedCommunications extends ReferenceDriverCommunications {
     protected GcodeServer gcodeServer;
     private Driver driver;
 
+    @Override
     public synchronized void connect() throws Exception {
         disconnect();
         if (gcodeServer == null) {
@@ -42,6 +43,7 @@ public class SimulatedCommunications extends ReferenceDriverCommunications {
         output = new DataOutputStream(clientSocket.getOutputStream());
     }
 
+    @Override
     public synchronized void disconnect() throws Exception {
         if (clientSocket != null && clientSocket.isBound()) {
             clientSocket.close();
@@ -57,8 +59,10 @@ public class SimulatedCommunications extends ReferenceDriverCommunications {
         }
     }
 
+    @Override
     public String getConnectionName(){
-        return "simulated: "+(gcodeServer == null ? "off" : "port "+gcodeServer.getListenerPort());
+        GcodeServer server = gcodeServer; // prevent race by taking a copy
+        return "simulated: "+(server == null ? "off" : "port "+server.getListenerPort());
     }
 
     @Override
@@ -66,54 +70,13 @@ public class SimulatedCommunications extends ReferenceDriverCommunications {
         return gcodeServer;
     }
 
-    /**
-     * Read a line from the socket. Blocks for the default timeout. If the read times out a
-     * TimeoutException is thrown. Any other failure to read results in an IOExeption;
-     * 
-     * @return
-     * @throws TimeoutException
-     * @throws IOException
-     */
-    public String readLine() throws TimeoutException, IOException {
-        StringBuffer line = new StringBuffer();
-        while (true) {
-            try {
-                int ch = input.read();
-                if (ch == -1) {
-                    return null;
-                }
-                else if (ch == '\n' || ch == '\r') {
-                    if (line.length() > 0) {
-                        return line.toString();
-                    }
-                }
-                else {
-                    line.append((char) ch);
-                }
-            }
-            catch (IOException ex) {
-                if (ex.getCause() instanceof SocketTimeoutException) {
-                    throw new TimeoutException(ex.getMessage());
-                }
-                throw ex;
-            }
-        }
-    }
-
-    public void writeLine(String data) throws IOException
-    {
-        try {
-            output.write(data.getBytes());
-            output.write(getLineEndingType().getLineEnding().getBytes());
-        }
-        catch (IOException ex) {
-            throw ex;
-        }
-    }
-
+    @Override
     public int read() throws TimeoutException, IOException {
         try {
             return input.read();
+        }
+        catch (NullPointerException ex) {
+            throw new IOException("Trying to read from a unconnected socket.");
         }
         catch (IOException ex) {
             if (ex.getCause() instanceof SocketTimeoutException) {
@@ -123,6 +86,7 @@ public class SimulatedCommunications extends ReferenceDriverCommunications {
         }
     }
 
+    @Override
     public void write(int d) throws IOException {
         output.write(d);
     }

--- a/src/main/java/org/openpnp/machine/reference/driver/TcpCommunications.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/TcpCommunications.java
@@ -32,6 +32,7 @@ public class TcpCommunications extends ReferenceDriverCommunications {
     protected GcodeServer gcodeServer;
     protected AbstractReferenceDriver driver;
 
+    @Override
     public synchronized void connect() throws Exception {
         disconnect();
         if (ipAddress.equals("GcodeServer")) {
@@ -47,6 +48,7 @@ public class TcpCommunications extends ReferenceDriverCommunications {
         output = new DataOutputStream(clientSocket.getOutputStream());
     }
 
+    @Override
     public synchronized void disconnect() throws Exception {
         if (clientSocket != null && clientSocket.isBound()) {
             clientSocket.close();
@@ -60,10 +62,12 @@ public class TcpCommunications extends ReferenceDriverCommunications {
         }
     }
 
+    @Override
     public String getConnectionName(){
         return "tcp://" + ipAddress + ":" + port;
     }
 
+    @Override
     public int read() throws TimeoutException, IOException {
         try {
             return input.read();

--- a/src/main/java/org/openpnp/machine/reference/driver/TcpCommunications.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/TcpCommunications.java
@@ -68,6 +68,9 @@ public class TcpCommunications extends ReferenceDriverCommunications {
         try {
             return input.read();
         }
+        catch (NullPointerException ex) {
+            throw new IOException("Trying to read from a unconnected socket.");
+        }
         catch (IOException ex) {
             if (ex.getCause() instanceof SocketTimeoutException) {
                 throw new TimeoutException(ex.getMessage());

--- a/src/main/java/org/openpnp/machine/reference/feeder/wizards/ReferenceStripFeederConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/wizards/ReferenceStripFeederConfigurationWizard.java
@@ -38,7 +38,6 @@ import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JTextField;
 import javax.swing.SwingUtilities;
-import javax.swing.border.EtchedBorder;
 import javax.swing.border.TitledBorder;
 
 import org.jdesktop.beansbinding.AutoBinding.UpdateStrategy;
@@ -514,7 +513,7 @@ public class ReferenceStripFeederConfigurationWizard extends AbstractConfigurati
                     catch (Exception e) {
                         if (!hasShownError) {
                             hasShownError = true;
-                            MessageBoxes.errorBox(MainFrame.get(), "Error", e);
+                            UiUtils.showError(e);
                         }
                         else {
                             Logger.debug("{}: {}", "Error", e);

--- a/src/main/java/org/openpnp/machine/reference/solutions/CalibrationSolutions.java
+++ b/src/main/java/org/openpnp/machine/reference/solutions/CalibrationSolutions.java
@@ -30,7 +30,6 @@ import org.openpnp.gui.MainFrame;
 import org.openpnp.gui.components.CameraView;
 import org.openpnp.gui.processes.CalibrateCameraProcess;
 import org.openpnp.gui.support.LengthConverter;
-import org.openpnp.gui.support.MessageBoxes;
 import org.openpnp.machine.reference.ReferenceCamera;
 import org.openpnp.machine.reference.ReferenceHead;
 import org.openpnp.machine.reference.ReferenceMachine;
@@ -1274,7 +1273,7 @@ public class CalibrationSolutions implements Solutions.Subject {
                         });
                     }
                     catch (Exception e) {
-                        MessageBoxes.errorBox(MainFrame.get(), "Error", e);
+                        UiUtils.showError(e);
                         advCal.setValid(false);
                         advCal.setEnabled(false);
                         advCal.setOverridingOldTransformsAndDistortionCorrectionSettings(false);

--- a/src/main/java/org/openpnp/machine/reference/wizards/ReferenceCameraCalibrationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/wizards/ReferenceCameraCalibrationWizard.java
@@ -1066,7 +1066,7 @@ public class ReferenceCameraCalibrationWizard extends AbstractConfigurationWizar
                                     postCalibrationProcessing();
                                 }
                                 catch (Exception e) {
-                                    MessageBoxes.errorBox(MainFrame.get(), "Error", e);
+                                    UiUtils.showError(e);
                                     advCal.setValid(false);
                                     advCal.setEnabled(false);
                                     chckbxEnable.setSelected(false);

--- a/src/main/java/org/openpnp/util/UiUtils.java
+++ b/src/main/java/org/openpnp/util/UiUtils.java
@@ -14,6 +14,7 @@ import org.openpnp.model.Configuration;
 import org.openpnp.model.Location;
 import org.openpnp.spi.HeadMountable;
 import org.openpnp.spi.MotionPlanner.CompletionType;
+import org.pmw.tinylog.Logger;
 
 import com.google.common.util.concurrent.FutureCallback;
 
@@ -57,11 +58,16 @@ public class UiUtils {
     }
 
     /**
-     * Show an error using a message box.
+     * Show an error using a message box, if the GUI is present, otherwise just log the error.
      * @param t
      */
     public static void showError(Throwable t) {
-        MessageBoxes.errorBox(MainFrame.get(), "Error", t);
+        if (MainFrame.get() != null) {
+            MessageBoxes.errorBox(MainFrame.get(), "Error", t);
+        }
+        else {
+            Logger.error(t);
+        }
     }
 
 

--- a/src/test/java/SampleJobTest.java
+++ b/src/test/java/SampleJobTest.java
@@ -72,6 +72,19 @@ public class SampleJobTest {
         ReferenceMachine machine = (ReferenceMachine) Configuration.get().getMachine();
         AbstractCamera camera = (AbstractCamera)machine.getDefaultHead().getDefaultCamera();
 
+        // There seems to be a race condition in imperfectMachine simulation where the camera is not yet ready
+        // this never happens in real OpenPnP so let's just settle things down.
+        try {
+            camera.capture();
+        }
+        catch (Exception e) {
+        }
+        try {
+            camera.capture();
+        }
+        catch (Exception e) {
+        }
+
         if (!imperfectMachine) {
             NullDriver driver = (NullDriver) machine.getDefaultDriver();
             // Make it faster for the test (now including axes).
@@ -109,16 +122,6 @@ public class SampleJobTest {
 
         machine.setEnabled(true);
         machine.execute(() -> {
-            // There seems to be a race condition in imperfectMachine simulation where the camera is not yet ready
-            // this never happens in real OpenPnP so let's just settle things down.
-            for (int i = 0; i < 4; i++) {
-                try {
-                    camera.capture();
-                    Thread.sleep(42);
-                }
-                catch (Exception e) {
-                }
-            }
             machine.home();
             jobProcessor.initialize(job);
             while (jobProcessor.next()) {

--- a/src/test/java/SampleJobTest.java
+++ b/src/test/java/SampleJobTest.java
@@ -100,6 +100,9 @@ public class SampleJobTest {
             camera.setSettleMethod(AbstractCamera.SettleMethod.FixedTime);
             camera.setSettleTimeMs(0);
         }
+        else {
+            System.out.println("SampleJobTest runs with imperfect machine in real-time, please be patient...");
+        }
 
 
         // File videoFile = new File("target");

--- a/src/test/java/SampleJobTest.java
+++ b/src/test/java/SampleJobTest.java
@@ -114,6 +114,7 @@ public class SampleJobTest {
             for (int i = 0; i < 4; i++) {
                 try {
                     camera.capture();
+                    Thread.sleep(42);
                 }
                 catch (Exception e) {
                 }

--- a/src/test/java/SampleJobTest.java
+++ b/src/test/java/SampleJobTest.java
@@ -63,7 +63,7 @@ public class SampleJobTest {
 
         Configurator
         .currentConfig()
-        .level(Level.TRACE) // change this for other log levels.
+        .level(Level.INFO) // change this for other log levels.
         .activate();
 
         Configuration.initialize(workingDirectory);

--- a/src/test/java/SampleJobTest.java
+++ b/src/test/java/SampleJobTest.java
@@ -72,19 +72,6 @@ public class SampleJobTest {
         ReferenceMachine machine = (ReferenceMachine) Configuration.get().getMachine();
         AbstractCamera camera = (AbstractCamera)machine.getDefaultHead().getDefaultCamera();
 
-        // There seems to be a race condition in imperfectMachine simulation where the camera is not yet ready
-        // this never happens in real OpenPnP so let's just settle things down.
-        try {
-            camera.capture();
-        }
-        catch (Exception e) {
-        }
-        try {
-            camera.capture();
-        }
-        catch (Exception e) {
-        }
-
         if (!imperfectMachine) {
             NullDriver driver = (NullDriver) machine.getDefaultDriver();
             // Make it faster for the test (now including axes).
@@ -122,6 +109,15 @@ public class SampleJobTest {
 
         machine.setEnabled(true);
         machine.execute(() -> {
+            // There seems to be a race condition in imperfectMachine simulation where the camera is not yet ready
+            // this never happens in real OpenPnP so let's just settle things down.
+            for (int i = 0; i < 4; i++) {
+                try {
+                    camera.capture();
+                }
+                catch (Exception e) {
+                }
+            }
             machine.home();
             jobProcessor.initialize(job);
             while (jobProcessor.next()) {

--- a/src/test/java/SampleJobTest.java
+++ b/src/test/java/SampleJobTest.java
@@ -63,7 +63,7 @@ public class SampleJobTest {
 
         Configurator
         .currentConfig()
-        .level(Level.INFO) // change this for other log levels.
+        .level(Level.TRACE) // change this for other log levels.
         .activate();
 
         Configuration.initialize(workingDirectory);

--- a/src/test/resources/config/SampleJobTest/machine.xml
+++ b/src/test/resources/config/SampleJobTest/machine.xml
@@ -488,7 +488,7 @@
          <mid-location-2 units="Millimeters" x="0.0" y="0.0" z="0.0" rotation="0.0"/>
          <end-location units="Millimeters" x="0.0" y="0.0" z="0.0" rotation="0.0"/>
       </motion-planner>
-      <home-after-enabled>true</home-after-enabled>
+      <home-after-enabled>false</home-after-enabled>
       <dismissed-solutions class="java.util.HashSet">
          <string>ebc08eb957002721ae303c54638ed1d0975f4538</string>
       </dismissed-solutions>

--- a/src/test/resources/config/SampleJobTest/machine.xml
+++ b/src/test/resources/config/SampleJobTest/machine.xml
@@ -446,42 +446,6 @@
       <pnp-job-processor class="org.openpnp.machine.reference.ReferencePnpJobProcessor" job-order="PartHeight" max-vision-retries="3">
          <planner class="org.openpnp.machine.reference.ReferencePnpJobProcessor$SimplePnpJobPlanner"/>
       </pnp-job-processor>
-      <fiducial-locator class="org.openpnp.machine.reference.vision.ReferenceFiducialLocator" enabled-averaging="false" repeat-fiducial-recognition="3">
-         <pipeline>
-		   <stages>
-			  <cv-stage class="org.openpnp.vision.pipeline.stages.CreateFootprintTemplateImage" name="template" enabled="true" footprint-view="Fiducial">
-				 <pads-color r="255" g="255" b="255" a="255"/>
-				 <body-color r="0" g="0" b="0" a="255"/>
-				 <background-color r="0" g="0" b="0" a="255"/>
-			  </cv-stage>
-			  <cv-stage class="org.openpnp.vision.pipeline.stages.ImageWriteDebug" name="debug_template" enabled="false" prefix="fidloc_template_" suffix=".png"/>
-			  <cv-stage class="org.openpnp.vision.pipeline.stages.ConvertColor" name="template_gray" enabled="true" conversion="Bgr2Gray"/>
-			  <cv-stage class="org.openpnp.vision.pipeline.stages.ImageCapture" name="image" enabled="true" default-light="true" settle-first="true" count="1"/>
-			  <cv-stage class="org.openpnp.vision.pipeline.stages.AffineWarp" name="warp" enabled="true" length-unit="Millimeters" x-0="-5.0" y-0="5.0" x-1="5.0" y-1="5.0" x-2="-5.0" y-2="-5.0" scale="1.0" rectify="true" region-of-interest-property="regionOfInterest"/>
-			  <cv-stage class="org.openpnp.vision.pipeline.stages.MaskHsv" name="check light" enabled="true" auto="false" fraction-to-mask="0.0" hue-min="0" hue-max="255" saturation-min="0" saturation-max="255" value-min="35" value-max="255" invert="true" binary-mask="false"/>
-			  <cv-stage class="org.openpnp.vision.pipeline.stages.ImageWriteDebug" name="debug_original" enabled="true" prefix="fidloc_original_" suffix=".png"/>
-			  <cv-stage class="org.openpnp.vision.pipeline.stages.ConvertColor" name="image_gray" enabled="true" conversion="Bgr2Gray"/>
-			  <cv-stage class="org.openpnp.vision.pipeline.stages.BlurGaussian" name="blur" enabled="true" kernel-size="3"/>
-			  <cv-stage class="org.openpnp.vision.pipeline.stages.MatchTemplate" name="match_template_warped" enabled="true" template-stage-name="template_gray" threshold="0.7" corr="0.85" normalize="false"/>
-			  <cv-stage class="org.openpnp.vision.pipeline.stages.AffineUnwarp" name="match_template" enabled="true" warp-stage-name="warp" results-stage-name="match_template_warped"/>
-			  <cv-stage class="org.openpnp.vision.pipeline.stages.ConvertModelToKeyPoints" name="results" enabled="true" model-stage-name="match_template"/>
-			  <cv-stage class="org.openpnp.vision.pipeline.stages.ImageRecall" name="recall_image" enabled="true" image-stage-name="warp"/>
-			  <cv-stage class="org.openpnp.vision.pipeline.stages.DrawTemplateMatches" name="draw_matches" enabled="true" template-matches-stage-name="match_template_warped"/>
-			  <cv-stage class="org.openpnp.vision.pipeline.stages.ConvertModelToKeyPoints" name="results_warped" enabled="true" model-stage-name="match_template_warped"/>
-			  <cv-stage class="org.openpnp.vision.pipeline.stages.DrawKeyPoints" name="draw_keypoints" enabled="true" key-points-stage-name="results_warped">
-				 <color r="255" g="255" b="0" a="255"/>
-			  </cv-stage>
-			  <cv-stage class="org.openpnp.vision.pipeline.stages.ImageWriteDebug" name="debug_results" enabled="true" prefix="fidloc_results_" suffix=".png"/>
-		   </stages>
-         </pipeline>
-         <part-settings-by-part-id class="java.util.HashMap">
-         </part-settings-by-part-id>
-         <tolerances>
-            <scaling-tolerance>0.05</scaling-tolerance>
-            <shearing-tolerance>0.05</shearing-tolerance>
-            <board-location-tolerance value="5.0" units="Millimeters"/>
-         </tolerances>
-      </fiducial-locator>
       <motion-planner class="org.openpnp.machine.reference.driver.ReferenceAdvancedMotionPlanner" maximum-plan-history="60.0" allow-continuous-motion="true" allow-uncoordinated="false" diagnostics-enabled="false" interpolation-retiming="true" show-approximation="true" to-mid-1-speed="1.0" to-mid-2-speed="1.0" to-end-speed="1.0" start-location-enabled="false" mid-1-location-enabled="false" mid-2-location-enabled="false" end-location-enabled="false" to-mid-1-safe-z="true" to-mid-2-safe-z="true" to-end-safe-z="true">
          <start-location units="Millimeters" x="0.0" y="0.0" z="0.0" rotation="0.0"/>
          <mid-location-1 units="Millimeters" x="0.0" y="0.0" z="0.0" rotation="0.0"/>


### PR DESCRIPTION
# Description
This PR tries to tackle a race condition that happens _intermittently_ on GitHub Actions and never in local `mvn test`.

## Message boxes that nobody dismisses

It was first exposed by through GitHub Actions that [seemed to hang for hours, seemingly waiting for someone to dismiss a message box](https://github.com/openpnp/openpnp/runs/6722724850?check_suite_focus=true). 

Although the head-less state was detected by a missing X11 `DISPLAY` variable, the unit would still hang on the message-box.

```Java
No X11 DISPLAY variable was set,
but this program performed an operation which requires it.
	at java.desktop/java.awt.GraphicsEnvironment.checkHeadless(GraphicsEnvironment.java:165)
	at java.desktop/java.awt.Window.<init>(Window.java:545)
	at java.desktop/java.awt.Frame.<init>(Frame.java:423)
	at java.desktop/java.awt.Frame.<init>(Frame.java:388)
	at java.desktop/javax.swing.SwingUtilities$SharedOwnerFrame.<init>(SwingUtilities.java:1919)
	at java.desktop/javax.swing.SwingUtilities.getSharedOwnerFrame(SwingUtilities.java:1995)
	at java.desktop/javax.swing.JOptionPane.getRootFrame(JOptionPane.java:1689)
	at java.desktop/javax.swing.JOptionPane.showOptionDialog(JOptionPane.java:868)
	at java.desktop/javax.swing.JOptionPane.showMessageDialog(JOptionPane.java:670)
	at java.desktop/javax.swing.JOptionPane.showMessageDialog(JOptionPane.java:641)
	at org.openpnp.gui.support.MessageBoxes.errorBox(MessageBoxes.java:55)
	at org.openpnp.util.UiUtils.showError(UiUtils.java:64)
```

So the first counter-measure was to prevent `UiUtils.showError()` to use message boxes when run from a non-gui context, such as Unit Tests. The PR checks for `MainFrame.get() != null` before displaying it. Otherwise, the error is just logged.

To make this change effective, all non-gui/task usages of `MessageBoxes.errorBox()` were replaced with `UiUtils.showError()`.

##  SampleTestJob Race condition

But it turned out fixing the message box issue just uncovered the underlying issue, namely a race condition exposed by `SampleTestJob`. 

As can be seen in the commits, several rounds were needed to find the real culprit.🤔😓😩😭😤😡🤬😳😁

Turns out that `SimulatedCommunications` created a `GcodeServer` on demand in the getter, which was prompted from the simulated camera and its thread. This created a race between the regular `GcodeServer` being created through `connect()` and the one pulled up from the camera thread.

## Cleanup of Communications Classes

The Communications classes were checked for races and some counter-measures added. However, this is probably not fully water-thight (adding `synchronized` deadlocks them). 

## Connection Wait Time

The GcodeDriver connection wait time is moved to _after_ the reader (and writer) threads are started. It did not make sense the other way around, there might be blocking on the reader.  

# Causes

These races are not new. Maybe this was exposed through #1414, plus some intermittent changes in the concurrency of GitHub Actions, to explain why it did not happen directly in #1414.

# Instructions for Use
No change.

# Implementation Details
1. Testing will only really be possible in the GitHub Actions triggered by this PR.
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. Successful `mvn test` before submitting the Pull Request.
