### PR TITLE
Feature / Log the AffineTransform Coefficients after Board Fiducial Check.

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/vision/ReferenceFiducialLocator.java
+++ b/src/main/java/org/openpnp/machine/reference/vision/ReferenceFiducialLocator.java
@@ -201,8 +201,18 @@ public class ReferenceFiducialLocator extends AbstractPartSettingsHolder impleme
         }
         
         Utils2D.AffineInfo ai = Utils2D.affineInfo(tx);
+        double[] matrix = new double[6];
+        tx.getMatrix(matrix);
         Logger.info("Fiducial results: " + ai);
-        
+        Logger.info("Linear Transform X-Axis:"
+                + " X Factor: "+String.format("%12.6f", matrix[0])
+                + " Y Factor: "+String.format("%12.6f", matrix[1])
+                + " X Offset: "+String.format("%12.6f", matrix[4]));
+        Logger.info("Linear Transform Y-Axis:"
+                + " X Factor: "+String.format("%12.6f", matrix[2])
+                + " Y Factor: "+String.format("%12.6f", matrix[3])
+                + " Y Offset: "+String.format("%12.6f", matrix[5]));
+
         double boardOffset = newBoardLocation.getLinearLengthTo(savedBoardLocation).convertToUnits(LengthUnit.Millimeters).getValue();
         Logger.info("Board origin offset distance: " + boardOffset + "mm");
         


### PR DESCRIPTION
# Description
Log the Affine Transformation coefficients after a Board fiducial check.

# Justification
Support a recipe to reconstruct a machine coordinate system from three or more fiducials. This may be needed after a machine was mechanically modified or suffered a bad crash.

See here:
https://groups.google.com/g/openpnp/c/4vEk9DeM2zM/m/XQEXB1JtBQAJ

# Instructions for Use

A machine coordinate system can be reconstructed from three or better more well-known locations, that are sufficiently far away from each other in both X and Y. Before modifying a machine, securely mount and capture multiple fiducials on PCB Z height. these will help reconstruct a machine coordinate system after the machine underwent modification.


1. **You must do this _before_ you modify the machine!!!**
1. Create a fake (huge) Board in OpenPnP.
   ![grafik](https://user-images.githubusercontent.com/9963310/178228834-b2a8f903-a57c-4889-ae87-a19c8895e59a.png)

1. Add the fiducials that you added to your table as Placements.
   ![grafik](https://user-images.githubusercontent.com/9963310/178229037-968a46cf-a4ea-48be-9fe3-42b35c84505d.png)

1. Capture their location as good as you can using the eye.
   ![grafik](https://user-images.githubusercontent.com/9963310/178231861-169aaefd-7a51-4d1f-83e1-140fb0e15551.png)

1. Run the fiducial check:
   ![grafik](https://user-images.githubusercontent.com/9963310/178229166-6e3850de-4f75-40aa-a091-5c9e8070f4fc.png)

1. Now position to each fiducial. It should now be the precision location determined by vision, i.e. the AffineTransform is applied:
   ![grafik](https://user-images.githubusercontent.com/9963310/178229248-fa6060f5-3034-41d9-be84-c5188b5c52b0.png)

1. Now copy what you see in your DRO into the fiducials location, manually:
   ![grafik](https://user-images.githubusercontent.com/9963310/178229360-ff3cf821-f95a-42ad-b9b2-7a03ab2e9f6f.png)

   **Note**, you can't use the capture button, because it would reverse-apply the AffineTransform, i.e. change nothing.
1. Repeat for each fiducial.
1. Once you have these precision fiducial coordinates, make sure to screenshot them, just to be sure to have a technically independent copy:
   ![grafik](https://user-images.githubusercontent.com/9963310/178229562-8df9067f-f0c3-41e7-98bf-92f07b8c83f6.png)

1. And save the Job:
   ![grafik](https://user-images.githubusercontent.com/9963310/178229599-e9babaf1-b031-418e-b68c-528d15c23ad9.png)

1. **This `.job.xml` file and more importantly the accompanying `.board.xml` file is now your very important record of your OpenPnP machine coordinate system. Go check them out where you saved them.**

1. Now you can safely modify the machine. 
1. Afterwards, try to make the coordinates as similar as possible on the controller side (set your homing coordinates, so the coordinates match up roughly, i.e. ±1mm).
1. Load the Job.
1. Perform another fiducial check:
   ![grafik](https://user-images.githubusercontent.com/9963310/178229166-6e3850de-4f75-40aa-a091-5c9e8070f4fc.png)
1. Now look in the log for lines like this:
   ![grafik](https://user-images.githubusercontent.com/9963310/178230327-e6394140-0106-4e07-9dcb-0de682d9b810.png)

1. Enter the coefficients into your X and Y `ReferenceLinearAxis`: 
   ![grafik](https://user-images.githubusercontent.com/9963310/178230526-7f80bfbd-e889-4986-ac8d-2f5eca7dd433.png)
   See also here: 
   https://github.com/openpnp/openpnp/wiki/Linear-Transformed-Axes#rotate-the-machine-table
   

# Implementation Details
1. Tested in simulation
3. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
4. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
5. Successful `mvn test` before submitting the Pull Request. 
