### PR TITLE
Feature / Footprint Generator

### DIFF
--- a/src/main/java/org/openpnp/gui/support/Icons.java
+++ b/src/main/java/org/openpnp/gui/support/Icons.java
@@ -116,6 +116,10 @@ public class Icons {
     public static Icon safeZDynamic = getIcon("/icons/safe-z-dynamic.svg", 96, 96);
     public static Icon safeZCapture = getIcon("/icons/safe-z-capture.svg", 96, 96);
 
+    public static Icon footprintQuad = getIcon("/icons/footprint-quad.svg");
+    public static Icon footprintDual = getIcon("/icons/footprint-dual.svg");
+    public static Icon footprintBga = getIcon("/icons/footprint-bga.svg");
+
     public static Icon getIcon(String resourceName, int width, int height) {
         if (resourceName.endsWith(".svg")) {
             return new FlatSVGIcon(resourceName.substring(1), width, height);

--- a/src/main/java/org/openpnp/model/Footprint.java
+++ b/src/main/java/org/openpnp/model/Footprint.java
@@ -33,7 +33,7 @@ import org.simpleframework.xml.ElementList;
  * A Footprint is a group of SMD pads along with length unit information. Footprints can be rendered
  * to a Shape for easy display using 2D primitives.
  */
-public class Footprint {
+public class Footprint extends AbstractModelObject{
     @Attribute
     private LengthUnit units = LengthUnit.Millimeters;
 
@@ -45,6 +45,24 @@ public class Footprint {
 
     @Attribute(required = false)
     private double bodyHeight;
+
+    @Attribute(required = false)
+    private double outerDimension;
+
+    @Attribute(required = false)
+    private double innerDimension;
+
+    @Attribute(required = false)
+    private int padCount;
+
+    @Attribute(required = false)
+    private double padPitch;
+
+    @Attribute(required = false)
+    private double padAcross;
+
+    @Attribute(required = false)
+    private double padRoundness;
 
     public Shape getShape() {
         Path2D.Double shape = new Path2D.Double();
@@ -93,6 +111,10 @@ public class Footprint {
         pads.remove(pad);
     }
 
+    public void removeAllPads() {
+        pads = new ArrayList<>();
+    }
+
     public void addPad(Pad pad) {
         pads.add(pad);
     }
@@ -102,7 +124,9 @@ public class Footprint {
     }
 
     public void setBodyWidth(double bodyWidth) {
+        Object oldValue = this.bodyWidth;
         this.bodyWidth = bodyWidth;
+        firePropertyChange("bodyWidth", oldValue, bodyWidth);
     }
 
     public double getBodyHeight() {
@@ -110,7 +134,71 @@ public class Footprint {
     }
 
     public void setBodyHeight(double bodyHeight) {
+        Object oldValue = this.bodyHeight;
         this.bodyHeight = bodyHeight;
+        firePropertyChange("bodyHeight", oldValue, bodyHeight);
+    }
+
+
+
+    public double getOuterDimension() {
+        return outerDimension;
+    }
+
+    public void setOuterDimension(double outerDimension) {
+        Object oldValue = this.outerDimension;
+        this.outerDimension = outerDimension;
+        firePropertyChange("outerDimension", oldValue, outerDimension);
+    }
+
+    public double getInnerDimension() {
+        return innerDimension;
+    }
+
+    public void setInnerDimension(double innerDimension) {
+        Object oldValue = this.innerDimension;
+        this.innerDimension = innerDimension;
+        firePropertyChange("innerDimension", oldValue, innerDimension);
+    }
+
+    public int getPadCount() {
+        return padCount;
+    }
+
+    public void setPadCount(int padCount) {
+        Object oldValue = this.padCount;
+        this.padCount = padCount;
+        firePropertyChange("padCount", oldValue, padCount);
+    }
+
+    public double getPadPitch() {
+        return padPitch;
+    }
+
+    public void setPadPitch(double padPitch) {
+        Object oldValue = this.padPitch;
+        this.padPitch = padPitch;
+        firePropertyChange("padPitch", oldValue, padPitch);
+    }
+
+    public double getPadAcross() {
+        return padAcross;
+    }
+
+    public void setPadAcross(double padAcross) {
+        Object oldValue = this.padAcross;
+        this.padAcross = padAcross;
+        firePropertyChange("padAcross", oldValue, padAcross);
+    }
+
+    public double getPadRoundness() {
+        return padRoundness;
+    }
+
+    public void setPadRoundness(double padRoundness) {
+        Object oldValue = this.padRoundness;
+        this.padRoundness = padRoundness;
+        firePropertyChange("padRoundness", oldValue, padRoundness);
     }
 
 

--- a/src/main/resources/icons/footprint-bga.svg
+++ b/src/main/resources/icons/footprint-bga.svg
@@ -1,0 +1,202 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="24"
+   height="24"
+   viewBox="0 0 24 24"
+   version="1.1"
+   id="svg2"
+   sodipodi:docname="footprint-bga.svg"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview20"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="true"
+     inkscape:zoom="26.833333"
+     inkscape:cx="11.981367"
+     inkscape:cy="11.981367"
+     inkscape:window-width="3840"
+     inkscape:window-height="2082"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid837" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata15">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>contact-probe-nozzle</dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <!-- Generator: Sketch 3.2.2 (9983) - http://www.bohemiancoding.com/sketch -->
+  <title
+     id="title4">contact-probe-nozzle</title>
+  <desc
+     id="desc6">Created with Sketch.</desc>
+  <defs
+     id="defs8" />
+  <circle
+     style="fill:#005bdc;fill-opacity:0.992157;stroke-width:1.012;stroke-dasharray:8.096, 1.012;stroke-dashoffset:10.12"
+     id="path1131"
+     cx="8"
+     cy="4"
+     r="1" />
+  <circle
+     style="fill:#005bdc;fill-opacity:0.992157;stroke-width:1.012;stroke-dasharray:8.096, 1.012;stroke-dashoffset:10.12"
+     id="path1131-2"
+     cx="4"
+     cy="4"
+     r="1" />
+  <circle
+     style="fill:#005bdc;fill-opacity:0.992157;stroke-width:1.012;stroke-dasharray:8.096, 1.012;stroke-dashoffset:10.12"
+     id="path1131-9"
+     cx="16"
+     cy="4"
+     r="1" />
+  <circle
+     style="fill:#005bdc;fill-opacity:0.992157;stroke-width:1.012;stroke-dasharray:8.096, 1.012;stroke-dashoffset:10.12"
+     id="path1131-9-1"
+     cx="20"
+     cy="4"
+     r="1" />
+  <circle
+     style="fill:#005bdc;fill-opacity:0.992157;stroke-width:1.012;stroke-dasharray:8.096, 1.012;stroke-dashoffset:10.12"
+     id="path1131-6"
+     cx="12"
+     cy="4"
+     r="1" />
+  <circle
+     style="fill:#005bdc;fill-opacity:0.992157;stroke-width:1.012;stroke-dasharray:8.096, 1.012;stroke-dashoffset:10.12"
+     id="path1131-23"
+     cx="8"
+     cy="20"
+     r="1" />
+  <circle
+     style="fill:#005bdc;fill-opacity:0.992157;stroke-width:1.012;stroke-dasharray:8.096, 1.012;stroke-dashoffset:10.12"
+     id="path1131-2-7"
+     cx="4"
+     cy="20"
+     r="1" />
+  <circle
+     style="fill:#005bdc;fill-opacity:0.992157;stroke-width:1.012;stroke-dasharray:8.096, 1.012;stroke-dashoffset:10.12"
+     id="path1131-9-5"
+     cx="16"
+     cy="20"
+     r="1" />
+  <circle
+     style="fill:#005bdc;fill-opacity:0.992157;stroke-width:1.012;stroke-dasharray:8.096, 1.012;stroke-dashoffset:10.12"
+     id="path1131-9-1-9"
+     cx="20"
+     cy="20"
+     r="1" />
+  <circle
+     style="fill:#005bdc;fill-opacity:0.992157;stroke-width:1.012;stroke-dasharray:8.096, 1.012;stroke-dashoffset:10.12"
+     id="path1131-6-2"
+     cx="12"
+     cy="20"
+     r="1" />
+  <circle
+     style="fill:#005bdc;fill-opacity:0.992157;stroke-width:1.012;stroke-dasharray:8.096, 1.012;stroke-dashoffset:10.12"
+     id="path1131-27"
+     cx="8"
+     cy="8"
+     r="1" />
+  <circle
+     style="fill:#005bdc;fill-opacity:0.992157;stroke-width:1.012;stroke-dasharray:8.096, 1.012;stroke-dashoffset:10.12"
+     id="path1131-2-0"
+     cx="4"
+     cy="8"
+     r="1" />
+  <circle
+     style="fill:#005bdc;fill-opacity:0.992157;stroke-width:1.012;stroke-dasharray:8.096, 1.012;stroke-dashoffset:10.12"
+     id="path1131-9-9"
+     cx="16"
+     cy="8"
+     r="1" />
+  <circle
+     style="fill:#005bdc;fill-opacity:0.992157;stroke-width:1.012;stroke-dasharray:8.096, 1.012;stroke-dashoffset:10.12"
+     id="path1131-9-1-3"
+     cx="20"
+     cy="8"
+     r="1" />
+  <circle
+     style="fill:#005bdc;fill-opacity:0.992157;stroke-width:1.012;stroke-dasharray:8.096, 1.012;stroke-dashoffset:10.12"
+     id="path1131-6-6"
+     cx="12"
+     cy="8"
+     r="1" />
+  <circle
+     style="fill:#005bdc;fill-opacity:0.992157;stroke-width:1.012;stroke-dasharray:8.096, 1.012;stroke-dashoffset:10.12"
+     id="path1131-0"
+     cx="8"
+     cy="12"
+     r="1" />
+  <circle
+     style="fill:#005bdc;fill-opacity:0.992157;stroke-width:1.012;stroke-dasharray:8.096, 1.012;stroke-dashoffset:10.12"
+     id="path1131-2-6"
+     cx="4"
+     cy="12"
+     r="1" />
+  <circle
+     style="fill:#005bdc;fill-opacity:0.992157;stroke-width:1.012;stroke-dasharray:8.096, 1.012;stroke-dashoffset:10.12"
+     id="path1131-9-2"
+     cx="16"
+     cy="12"
+     r="1" />
+  <circle
+     style="fill:#005bdc;fill-opacity:0.992157;stroke-width:1.012;stroke-dasharray:8.096, 1.012;stroke-dashoffset:10.12"
+     id="path1131-9-1-6"
+     cx="20"
+     cy="12"
+     r="1" />
+  <circle
+     style="fill:#005bdc;fill-opacity:0.992157;stroke-width:1.012;stroke-dasharray:8.096, 1.012;stroke-dashoffset:10.12"
+     id="path1131-27-8"
+     cx="8"
+     cy="16"
+     r="1" />
+  <circle
+     style="fill:#005bdc;fill-opacity:0.992157;stroke-width:1.012;stroke-dasharray:8.096, 1.012;stroke-dashoffset:10.12"
+     id="path1131-2-0-7"
+     cx="4"
+     cy="16"
+     r="1" />
+  <circle
+     style="fill:#005bdc;fill-opacity:0.992157;stroke-width:1.012;stroke-dasharray:8.096, 1.012;stroke-dashoffset:10.12"
+     id="path1131-9-9-9"
+     cx="16"
+     cy="16"
+     r="1" />
+  <circle
+     style="fill:#005bdc;fill-opacity:0.992157;stroke-width:1.012;stroke-dasharray:8.096, 1.012;stroke-dashoffset:10.12"
+     id="path1131-9-1-3-2"
+     cx="20"
+     cy="16"
+     r="1" />
+  <circle
+     style="fill:#005bdc;fill-opacity:0.992157;stroke-width:1.012;stroke-dasharray:8.096, 1.012;stroke-dashoffset:10.12"
+     id="path1131-6-6-0"
+     cx="12"
+     cy="16"
+     r="1" />
+</svg>

--- a/src/main/resources/icons/footprint-bga_dark.svg
+++ b/src/main/resources/icons/footprint-bga_dark.svg
@@ -1,0 +1,202 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="24"
+   height="24"
+   viewBox="0 0 24 24"
+   version="1.1"
+   id="svg2"
+   sodipodi:docname="footprint-bga_dark.svg"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview20"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="true"
+     inkscape:zoom="26.833333"
+     inkscape:cx="11.981367"
+     inkscape:cy="11.981367"
+     inkscape:window-width="3840"
+     inkscape:window-height="2082"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid837" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata15">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>contact-probe-nozzle</dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <!-- Generator: Sketch 3.2.2 (9983) - http://www.bohemiancoding.com/sketch -->
+  <title
+     id="title4">contact-probe-nozzle</title>
+  <desc
+     id="desc6">Created with Sketch.</desc>
+  <defs
+     id="defs8" />
+  <circle
+     style="fill:#0070ff;fill-opacity:0.99215686;stroke-width:1.012;stroke-dasharray:8.096, 1.012;stroke-dashoffset:10.12"
+     id="path1131"
+     cx="8"
+     cy="4"
+     r="1" />
+  <circle
+     style="fill:#0070ff;fill-opacity:0.99215686;stroke-width:1.012;stroke-dasharray:8.096, 1.012;stroke-dashoffset:10.12"
+     id="path1131-2"
+     cx="4"
+     cy="4"
+     r="1" />
+  <circle
+     style="fill:#0070ff;fill-opacity:0.99215686;stroke-width:1.012;stroke-dasharray:8.096, 1.012;stroke-dashoffset:10.12"
+     id="path1131-9"
+     cx="16"
+     cy="4"
+     r="1" />
+  <circle
+     style="fill:#0070ff;fill-opacity:0.99215686;stroke-width:1.012;stroke-dasharray:8.096, 1.012;stroke-dashoffset:10.12"
+     id="path1131-9-1"
+     cx="20"
+     cy="4"
+     r="1" />
+  <circle
+     style="fill:#0070ff;fill-opacity:0.99215686;stroke-width:1.012;stroke-dasharray:8.096, 1.012;stroke-dashoffset:10.12"
+     id="path1131-6"
+     cx="12"
+     cy="4"
+     r="1" />
+  <circle
+     style="fill:#0070ff;fill-opacity:0.99215686;stroke-width:1.012;stroke-dasharray:8.096, 1.012;stroke-dashoffset:10.12"
+     id="path1131-23"
+     cx="8"
+     cy="20"
+     r="1" />
+  <circle
+     style="fill:#0070ff;fill-opacity:0.99215686;stroke-width:1.012;stroke-dasharray:8.096, 1.012;stroke-dashoffset:10.12"
+     id="path1131-2-7"
+     cx="4"
+     cy="20"
+     r="1" />
+  <circle
+     style="fill:#0070ff;fill-opacity:0.99215686;stroke-width:1.012;stroke-dasharray:8.096, 1.012;stroke-dashoffset:10.12"
+     id="path1131-9-5"
+     cx="16"
+     cy="20"
+     r="1" />
+  <circle
+     style="fill:#0070ff;fill-opacity:0.99215686;stroke-width:1.012;stroke-dasharray:8.096, 1.012;stroke-dashoffset:10.12"
+     id="path1131-9-1-9"
+     cx="20"
+     cy="20"
+     r="1" />
+  <circle
+     style="fill:#0070ff;fill-opacity:0.99215686;stroke-width:1.012;stroke-dasharray:8.096, 1.012;stroke-dashoffset:10.12"
+     id="path1131-6-2"
+     cx="12"
+     cy="20"
+     r="1" />
+  <circle
+     style="fill:#0070ff;fill-opacity:0.99215686;stroke-width:1.012;stroke-dasharray:8.096, 1.012;stroke-dashoffset:10.12"
+     id="path1131-27"
+     cx="8"
+     cy="8"
+     r="1" />
+  <circle
+     style="fill:#0070ff;fill-opacity:0.99215686;stroke-width:1.012;stroke-dasharray:8.096, 1.012;stroke-dashoffset:10.12"
+     id="path1131-2-0"
+     cx="4"
+     cy="8"
+     r="1" />
+  <circle
+     style="fill:#0070ff;fill-opacity:0.99215686;stroke-width:1.012;stroke-dasharray:8.096, 1.012;stroke-dashoffset:10.12"
+     id="path1131-9-9"
+     cx="16"
+     cy="8"
+     r="1" />
+  <circle
+     style="fill:#0070ff;fill-opacity:0.99215686;stroke-width:1.012;stroke-dasharray:8.096, 1.012;stroke-dashoffset:10.12"
+     id="path1131-9-1-3"
+     cx="20"
+     cy="8"
+     r="1" />
+  <circle
+     style="fill:#0070ff;fill-opacity:0.99215686;stroke-width:1.012;stroke-dasharray:8.096, 1.012;stroke-dashoffset:10.12"
+     id="path1131-6-6"
+     cx="12"
+     cy="8"
+     r="1" />
+  <circle
+     style="fill:#0070ff;fill-opacity:0.99215686;stroke-width:1.012;stroke-dasharray:8.096, 1.012;stroke-dashoffset:10.12"
+     id="path1131-0"
+     cx="8"
+     cy="12"
+     r="1" />
+  <circle
+     style="fill:#0070ff;fill-opacity:0.99215686;stroke-width:1.012;stroke-dasharray:8.096, 1.012;stroke-dashoffset:10.12"
+     id="path1131-2-6"
+     cx="4"
+     cy="12"
+     r="1" />
+  <circle
+     style="fill:#0070ff;fill-opacity:0.99215686;stroke-width:1.012;stroke-dasharray:8.096, 1.012;stroke-dashoffset:10.12"
+     id="path1131-9-2"
+     cx="16"
+     cy="12"
+     r="1" />
+  <circle
+     style="fill:#0070ff;fill-opacity:0.99215686;stroke-width:1.012;stroke-dasharray:8.096, 1.012;stroke-dashoffset:10.12"
+     id="path1131-9-1-6"
+     cx="20"
+     cy="12"
+     r="1" />
+  <circle
+     style="fill:#0070ff;fill-opacity:0.99215686;stroke-width:1.012;stroke-dasharray:8.096, 1.012;stroke-dashoffset:10.12"
+     id="path1131-27-8"
+     cx="8"
+     cy="16"
+     r="1" />
+  <circle
+     style="fill:#0070ff;fill-opacity:0.99215686;stroke-width:1.012;stroke-dasharray:8.096, 1.012;stroke-dashoffset:10.12"
+     id="path1131-2-0-7"
+     cx="4"
+     cy="16"
+     r="1" />
+  <circle
+     style="fill:#0070ff;fill-opacity:0.99215686;stroke-width:1.012;stroke-dasharray:8.096, 1.012;stroke-dashoffset:10.12"
+     id="path1131-9-9-9"
+     cx="16"
+     cy="16"
+     r="1" />
+  <circle
+     style="fill:#0070ff;fill-opacity:0.99215686;stroke-width:1.012;stroke-dasharray:8.096, 1.012;stroke-dashoffset:10.12"
+     id="path1131-9-1-3-2"
+     cx="20"
+     cy="16"
+     r="1" />
+  <circle
+     style="fill:#0070ff;fill-opacity:0.99215686;stroke-width:1.012;stroke-dasharray:8.096, 1.012;stroke-dashoffset:10.12"
+     id="path1131-6-6-0"
+     cx="12"
+     cy="16"
+     r="1" />
+</svg>

--- a/src/main/resources/icons/footprint-dual.svg
+++ b/src/main/resources/icons/footprint-dual.svg
@@ -1,0 +1,134 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="24"
+   height="24"
+   viewBox="0 0 24 24"
+   version="1.1"
+   id="svg2"
+   sodipodi:docname="footprint-dual.svg"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview20"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="true"
+     inkscape:zoom="26.833333"
+     inkscape:cx="11.981366"
+     inkscape:cy="11.981366"
+     inkscape:window-width="3840"
+     inkscape:window-height="2082"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid837" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata15">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>contact-probe-nozzle</dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <!-- Generator: Sketch 3.2.2 (9983) - http://www.bohemiancoding.com/sketch -->
+  <title
+     id="title4">contact-probe-nozzle</title>
+  <desc
+     id="desc6">Created with Sketch.</desc>
+  <defs
+     id="defs8" />
+  <rect
+     y="6.9999995"
+     x="2"
+     height="1.9999998"
+     width="5"
+     id="rect828-6"
+     style="fill:#005bdc;fill-opacity:0.992157;fill-rule:evenodd;stroke:none;stroke-width:2.04482;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.992157" />
+  <rect
+     y="11"
+     x="2"
+     height="1.9999998"
+     width="5"
+     id="rect828-6-3"
+     style="fill:#005bdc;fill-opacity:0.992157;fill-rule:evenodd;stroke:none;stroke-width:2.04482;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.992157" />
+  <rect
+     y="15"
+     x="2"
+     height="1.9999998"
+     width="5"
+     id="rect828-6-5"
+     style="fill:#005bdc;fill-opacity:0.992157;fill-rule:evenodd;stroke:none;stroke-width:2.04482;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.992157" />
+  <rect
+     y="7"
+     x="17"
+     height="1.9999998"
+     width="5"
+     id="rect828-6-27"
+     style="fill:#005bdc;fill-opacity:0.992157;fill-rule:evenodd;stroke:none;stroke-width:2.04482;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.992157" />
+  <rect
+     y="2.9999995"
+     x="2"
+     height="1.9999998"
+     width="5"
+     id="rect828-6-36"
+     style="fill:#005bdc;fill-opacity:0.992157;fill-rule:evenodd;stroke:none;stroke-width:2.04482;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.992157" />
+  <rect
+     y="3"
+     x="17"
+     height="1.9999998"
+     width="5"
+     id="rect828-6-27-7"
+     style="fill:#005bdc;fill-opacity:0.992157;fill-rule:evenodd;stroke:none;stroke-width:2.04482;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.992157" />
+  <rect
+     y="19"
+     x="2"
+     height="1.9999998"
+     width="5"
+     id="rect828-6-53"
+     style="fill:#005bdc;fill-opacity:0.992157;fill-rule:evenodd;stroke:none;stroke-width:2.04482;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.992157" />
+  <rect
+     y="19"
+     x="17"
+     height="1.9999998"
+     width="5"
+     id="rect828-6-27-5"
+     style="fill:#005bdc;fill-opacity:0.992157;fill-rule:evenodd;stroke:none;stroke-width:2.04482;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.992157" />
+  <rect
+     y="11"
+     x="17"
+     height="1.9999998"
+     width="5"
+     id="rect828-6-3-0"
+     style="fill:#005bdc;fill-opacity:0.992157;fill-rule:evenodd;stroke:none;stroke-width:2.04482;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.992157" />
+  <rect
+     y="15"
+     x="17"
+     height="1.9999998"
+     width="5"
+     id="rect828-6-5-9"
+     style="fill:#005bdc;fill-opacity:0.992157;fill-rule:evenodd;stroke:none;stroke-width:2.04482;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.992157" />
+  <circle
+     style="fill:#af1f23;stroke-width:1.012;stroke-dasharray:8.096, 1.012;stroke-dashoffset:10.12"
+     id="path2017"
+     cx="12"
+     cy="12"
+     r="1" />
+</svg>

--- a/src/main/resources/icons/footprint-dual_dark.svg
+++ b/src/main/resources/icons/footprint-dual_dark.svg
@@ -1,0 +1,135 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="24"
+   height="24"
+   viewBox="0 0 24 24"
+   version="1.1"
+   id="svg2"
+   sodipodi:docname="footprint-dual_dark.svg"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview13"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="true"
+     inkscape:zoom="25.15625"
+     inkscape:cx="12.780124"
+     inkscape:cy="12.780124"
+     inkscape:window-width="3840"
+     inkscape:window-height="2082"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid830"
+       empspacing="6" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata15">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>contact-probe-nozzle</dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <!-- Generator: Sketch 3.2.2 (9983) - http://www.bohemiancoding.com/sketch -->
+  <title
+     id="title4">contact-probe-nozzle</title>
+  <desc
+     id="desc6">Created with Sketch.</desc>
+  <defs
+     id="defs8" />
+  <rect
+     y="6.9999995"
+     x="2"
+     height="1.9999998"
+     width="5"
+     id="rect828-6"
+     style="fill:#0070ff;fill-opacity:0.992157;fill-rule:evenodd;stroke:none;stroke-width:2.04482;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.992157" />
+  <rect
+     y="3"
+     x="2"
+     height="1.9999998"
+     width="5"
+     id="rect828-6-6"
+     style="fill:#0070ff;fill-opacity:0.992157;fill-rule:evenodd;stroke:none;stroke-width:2.04482;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.992157" />
+  <rect
+     y="19"
+     x="2"
+     height="1.9999998"
+     width="5"
+     id="rect828-6-2"
+     style="fill:#0070ff;fill-opacity:0.992157;fill-rule:evenodd;stroke:none;stroke-width:2.04482;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.992157" />
+  <rect
+     y="7.0000005"
+     x="17"
+     height="1.9999998"
+     width="5"
+     id="rect828-6-61"
+     style="fill:#0070ff;fill-opacity:0.992157;fill-rule:evenodd;stroke:none;stroke-width:2.04482;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.992157" />
+  <rect
+     y="19"
+     x="17"
+     height="1.9999998"
+     width="5"
+     id="rect828-6-8"
+     style="fill:#0070ff;fill-opacity:0.992157;fill-rule:evenodd;stroke:none;stroke-width:2.04482;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.992157" />
+  <rect
+     y="11"
+     x="2"
+     height="1.9999998"
+     width="5"
+     id="rect828-6-3"
+     style="fill:#0070ff;fill-opacity:0.992157;fill-rule:evenodd;stroke:none;stroke-width:2.04482;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.992157" />
+  <rect
+     y="15"
+     x="2"
+     height="1.9999998"
+     width="5"
+     id="rect828-6-5"
+     style="fill:#0070ff;fill-opacity:0.992157;fill-rule:evenodd;stroke:none;stroke-width:2.04482;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.992157" />
+  <rect
+     y="3"
+     x="17"
+     height="1.9999998"
+     width="5"
+     id="rect828-6-27"
+     style="fill:#0070ff;fill-opacity:0.992157;fill-rule:evenodd;stroke:none;stroke-width:2.04482;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.992157" />
+  <rect
+     y="11"
+     x="17"
+     height="1.9999998"
+     width="5"
+     id="rect828-6-3-0"
+     style="fill:#0070ff;fill-opacity:0.992157;fill-rule:evenodd;stroke:none;stroke-width:2.04482;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.992157" />
+  <rect
+     y="15"
+     x="17"
+     height="1.9999998"
+     width="5"
+     id="rect828-6-5-9"
+     style="fill:#0070ff;fill-opacity:0.992157;fill-rule:evenodd;stroke:none;stroke-width:2.04482;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.992157" />
+  <circle
+     style="fill:#ff2222;stroke-width:1.012;stroke-dasharray:8.096, 1.012;stroke-dashoffset:10.12;fill-opacity:1"
+     id="path2017"
+     cx="12"
+     cy="12"
+     r="1" />
+</svg>

--- a/src/main/resources/icons/footprint-quad.svg
+++ b/src/main/resources/icons/footprint-quad.svg
@@ -1,0 +1,128 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="24"
+   height="24"
+   viewBox="0 0 24 24"
+   version="1.1"
+   id="svg2"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <metadata
+     id="metadata15">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>contact-probe-nozzle</dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <!-- Generator: Sketch 3.2.2 (9983) - http://www.bohemiancoding.com/sketch -->
+  <title
+     id="title4">contact-probe-nozzle</title>
+  <desc
+     id="desc6">Created with Sketch.</desc>
+  <defs
+     id="defs8" />
+  <rect
+     y="6.9999995"
+     x="1"
+     height="1.9999998"
+     width="5"
+     id="rect828-6"
+     style="fill:#005bdc;fill-opacity:0.992157;fill-rule:evenodd;stroke:none;stroke-width:2.04482;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.992157" />
+  <rect
+     y="11"
+     x="1"
+     height="1.9999998"
+     width="5"
+     id="rect828-6-3"
+     style="fill:#005bdc;fill-opacity:0.992157;fill-rule:evenodd;stroke:none;stroke-width:2.04482;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.992157" />
+  <rect
+     y="15"
+     x="1"
+     height="1.9999998"
+     width="5"
+     id="rect828-6-5"
+     style="fill:#005bdc;fill-opacity:0.992157;fill-rule:evenodd;stroke:none;stroke-width:2.04482;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.992157" />
+  <rect
+     y="7"
+     x="18"
+     height="1.9999998"
+     width="5"
+     id="rect828-6-27"
+     style="fill:#005bdc;fill-opacity:0.992157;fill-rule:evenodd;stroke:none;stroke-width:2.04482;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.992157" />
+  <rect
+     y="11"
+     x="18"
+     height="1.9999998"
+     width="5"
+     id="rect828-6-3-0"
+     style="fill:#005bdc;fill-opacity:0.992157;fill-rule:evenodd;stroke:none;stroke-width:2.04482;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.992157" />
+  <rect
+     y="15"
+     x="18"
+     height="1.9999998"
+     width="5"
+     id="rect828-6-5-9"
+     style="fill:#005bdc;fill-opacity:0.992157;fill-rule:evenodd;stroke:none;stroke-width:2.04482;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.992157" />
+  <rect
+     y="7"
+     x="-6"
+     height="1.9999998"
+     width="5"
+     id="rect828-6-2"
+     style="fill:#005bdc;fill-opacity:0.992157;fill-rule:evenodd;stroke:none;stroke-width:2.04482;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.992157"
+     transform="rotate(-90)" />
+  <rect
+     y="11"
+     x="-6"
+     height="1.9999998"
+     width="5"
+     id="rect828-6-3-9"
+     style="fill:#005bdc;fill-opacity:0.992157;fill-rule:evenodd;stroke:none;stroke-width:2.04482;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.992157"
+     transform="rotate(-90)" />
+  <rect
+     y="15"
+     x="-6"
+     height="1.9999998"
+     width="5"
+     id="rect828-6-5-1"
+     style="fill:#005bdc;fill-opacity:0.992157;fill-rule:evenodd;stroke:none;stroke-width:2.04482;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.992157"
+     transform="rotate(-90)" />
+  <rect
+     y="7"
+     x="-23"
+     height="1.9999998"
+     width="5"
+     id="rect828-6-2-3"
+     style="fill:#005bdc;fill-opacity:0.992157;fill-rule:evenodd;stroke:none;stroke-width:2.04482;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.992157"
+     transform="rotate(-90)" />
+  <rect
+     y="11"
+     x="-23"
+     height="1.9999998"
+     width="5"
+     id="rect828-6-3-9-6"
+     style="fill:#005bdc;fill-opacity:0.992157;fill-rule:evenodd;stroke:none;stroke-width:2.04482;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.992157"
+     transform="rotate(-90)" />
+  <rect
+     y="15"
+     x="-23"
+     height="1.9999998"
+     width="5"
+     id="rect828-6-5-1-0"
+     style="fill:#005bdc;fill-opacity:0.992157;fill-rule:evenodd;stroke:none;stroke-width:2.04482;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.992157"
+     transform="rotate(-90)" />
+  <circle
+     style="fill:#af1f23;stroke-width:1.012;stroke-dasharray:8.096, 1.012;stroke-dashoffset:10.12"
+     id="path2017"
+     cx="12"
+     cy="12"
+     r="1" />
+</svg>

--- a/src/main/resources/icons/footprint-quad_dark.svg
+++ b/src/main/resources/icons/footprint-quad_dark.svg
@@ -1,0 +1,155 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="24"
+   height="24"
+   viewBox="0 0 24 24"
+   version="1.1"
+   id="svg2"
+   sodipodi:docname="footprint-quad_dark.svg"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview13"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="true"
+     inkscape:zoom="25.15625"
+     inkscape:cx="12.780124"
+     inkscape:cy="12.780124"
+     inkscape:window-width="3840"
+     inkscape:window-height="2082"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid830"
+       empspacing="6" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata15">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>contact-probe-nozzle</dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <!-- Generator: Sketch 3.2.2 (9983) - http://www.bohemiancoding.com/sketch -->
+  <title
+     id="title4">contact-probe-nozzle</title>
+  <desc
+     id="desc6">Created with Sketch.</desc>
+  <defs
+     id="defs8" />
+  <rect
+     y="6.9999995"
+     x="1"
+     height="1.9999998"
+     width="5"
+     id="rect828-6"
+     style="fill:#0070ff;fill-opacity:0.99215686;fill-rule:evenodd;stroke:none;stroke-width:2.04482;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.992157" />
+  <rect
+     y="11"
+     x="1"
+     height="1.9999998"
+     width="5"
+     id="rect828-6-3"
+     style="fill:#0070ff;fill-opacity:0.99215686;fill-rule:evenodd;stroke:none;stroke-width:2.04482;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.992157" />
+  <rect
+     y="15"
+     x="1"
+     height="1.9999998"
+     width="5"
+     id="rect828-6-5"
+     style="fill:#0070ff;fill-opacity:0.99215686;fill-rule:evenodd;stroke:none;stroke-width:2.04482;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.992157" />
+  <rect
+     y="7"
+     x="18"
+     height="1.9999998"
+     width="5"
+     id="rect828-6-27"
+     style="fill:#0070ff;fill-opacity:0.99215686;fill-rule:evenodd;stroke:none;stroke-width:2.04482;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.992157" />
+  <rect
+     y="11"
+     x="18"
+     height="1.9999998"
+     width="5"
+     id="rect828-6-3-0"
+     style="fill:#0070ff;fill-opacity:0.99215686;fill-rule:evenodd;stroke:none;stroke-width:2.04482;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.992157" />
+  <rect
+     y="15"
+     x="18"
+     height="1.9999998"
+     width="5"
+     id="rect828-6-5-9"
+     style="fill:#0070ff;fill-opacity:0.99215686;fill-rule:evenodd;stroke:none;stroke-width:2.04482;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.992157" />
+  <rect
+     y="7"
+     x="-6"
+     height="1.9999998"
+     width="5"
+     id="rect828-6-2"
+     style="fill:#0070ff;fill-opacity:0.99215686;fill-rule:evenodd;stroke:none;stroke-width:2.04482;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.992157"
+     transform="rotate(-90)" />
+  <rect
+     y="11"
+     x="-6"
+     height="1.9999998"
+     width="5"
+     id="rect828-6-3-9"
+     style="fill:#0070ff;fill-opacity:0.99215686;fill-rule:evenodd;stroke:none;stroke-width:2.04482;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.992157"
+     transform="rotate(-90)" />
+  <rect
+     y="15"
+     x="-6"
+     height="1.9999998"
+     width="5"
+     id="rect828-6-5-1"
+     style="fill:#0070ff;fill-opacity:0.99215686;fill-rule:evenodd;stroke:none;stroke-width:2.04482;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.992157"
+     transform="rotate(-90)" />
+  <rect
+     y="7"
+     x="-23"
+     height="1.9999998"
+     width="5"
+     id="rect828-6-2-3"
+     style="fill:#0070ff;fill-opacity:0.99215686;fill-rule:evenodd;stroke:none;stroke-width:2.04482;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.992157"
+     transform="rotate(-90)" />
+  <rect
+     y="11"
+     x="-23"
+     height="1.9999998"
+     width="5"
+     id="rect828-6-3-9-6"
+     style="fill:#0070ff;fill-opacity:0.99215686;fill-rule:evenodd;stroke:none;stroke-width:2.04482;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.992157"
+     transform="rotate(-90)" />
+  <rect
+     y="15"
+     x="-23"
+     height="1.9999998"
+     width="5"
+     id="rect828-6-5-1-0"
+     style="fill:#0070ff;fill-opacity:0.99215686;fill-rule:evenodd;stroke:none;stroke-width:2.04482;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.992157"
+     transform="rotate(-90)" />
+  <circle
+     style="fill:#ff2222;stroke-width:1.012;stroke-dasharray:8.096, 1.012;stroke-dashoffset:10.12;fill-opacity:1"
+     id="path2017"
+     cx="12"
+     cy="12"
+     r="1" />
+</svg>


### PR DESCRIPTION
# Description

Adding a simple footprint generator: 

- Dual form factor packages.
- Quad form factor packages.
- BGA packages.

Given a few inputs, it can generate the pads for the most common ICs. 

### Limitations

- Can only generate Dual form factor packages with pins left-right, as is the [Part Zero Orientation](https://ohm.bu.edu/~pbohn/__Engineering_Reference/pcb_layout/pcbmatrix/Component%20Zero%20Orientations%20for%20CAD%20Libraries.pdf) industry standard. 
- Can only generate quadratic Quad form factor packages.
- Can only generate quadratic BGA packages.

# Justification

Footprints will be required in the upcoming multi-shot bottom vision. 

# Instructions for Use

The footprint generator can currently create three types of footprints:

- **Dual** form factor packages.
- **Quad** form factor packages.
- **BGA** packages.

![Footprint generated](https://user-images.githubusercontent.com/9963310/177056831-615fa5bb-6d03-4fdf-ac92-b9f7c448f88b.png)

The generators are parametrized by the following settings:

- **Outside dimension**: determines the outside span of the part, bounding the pads. For **Dual** this is the width. For **Quad** it is both width and height (only square footprints supported). For **BGA** the dimension is not an input but an output being computed by the generator. 
- **Inside dimension**: determines the dimension of the central empty space between the pads (same direction as the **Outside Dimension**). For **BGA** this is the area where pads are left out.
- **Pad count**: number of pads. For **Dual** this must be a multiple of two. For **Quad** a multiple of four. For **BGA** a square number, and it _includes_ the pads that are masked out by the **Inside dimension**.
- **Pad Pitch**: pitch between pads.
- **Pad Across**: size across the pads, i.e. measured in the same direction as the pitch. 
- **% Round**: roundness of the pads.

After having set the parameters, press one of the buttons:

![Footprint generator buttons](https://user-images.githubusercontent.com/9963310/177057130-83b4b74a-ac59-4095-8fb4-178984536b9b.png)

If pads are already existing, it will ask you before it overwrites them.

### Examples

![Dual](https://user-images.githubusercontent.com/9963310/177057286-2e84f736-e6c1-4c61-8b36-3acc8cabd0e7.png) ![Quad](https://user-images.githubusercontent.com/9963310/177057304-6d365295-a556-4330-ae5b-b2457fe45340.png) ![BGA](https://user-images.githubusercontent.com/9963310/177057271-c6055d05-fdc5-4622-9c4a-ac412c33e49f.png)

# Implementation Details
1. Tested in simulation.
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. Successful `mvn test` before submitting the Pull Request. 
