### PR TITLE
Feature / MinAreaRect partial Edges

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/vision/ReferenceBottomVision.java
+++ b/src/main/java/org/openpnp/machine/reference/vision/ReferenceBottomVision.java
@@ -418,6 +418,8 @@ public class ReferenceBottomVision extends AbstractPartAlignment {
             partSize = bottomVisionSettings.getPartCheckSize(nozzle.getPart(), true);
         }
         // Set alignment parameters.
+        pipeline.setProperty("MinAreaRect.center", wantedLocation);
+        pipeline.setProperty("MinAreaRect.expectedAngle", wantedLocation.getRotation());
         pipeline.setProperty("DetectRectlinearSymmetry.center", wantedLocation);
         pipeline.setProperty("DetectRectlinearSymmetry.expectedAngle", wantedLocation.getRotation());
         // Set the background removal properties.

--- a/src/main/java/org/openpnp/vision/pipeline/stages/MinAreaRect.java
+++ b/src/main/java/org/openpnp/vision/pipeline/stages/MinAreaRect.java
@@ -1,29 +1,64 @@
 package org.openpnp.vision.pipeline.stages;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import org.opencv.core.Mat;
 import org.opencv.core.MatOfPoint2f;
 import org.opencv.core.Point;
 import org.opencv.core.RotatedRect;
+import org.opencv.core.Scalar;
+import org.opencv.core.Size;
 import org.opencv.imgproc.Imgproc;
+import org.openpnp.model.Location;
+import org.openpnp.util.Utils2D;
 import org.openpnp.vision.FluentCv;
 import org.openpnp.vision.pipeline.CvPipeline;
 import org.openpnp.vision.pipeline.CvStage;
+import org.openpnp.vision.pipeline.Property;
+import org.openpnp.vision.pipeline.Stage;
 import org.simpleframework.xml.Attribute;
 
 /**
  * Finds the smallest rotated rectangle that encloses pixels that fall within the given range.
  * Input should be a grayscale image. 
  */
+@Stage(description="Finds the smallest rotated rectangle that encloses pixels that fall within the given range.\n"
+        + "Input should be a grayscale image.")
 public class MinAreaRect extends CvStage {
     @Attribute
+    @Property(description = "Threshold minimum grayscale value of the pixel to be considered \"set\".")
     private int thresholdMin;
-    
+
     @Attribute
+    @Property(description = "Threshold mayimum grayscale value of the pixel to be considered \"set\".")
     private int thresholdMax;
-    
+
+    @Attribute(required = false)
+    @Property(description = "Expected angle of the rectangular hull to be detected.")
+    private double expectedAngle = 0;
+
+    @Attribute(required = false)
+    @Property(description = "Detect the left edge of the rectangle (rotated to expectedAngle).")
+    private boolean leftEdge = true;
+
+    @Attribute(required = false)
+    @Property(description = "Detect the right edge of the rectangle (rotated to expectedAngle).")
+    private boolean rightEdge = true;
+
+    @Attribute(required = false)
+    @Property(description = "Detect the top edge of the rectangle (rotated to expectedAngle).")
+    private boolean topEdge = true;
+
+    @Attribute(required = false)
+    @Property(description = "Detect the bottom edge of the rectangle (rotated to expectedAngle).")
+    private boolean bottomEdge = true;
+
+    @Attribute(required = false)
+    @Property(description = "Display the detection result diagnostics.")
+    private boolean diagnostics = false;
+
     public int getThresholdMin() {
         return thresholdMin;
     }
@@ -39,32 +74,278 @@ public class MinAreaRect extends CvStage {
     public void setThresholdMax(int thresholdMax) {
         this.thresholdMax = thresholdMax;
     }
-    
-    
+
+    public double getExpectedAngle() {
+        return expectedAngle;
+    }
+
+    public void setExpectedAngle(double expectedAngle) {
+        this.expectedAngle = expectedAngle;
+    }
+
+    public boolean isLeftEdge() {
+        return leftEdge;
+    }
+
+    public void setLeftEdge(boolean leftEdge) {
+        this.leftEdge = leftEdge;
+    }
+
+    public boolean isRightEdge() {
+        return rightEdge;
+    }
+
+    public void setRightEdge(boolean rightEdge) {
+        this.rightEdge = rightEdge;
+    }
+
+    public boolean isBottomEdge() {
+        return bottomEdge;
+    }
+
+    public void setTopEdge(boolean topEdge) {
+        this.topEdge = topEdge;
+    }
+
+    public boolean isDiagnostics() {
+        return diagnostics;
+    }
+
+    public void setBottomEdge(boolean bottomEdge) {
+        this.bottomEdge = bottomEdge;
+    }
+
+    public boolean isTopEdge() {
+        return topEdge;
+    }
+
+    public void setDiagnostics(boolean diagnostics) {
+        this.diagnostics = diagnostics;
+    }
+
+    public String getPropertyName() {
+        return propertyName;
+    }
+
+    public void setPropertyName(String propertyName) {
+        this.propertyName = propertyName;
+    }
+
+    @Attribute(required = false)
+    @Property(description = "determines the pipeline property name under which this stage is controlled by the vision operation. "
+            + "If set, these will override some of the properties configured here. Use \"MinAreaRect\" for default control.")
+    private String propertyName = "MinAreaRect";
+
+
     @Override
     public Result process(CvPipeline pipeline) throws Exception {
         if (pipeline.getWorkingColorSpace() != FluentCv.ColorSpace.Gray){
             throw new Exception(String.format("%s is not compatible with %s colorspace. Only Grey colorspace is supported.", MinAreaRect.class.getSimpleName(), pipeline.getWorkingColorSpace()));
         }
-
         Mat mat = pipeline.getWorkingImage();
+        Point center = new Point(mat.cols()*0.5, mat.rows()*0.5);
+        double expectedAngle = getExpectedAngle();
+        boolean leftEdge = isLeftEdge();
+        boolean rightEdge = isRightEdge();
+        boolean topEdge = isTopEdge();
+        boolean bottomEdge = isBottomEdge();
+
+        if (!propertyName.isEmpty()) {
+
+            center = getPossiblePipelinePropertyOverride(center, pipeline, 
+                    propertyName + ".center", Point.class, org.opencv.core.Point.class, 
+                    Location.class);
+
+            expectedAngle = getPossiblePipelinePropertyOverride(expectedAngle, pipeline, 
+                    propertyName + ".expectedAngle", Double.class, Integer.class);
+
+            leftEdge = getPossiblePipelinePropertyOverride(leftEdge, pipeline, 
+                    propertyName + ".leftEdge");
+            rightEdge = getPossiblePipelinePropertyOverride(rightEdge, pipeline, 
+                    propertyName + ".rightEdge");
+            topEdge = getPossiblePipelinePropertyOverride(topEdge, pipeline, 
+                    propertyName + ".topEdge");
+            bottomEdge = getPossiblePipelinePropertyOverride(bottomEdge, pipeline, 
+                    propertyName + ".bottomEdge");
+        }
+
         List<Point> points = new ArrayList<>();
         byte[] rowData = new byte[mat.cols()];
-        for (int row = 0, rows = mat.rows(); row < rows; row++) {
+        final int cols = mat.cols();
+        final int rows = mat.rows();
+        // Only take the set pixels that are the first or last pixel in BOTH their horizontal AND vertical 
+        // scan-lines. These few pixels are sufficient to stake out the convex hull of the subject. 
+        int[] firstRowVertical = new int[cols]; 
+        int[] lastRowVertical = new int[cols];
+        // -1 means uninitialized.
+        Arrays.fill(firstRowVertical, -1);
+        for (int row = 0; row < rows; row++) {
             mat.get(row, 0, rowData);
-            for (int col = 0, cols = mat.cols(); col < cols; col++) {
+            int firstColHorizontal = -1;
+            int lastColHorizontal = -1;
+            for (int col = 0; col < cols; col++) {
                 int pixel = ((int) rowData[col]) & 0xff;
                 if (pixel >= thresholdMin && pixel <= thresholdMax) {
-                    points.add(new Point(col, row));
+                    if (firstColHorizontal < 0) {
+                        firstColHorizontal = col;
+                    }
+                    lastColHorizontal = col;
+                }
+            }
+            if (firstColHorizontal >= 0) {
+                if (firstRowVertical[firstColHorizontal] < 0) {
+                    firstRowVertical[firstColHorizontal] = row;
+                }
+                if (firstRowVertical[lastColHorizontal] < 0) {
+                    firstRowVertical[lastColHorizontal] = row;
+                }
+                lastRowVertical[firstColHorizontal] = row;
+                lastRowVertical[lastColHorizontal] = row;
+            }
+        }
+        if (diagnostics) {
+            mat.setTo(new Scalar(0, 0, 0));
+        }
+        for (int col = 0; col < cols; col++) {
+            if (firstRowVertical[col] >= 0) {
+                points.add(new Point(col, firstRowVertical[col]));
+                points.add(new Point(col, lastRowVertical[col]));
+                if (diagnostics) {
+                    byte[] pixelData = new byte[] { -1 };
+                    mat.put(firstRowVertical[col], col, pixelData);
+                    mat.put(lastRowVertical[col], col, pixelData);
                 }
             }
         }
         if (points.isEmpty()) {
             return null;
         }
-        MatOfPoint2f pointsMat = new MatOfPoint2f(points.toArray(new Point[]{}));
-        RotatedRect r = Imgproc.minAreaRect(pointsMat);
-        pointsMat.release();
+        RotatedRect r;
+        if (leftEdge && rightEdge && bottomEdge && topEdge) {
+            // All edges, use OpenCv method.
+            MatOfPoint2f pointsMat = new MatOfPoint2f(points.toArray(new Point[points.size()]));
+            r = Imgproc.minAreaRect(pointsMat);
+            pointsMat.release();
+
+            // Rotate nearest to expectedAngle in 90° steps.
+            // Note, the angles in RotatedRect are left-handed (we reverse the sign).
+            int steps90 = (int) Math.round((expectedAngle + r.angle)/90);
+            if (steps90 != 0) {
+                if ((steps90 & 1) != 0) {
+                    // Odd 90° rotation, must swap size
+                    r = new RotatedRect(
+                            r.center, 
+                            new Size(r.size.height, r.size.width), 
+                            Utils2D.angleNorm(r.angle - steps90*90, 180));
+                }
+                else {
+                    r = new RotatedRect(
+                            r.center, 
+                            r.size, 
+                            Utils2D.angleNorm(r.angle - steps90*90, 180));
+                }
+            }
+        }
+        else {
+            // Partial edges, use own method.
+            // Translate points to center relative.
+            for (Point p : points) {
+                p.x -= center.x;
+                p.y -= center.y;
+            }
+            // Detect the minimum area edges.
+            r = minAreaEdges(points, leftEdge, rightEdge, topEdge, bottomEdge, 
+                    expectedAngle, 45, 
+                    cols, rows);
+            // Translate rotated rect back to mat coordinates. 
+            if (r != null) {
+                r = new RotatedRect(
+                        new Point(center.x + r.center.x, center.y + r.center.y), 
+                        r.size, 
+                        r.angle);
+            }
+        }
         return new Result(null, r);
+    }
+
+    private final static int stepsPerSearch = 18;
+    private final static double angularResolution = 0.01;
+
+    public static RotatedRect minAreaEdges(List<Point> points,
+            boolean leftEdge, boolean rightEdge,
+            boolean topEdge, boolean bottomEdge, 
+            double expectedAngle, double searchAngle,  
+            int cols, int rows) {
+        // Search the best angle.
+        double bestArea = Double.POSITIVE_INFINITY;
+        double bestAngle = Double.NaN;
+        RotatedRect bestRect = null;
+        final double unbounded = Math.hypot(cols, rows);
+        final double step = searchAngle/stepsPerSearch;
+        final double da = Math.toRadians(step);
+        for (double angle = Math.toRadians(expectedAngle - searchAngle), 
+                angleMax = Math.toRadians(angleMax = expectedAngle + searchAngle); 
+                angle < angleMax; 
+                angle += da) {
+            // Note this is the OpenCv 2D left-handed coordinate system, Y pointing down.
+            double s = Math.sin(angle);
+            double c = Math.cos(angle);
+            double x0 = Double.POSITIVE_INFINITY;
+            double x1 = Double.NEGATIVE_INFINITY;
+            double y0 = Double.POSITIVE_INFINITY;
+            double y1 = Double.NEGATIVE_INFINITY;
+            for (Point p : points) {
+                // Rotate the point to neutral from detection angle.
+                double x = c*p.x + -s*p.y;
+                double y = s*p.x + c*p.y;
+                if (x0 > x) {
+                    x0 = x;
+                }
+                if (x1 < x) {
+                    x1 = x;
+                }
+                if (y0 > y) {
+                    y0 = y;
+                }
+                if (y1 < y) {
+                    y1 = y;
+                }
+            }
+            // Enlarge unbounded edges to the maximum.
+            if (!leftEdge) {
+                x0 = -unbounded;
+            }
+            if (!rightEdge) {
+                x1 = +unbounded;
+            }
+            if (!topEdge) {
+                y0 = -unbounded;
+            }
+            if (!bottomEdge) {
+                y1 = +unbounded;
+            }
+            // calculate the area
+            double area = (x1 - x0)*(y1 - y0);
+            if (bestArea > area) {
+                bestArea = area;
+                double dx = (x0 + x1)/2;
+                double dy = (y0 + y1)/2;
+                double px = c*dx + s*dy;
+                double py = -s*dx + c*dy;
+                bestAngle = Math.toDegrees(angle);
+                bestRect = new RotatedRect(
+                        new Point(px, py), 
+                        new Size(x1 - x0, y1 - y0), 
+                        -bestAngle);
+            }
+        }
+        if (step > angularResolution) {
+            // Refine in recursion.
+            return minAreaEdges(points, leftEdge, rightEdge, topEdge, bottomEdge, 
+                    bestAngle, step, cols, rows);
+        }
+        else {
+            return bestRect;
+        }
     }
 }


### PR DESCRIPTION
# Description

The `MinAreaRect` stage is extended to allow detection of less that four edges of the Rectangle.

This PR contains the following parts:

- Adds the new selective edge detection. See **Instructions for Use**.
- Optimize the pixels that are taken into consideration. Only threshold-selected pixels that are at the first or last of **both** a vertical **and** horizontal scan-line are considered. These are enough to define the convex hull of the subject. A small pixel list greatly reduces the amount of computation in the new (and old) `MinAreaRect` algorithm. 
      ![hull pixels](https://user-images.githubusercontent.com/9963310/177055104-4aca4b62-8dbb-403f-8bd0-fc29448acd8b.png)
- This also allows to optionally use (grayscale) subject images directly, regardless of how large the threshold-selected areas are. Contour detection and redrawing is no longer required. 
- In order to determine the sense of what is "left", "right", "top" and "bottom", the `expectedAngle` is introduced, and controlled by bottom vision. For other uses of the stage the angle remains irrelevant (you can leave it at zero).
- As a side benefit, the detected angle is now always made to be within ±45° of the `expectedAngle`. The detected rectangle will respect what is the "width" and what is the "height" correctly.

# Justification
This will be used to detect multi-shot Bottom Vision, where packages that are too large for the camera view, are detected with multiple corner shots. By using the augmented `MinAreaRect`, we can composite an overall bounding box from multiple shots. 

The new detection method is almost as fast as the OpenCV implementation (sub-millisecond stage time). Nevertheless, if all edges are switched **on**, the OpenCv method is still used as before. 

The upgrade is carefully crafted to allow existing pipelines (including the standard one) to continue to be used even for multiple corner shots.

# Instructions for Use
The MinAreaRect stage finds the smallest rotated rectangle that encloses pixels that fall within the given brightness range. Input should be a grayscale image.

![MinAreaRect partial edges](https://user-images.githubusercontent.com/9963310/177054694-9e1e339c-3dd0-4335-ae8e-26ae7e798cd9.png)

- **thresholdMin**: the minimum brightness to include the pixel. 
- **thresholdMax**: the maximum brightness to include the pixel. 
- **expectedAngle**: the angle at which the rectangular outline is expected. This will usually be controlled by the pipeline caller. In bottom vision, it will supply the (pre-rotate) angle of the part to be detected. For use cases other than bottom vision, and conventional all-edges detection, the angle remains irrelevant. 
- **leftEdge**, **rightEdge**, **topEdge**, **bottomEdge**: the four edges of the rectangle to be detected. If a switch is **off**, the edge is not considered in fitting the rectangle, i.e. the subject can be non-rectangular on this side. This is typically the case when the camera can only get a partial view of a large subject. The sense of "left", "right", "top" and "bottom" is at neutral rotation, i.e. when the **expectedAngle** is at zero degrees, e.g., when the part to be detected in bottom vision is upright. This sense will be rotated correctly for other **expectedAngle**s. 
- **diagnostics**: this can be used to display the edge pixels that are considered for the convex hull of the subject.  
   ![hull pixels](https://user-images.githubusercontent.com/9963310/177055104-4aca4b62-8dbb-403f-8bd0-fc29448acd8b.png)
- **propertyName**: determines the pipeline property name under which this stage is controlled by the vision operation. If set, these will override some of the properties configured here. Use "MinAreaRect" for default control.

# Implementation Details
1. Tested in simulation.
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. Successful `mvn test` before submitting the Pull Request.
