### PR TITLE
Fix / Improve Pick Part Action Error Messages 

### DIFF
--- a/src/main/java/org/openpnp/gui/PackagesPanel.java
+++ b/src/main/java/org/openpnp/gui/PackagesPanel.java
@@ -428,7 +428,7 @@ public class PackagesPanel extends JPanel implements WizardContainer {
         tabbedPane.removeAll();
         if (selectedPackage != null) {
             tabbedPane.add("Nozzle Tips", new PackageNozzleTipsPanel(selectedPackage));
-            tabbedPane.add("Vision", new JScrollPane(new PackageVisionPanel(selectedPackage)));
+            tabbedPane.add("Footprint", new JScrollPane(new PackageVisionPanel(selectedPackage)));
             tabbedPane.add("Settings", new JScrollPane(new PackageSettingsPanel(selectedPackage)));
             Machine machine = Configuration.get().getMachine();
             for (PartAlignment partAlignment : machine.getPartAlignments()) {

--- a/src/main/java/org/openpnp/machine/reference/ReferenceNozzle.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceNozzle.java
@@ -620,9 +620,9 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
             throw new Exception("Can't load incompatible nozzle tip.");
         }
 
-        if (nt.getNozzleAttachedTo() != null) {
+        if (nt.getNozzleWhereLoaded() != null) {
             // Nozzle tip is on different nozzle - unload it from there first.  
-            nt.getNozzleAttachedTo().unloadNozzleTip();
+            nt.getNozzleWhereLoaded().unloadNozzleTip();
         }
 
         unloadNozzleTip();

--- a/src/main/java/org/openpnp/machine/reference/ReferenceNozzleTip.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceNozzleTip.java
@@ -511,7 +511,8 @@ public class ReferenceNozzleTip extends AbstractNozzleTip {
         firePropertyChange("visionCalibrationTrigger", oldValue, visionCalibrationTrigger);
     }
 
-    public ReferenceNozzle getNozzleAttachedTo() {
+    @Override
+    public ReferenceNozzle getNozzleWhereLoaded() {
         for (Head head : Configuration.get().getMachine().getHeads()) {
             for (Nozzle nozzle : head.getNozzles()) {
                 if (nozzle instanceof ReferenceNozzle) {
@@ -715,7 +716,7 @@ public class ReferenceNozzleTip extends AbstractNozzleTip {
      */
     public Length getCalibrationOffsetZ() {
         Length offsetZ = null;
-        Nozzle nozzle = getNozzleAttachedTo();
+        Nozzle nozzle = getNozzleWhereLoaded();
         if (nozzle instanceof ContactProbeNozzle) {
             offsetZ = ((ContactProbeNozzle) nozzle).getCalibrationOffsetZ();
         }
@@ -1193,7 +1194,7 @@ public class ReferenceNozzleTip extends AbstractNozzleTip {
                 Mat templateMatOccupied = OpenCvUtils.toMat(templateOccupied);
                 try {
                     Location originalLocation = location;
-                    boolean shouldBeOccupied = (getNozzleAttachedTo() == null);
+                    boolean shouldBeOccupied = (getNozzleWhereLoaded() == null);
                     for (int pass = 0; pass < visionCalibrationMaxPasses; ++pass) {
                         BufferedImage cameraImage = camera.lightSettleAndCapture();
                         int x = (cameraImage.getWidth() - width) / 2;

--- a/src/main/java/org/openpnp/machine/reference/wizards/ReferenceNozzleTipCalibrationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/wizards/ReferenceNozzleTipCalibrationWizard.java
@@ -554,7 +554,7 @@ public class ReferenceNozzleTipCalibrationWizard extends AbstractConfigurationWi
         }
         else {
             // For real nozzle tips, the nozzle where it is currently attached to is well-defined.
-            refNozzle = nozzleTip.getNozzleAttachedTo();
+            refNozzle = nozzleTip.getNozzleWhereLoaded();
             if (refNozzle == null) {
                 throw new Exception("Please load the nozzle tip on a nozzle.");
             }

--- a/src/main/java/org/openpnp/spi/NozzleTip.java
+++ b/src/main/java/org/openpnp/spi/NozzleTip.java
@@ -28,4 +28,9 @@ public interface NozzleTip extends Identifiable, Named, Solutions.Subject, Wizar
      * @throws Exception
      */
     void home() throws Exception;
+
+    /**
+     * @return the Nozzle where this tip is currently loaded, or null.
+     */
+    Nozzle getNozzleWhereLoaded();
 }


### PR DESCRIPTION
# Description

This is about nozzle tips compatible with the selected nozzle and with the package to be picked. It is primarily used in the various **Pick** actions:

![Pick Action Button](https://user-images.githubusercontent.com/9963310/177035078-c545fe1b-e5b7-4dd7-9a22-994516442a53.png)

If the nozzle tip on the currently selected nozzle is not compatible, the function tries to load a compatible nozzle tip, if automatic loading is enabled. Conversely, if automatic nozzle tip loading is disabled, the user is told to consider switching it on.

This fix handles some complications:

- The automatic nozzle tip loading option was suggested, even though it was already on (but another condition prevented it from happening).
- A compatible nozzle tip could be already loaded on another nozzle, so the user is instead told to select the other nozzle instead.
- A part could already be loaded on the selected nozzle, preventing nozzle tip unloading/loading in the first place.
- The user is reminded that the pick always happens with the nozzle selected in the Machine Controls.
- Note: an automatic nozzle selection is not admissible, as it might be dangerous on a half-finished machine.

The method `org.openpnp.spi.NozzleTip.getNozzleWhereLoaded()` is promoted to the `Nozzle` interface to be made available outside `ReferenceNozzleTip`. The method was renamed from "attached" to match nomenclature of `Nozzle.loadNozzleTip()`, some existing calls had to be refactored.

# Justification
While developing another feature I was repeatedly misled by erroneous and incomplete messages. 

# Instructions for Use

Use as before. Error messages will now correctly and fully describe what is wrong (the example shows how multiple things can be wrong/suggested):

![Pick Error Messages](https://user-images.githubusercontent.com/9963310/177035528-83155082-3702-443b-b530-0fe6e5c09a03.png)

# Implementation Details
1. Tested in dual nozzle simulation.
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. Added  `org.openpnp.spi.NozzleTip.getNozzleWhereLoaded()` as documented.
4. Successful `mvn test` before submitting the Pull Request.
