### PR TITLE
Fix / Swap the unnatural max, min diameter order in function signatures.

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/solutions/VisionSolutions.java
+++ b/src/main/java/org/openpnp/machine/reference/solutions/VisionSolutions.java
@@ -1342,7 +1342,7 @@ public class VisionSolutions implements Solutions.Subject {
             int minDiameter = (int) (expectedOffsetAndDiameter != null ? 
                     expectedDiameter/fiducialMargin - 1
                     : 7);
-            int maxDistance = (int) (maxDiameter*2*fiducialMargin
+            int maxDistance = (int) (Math.max(subjectAreaDiameter/2, maxDiameter*2*fiducialMargin)
                     + Math.min(image.cols(), image.rows())*extraSearchRange);
             int expectedX = bufferedImage.getWidth()/2 + (int) (expectedOffsetAndDiameter != null ? expectedOffsetAndDiameter.getX() : 0);
             int expectedY = bufferedImage.getHeight()/2 + (int) (expectedOffsetAndDiameter != null ? expectedOffsetAndDiameter.getY() : 0);
@@ -1374,8 +1374,8 @@ public class VisionSolutions implements Solutions.Subject {
                     bufferedImage = camera.lightSettleAndCapture();
                     image.release();
                     image = OpenCvUtils.toMat(bufferedImage);
-                    result = getPixelLocationShot(camera, diagnostics, image, maxDiameter,
-                            minDiameter, maxDistance, expectedX, expectedY, 
+                    result = getPixelLocationShot(camera, diagnostics, image, minDiameter,
+                            maxDiameter, maxDistance, expectedX, expectedY, 
                             n == 0 ? scoreRange : new ScoreRange());
                     // Accumulate
                     x += result.getX();
@@ -1388,8 +1388,8 @@ public class VisionSolutions implements Solutions.Subject {
             }
             else {
                 // Fiducial can be detected by one shot.
-                result = getPixelLocationShot(camera, diagnostics, image, maxDiameter,
-                        minDiameter, maxDistance, expectedX, expectedY, scoreRange);
+                result = getPixelLocationShot(camera, diagnostics, image, minDiameter,
+                        maxDiameter, maxDistance, expectedX, expectedY, scoreRange);
             }
             return result;
         }
@@ -1399,11 +1399,11 @@ public class VisionSolutions implements Solutions.Subject {
     }
 
     private Circle getPixelLocationShot(ReferenceCamera camera, String diagnostics, Mat image,
-            int maxDiameter, int minDiameter, int maxDistance, int expectedX, int expectedY, ScoreRange scoreRange) 
+            int minDiameter, int maxDiameter, int maxDistance, int expectedX, int expectedY, ScoreRange scoreRange) 
                     throws Exception, IOException {
         List<Circle> results = DetectCircularSymmetry.findCircularSymmetry(image, 
                 expectedX, expectedY, 
-                maxDiameter, minDiameter, maxDistance, maxDistance, maxDistance, 1,
+                minDiameter, maxDiameter, maxDistance, maxDistance, maxDistance, 1,
                 minSymmetry, 0.0, subSampling, superSampling, diagnostics != null, false, scoreRange);
         if (diagnostics != null) {
             if (LogUtils.isDebugEnabled()) {

--- a/src/main/java/org/openpnp/vision/pipeline/stages/DetectCircularSymmetry.java
+++ b/src/main/java/org/openpnp/vision/pipeline/stages/DetectCircularSymmetry.java
@@ -273,7 +273,7 @@ public class DetectCircularSymmetry extends CvStage {
         }
 
         List<Result.Circle> circles = findCircularSymmetry(mat, (int)center.x, (int)center.y, 
-                maxDiameter, minDiameter, maxDistance*2, searchWidth, searchHeight, maxTargetCount, minSymmetry, corrSymmetry, 
+                minDiameter, maxDiameter, maxDistance*2, searchWidth, searchHeight, maxTargetCount, minSymmetry, corrSymmetry, 
                 subSampling, superSampling, diagnostics, heatMap, new ScoreRange());
         return new Result(null, circles);
     }
@@ -334,8 +334,8 @@ public class DetectCircularSymmetry extends CvStage {
      * @param image             Image to be searched. If diagnostics are enabled, this image will be modified. 
      * @param xCenter           Nominal X center of the search area inside the given image, in pixels.
      * @param yCenter           Nominal Y center of the search area inside the given image, in pixels.
-     * @param maxDiameter       Maximum diameter of the examined circular symmetry area (pixels outside it are ignored).
      * @param minDiameter       Minimum diameter of the examined circular symmetry area (pixels inside it are ignored).
+     * @param maxDiameter       Maximum diameter of the examined circular symmetry area (pixels outside it are ignored).
      * @param searchDiameter    Search diameter across the given center. Limited by image margins and searchWidth, searchHeight.
      * @param searchWidth       Search height across the given center. Limited by image margins.
      * @param searchHeight      Search height across the given center. Limited by image margins.
@@ -354,7 +354,7 @@ public class DetectCircularSymmetry extends CvStage {
      * @throws Exception
      */
     public static  List<Result.Circle> findCircularSymmetry(Mat image, int xCenter, int yCenter,
-            int maxDiameter, int minDiameter, int searchDiameter, int searchWidth, 
+            int minDiameter, int maxDiameter, int searchDiameter, int searchWidth, 
             int searchHeight, int maxTargetCount, double minSymmetry,
             double corrSymmetry, int subSampling, int superSampling, boolean diagnostics, boolean heatMap, ScoreRange scoreRange) throws Exception {
         boolean outermost = !Double.isFinite(scoreRange.finalScore);
@@ -643,7 +643,7 @@ public class DetectCircularSymmetry extends CvStage {
                     // For each local maxima...
                     for (SymmetryCircle localBest : maximaFiltered) {
                         // ... recursion into finer subSampling and local search.
-                        List<CvStage.Result.Circle> localRet = findCircularSymmetry(image, (int)localBest.x, (int)localBest.y, maxDiameter, minDiameter, 
+                        List<CvStage.Result.Circle> localRet = findCircularSymmetry(image, (int)localBest.x, (int)localBest.y, minDiameter, maxDiameter, 
                                 subSamplingEff*iterationRadius, subSamplingEff*iterationRadius, subSamplingEff*iterationRadius, 1,
                                 minSymmetry, corrSymmetry, subSamplingEff/iterationDivision, superSampling, diagnostics, heatMap, scoreRange);
                         if (localRet.size() > 0) { 
@@ -692,7 +692,7 @@ public class DetectCircularSymmetry extends CvStage {
             }
             else {
                 // Recursion into finer subSampling and local search.
-                ret = findCircularSymmetry(image, (int)(xBest), (int)(yBest), maxDiameter, minDiameter, 
+                ret = findCircularSymmetry(image, (int)(xBest), (int)(yBest), minDiameter, maxDiameter, 
                         subSamplingEff*iterationRadius, subSamplingEff*iterationRadius, subSamplingEff*iterationRadius, 1,
                         minSymmetry, corrSymmetry, subSamplingEff/iterationDivision, superSampling, diagnostics, heatMap, scoreRange);
             }


### PR DESCRIPTION
# Description
This just swaps the unnatural `max` before `min` diameter order in `findCircularSymmetry()` function signatures.

# Justification
Makes it more understandable.

# Instructions for Use
No chnage.

# Implementation Details
1. Tested in simulation.
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. Successful `mvn test` before submitting the Pull Request.
