### PR TITLE
Fix / Home after Enabled

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/ReferenceMachine.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceMachine.java
@@ -111,6 +111,7 @@ import org.openpnp.spi.base.AbstractMachine;
 import org.openpnp.spi.base.SimplePropertySheetHolder;
 import org.openpnp.util.Collect;
 import org.openpnp.util.MovableUtils;
+import org.openpnp.util.UiUtils;
 import org.pmw.tinylog.Logger;
 import org.simpleframework.xml.Attribute;
 import org.simpleframework.xml.Element;
@@ -223,7 +224,7 @@ public class ReferenceMachine extends AbstractMachine {
                     getMotionPlanner().waitForCompletion(null, CompletionType.WaitForStillstand);
                 }
                 if (getHomeAfterEnabled() && isTask(Thread.currentThread())) {
-                    home();
+                    UiUtils.submitUiMachineTask(() -> home());
                 }
             }
             catch (Exception e) {


### PR DESCRIPTION
# Description
This reverts one #1425 fix that executed the "Home after Enabled" synchronously inside the enabled setter. This is not right, it must be queued as a separate machine task.

This fix keeps the check for `isTask()` so if `setEnabled()` is called from unit tests etc. that do not use machine tasks, homing is still prevented. 

# Justification
When the homing fails, it fails the enabling of the machine. This is not wanted, the homing should still be a separate task, even if triggered automatically after the machine is enabled.

# Instructions for Use
No change.

# Implementation Details
1. Tested in simulation.
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. Successful `mvn test` before submitting the Pull Request. 
