### PR TITLE
Feature / Vision Compositing - Multi-Shot Bottom Vision

### DIFF
--- a/src/main/java/org/openpnp/gui/PackageCompositingPanel.java
+++ b/src/main/java/org/openpnp/gui/PackageCompositingPanel.java
@@ -1,0 +1,313 @@
+/*
+ * Copyright (C) 2022 <mark@makr.zone>
+ * inspired and based on work
+ * Copyright (C) 2011 Jason von Nieda <jason@vonnieda.org>
+ * 
+ * This file is part of OpenPnP.
+ * 
+ * OpenPnP is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * OpenPnP is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License along with OpenPnP. If not, see
+ * <http://www.gnu.org/licenses/>.
+ * 
+ * For more information about OpenPnP visit http://openpnp.org
+ */
+
+
+package org.openpnp.gui;
+
+import java.awt.BorderLayout;
+import java.awt.event.ActionEvent;
+
+import javax.swing.AbstractAction;
+import javax.swing.Action;
+import javax.swing.JButton;
+import javax.swing.JCheckBox;
+import javax.swing.JComboBox;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JTextField;
+import javax.swing.border.BevelBorder;
+import javax.swing.border.TitledBorder;
+
+import org.jdesktop.beansbinding.AutoBinding;
+import org.jdesktop.beansbinding.AutoBinding.UpdateStrategy;
+import org.jdesktop.beansbinding.BeanProperty;
+import org.jdesktop.beansbinding.Bindings;
+import org.jdesktop.beansbinding.Converter;
+import org.openpnp.gui.components.ComponentDecorators;
+import org.openpnp.gui.components.VisionCompositingPreview;
+import org.openpnp.gui.support.DoubleConverter;
+import org.openpnp.gui.support.Icons;
+import org.openpnp.gui.support.LengthConverter;
+import org.openpnp.machine.reference.vision.ReferenceBottomVision;
+import org.openpnp.model.BottomVisionSettings;
+import org.openpnp.model.Configuration;
+import org.openpnp.model.Length;
+import org.openpnp.model.Location;
+import org.openpnp.model.VisionCompositing;
+import org.openpnp.model.VisionCompositing.Composite;
+import org.openpnp.model.VisionCompositing.CompositingMethod;
+import org.openpnp.model.VisionCompositing.Shot;
+import org.openpnp.spi.Camera;
+import org.openpnp.spi.Head;
+import org.openpnp.spi.Machine;
+import org.openpnp.spi.Nozzle;
+import org.openpnp.spi.NozzleTip;
+import org.openpnp.util.UiUtils;
+import org.openpnp.util.VisionUtils;
+
+import com.jgoodies.forms.layout.ColumnSpec;
+import com.jgoodies.forms.layout.FormLayout;
+import com.jgoodies.forms.layout.FormSpecs;
+import com.jgoodies.forms.layout.RowSpec;
+
+@SuppressWarnings("serial")
+public class PackageCompositingPanel extends JPanel {
+    private final org.openpnp.model.Package pkg;
+    private JPanel compositingPanel;
+    private JLabel lblMethod;
+    private JLabel lblMaxPickTolerance;
+    private JTextField maxPickTolerance;
+    private JComboBox compositingMethod;
+    private JLabel lblAllowInsideCorner;
+    private JCheckBox allowInside;
+    private JLabel lblMinAngleLeverage;
+    private JTextField minLeverageFactor;
+    private JButton btnTest;
+
+    private VisionCompositing visionCompositing;
+    private VisionCompositingPreview visionPreview;
+    private JLabel lblExtraShots;
+    private JTextField extraShots;
+    private JTextField compositeSolution;
+
+    public PackageCompositingPanel(org.openpnp.model.Package pkg) {
+        this.pkg = pkg;
+        this.visionCompositing = pkg.getVisionCompositing();
+        createUi();
+        initDataBindings();
+
+        ComponentDecorators.decorateWithAutoSelectAndLengthConversion(maxPickTolerance);
+        ComponentDecorators.decorateWithAutoSelect(minLeverageFactor);
+        ComponentDecorators.decorateWithAutoSelect(extraShots);
+        
+        UiUtils.messageBoxOnExceptionLater(() -> computeCompositingAction.actionPerformed(null));
+    }
+
+    private void createUi() {
+        setLayout(new BorderLayout(0, 0));
+
+        compositingPanel = new JPanel();
+        compositingPanel.setBorder(new TitledBorder(null, "Compositing", TitledBorder.LEADING, TitledBorder.TOP, null, null));
+        add(compositingPanel, BorderLayout.NORTH);
+        compositingPanel.setLayout(new FormLayout(new ColumnSpec[] {
+                FormSpecs.RELATED_GAP_COLSPEC,
+                ColumnSpec.decode("max(70dlu;default)"),
+                FormSpecs.RELATED_GAP_COLSPEC,
+                FormSpecs.DEFAULT_COLSPEC,
+                FormSpecs.RELATED_GAP_COLSPEC,
+                FormSpecs.DEFAULT_COLSPEC,
+                FormSpecs.RELATED_GAP_COLSPEC,
+                FormSpecs.DEFAULT_COLSPEC,
+                FormSpecs.RELATED_GAP_COLSPEC,
+                ColumnSpec.decode("default:grow"),},
+                new RowSpec[] {
+                        FormSpecs.RELATED_GAP_ROWSPEC,
+                        FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC,
+                        FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC,
+                        FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC,
+                        FormSpecs.DEFAULT_ROWSPEC,}));
+
+        lblMethod = new JLabel("Method");
+        lblMethod.setToolTipText("<html>\n<p>Compositing method:</p>\n<ul>\n<li><strong>None:</strong> no compositing is performed.</li>\n<li><strong>Restricted:</strong> compositing is only performed, when the <br/>\nfootprint size is too large, or if it is asymmetric.</li>\n<li><strong>Automatic:</strong> compositing is always performed. It can still <br/>\nresult in a one-shot solution, if the corners are all convex <br/>\nand symmetric.</li>\n<li><strong>SingleCorner:</strong> compositing is always performed. Each <br/>\ncorner is individually shot. Reduces parallax errors, as <br/>\neach corner is centered in the camera.</li>\n</ul>\n</html>\n\n");
+        compositingPanel.add(lblMethod, "2, 2, right, default");
+
+        compositingMethod = new JComboBox(VisionCompositing.CompositingMethod.values());
+        compositingPanel.add(compositingMethod, "4, 2, fill, default");
+
+        lblExtraShots = new JLabel("Extra Shots");
+        lblExtraShots.setToolTipText("<html>\n<p>Vision Compositing determines the optimal minimum set of required shot to determine<br/>\nthe part position and angle. On top of that, it suggests extra shots, that can be used to <br/>\nimprove positional and angular accuracy. </p>\n<br/>\n<p>Example: a square part can be determined in two diagonal corner shots. The opposite two<br/>\ncorners of the square are proposed as extra shots.</p>\n<br/>\n<p><strong>Extra Shots</strong> indicates how man of these extra shots should be used. \n</html>");
+        compositingPanel.add(lblExtraShots, "2, 4, right, default");
+
+        extraShots = new JTextField();
+        compositingPanel.add(extraShots, "4, 4, fill, default");
+        extraShots.setColumns(10);
+
+        lblMaxPickTolerance = new JLabel("Max. Pick Tolerance");
+        lblMaxPickTolerance.setToolTipText("<html>\n<p>If zero, the <strong>Max. Pick Tolerance</strong> on the nozzle tip is taken.</p>\n<br/>\n<p>If non-zero, this <strong>Max. Pick Tolerance</strong> overrides it for this package.</p>\n<br/>\n<p>In both cases, the <strong>Max. Pick Tolerance</strong> must cover linear <br/>\noffsets of the picked part on the nozzle, and corner offsets <br/>\ncaused by rotational offsets, as well as combinations of the two.</p>\n</html>");
+        compositingPanel.add(lblMaxPickTolerance, "6, 4, right, default");
+
+        maxPickTolerance = new JTextField();
+        compositingPanel.add(maxPickTolerance, "8, 4, fill, default");
+        maxPickTolerance.setColumns(10);
+
+        lblMinAngleLeverage = new JLabel("Min. Angle Leverage");
+        lblMinAngleLeverage.setToolTipText("<html>\n<p>Minimum leverage required to derive angular information from two corners.</p>\n<br/>\n<p><strong>Min. Angle Leverage</strong> is given <em>relative</em> to the footprint width and height<br/>\n(the lesser of the two).</p>\n<br/>\n<p>Example: setting 0.5 requires two corners to span at least half the part dimension<br/>\nto provide angular information.</p>\n</html>");
+        compositingPanel.add(lblMinAngleLeverage, "2, 6, right, default");
+
+        minLeverageFactor = new JTextField();
+        compositingPanel.add(minLeverageFactor, "4, 6, fill, default");
+        minLeverageFactor.setColumns(10);
+
+        lblAllowInsideCorner = new JLabel("Allow inside corner?");
+        lblAllowInsideCorner.setToolTipText("<html>\n<p>Allows the inclusion of corners facing inside, towards the center of the part. <br/>\nThis can be used to align parts that are still too large, i.e., where the <strong>Roaming Radius</strong><br/>\nof the camera is too small. It typically requires large, well-spaced pads.</p>\n<br/>\n<p>Example: SMD power rectifiers.</p>\n</html>");
+        compositingPanel.add(lblAllowInsideCorner, "6, 6, right, default");
+
+        allowInside = new JCheckBox("");
+        compositingPanel.add(allowInside, "8, 6");
+
+        btnTest = new JButton(computeCompositingAction);
+        btnTest.setToolTipText("Compute the vision compositing, and preview the result.");
+        compositingPanel.add(btnTest, "2, 8");
+
+        compositeSolution = new JTextField();
+        compositeSolution.setEditable(false);
+        compositingPanel.add(compositeSolution, "4, 8, 7, 1, fill, default");
+        compositeSolution.setColumns(10);
+
+        visionPreview = new VisionCompositingPreview();
+        visionPreview.setBorder(new BevelBorder(BevelBorder.LOWERED, null, null, null, null));
+        add(visionPreview, BorderLayout.CENTER);
+
+        pkg.addPropertyChangeListener("footprint", (e) -> computeCompositingAction.actionPerformed(null));
+    }
+
+    public final Action computeCompositingAction = new AbstractAction() {
+        {
+            putValue(SMALL_ICON, Icons.refresh);
+            putValue(NAME, "Compute");
+            putValue(SHORT_DESCRIPTION, "Recompute the vision compositing.");
+        }
+
+        @Override
+        public void actionPerformed(ActionEvent arg0) {
+            computePreviewComposite();
+        }
+    };
+
+    private VisionCompositing.Composite composite;
+    private String status;
+
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        Object oldValue = this.status;
+        this.status = status;
+        firePropertyChange("status", oldValue, status);
+    }
+
+    public VisionCompositing.Composite getComposite() {
+        return composite;
+    }
+
+    public void setComposite(VisionCompositing.Composite composite) {
+        Object oldValue = this.composite;
+        this.composite = composite;
+        firePropertyChange("composite", oldValue, composite);
+    }
+
+    private VisionCompositing.Composite computePreviewComposite() {
+        try {
+            Machine machine = Configuration.get().getMachine();
+            Camera camera = VisionUtils.getBottomVisionCamera();
+            Nozzle nozzle = null;
+            NozzleTip nozzleTip = null;
+            for (Head head : machine.getHeads()) {
+                for (Nozzle n :  head.getNozzles()) {
+                    for (NozzleTip nt : n.getCompatibleNozzleTips()) {
+                        if (pkg.getCompatibleNozzleTips().contains(nt)) {
+                            // We got us a winning pair.
+                            nozzle = n;
+                            nozzleTip = nt;
+                            break;
+                        }
+                    }
+                    if (nozzleTip != null) {
+                        break;
+                    }
+                }
+                if (nozzleTip != null) {
+                    break;
+                }
+            }
+            BottomVisionSettings bottomVisionSettings = ReferenceBottomVision.getDefault()
+                    .getInheritedVisionSettings(pkg);
+            if (nozzleTip == null) {
+                throw new Exception("No compatible nozzle tip found for "+pkg.getId()+".");
+            }
+            Composite composite = visionCompositing.new Composite(pkg, bottomVisionSettings, nozzle, nozzleTip, camera, Location.origin);
+            int minShots = 0;
+            int maxShots = 0;
+            for (Shot shot : composite.getCompositeShots()) {
+                maxShots++;
+                if (!shot.isOptional()) {
+                    minShots++;
+                }
+            }
+            setComposite(composite);
+            setStatus((composite.getCompositingSolution().isInvalid() ? "Error: " : "Solution: ")
+                    +composite.getCompositingSolution()+" | Min. shots: "+minShots+" | Max. shots: "+maxShots+" | Computation: "+String.format("%.2f", composite.getComputeTime())+"ms");
+            return composite;
+        }
+        catch (Exception e) {
+            setStatus("Error: "+e.getMessage());
+            return null;
+        }
+    }
+
+    protected void initDataBindings() {
+        BeanProperty<VisionCompositing, CompositingMethod> visionCompositingBeanProperty = BeanProperty.create("compositingMethod");
+        BeanProperty<JComboBox, Object> jComboBoxBeanProperty = BeanProperty.create("selectedItem");
+        AutoBinding<VisionCompositing, CompositingMethod, JComboBox, Object> autoBinding = Bindings.createAutoBinding(UpdateStrategy.READ_WRITE, visionCompositing, visionCompositingBeanProperty, compositingMethod, jComboBoxBeanProperty);
+        autoBinding.bind();
+        //
+        BeanProperty<VisionCompositing, Length> visionCompositingBeanProperty_1 = BeanProperty.create("maxPickTolerance");
+        BeanProperty<JTextField, String> jTextFieldBeanProperty = BeanProperty.create("text");
+        AutoBinding<VisionCompositing, Length, JTextField, String> autoBinding_1 = Bindings.createAutoBinding(UpdateStrategy.READ_WRITE, visionCompositing, visionCompositingBeanProperty_1, maxPickTolerance, jTextFieldBeanProperty);
+        Converter lengthConverter = new LengthConverter();
+        autoBinding_1.setConverter(lengthConverter);
+        autoBinding_1.bind();
+        //
+        BeanProperty<VisionCompositing, Double> visionCompositingBeanProperty_3 = BeanProperty.create("minLeverageFactor");
+        BeanProperty<JTextField, String> jTextFieldBeanProperty_2 = BeanProperty.create("text");
+        AutoBinding<VisionCompositing, Double, JTextField, String> autoBinding_3 = Bindings.createAutoBinding(UpdateStrategy.READ_WRITE, visionCompositing, visionCompositingBeanProperty_3, minLeverageFactor, jTextFieldBeanProperty_2);
+        Converter doubleConverter = new DoubleConverter(Configuration.get().getLengthDisplayFormat());
+        autoBinding_3.setConverter(doubleConverter);
+        autoBinding_3.bind();
+        //
+        BeanProperty<VisionCompositing, Boolean> visionCompositingBeanProperty_4 = BeanProperty.create("allowInside");
+        BeanProperty<JCheckBox, Boolean> jCheckBoxBeanProperty = BeanProperty.create("selected");
+        AutoBinding<VisionCompositing, Boolean, JCheckBox, Boolean> autoBinding_4 = Bindings.createAutoBinding(UpdateStrategy.READ_WRITE, visionCompositing, visionCompositingBeanProperty_4, allowInside, jCheckBoxBeanProperty);
+        autoBinding_4.bind();
+        //
+        BeanProperty<VisionCompositing, Integer> extraShotsBeanProperty_5 = BeanProperty.create("extraShots");
+        BeanProperty<JTextField, String> jTextFieldBeanProperty_3 = BeanProperty.create("text");
+        AutoBinding<VisionCompositing, Integer, JTextField, String> autoBinding_5 = Bindings.createAutoBinding(UpdateStrategy.READ_WRITE, visionCompositing, extraShotsBeanProperty_5, extraShots, jTextFieldBeanProperty_3);
+        autoBinding_5.bind();
+
+        //
+        BeanProperty<PackageCompositingPanel, String> statusBeanProperty_2 = BeanProperty.create("status");
+        BeanProperty<JTextField, String> jTextFieldBeanProperty_1 = BeanProperty.create("text");
+        AutoBinding<PackageCompositingPanel, String, JTextField, String> autoBinding_2 = Bindings.createAutoBinding(UpdateStrategy.READ, this, statusBeanProperty_2, compositeSolution, jTextFieldBeanProperty_1);
+        autoBinding_2.bind();
+
+        BeanProperty<PackageCompositingPanel,  VisionCompositing.Composite> cameraBeanProperty = BeanProperty.create("composite");
+        BeanProperty<VisionCompositingPreview,  VisionCompositing.Composite> cameraProperty = BeanProperty.create("composite");
+        AutoBinding<PackageCompositingPanel,  VisionCompositing.Composite, VisionCompositingPreview,  VisionCompositing.Composite> autoBinding_6 = 
+                Bindings.createAutoBinding(UpdateStrategy.READ, this, cameraBeanProperty, visionPreview, cameraProperty);
+        autoBinding_6.bind();
+    }
+}

--- a/src/main/java/org/openpnp/gui/PackagesPanel.java
+++ b/src/main/java/org/openpnp/gui/PackagesPanel.java
@@ -376,19 +376,25 @@ public class PackagesPanel extends JPanel implements WizardContainer {
 
         @Override
         public void actionPerformed(ActionEvent arg0) {
+            String id;
+            while ((id = JOptionPane.showInputDialog(frame,
+                    "Please enter an ID for the pasted package.")) != null) {
+                if (configuration.getPackage(id) == null) {
+                    break;
+                }
+                MessageBoxes.errorBox(frame, "Error", "Package ID " + id + " already exists.");
+            }
+            if (id == null || id.isEmpty()) {
+                return;
+            }
             try {
                 Serializer ser = Configuration.createSerializer();
                 Clipboard clipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
                 String s = (String) clipboard.getData(DataFlavor.stringFlavor);
                 StringReader r = new StringReader(s);
                 Package pkg = ser.read(Package.class, s);
-                for (int i = 0;; i++) {
-                    if (Configuration.get().getPackage(pkg.getId() + "-" + i) == null) {
-                        pkg.setId(pkg.getId() + "-" + i);
-                        Configuration.get().addPackage(pkg);
-                        break;
-                    }
-                }
+                pkg.setId(id);
+                Configuration.get().addPackage(pkg);
                 tableModel.fireTableDataChanged();
                 Helpers.selectObjectTableRow(table, pkg);
             }
@@ -428,8 +434,9 @@ public class PackagesPanel extends JPanel implements WizardContainer {
         tabbedPane.removeAll();
         if (selectedPackage != null) {
             tabbedPane.add("Nozzle Tips", new PackageNozzleTipsPanel(selectedPackage));
-            tabbedPane.add("Footprint", new JScrollPane(new PackageVisionPanel(selectedPackage)));
             tabbedPane.add("Settings", new JScrollPane(new PackageSettingsPanel(selectedPackage)));
+            tabbedPane.add("Footprint", new JScrollPane(new PackageVisionPanel(selectedPackage)));
+            tabbedPane.add("Vision Compositing", new JScrollPane(new PackageCompositingPanel(selectedPackage)));
             Machine machine = Configuration.get().getMachine();
             for (PartAlignment partAlignment : machine.getPartAlignments()) {
                 Wizard wizard = partAlignment.getPartConfigurationWizard(selectedPackage);

--- a/src/main/java/org/openpnp/gui/PartsPanel.java
+++ b/src/main/java/org/openpnp/gui/PartsPanel.java
@@ -398,19 +398,25 @@ public class PartsPanel extends JPanel implements WizardContainer {
 
         @Override
         public void actionPerformed(ActionEvent arg0) {
+            String id;
+            while ((id = JOptionPane.showInputDialog(frame,
+                    "Please enter an ID for the pasted part.")) != null) {
+                if (configuration.getPart(id) == null) {
+                    break;
+                }
+                MessageBoxes.errorBox(frame, "Error", "Part ID " + id + " already exists.");
+            }
+            if (id == null || id.isEmpty()) {
+                return;
+            }
             try {
                 Serializer ser = Configuration.createSerializer();
                 Clipboard clipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
                 String s = (String) clipboard.getData(DataFlavor.stringFlavor);
                 StringReader r = new StringReader(s);
                 Part part = ser.read(Part.class, s);
-                for (int i = 0;; i++) {
-                    if (Configuration.get().getPart(part.getId() + "-" + i) == null) {
-                        part.setId(part.getId() + "-" + i);
-                        Configuration.get().addPart(part);
-                        break;
-                    }
-                }
+                part.setId(id);
+                Configuration.get().addPart(part);
                 tableModel.fireTableDataChanged();
                 Helpers.selectLastTableRow(table);
             }

--- a/src/main/java/org/openpnp/gui/components/CameraView.java
+++ b/src/main/java/org/openpnp/gui/components/CameraView.java
@@ -1524,12 +1524,21 @@ public class CameraView extends JComponent implements CameraListener {
                 // The camera is non-movable
                 // Get the selected nozzle
                 Nozzle nozzle = MainFrame.get().getMachineControls().getSelectedNozzle();
+                Location currentLocation = nozzle.getLocation();
                 // Subtract the offsets from the nozzle position.
-                Location location = nozzle.getLocation().subtract(offsets);
+                Location location = currentLocation.subtract(offsets);
                 // Only change X/Y. 
-                location = nozzle.getLocation().derive(location, true, true, false, false);
+                location = currentLocation.derive(location, true, true, false, false);
                 // Move the nozzle such that the clicked position is moved to the center of the camera view
-                MovableUtils.moveToLocationAtSafeZ(nozzle, location);
+                if (currentLocation.getLinearLengthTo(camera.getLocation()).compareTo(camera.getRoamingRadius()) < 0
+                        && location.getLinearLengthTo(camera.getLocation()).compareTo(camera.getRoamingRadius()) < 0) {
+                    // Within the roaming area, no need to go to Safe Z.
+                    nozzle.moveTo(location);
+                }
+                else {
+                    // Current or new location outside roaming area. Move to safe Z.
+                    MovableUtils.moveToLocationAtSafeZ(nozzle, location);
+                }
             }
             else { 
                 // The camera is movable

--- a/src/main/java/org/openpnp/gui/components/VisionCompositingPreview.java
+++ b/src/main/java/org/openpnp/gui/components/VisionCompositingPreview.java
@@ -1,0 +1,325 @@
+/*
+ * Copyright (C) 2022 <mark@makr.zone>
+ * 
+ * This file is part of OpenPnP.
+ * 
+ * OpenPnP is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * OpenPnP is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License along with OpenPnP. If not, see
+ * <http://www.gnu.org/licenses/>.
+ * 
+ * For more information about OpenPnP visit http://openpnp.org
+ */
+
+package org.openpnp.gui.components;
+
+import java.awt.BasicStroke;
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.Font;
+import java.awt.FontMetrics;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.RenderingHints;
+import java.awt.Shape;
+import java.awt.event.MouseEvent;
+import java.awt.event.MouseListener;
+import java.awt.event.MouseMotionListener;
+import java.awt.geom.AffineTransform;
+import java.awt.geom.Area;
+import java.awt.geom.Ellipse2D;
+import java.awt.geom.Line2D;
+import java.awt.geom.Rectangle2D;
+import java.util.List;
+
+import javax.swing.JComponent;
+import javax.swing.UIManager;
+
+import org.openpnp.model.Footprint;
+import org.openpnp.model.LengthUnit;
+import org.openpnp.model.Location;
+import org.openpnp.model.Package;
+import org.openpnp.model.VisionCompositing;
+import org.openpnp.model.VisionCompositing.Corner;
+import org.openpnp.model.VisionCompositing.Shot;
+import org.openpnp.spi.Camera;
+
+public class VisionCompositingPreview extends JComponent implements MouseMotionListener, MouseListener {
+
+    public VisionCompositingPreview() {
+        super();
+        addMouseMotionListener(this);
+        addMouseListener(this);
+    }
+
+    VisionCompositing.Composite composite;
+
+    public VisionCompositing.Composite getComposite() {
+        return composite;
+    }
+    public void setComposite(VisionCompositing.Composite composite) {
+        this.composite = composite;
+        repaint();
+    }
+
+    private Integer xMouse;
+    private Integer yMouse;
+    private boolean pressedMouse;
+
+
+    @Override
+    public Dimension getPreferredSize() {
+        Dimension superDim = super.getPreferredSize();
+        int width = (int)Math.max(superDim.getWidth(), 480);
+        int height = (int)Math.max(superDim.getHeight(), 320); 
+        return new Dimension(width, height);
+    }
+
+    protected void paintComponent(Graphics g) {
+        super.paintComponent(g);
+        Graphics2D g2d = (Graphics2D) g;
+        if (composite != null) {
+            final Package pkg = composite.getPackage();
+            final Footprint footprint = composite.getFootprint();
+            final LengthUnit units = composite.getUnits();
+            final Camera camera = composite.getCamera(); 
+            VisionCompositing compositing = composite.getParent();
+            AffineTransform txOld = g2d.getTransform();
+            g2d.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+            int width = getWidth();
+            int height = getHeight();
+            // Get the shape.
+            Shape bodyShape = footprint.getBodyShape();
+            Shape padsShape = footprint.getPadsShape();
+            // Transform to right-hand coordinate system.
+            AffineTransform txShape = new AffineTransform();
+            txShape.scale(1, -1);
+            padsShape = txShape.createTransformedShape(padsShape);
+            bodyShape = txShape.createTransformedShape(bodyShape);
+            Rectangle2D bounds = padsShape.getBounds2D();
+            // Compute scale.
+            Location upp = camera.getUnitsPerPixel().convertToUnits(footprint.getUnits());
+            double cameraWidth = camera.getWidth()*upp.getX();
+            double cameraHeight = camera.getHeight()*upp.getY();
+            double cameraRoamingRadius = camera.getRoamingRadius().convertToUnits(units).getValue();
+            double cameraMaxRadius = Math.min(cameraWidth, cameraHeight) / 2;
+            double scale = Math.min((width - 16) / (bounds.getWidth() + cameraMaxRadius*2),
+                    (height - 16) / (bounds.getHeight() + cameraMaxRadius*2));
+            g2d.setBackground(Color.black);
+            g2d.clearRect(0, 0, width, height);
+            // Create a transform to scale the shape by
+            AffineTransform tx = new AffineTransform(txOld);
+            tx.translate(width/2, height/2);
+            tx.scale(scale, -scale);
+            g2d.setTransform(tx);
+
+            // Draw the package.
+            g2d.setColor(Color.darkGray);
+            g2d.fill(bodyShape);
+            g2d.setColor(Color.white);
+            g2d.fill(padsShape);
+
+            // Draw fused pads.
+            if (pressedMouse && composite.getRectifiedPads() != null) {
+                g2d.setColor(new Color(255, 255, 255, 220));
+                for (Footprint.Pad pad : composite.getRectifiedPads()) {
+                    g2d.fill(pad.getShape());
+                }
+            }
+
+            List<Shot> shots = composite.getCompositeShots();
+            if (composite.getCompositingSolution().isInvalid()) {
+                // Invalid shots.
+                for (Shot shot : shots) {
+                    drawCameraView(g2d, scale, width, height, 0, 0, cameraWidth, cameraHeight, cameraRoamingRadius, Color.red, shot);
+                    drawShot(g2d, scale, cameraHeight, cameraWidth, shot, Color.red);
+                    g2d.draw(new Line2D.Double(
+                            -width/scale, -height/scale,
+                            +width/scale, +height/scale));
+                }
+            }
+            else {
+                Shot mouseShot = null;
+                double bestDistance = Double.POSITIVE_INFINITY; 
+                for (Shot shot : shots) {
+                    // check if mouse over
+                    if (xMouse != null && yMouse != null) {
+                        double xMouse = (this.xMouse - width/2.0)/scale;
+                        double yMouse = (this.yMouse - height/2.0)/-scale;
+                        double distance = Math.hypot(xMouse - shot.getX(), yMouse - shot.getY());
+                        if (distance < shot.getMaxMaskRadius()
+                                && bestDistance > distance) {
+                            bestDistance = distance;
+                            mouseShot = shot;
+                        }
+                    }
+                }
+                if (mouseShot != null) {
+                    drawCameraView(g2d, scale, width, height, mouseShot.getX(), mouseShot.getY(), cameraWidth, cameraHeight, cameraRoamingRadius, Color.black, mouseShot);
+                    drawShot(g2d, scale, cameraHeight, cameraWidth, mouseShot, Color.yellow);
+                }
+                else {
+                    // Overdraw in reverse. 
+                    for (int i = shots.size()-1; i >= 0; --i) {
+                        Shot shot = shots.get(i);
+                        Color color = shot.isOptional() ? 
+                                Color.blue : Color.red;
+                        drawShot(g2d, scale, cameraHeight, cameraWidth, shot, color);
+                    }
+                }
+            }
+
+            // Restore
+            g2d.setTransform(txOld);
+        }
+        else {
+            Font font = getFont();
+            FontMetrics dfm = g2d.getFontMetrics(font);
+            Color gridColor = getDefaultGridColor();
+            g2d.setFont(font);
+            g2d.setColor(gridColor);
+            String text = "no data";
+            Rectangle2D bounds = dfm.getStringBounds(text, 0, text.length(), g2d);
+            g2d.drawString(text, (int)(getWidth() - bounds.getWidth())/2, (int)(getHeight()/2));
+        }
+    }
+
+    private void drawCameraView(Graphics2D g2d, double scale, int width, int height,
+            double cameraX, double cameraY, double cameraWidth, double cameraHeight, double cameraRoamingRadius, Color color, Shot shot) {
+        Area shade = new Area(new Rectangle2D.Double(
+                -width/scale/2, 
+                -height/scale/2, 
+                width/scale, 
+                height/scale));
+        Area camView = new Area(new Rectangle2D.Double(
+                cameraX - cameraWidth/2, 
+                cameraY - cameraHeight/2, 
+                cameraWidth, 
+                cameraHeight));
+        if (shot != null) {
+            double radius = shot.getMaxMaskRadius();
+            Area mask = new Area(new Ellipse2D.Double(
+                    shot.getX() - radius, shot.getY() - radius,
+                    radius*2,  radius*2));
+            shade.subtract(mask);
+            g2d.setColor(new Color(color.getRed()/4, color.getGreen()/4, color.getBlue()/4, 180));
+            g2d.fill(shade);
+            g2d.setColor(new Color(255, 255, 255, 32));
+            g2d.fill(mask);
+            float stroke = (float)(1.0/scale);
+            g2d.setStroke(new BasicStroke(stroke));
+            g2d.setColor(color);
+            drawCircle(g2d, shot.getX(), shot.getY(), shot.getMinMaskRadius());
+        }
+        else {
+            g2d.setColor(new Color(255, 255, 255, 32));
+            g2d.fill(camView);
+        }
+        shade.subtract(camView);
+        g2d.setColor(new Color(color.getRed()/4, color.getGreen()/4, color.getBlue()/4, 64));
+        g2d.fill(shade);
+        float stroke = (float)(1.0/scale);
+        g2d.setStroke(new BasicStroke(stroke));
+        g2d.setColor(Color.gray);
+        g2d.draw(camView);
+        if (cameraRoamingRadius > 0) {
+            // Draw the roaming circle. 
+            stroke = (float)(composite.getTolerance());
+            float[] dash1 = { (float) composite.getTolerance(), (float) composite.getTolerance()*0.25f  };
+            g2d.setStroke(new BasicStroke(stroke,
+                    BasicStroke.CAP_BUTT, 
+                    BasicStroke.JOIN_ROUND, 
+                    dash1[0], 
+                    dash1,
+                    0f));
+            g2d.setColor(new Color(255, 0, 0, 128));
+            drawCircle(g2d, shot.getX(), shot.getY(), cameraRoamingRadius+composite.getTolerance()/2);
+        }
+    }
+
+    private void drawShot(Graphics2D g2d, double scale, double cameraHeight, double cameraWidth, Shot shot, Color color) {
+        float stroke = (float)(2.0/scale);
+        g2d.setStroke(new BasicStroke(stroke));
+        g2d.setColor(new Color(color.getRed(), color.getGreen(), color.getBlue(), 128));
+        drawCircle(g2d, shot.getX(), shot.getY(), shot.getMinMaskRadius());
+        g2d.setColor(new Color(color.getRed(), color.getGreen(), color.getBlue(), 64));
+        drawCircle(g2d, shot.getX(), shot.getY(), shot.getMaxMaskRadius());
+        for (Corner corner : shot.getCorners()) {
+            stroke = (float)(4.0/scale);
+            g2d.setStroke(new BasicStroke(stroke));
+            g2d.setColor(color);
+            double x = corner.getX();
+            double y = corner.getY();
+            int xSign = corner.getXSign();
+            int ySign = corner.getYSign();
+            g2d.draw(new Line2D.Double(
+                    x + xSign*stroke,                    y + ySign*stroke,
+                    x - xSign*corner.getMinMaskRadius() + xSign*stroke/2, y + ySign*stroke));
+            g2d.draw(new Line2D.Double(
+                    x + xSign*stroke,  y,
+                    x + xSign*stroke,  y - ySign*corner.getMinMaskRadius() + ySign*stroke/2));
+            if (pressedMouse) {
+                stroke = (float)(0.5/scale);
+                g2d.setStroke(new BasicStroke(stroke));
+                g2d.setColor(new Color(color.getRed(), color.getGreen(), color.getBlue(), 64));
+                //drawCircle(g2d, corner.getX(), corner.getY(), corner.getMinMaskRadius());
+                drawCircle(g2d, corner.getX(), corner.getY(), corner.getMaxMaskRadius());
+            }
+        }
+    }
+
+    private void drawCircle(Graphics2D g2d, double x, double y, double r) {
+        g2d.draw(new Ellipse2D.Double(x - r, y - r, r*2, r*2));
+    }
+
+    @Override
+    public void mouseDragged(MouseEvent e) {
+    }
+    @Override
+    public void mouseMoved(MouseEvent e) {
+        xMouse = e.getX();
+        yMouse = e.getY();
+        repaint();
+    }
+    @Override
+    public void mouseClicked(MouseEvent e) {
+        //pressedMouse = true;
+        repaint();
+    }
+    @Override
+    public void mousePressed(MouseEvent e) {
+        pressedMouse = true;
+        repaint();
+    }
+    @Override
+    public void mouseReleased(MouseEvent e) {
+        pressedMouse = false;
+        repaint();
+    }
+    @Override
+    public void mouseEntered(MouseEvent e) {
+    }
+    @Override
+    public void mouseExited(MouseEvent e) {
+        xMouse = null;
+        yMouse = null;
+        pressedMouse = false;
+        repaint();
+    }
+
+    public static Color getDefaultGridColor() {
+        Color gridColor = UIManager.getColor ( "PasswordField.capsLockIconColor" );
+        if (gridColor == null) {
+            gridColor = new Color(0, 0, 0, 64);
+        } else {
+            gridColor = new Color(gridColor.getRed(), gridColor.getGreen(), gridColor.getBlue(), 64);
+        }
+        return gridColor;
+    }
+}

--- a/src/main/java/org/openpnp/gui/support/Helpers.java
+++ b/src/main/java/org/openpnp/gui/support/Helpers.java
@@ -89,9 +89,11 @@ public class Helpers {
                 int index = tableModel.indexOf(row);
                 if (index >= 0) {
                     int viewIndex = table.getRowSorter().convertRowIndexToView(index);
-                    table.addRowSelectionInterval(viewIndex, viewIndex);
-                    Rectangle cellRect = table.getCellRect(viewIndex, viewIndex, true);
-                    table.scrollRectToVisible(cellRect);
+                    if (viewIndex >= 0 && viewIndex < table.getRowCount()) {
+                        table.addRowSelectionInterval(viewIndex, viewIndex);
+                        Rectangle cellRect = table.getCellRect(viewIndex, viewIndex, true);
+                        table.scrollRectToVisible(cellRect);
+                    }
                 }
             }
         });

--- a/src/main/java/org/openpnp/gui/tablemodel/FootprintTableModel.java
+++ b/src/main/java/org/openpnp/gui/tablemodel/FootprintTableModel.java
@@ -38,9 +38,11 @@ public class FootprintTableModel extends AbstractTableModel {
                     LengthCellValue.class, LengthCellValue.class, String.class, String.class};
 
     final private Footprint footprint;
+    final private org.openpnp.model.Package pkg;
 
-    public FootprintTableModel(Footprint footprint) {
+    public FootprintTableModel(Footprint footprint, org.openpnp.model.Package pkg) {
         this.footprint = footprint;
+        this.pkg = pkg;
     }
 
     public Pad getPad(int index) {
@@ -121,10 +123,11 @@ public class FootprintTableModel extends AbstractTableModel {
             }
             else if (columnIndex == 6) {
                 double val = Double.parseDouble(aValue.toString());
-                val = Math.max(val, 0);
+                val = Math.max(val, -100);
                 val = Math.min(val, 100);
                 pad.setRoundness(val);
             }
+            pkg.fireFootprintChanged();
         }
         catch (Exception e) {
             // TODO: dialog, bad input

--- a/src/main/java/org/openpnp/machine/reference/ReferenceNozzle.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceNozzle.java
@@ -492,16 +492,16 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
     @Override
     public Location toHeadLocation(Location location, Location currentLocation, LocationOption... options) {
         boolean quiet = Arrays.asList(options).contains(LocationOption.Quiet);
-        // Apply the rotationModeOffset.
-        if (rotationModeOffset != null) { 
-            location = location.subtractWithRotation(new Location(location.getUnits(), 0, 0, 0, rotationModeOffset));
-            if (!quiet) {
-                Logger.trace("{}.toHeadLocation({}, ...) rotation mode offset {}", getName(), location, rotationModeOffset);
-            }
-        }
-        // Apply runout compensation.
         // Check SuppressCompensation, in that case disable nozzle calibration
         if (! Arrays.asList(options).contains(LocationOption.SuppressDynamicCompensation)) {
+            // Apply the rotationModeOffset.
+            if (rotationModeOffset != null) { 
+                location = location.subtractWithRotation(new Location(location.getUnits(), 0, 0, 0, rotationModeOffset));
+                if (!quiet) {
+                    Logger.trace("{}.toHeadLocation({}, ...) rotation mode offset {}", getName(), location, rotationModeOffset);
+                }
+            }
+            // Apply runout compensation.
             ReferenceNozzleTip calibrationNozzleTip = getCalibrationNozzleTip();
             if (calibrationNozzleTip != null && calibrationNozzleTip.getCalibration().isCalibrated(this)) {
                 Location correctionOffset = calibrationNozzleTip.getCalibration().getCalibratedOffset(this, location.getRotation());
@@ -526,11 +526,11 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
                         calibrationNozzleTip.getCalibration().getCalibratedOffset(this, location.getRotation());
                 location = location.add(offset);
             }
-        }
-        // Unapply the rotationModeOffset.
-        if (rotationModeOffset != null) { 
-            location = location.addWithRotation(new Location(location.getUnits(), 
-                    0, 0, 0, rotationModeOffset));
+            // Unapply the rotationModeOffset.
+            if (rotationModeOffset != null) { 
+                location = location.addWithRotation(new Location(location.getUnits(), 
+                        0, 0, 0, rotationModeOffset));
+            }
         }
         return location;
     }

--- a/src/main/java/org/openpnp/machine/reference/ReferenceNozzleTip.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceNozzleTip.java
@@ -168,7 +168,7 @@ public class ReferenceNozzleTip extends AbstractNozzleTip {
     private Length maxPartDiameter = new Length(20, LengthUnit.Millimeters);
 
     @Element(required = false)
-    private Length maxPartHeight = new Length(10, LengthUnit.Millimeters);
+    private Length maxPartHeight = new Length(5, LengthUnit.Millimeters);
 
     @Element(required = false)
     protected Length maxPickTolerance = new Length(1, LengthUnit.Millimeters);
@@ -343,6 +343,7 @@ public class ReferenceNozzleTip extends AbstractNozzleTip {
                 };
     }
 
+    @Override
     public Length getMaxPartHeight() {
         return maxPartHeight;
     }
@@ -351,6 +352,7 @@ public class ReferenceNozzleTip extends AbstractNozzleTip {
         this.maxPartHeight = maxPartHeight;
     }
 
+    @Override
     public Length getMaxPartDiameter() {
         return maxPartDiameter;
     }
@@ -359,6 +361,7 @@ public class ReferenceNozzleTip extends AbstractNozzleTip {
         this.maxPartDiameter = maxPartDiameter;
     }
 
+    @Override
     public Length getMinPartDiameter() {
         return minPartDiameter;
     }
@@ -367,22 +370,13 @@ public class ReferenceNozzleTip extends AbstractNozzleTip {
         this.minPartDiameter = minPartDiameter;
     }
 
+    @Override
     public Length getMaxPickTolerance() {
         return maxPickTolerance;
     }
 
     public void setMaxPickTolerance(Length maxPickTolerance) {
         this.maxPickTolerance = maxPickTolerance;
-    }
-
-    public Length getMinPartDiameterWithTolerance() {
-        return getMinPartDiameter()
-                .subtract(getMaxPickTolerance().multiply(2.0));
-    }
-
-    public Length getMaxPartDiameterWithTolerance() {
-        return getMaxPartDiameter()
-                .add(getMaxPickTolerance().multiply(2.0));
     }
 
     public int getPickDwellMilliseconds() {

--- a/src/main/java/org/openpnp/machine/reference/ReferenceNozzleTipCalibration.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceNozzleTipCalibration.java
@@ -1000,7 +1000,8 @@ public class ReferenceNozzleTipCalibration extends AbstractModelObject {
                 // Blot out the nozzle tip center part.
                 Point center = VisionUtils.getLocationPixels(camera, location.add(camera.getLocation()));
                 org.opencv.core.Point center2 = new org.opencv.core.Point(center.x, center.y);
-                Length minPartDiameter = nozzleTip.getMinPartDiameterWithTolerance();
+                Length minPartDiameter = nozzleTip.getMinPartDiameter()
+                .subtract(nozzleTip.getMaxPickTolerance().multiply(2.0));
                 if (minPartDiameter.compareTo(getCalibrationTipDiameter()) < 0) {
                     minPartDiameter = getCalibrationTipDiameter();
                 }
@@ -1039,7 +1040,8 @@ public class ReferenceNozzleTipCalibration extends AbstractModelObject {
             if (nozzleTip != null 
                     && backgroundImages.size() > 3) {
                 double t0 = NanosecondTime.getRuntimeSeconds();
-                double maskDiameterPixels = nozzleTip.getMaxPartDiameterWithTolerance()
+                double maskDiameterPixels = nozzleTip.getMaxPartDiameter()
+                .add(nozzleTip.getMaxPickTolerance().multiply(2.0))
                         .divide(camera.getUnitsPerPixel().getLengthX())*0.5;
                 int maskSq = (int)Math.pow(maskDiameterPixels, 2);
                 int rows = backgroundImageRows, cols = backgroundImageCols, ch = backgroundImageChannels;

--- a/src/main/java/org/openpnp/machine/reference/SimulationModeMachine.java
+++ b/src/main/java/org/openpnp/machine/reference/SimulationModeMachine.java
@@ -54,6 +54,7 @@ import org.openpnp.spi.HeadMountable;
 import org.openpnp.spi.Locatable.LocationOption;
 import org.openpnp.spi.Machine;
 import org.openpnp.spi.Nozzle;
+import org.openpnp.spi.base.AbstractNozzle;
 import org.openpnp.util.Collect;
 import org.openpnp.util.GcodeServer;
 import org.openpnp.util.NanosecondTime;
@@ -334,6 +335,8 @@ public class SimulationModeMachine extends ReferenceMachine {
         return null;
     }
 
+    static private HashMap<Nozzle, Double> rotationModeOffsetAtPick = new HashMap<>();
+    
     /**
      * Simulates the Actuator. 
      * 
@@ -346,7 +349,7 @@ public class SimulationModeMachine extends ReferenceMachine {
         SimulationModeMachine machine = getSimulationModeMachine();
         if (machine != null 
                 && machine.getSimulationMode() != SimulationMode.Off) {
-            if (value instanceof Boolean && machine.isPickAndPlaceChecking()) {
+            if (value instanceof Boolean) {
                 // Check if this is a nozzle vacuum actuator.
                 if (actuator.getHead() != null) {
                     Camera camera = actuator.getHead().getDefaultCamera();
@@ -356,17 +359,29 @@ public class SimulationModeMachine extends ReferenceMachine {
                                     && ((ReferenceNozzle) nozzle).getVacuumActuator() == actuator) {
                                 // Got the vacuum actuator, which is a signal to check for pick/place.
                                 if (nozzle.getPart() != null) {
-                                    Location location = SimulationModeMachine.getSimulatedPhysicalLocation(nozzle, null);
-                                    if (location.getLinearDistanceTo(machine.getDiscardLocation()) > 4.0) {
-                                        if ((Boolean)value == true) {
-                                            // Pick
+                                    if ((Boolean)value == true) {
+                                        // New pick, remove any old offsets.
+                                        rotationModeOffsetAtPick.remove(nozzle);
+                                    }
+                                    Location location = SimulationModeMachine.getSimulatedPhysicalLocation(nozzle, null, true);
+                                    boolean checkPnP = machine.isPickAndPlaceChecking()
+                                            && (location.getLinearDistanceTo(machine.getDiscardLocation()) > 4.0); 
+                                    if ((Boolean)value == true) {
+                                        // Pick
+                                        if (checkPnP) {
                                             if (!((ImageCamera) camera).isPickLocation(location, nozzle)) {
                                                 throw new Exception("Nozzle "+nozzle.getName()+" part "+nozzle.getPart().getId()
                                                         +" pick location not recognized.");
                                             }
                                         }
-                                        else {
-                                            // Pick
+                                        if (nozzle instanceof AbstractNozzle) {
+                                            rotationModeOffsetAtPick.put(nozzle, ((AbstractNozzle) nozzle).getRotationModeOffset());
+                                        }
+                                    }
+                                    else {
+                                        // Place
+                                        if (checkPnP) {
+                                            rotationModeOffsetAtPick.remove(nozzle);
                                             if (!((ImageCamera) camera).isPlaceLocation(location, nozzle)) {
                                                 throw new Exception("Nozzle "+nozzle.getName()+" part "+nozzle.getPart().getId()
                                                         +" place location not recognized.");
@@ -382,7 +397,7 @@ public class SimulationModeMachine extends ReferenceMachine {
         }
         if (realtime) {
             try {
-                Thread.sleep(500);
+                Thread.sleep(50);
             }
             catch (InterruptedException e) {
             }
@@ -394,9 +409,10 @@ public class SimulationModeMachine extends ReferenceMachine {
      *  
      * @param hm
      * @param looking
+     * @param partRotation 
      * @return
      */
-    public static Location getSimulatedPhysicalLocation(HeadMountable hm, Looking looking) {
+    public static Location getSimulatedPhysicalLocation(HeadMountable hm, Looking looking, boolean partRotation) {
         // Use ideal location as a default, used in case this fails (not a place to throw).
         Location location = hm.getLocation().convertToUnits(AxesLocation.getUnits());
         Machine plainMachine = Configuration.get().getMachine();
@@ -507,6 +523,19 @@ public class SimulationModeMachine extends ReferenceMachine {
                         LocationOption.SuppressCameraCalibration,
                         LocationOption.SuppressStaticCompensation,
                         LocationOption.SuppressDynamicCompensation);
+                // If the part rotation is wanted, we need to adjust the 
+                if (partRotation && hm instanceof AbstractNozzle) {
+                    Double rotationOffset = rotationModeOffsetAtPick.get(hm);
+                    if (rotationOffset != null) {
+                        location = location.derive(null, null, null, location.getRotation() + rotationOffset);
+                    }
+                    else {
+                        rotationOffset = ((AbstractNozzle)hm).getRotationModeOffset();
+                        if (rotationOffset != null) {
+                            location = location.derive(null, null, null, location.getRotation() + rotationOffset);
+                        }
+                    }
+                }
             }
             catch (Exception e) {
                 Logger.error(e);

--- a/src/main/java/org/openpnp/machine/reference/camera/ImageCamera.java
+++ b/src/main/java/org/openpnp/machine/reference/camera/ImageCamera.java
@@ -254,7 +254,7 @@ public class ImageCamera extends ReferenceCamera {
         if (! ensureOpen()) {
             return null;
         }
-        Location location = SimulationModeMachine.getSimulatedPhysicalLocation(this, getLooking());
+        Location location = SimulationModeMachine.getSimulatedPhysicalLocation(this, getLooking(), false);
 
         BufferedImage frame = locationCapture(location, width, height, true);
         return frame;
@@ -562,7 +562,7 @@ public class ImageCamera extends ReferenceCamera {
             // Blur it to give us a tolerant best match.
             Imgproc.GaussianBlur(templateMat, templateMat, new Size(kernelSize, kernelSize), 0);
 
-            // Get a view of the target area that is 5 x bigger than the template but at least 100px. 
+            // Get a view of the target area that is 5 x bigger than the template but at least 80px. 
             int dimension = Math.max(Math.max(template.getWidth(), template.getHeight())*5, 80);
             BufferedImage targetArea = locationCapture(physicalLocation, dimension, dimension, false);
             mat = OpenCvUtils.toMat(targetArea);

--- a/src/main/java/org/openpnp/machine/reference/camera/SimulatedUpCamera.java
+++ b/src/main/java/org/openpnp/machine/reference/camera/SimulatedUpCamera.java
@@ -93,10 +93,10 @@ public class SimulatedUpCamera extends ReferenceCamera {
         // figure out our physical viewport size
         Location phySize = getSimulatedUnitsPerPixel().convertToUnits(LengthUnit.Millimeters)
                 .multiply(width, height, 0, 0);
-        double phyWidth = phySize.getX();
-        double phyHeight = phySize.getY();
+        double phyWidth = phySize.getX()*2;
+        double phyHeight = phySize.getY()*2;
 
-        // and bounds (times two to cover perspective projection)
+        // and bounds (times two to cover perspective projection and large ICs)
         Location location = getSimulatedLocation().convertToUnits(LengthUnit.Millimeters);
         Rectangle2D.Double phyBounds = new Rectangle2D.Double(location.getX() - phyWidth,
                 location.getY() - phyHeight, phyWidth*2, phyHeight*2);
@@ -108,7 +108,7 @@ public class SimulatedUpCamera extends ReferenceCamera {
             try {
                 for (Head head :  machine.getHeads()) {
                     for (Nozzle nozzle : head.getNozzles()) {
-                        Location l = SimulationModeMachine.getSimulatedPhysicalLocation(nozzle, getLooking());
+                        Location l = SimulationModeMachine.getSimulatedPhysicalLocation(nozzle, getLooking(), true);
                         if (phyBounds.contains(l.getX(), l.getY())) {
                             drawNozzle(g, nozzle, l);
                         }
@@ -185,8 +185,14 @@ public class SimulatedUpCamera extends ReferenceCamera {
                 throw new Error("Not yet supported.");
             }
 
-            // Account for the patu height.
-            Location partUndersideLocation = l.subtract(new Location(part.getHeight().getUnits(), 0, 0, Math.abs(part.getHeight().getValue()), 0));
+            // Account for the part height.
+            double partHeightMm = Math.abs(part.getHeight().convertToUnits(LengthUnit.Millimeters).getValue());
+            if (partHeightMm == 0) {
+                // Just simulate something.
+                partHeightMm = 1.0;
+            }
+            Location partUndersideLocation = l.subtract(new Location(LengthUnit.Millimeters, 
+                    0, 0, partHeightMm, 0));
             offsets = partUndersideLocation.subtractWithRotation(getSimulatedLocation());
 
             // First draw the body in dark grey.

--- a/src/main/java/org/openpnp/machine/reference/camera/wizards/AutoFocusProviderConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/camera/wizards/AutoFocusProviderConfigurationWizard.java
@@ -191,7 +191,8 @@ public class AutoFocusProviderConfigurationWizard extends AbstractConfigurationW
                 Length maxPartHeight = nt.getMaxPartHeight();
                 Location location0 = location1.add(new Location(maxPartHeight.getUnits(), 
                         0, 0, maxPartHeight.getValue(), 0));
-                Location focus = focusProvider.autoFocus(camera, nozzle, nt.getMaxPartDiameterWithTolerance(), location0, location1);
+                Location focus = focusProvider.autoFocus(camera, nozzle, nt.getMaxPartDiameter()
+                .add(nt.getMaxPickTolerance().multiply(2.0)), location0, location1);
                 setLastFocusDistance(focus.getXyzLengthTo(location1));
                 MovableUtils.fireTargetedUserAction(camera);
             });

--- a/src/main/java/org/openpnp/machine/reference/driver/GcodeDriver.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/GcodeDriver.java
@@ -39,6 +39,7 @@ import org.openpnp.gui.support.PropertySheetWizardAdapter;
 import org.openpnp.machine.reference.ReferenceActuator;
 import org.openpnp.machine.reference.ReferenceMachine;
 import org.openpnp.machine.reference.ReferenceNozzle;
+import org.openpnp.machine.reference.SimulationModeMachine;
 import org.openpnp.machine.reference.axis.ReferenceCamClockwiseAxis;
 import org.openpnp.machine.reference.axis.ReferenceCamCounterClockwiseAxis;
 import org.openpnp.machine.reference.axis.ReferenceControllerAxis;
@@ -903,6 +904,7 @@ public class GcodeDriver extends AbstractReferenceDriver implements Named {
         command = substituteVariable(command, "True", on ? on : null);
         command = substituteVariable(command, "False", on ? null : on);
         sendGcode(command);
+        SimulationModeMachine.simulateActuate(actuator, on, true);
     }
 
     @Override
@@ -916,6 +918,7 @@ public class GcodeDriver extends AbstractReferenceDriver implements Named {
         command = substituteVariable(command, "DoubleValue", value);
         command = substituteVariable(command, "IntegerValue", (int) value);
         sendGcode(command);
+        SimulationModeMachine.simulateActuate(actuator, value, true);
     }
 
     @Override

--- a/src/main/java/org/openpnp/machine/reference/vision/AbstractPartAlignment.java
+++ b/src/main/java/org/openpnp/machine/reference/vision/AbstractPartAlignment.java
@@ -88,6 +88,9 @@ public abstract class AbstractPartAlignment extends AbstractPartSettingsHolder i
     @Override
     public Wizard getPartConfigurationWizard(PartSettingsHolder partSettingsHolder) {
         BottomVisionSettings visionSettings = getInheritedVisionSettings(partSettingsHolder);
+        if (visionSettings == null) {
+            return null;
+        }
         try {
             visionSettings.getPipeline().setProperty("camera", VisionUtils.getBottomVisionCamera());
         }

--- a/src/main/java/org/openpnp/machine/reference/vision/ReferenceBottomVision.java
+++ b/src/main/java/org/openpnp/machine/reference/vision/ReferenceBottomVision.java
@@ -10,6 +10,7 @@ import org.opencv.core.RotatedRect;
 import org.opencv.core.Size;
 import org.openpnp.ConfigurationListener;
 import org.openpnp.gui.MainFrame;
+import org.openpnp.gui.support.DoubleConverter;
 import org.openpnp.gui.support.LengthConverter;
 import org.openpnp.gui.support.PropertySheetWizardAdapter;
 import org.openpnp.machine.reference.ReferenceNozzleTip;
@@ -22,21 +23,28 @@ import org.openpnp.model.AbstractVisionSettings;
 import org.openpnp.model.BoardLocation;
 import org.openpnp.model.BottomVisionSettings;
 import org.openpnp.model.Configuration;
-import org.openpnp.model.Footprint;
 import org.openpnp.model.Length;
 import org.openpnp.model.LengthUnit;
 import org.openpnp.model.Location;
+import org.openpnp.model.Package;
 import org.openpnp.model.Part;
 import org.openpnp.model.PartSettingsHolder;
+import org.openpnp.model.VisionCompositing;
+import org.openpnp.model.VisionCompositing.Composite;
+import org.openpnp.model.VisionCompositing.Shot;
 import org.openpnp.spi.Camera;
 import org.openpnp.spi.Nozzle;
+import org.openpnp.spi.NozzleTip;
 import org.openpnp.spi.PartAlignment;
 import org.openpnp.spi.PropertySheetHolder;
+import org.openpnp.spi.base.AbstractNozzle;
 import org.openpnp.util.MovableUtils;
 import org.openpnp.util.OpenCvUtils;
+import org.openpnp.util.UiUtils;
 import org.openpnp.util.Utils2D;
 import org.openpnp.util.VisionUtils;
 import org.openpnp.vision.pipeline.CvPipeline;
+import org.openpnp.vision.pipeline.CvPipeline.PipelineShot;
 import org.openpnp.vision.pipeline.CvStage.Result;
 import org.pmw.tinylog.Logger;
 import org.simpleframework.xml.Attribute;
@@ -111,14 +119,24 @@ public class ReferenceBottomVision extends AbstractPartAlignment {
         }
 
         Camera camera = VisionUtils.getBottomVisionCamera();
-
+        PartAlignmentOffset offsets;
         if ((bottomVisionSettings.getPreRotateUsage() == PreRotateUsage.Default && preRotate)
                 || (bottomVisionSettings.getPreRotateUsage() == PreRotateUsage.AlwaysOn)) {
-            return findOffsetsPreRotate(part, boardLocation, placementLocation, nozzle, camera, bottomVisionSettings);
+            offsets = findOffsetsPreRotate(part, boardLocation, placementLocation, nozzle, camera, bottomVisionSettings);
         }
         else {
-            return findOffsetsPostRotate(part, boardLocation, placementLocation, nozzle, camera, bottomVisionSettings);
+            offsets = findOffsetsPostRotate(part, boardLocation, placementLocation, nozzle, camera, bottomVisionSettings);
         }
+        if (nozzle.isAligningRotationMode() && nozzle instanceof AbstractNozzle) {
+            // Add the rotation offset to the rotation mode rather than adjusting for it in placement. This has the advantage of
+            // showing the rotation aligned with the part rotation in the DRO, cross-hairs etc.
+            AbstractNozzle abstractNozzle = (AbstractNozzle) nozzle;
+            double rotOff = abstractNozzle.getRotationModeOffset() != null ? abstractNozzle.getRotationModeOffset() : 0;
+            abstractNozzle.setRotationModeOffset(rotOff + offsets.getLocation().getRotation());
+            Location newOffsets = offsets.getLocation()/*.rotateXy(offsets.getLocation().getRotation())*/.derive(null, null, null, 0.);
+            offsets = new PartAlignmentOffset(newOffsets, offsets.getPreRotated()); 
+        }
+        return offsets;
     }
 
     public Location getCameraLocationAtPartHeight(Part part, Camera camera, Nozzle nozzle, double angle) throws Exception {
@@ -129,15 +147,28 @@ public class ReferenceBottomVision extends AbstractPartAlignment {
         }
         if (part.isPartHeightUnknown()) {
             if (camera.getFocusProvider() != null
-                    && nozzle.getNozzleTip() instanceof ReferenceNozzleTip) {
-                ReferenceNozzleTip nt = (ReferenceNozzleTip) nozzle.getNozzleTip(); 
-                Location location1 = camera.getLocation(nozzle)
+                    && nozzle.getNozzleTip() != null) {
+                NozzleTip nt = nozzle.getNozzleTip();
+                
+                Location locationNominal = camera.getLocation(nozzle)
                         .derive(null, null, null, angle);
-                Location location0 = location1.add(new Location(nt.getMaxPartHeight().getUnits(), 
-                        0, 0, nt.getMaxPartHeight().getValue(), 0));
-                Location focus = camera.getFocusProvider().autoFocus(camera, nozzle, nt.getMaxPartDiameterWithTolerance(), location0, location1);
-                Length partHeight = focus.getLengthZ().subtract(location1.getLengthZ());
-                if (partHeight.getValue() <= 0.001) {
+                BottomVisionSettings bottomVisionSettings = ReferenceBottomVision.getDefault()
+                        .getInheritedVisionSettings(part);
+                Composite composite = part.getPackage().getVisionCompositing().new Composite(part.getPackage(), bottomVisionSettings, nozzle, nt, 
+                        camera, locationNominal);
+                Length partHeight = new Length(0, LengthUnit.Millimeters);
+                int weight = 0;
+                for (Shot shot : composite.getShotsTravel()) {
+                    Location location1 = composite.getShotLocation(shot);
+                    Location location0 = location1.add(new Location(nt.getMaxPartHeight().getUnits(), 
+                            0, 0, nt.getMaxPartHeight().getValue(), 0));
+                    Location focus = camera.getFocusProvider().autoFocus(camera, nozzle, nt.getMaxPartDiameter()
+                            .add(nt.getMaxPickTolerance().multiply(2.0)), location0, location1);
+                    partHeight = partHeight.add(focus.getLengthZ().subtract(location1.getLengthZ()));
+                    weight++;
+                }
+                partHeight = partHeight.divide(weight);
+                if (partHeight.convertToUnits(LengthUnit.Millimeters).getValue() <= 0.001) {
                     throw new Exception("Auto focus part height determination failed. Camera seems to have focused on nozzle tip.");
                 }
                 Logger.info("Part "+part.getId()+" height set to "+partHeight+" by camera focus provider.");
@@ -169,7 +200,6 @@ public class ReferenceBottomVision extends AbstractPartAlignment {
         Location wantedLocation = getCameraLocationAtPartHeight(part, camera, nozzle, wantedAngle);
 
         Location nozzleLocation = wantedLocation;
-        MovableUtils.moveToLocationAtSafeZ(nozzle, nozzleLocation);
         final Location center = new Location(maxLinearOffset.getUnits());
 
         try (CvPipeline pipeline = bottomVisionSettings.getPipeline()) {
@@ -179,8 +209,7 @@ public class ReferenceBottomVision extends AbstractPartAlignment {
             // Try getting a good fix on the part in multiple passes.
             for(int pass = 0;;) {
                 RotatedRect rect = processPipelineAndGetResult(pipeline, camera, part, nozzle,
-                        wantedLocation, bottomVisionSettings);
-                camera=(Camera)pipeline.getProperty("camera");
+                        wantedLocation, nozzleLocation, bottomVisionSettings);
 
                 Logger.debug("Bottom vision part {} result rect {}", part.getId(), rect);
 
@@ -204,7 +233,7 @@ public class ReferenceBottomVision extends AbstractPartAlignment {
                 // will change too, as the off-center part rotates around the nozzle axis.
                 // So we need to compensate for that.
                 offsets = offsets.rotateXy(-angleOffset)
-                        .derive(null, null,	null, angleOffset);
+                        .derive(null, null, null, angleOffset);
                 nozzleLocation = nozzleLocation.subtractWithRotation(offsets);
 
                 if (++pass >= maxVisionPasses) {
@@ -235,11 +264,10 @@ public class ReferenceBottomVision extends AbstractPartAlignment {
                 }
                 else {
                     // We have a good enough fix - go on with that. 
-                    break;                		
+                    break;
                 }
 
                 // Not a good enough fix - try again with corrected position.
-                nozzle.moveTo(nozzleLocation);
             }
             Logger.debug("Offsets accepted {}", offsets);
             // Calculate cumulative offsets over all the passes.  
@@ -262,11 +290,8 @@ public class ReferenceBottomVision extends AbstractPartAlignment {
         // and a rotation of 0, unless preRotate is enabled
         Location wantedLocation = getCameraLocationAtPartHeight(part, camera, nozzle, 0.);
 
-        MovableUtils.moveToLocationAtSafeZ(nozzle, wantedLocation);
-
         try (CvPipeline pipeline = bottomVisionSettings.getPipeline()) {
-            RotatedRect rect = processPipelineAndGetResult(pipeline, camera, part, nozzle, wantedLocation, bottomVisionSettings);
-            camera=(Camera)pipeline.getProperty("camera");
+            RotatedRect rect = processPipelineAndGetResult(pipeline, camera, part, nozzle, wantedLocation, wantedLocation, bottomVisionSettings);
 
             Logger.debug("Bottom vision part {} result rect {}", part.getId(), rect);
 
@@ -302,8 +327,8 @@ public class ReferenceBottomVision extends AbstractPartAlignment {
     }
 
     protected void offsetsCheck(Part part, Nozzle nozzle, Location offsets) throws Exception {
-        if (nozzle.getNozzleTip() instanceof ReferenceNozzleTip) {
-            ReferenceNozzleTip nt = (ReferenceNozzleTip) nozzle.getNozzleTip();
+        if (nozzle.getNozzleTip() != null) {
+            NozzleTip nt = nozzle.getNozzleTip();
             Length offsetsLength = offsets.getLinearLengthTo(Location.origin);
             Length maxPickTolerance = nt.getMaxPickTolerance();
             if (offsetsLength.compareTo(maxPickTolerance) > 0) {
@@ -386,16 +411,24 @@ public class ReferenceBottomVision extends AbstractPartAlignment {
     }
 
     private static void displayResult(CvPipeline pipeline, Part part, Location offsets, Camera camera, Nozzle nozzle) {
-        Logger.debug("Final offsets {}, distance {}", offsets, offsets.getLinearDistanceTo(Location.origin));
+        String s = part.getId();
+        if (offsets != null) {
+            LengthConverter lengthConverter = new LengthConverter();
+            DoubleConverter doubleConverter = new DoubleConverter(Configuration.get().getLengthDisplayFormat());
+            s += "  |  X:"+lengthConverter.convertForward(offsets.getLengthX())+" "
+                    +"Y:"+lengthConverter.convertForward(offsets.getLengthY())+" "
+                    +"C:"+doubleConverter.convertForward(offsets.getRotation())
+                    +" Δ:"+lengthConverter.convertForward(offsets.getLinearLengthTo(Location.origin));
+        }
+        Logger.debug("Alignment result: {}", s);
         MainFrame mainFrame = MainFrame.get();
         if (mainFrame != null) {
             try {
-                String s = String.format("%s : %s", part.getId(), offsets.toString());
                 mainFrame
                 .getCameraViews()
                 .getCameraView(camera)
                 .showFilteredImage(OpenCvUtils.toBufferedImage(pipeline.getWorkingImage()), s,
-                        1500);
+                        2000);
                 // Also make sure the right nozzle is selected for correct cross-hair rotation.
                 MovableUtils.fireTargetedUserAction(nozzle);
             }
@@ -406,103 +439,148 @@ public class ReferenceBottomVision extends AbstractPartAlignment {
     }
 
     public void preparePipeline(CvPipeline pipeline, Map<String, Object> pipelineParameterAssignments, 
-            Camera camera, Nozzle nozzle, Location wantedLocation, BottomVisionSettings bottomVisionSettings) {
-        Location upp = camera.getUnitsPerPixelAtZ();
-        pipeline.setProperty("camera", camera);
-        Location partSize = null;
-        Length samplingSize = new Length(0.1, LengthUnit.Millimeters); // Default, if no setting on nozzle tip. 
-        // Set the footprint.
-        if (nozzle.getPart() != null && nozzle.getPart().getPackage() != null) {
-            Footprint footprint = nozzle.getPart().getPackage().getFootprint();
-            pipeline.setProperty("footprint", footprint);
-            partSize = bottomVisionSettings.getPartCheckSize(nozzle.getPart(), true);
+            Camera camera, Package pkg, Nozzle nozzle, NozzleTip nozzleTip, Location wantedLocation, 
+            Location adjustedNozzleLocation, BottomVisionSettings bottomVisionSettings) throws Exception {
+        VisionCompositing visionCompositing = pkg.getVisionCompositing();
+        VisionCompositing.Composite composite = visionCompositing.new Composite(
+                pkg, bottomVisionSettings, nozzle, nozzleTip, camera, wantedLocation);
+        if (visionCompositing.getCompositingMethod().isEnforced() 
+                && composite.getCompositingSolution().isInvalid()) {
+            throw new Exception("Vision Compositing has not found a valid solution for package "+pkg.getId()+". "
+                    + "Status: "+composite.getCompositingSolution()+". "
+                    + "For more diagnostic information go to the Vision Compositing tab on package "+pkg.getId()+". ");
         }
-        // Set alignment parameters.
-        pipeline.setProperty("MinAreaRect.center", wantedLocation);
-        pipeline.setProperty("MinAreaRect.expectedAngle", wantedLocation.getRotation());
-        pipeline.setProperty("DetectRectlinearSymmetry.center", wantedLocation);
-        pipeline.setProperty("DetectRectlinearSymmetry.expectedAngle", wantedLocation.getRotation());
-        // Set the background removal properties.
-        if (nozzle.getNozzleTip() instanceof ReferenceNozzleTip) { 
-            ReferenceNozzleTip referenceNozzleTip = (ReferenceNozzleTip) nozzle.getNozzleTip();
-            pipeline.setProperty("DetectRectlinearSymmetry.searchDistance", referenceNozzleTip.getMaxPickTolerance()
+        pipeline.resetReusedPipeline();
+        for (Shot shot : composite.getShotsTravel()) {
+            Location upp = camera.getUnitsPerPixelAtZ();
+            pipeline.setProperty("camera", camera);
+            Length samplingSize = new Length(0.1, LengthUnit.Millimeters); // Default, if no setting on nozzle tip. 
+            // Set the footprint.
+            pipeline.setProperty("footprint", composite.getFootprint());
+            // Set alignment parameters.
+            pipeline.setProperty("MinAreaRect.center", wantedLocation);
+            pipeline.setProperty("MinAreaRect.expectedAngle", wantedLocation.getRotation());
+            pipeline.setProperty("DetectRectlinearSymmetry.center", wantedLocation);
+            pipeline.setProperty("DetectRectlinearSymmetry.expectedAngle", wantedLocation.getRotation());
+            // Set the background removal properties.
+            pipeline.setProperty("DetectRectlinearSymmetry.searchDistance", nozzleTip.getMaxPickTolerance()
                     .multiply(1.2)); // Allow for some tolerance, we will check the result later.
-            pipeline.setProperty("MaskCircle.diameter", referenceNozzleTip.getMaxPartDiameterWithTolerance());
-            ReferenceNozzleTipCalibration calibration = referenceNozzleTip.getCalibration();
-            if (calibration != null 
-                    && calibration.getBackgroundCalibrationMethod() != BackgroundCalibrationMethod.None) {
-                samplingSize = calibration.getMinimumDetailSize().multiply(0.5);
-                pipeline.setProperty("MaskHsv.hueMin", 
-                        Math.max(0, calibration.getBackgroundMinHue() - calibration.getBackgroundTolHue()));
-                pipeline.setProperty("MaskHsv.hueMax", 
-                        Math.min(255, calibration.getBackgroundMaxHue() + calibration.getBackgroundTolHue()));
-                pipeline.setProperty("MaskHsv.saturationMin", 
-                        Math.max(0, calibration.getBackgroundMinSaturation() - calibration.getBackgroundTolSaturation()));
-                pipeline.setProperty("MaskHsv.saturationMax", 255);  
-                // no need to restrict to this: Math.min(255, calibration.getBackgroundMaxSaturation() + calibration.getBackgroundTolSaturation()));
-                pipeline.setProperty("MaskHsv.valueMin", 0); 
-                // no need to restrict to this: Math.max(0, calibration.getBackgroundMinValue() - calibration.getBackgroundTolValue()));
-                pipeline.setProperty("MaskHsv.valueMax", 
-                        Math.min(255, calibration.getBackgroundMaxValue() +  calibration.getBackgroundTolValue()));
+            pipeline.setProperty("MaskCircle.diameter", new Length(shot.getMaxMaskRadius()*2, composite.getUnits()));
+            if (nozzleTip instanceof ReferenceNozzleTip) {
+                ReferenceNozzleTipCalibration calibration = ((ReferenceNozzleTip) nozzleTip).getCalibration();
+                if (calibration != null 
+                        && calibration.getBackgroundCalibrationMethod() != BackgroundCalibrationMethod.None) {
+                    samplingSize = calibration.getMinimumDetailSize().multiply(0.5);
+                    pipeline.setProperty("MaskHsv.hueMin", 
+                            Math.max(0, calibration.getBackgroundMinHue() - calibration.getBackgroundTolHue()));
+                    pipeline.setProperty("MaskHsv.hueMax", 
+                            Math.min(255, calibration.getBackgroundMaxHue() + calibration.getBackgroundTolHue()));
+                    pipeline.setProperty("MaskHsv.saturationMin", 
+                            Math.max(0, calibration.getBackgroundMinSaturation() - calibration.getBackgroundTolSaturation()));
+                    pipeline.setProperty("MaskHsv.saturationMax", 255);  
+                    // no need to restrict to this: Math.min(255, calibration.getBackgroundMaxSaturation() + calibration.getBackgroundTolSaturation()));
+                    pipeline.setProperty("MaskHsv.valueMin", 0); 
+                    // no need to restrict to this: Math.max(0, calibration.getBackgroundMinValue() - calibration.getBackgroundTolValue()));
+                    pipeline.setProperty("MaskHsv.valueMax", 
+                            Math.min(255, calibration.getBackgroundMaxValue() +  calibration.getBackgroundTolValue()));
+                }
             }
-        }
-        if (samplingSize.compareTo(upp.getLengthX().multiply(2)) < 0) {
-            // We want the sampling size to at least be 2 pixels, otherwise subSampling will be too costly. 
-            // This means: a camera with less than 4 pixels per smallest contact size, is likely to cause problems
-            // but that's to be expected anyways.
-            samplingSize = upp.getLengthX().multiply(2);
-        }
-        pipeline.setProperty("BlurGaussian.kernelSize", samplingSize);
-        pipeline.setProperty("DetectRectlinearSymmetry.subSampling", samplingSize);
-        if (partSize != null) {
+            if (samplingSize.compareTo(upp.getLengthX().multiply(2)) < 0) {
+                // We want the sampling size to at least be 2 pixels, otherwise subSampling will be too costly. 
+                // This means: a camera with less than 4 pixels per smallest contact size, is likely to cause problems
+                // but that's to be expected anyways.
+                samplingSize = upp.getLengthX().multiply(2);
+            }
+            pipeline.setProperty("BlurGaussian.kernelSize", samplingSize);
+            pipeline.setProperty("DetectRectlinearSymmetry.subSampling", samplingSize);
             // Add a margin for edge detection.
-            pipeline.setProperty("DetectRectlinearSymmetry.maxWidth", partSize.getLengthX()
+            pipeline.setProperty("DetectRectlinearSymmetry.maxWidth",
+                    new Length(shot.getWidth(), composite.getUnits())
                     .add(samplingSize.multiply(2)));
-            pipeline.setProperty("DetectRectlinearSymmetry.maxHeight", partSize.getLengthY()
+            pipeline.setProperty("DetectRectlinearSymmetry.maxHeight",
+                    new Length(shot.getHeight(), composite.getUnits())
                     .add(samplingSize.multiply(2)));
-        }
-        else if (nozzle.getNozzleTip() instanceof ReferenceNozzleTip) {
-            // No part size available. Use the maximum diameter. 
-            Length maxPartDiameter = ((ReferenceNozzleTip) nozzle.getNozzleTip()).getMaxPartDiameter();
-            pipeline.setProperty("DetectRectlinearSymmetry.maxWidth", maxPartDiameter);
-            pipeline.setProperty("DetectRectlinearSymmetry.maxHeight", maxPartDiameter);
-        }
 
-        pipeline.setProperties(pipelineParameterAssignments);
+            if (composite.getCompositingSolution().isAdvanced()) {
+                pipeline.setProperty("MinAreaRect.leftEdge", shot.hasLeftEdge());
+                pipeline.setProperty("MinAreaRect.rightEdge", shot.hasRightEdge());
+                pipeline.setProperty("MinAreaRect.topEdge", shot.hasTopEdge());
+                pipeline.setProperty("MinAreaRect.bottomEdge", shot.hasBottomEdge());
+                pipeline.setProperty("MinAreaRect.searchAngle", Math.toDegrees(Math.atan2(composite.getTolerance(), composite.getMaxCornerRadius())));
+            }
+            pipeline.addProperties(pipelineParameterAssignments);
+
+            // Get the shot location, but adjusted by the adjustedNozzleLocation.
+            Location shotLocation = composite.getShotLocation(shot)
+                    .addWithRotation(adjustedNozzleLocation.subtractWithRotation(wantedLocation)); 
+            pipeline.new PipelineShot() {
+                @Override
+                public void apply() {
+                    UiUtils.messageBoxOnException(() -> {
+                        if (nozzle.getLocation().getLinearLengthTo(camera.getLocation())
+                                .compareTo(camera.getRoamingRadius()) > 0) {
+                            // Nozzle is not yet in camera roaming radius. Move at safe Z.
+                            MovableUtils.moveToLocationAtSafeZ(nozzle, shotLocation);
+                        }
+                        else {
+                            nozzle.moveTo(shotLocation);
+                        }
+                        super.apply();
+                    });
+                }
+
+                @Override 
+                public void processResult(Result result) {
+                    composite.accumulateShotDetection(shot, (RotatedRect) result.model);
+                }
+
+                @Override 
+                public Result processCompositeResult() {
+                    composite.interpret();
+                    return new Result(null, composite.getDetectedRotatedRect());
+                }
+            };
+        }
     }
 
-    private RotatedRect processPipelineAndGetResult(CvPipeline pipeline, Camera camera, Part part,
-            Nozzle nozzle, Location wantedLocation, BottomVisionSettings bottomVisionSettings) throws Exception {
-        preparePipeline(pipeline, bottomVisionSettings.getPipelineParameterAssignments(), camera, nozzle, wantedLocation, bottomVisionSettings);
-        pipeline.process();
+    private RotatedRect processPipelineAndGetResult(CvPipeline pipeline, Camera camera,
+            Part part, Nozzle nozzle, Location wantedLocation, Location adjustedNozzleLocation, BottomVisionSettings bottomVisionSettings) throws Exception {
+        preparePipeline(pipeline, bottomVisionSettings.getPipelineParameterAssignments(), camera, part.getPackage(), 
+                nozzle, nozzle.getNozzleTip(), wantedLocation, adjustedNozzleLocation, bottomVisionSettings);
+        for (PipelineShot pipelineShot : pipeline.getPipelineShots()) {
+            pipelineShot.apply();
 
-        Result result = pipeline.getResult(VisionUtils.PIPELINE_RESULTS_NAME);
+            pipeline.process();
+            Result result = pipeline.getResult(VisionUtils.PIPELINE_RESULTS_NAME);
 
-        // Fall back to the old name of "result" instead of "results" for backwards
-        // compatibility.
-        if (result == null) {
-            result = pipeline.getResult("result");
+            // Fall back to the old name of "result" instead of "results" for backwards
+            // compatibility.
+            if (result == null) {
+                result = pipeline.getResult("result");
+            }
+
+            if (result == null) {
+                throw new Exception(String.format(
+                        "ReferenceBottomVision (%s): Pipeline error. Pipeline must contain a result named '%s'.",
+                        part.getId(), VisionUtils.PIPELINE_RESULTS_NAME));
+            }
+
+            if (result.model == null) {
+                throw new Exception(String.format(
+                        "ReferenceBottomVision (%s): No result found.",
+                        part.getId()));
+            }
+
+            if (!(result.model instanceof RotatedRect)) {
+                throw new Exception(String.format(
+                        "ReferenceBottomVision (%s): Incorrect pipeline result type (%s). Expected RotatedRect.",
+                        part.getId(), result.model.getClass().getSimpleName()));
+            }
+            pipelineShot.processResult(result);
+            // Display the shot result.   
+            displayResult(pipeline, part, null, camera, nozzle);
         }
-
-        if (result == null) {
-            throw new Exception(String.format(
-                    "ReferenceBottomVision (%s): Pipeline error. Pipeline must contain a result named '%s'.",
-                    part.getId(), VisionUtils.PIPELINE_RESULTS_NAME));
-        }
-
-        if (result.model == null) {
-            throw new Exception(String.format(
-                    "ReferenceBottomVision (%s): No result found.",
-                    part.getId()));
-        }
-
-        if (!(result.model instanceof RotatedRect)) {
-            throw new Exception(String.format(
-                    "ReferenceBottomVision (%s): Incorrect pipeline result type (%s). Expected RotatedRect.",
-                    part.getId(), result.model.getClass().getSimpleName()));
-        }
-
-        return (RotatedRect) result.model;
+        return (RotatedRect) pipeline.getCurrentPipelineShot().processCompositeResult().getModel();
     }
 
     @Override

--- a/src/main/java/org/openpnp/machine/reference/vision/ReferenceFiducialLocator.java
+++ b/src/main/java/org/openpnp/machine/reference/vision/ReferenceFiducialLocator.java
@@ -439,7 +439,7 @@ public class ReferenceFiducialLocator extends AbstractPartSettingsHolder impleme
             pipeline.setProperty("fiducial.diameter", diameter);
             pipeline.setProperty("fiducial.maxDistance", getMaxDistance());
         }
-        pipeline.setProperties(pipelineParameterAssignments);
+        pipeline.addProperties(pipelineParameterAssignments);
     }
 
     public Location getFiducialLocation(Location nominalLocation, PartSettingsHolder partSettingsHolder) throws Exception {
@@ -660,6 +660,9 @@ public class ReferenceFiducialLocator extends AbstractPartSettingsHolder impleme
     @Override
     public Wizard getPartConfigurationWizard(PartSettingsHolder partSettingsHolder) {
         FiducialVisionSettings visionSettings = getInheritedVisionSettings(partSettingsHolder);
+        if (visionSettings == null) {
+            return null;
+        }
         try {
             visionSettings.getPipeline().setProperty("camera", getVisionCamera());
         }

--- a/src/main/java/org/openpnp/machine/reference/vision/wizards/BottomVisionSettingsConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/vision/wizards/BottomVisionSettingsConfigurationWizard.java
@@ -17,7 +17,7 @@ import javax.swing.border.TitledBorder;
 import org.jdesktop.beansbinding.AutoBinding.UpdateStrategy;
 import org.openpnp.gui.MainFrame;
 import org.openpnp.gui.components.ComponentDecorators;
-import org.openpnp.gui.components.PipelinePanel;
+import org.openpnp.gui.components.PipelineControls;
 import org.openpnp.gui.support.AbstractConfigurationWizard;
 import org.openpnp.gui.support.DoubleConverter;
 import org.openpnp.gui.support.IntegerConverter;
@@ -71,7 +71,7 @@ public class BottomVisionSettingsConfigurationWizard extends AbstractConfigurati
 
     private JButton btnSpecializeSetting;
     private JButton btnGeneralizeSettings;
-    private PipelinePanel pipelinePanel;
+    private PipelineControls pipelinePanel;
     private JPanel panelDetectOffset;
 
     public BottomVisionSettingsConfigurationWizard(BottomVisionSettings visionSettings, 
@@ -224,26 +224,26 @@ public class BottomVisionSettingsConfigurationWizard extends AbstractConfigurati
         panel.add(comboBoxPreRotate, "4, 10");
 
         JLabel lblMaxRotation = new JLabel("Rotation");
-        panel.add(lblMaxRotation, "2, 12, right, default");
+        panel.add(lblMaxRotation, "6, 10, right, default");
 
         comboBoxMaxRotation = new JComboBox(ReferenceBottomVision.MaxRotation.values());
         comboBoxMaxRotation.setToolTipText(
                 "Adjust for all parts, where only some minor offset is expected. Full for parts, where bottom vision detects pin 1");
-        panel.add(comboBoxMaxRotation, "4, 12, fill, default");
+        panel.add(comboBoxMaxRotation, "8, 10, fill, default");
 
         JLabel lblPartCheckType = new JLabel("Part size check");
-        panel.add(lblPartCheckType, "2, 14");
+        panel.add(lblPartCheckType, "2, 12");
 
         comboBoxCheckPartSizeMethod = new JComboBox(ReferenceBottomVision.PartSizeCheckMethod.values());
-        panel.add(comboBoxCheckPartSizeMethod, "4, 14, fill, default");
+        panel.add(comboBoxCheckPartSizeMethod, "4, 12, fill, default");
 
         JLabel lblPartSizeTolerance = new JLabel("Size tolerance (%)");
-        panel.add(lblPartSizeTolerance, "2, 16");
+        panel.add(lblPartSizeTolerance, "6, 12, right, default");
 
         textPartSizeTolerance = new JTextField();
-        panel.add(textPartSizeTolerance, "4, 16, fill, default");
+        panel.add(textPartSizeTolerance, "8, 12, fill, default");
 
-        pipelinePanel = new PipelinePanel() {
+        pipelinePanel = new PipelineControls() {
 
             @Override
             public void configurePipeline(CvPipeline pipeline, Map<String, Object> pipelineParameterAssignments, boolean edit) throws Exception {
@@ -278,7 +278,7 @@ public class BottomVisionSettingsConfigurationWizard extends AbstractConfigurati
         };
         pipelinePanel.setResetable(true);
         pipelinePanel.setEditable(true);
-        panel.add(pipelinePanel, "1, 20, 14, 1, fill, fill");
+        panel.add(pipelinePanel, "1, 14, 14, 1, fill, fill");
 
         JPanel panelAlign = new JPanel();
         contentPanel.add(panelAlign);
@@ -291,14 +291,12 @@ public class BottomVisionSettingsConfigurationWizard extends AbstractConfigurati
                 FormSpecs.RELATED_GAP_COLSPEC,
                 ColumnSpec.decode("max(70dlu;default)"),
                 FormSpecs.RELATED_GAP_COLSPEC,
-                new ColumnSpec(ColumnSpec.FILL, Sizes.bounded(Sizes.DEFAULT, Sizes.constant("50dlu", true), Sizes.constant("70dlu", true)), 0),
+                new ColumnSpec(ColumnSpec.FILL, Sizes.bounded(Sizes.DEFAULT, Sizes.constant("50dlu", true), Sizes.constant("70dlu", true)), 1),
                 FormSpecs.RELATED_GAP_COLSPEC,
                 ColumnSpec.decode("default:grow"),},
-                new RowSpec[] {
-                        FormSpecs.RELATED_GAP_ROWSPEC,
-                        FormSpecs.DEFAULT_ROWSPEC,
-                        FormSpecs.RELATED_GAP_ROWSPEC,
-                        FormSpecs.DEFAULT_ROWSPEC,}));
+            new RowSpec[] {
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,}));
 
         JLabel lblTestPlacementAngle = new JLabel("Placement Angle");
         panelAlign.add(lblTestPlacementAngle, "2, 2");
@@ -435,27 +433,21 @@ public class BottomVisionSettingsConfigurationWizard extends AbstractConfigurati
                 FormSpecs.DEFAULT_COLSPEC,
                 FormSpecs.RELATED_GAP_COLSPEC,
                 ColumnSpec.decode("default:grow"),},
-                new RowSpec[] {
-                        FormSpecs.RELATED_GAP_ROWSPEC,
-                        FormSpecs.DEFAULT_ROWSPEC,
-                        FormSpecs.RELATED_GAP_ROWSPEC,
-                        FormSpecs.DEFAULT_ROWSPEC,
-                        FormSpecs.RELATED_GAP_ROWSPEC,
-                        FormSpecs.DEFAULT_ROWSPEC,
-                        FormSpecs.RELATED_GAP_ROWSPEC,
-                        FormSpecs.DEFAULT_ROWSPEC,
-                        FormSpecs.RELATED_GAP_ROWSPEC,
-                        FormSpecs.DEFAULT_ROWSPEC,
-                        FormSpecs.RELATED_GAP_ROWSPEC,
-                        FormSpecs.DEFAULT_ROWSPEC,
-                        FormSpecs.RELATED_GAP_ROWSPEC,
-                        FormSpecs.DEFAULT_ROWSPEC,
-                        FormSpecs.RELATED_GAP_ROWSPEC,
-                        FormSpecs.DEFAULT_ROWSPEC,
-                        FormSpecs.RELATED_GAP_ROWSPEC,
-                        FormSpecs.DEFAULT_ROWSPEC,
-                        FormSpecs.RELATED_GAP_ROWSPEC,
-                        RowSpec.decode("default:grow"),}));
+            new RowSpec[] {
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                RowSpec.decode("default:grow"),}));
     }
 
     private void pipelineConfiguration(CvPipeline pipeline, Map<String, Object> pipelineParameterAssignments, boolean edit) throws Exception {
@@ -467,8 +459,8 @@ public class BottomVisionSettingsConfigurationWizard extends AbstractConfigurati
         Location location = bottomVision.getCameraLocationAtPartHeight(nozzle.getPart(), 
                 camera,
                 nozzle, angle);
-        bottomVision.preparePipeline(pipeline, pipelineParameterAssignments, camera, nozzle, location, visionSettings);
-
+        bottomVision.preparePipeline(pipeline, pipelineParameterAssignments, camera, nozzle.getPart().getPackage(), nozzle, nozzle.getNozzleTip(), 
+                location, location, visionSettings);
         if (edit) {
             
             pipelinePanel.openPipelineEditor("Bottom Vision Pipeline", pipeline, 
@@ -502,13 +494,8 @@ public class BottomVisionSettingsConfigurationWizard extends AbstractConfigurati
                 nozzle, angle);
 
         if (alignmentOffset.getPreRotated()) {
-            // See https://github.com/openpnp/openpnp/pull/590 for explanations of the magic
-            // value below.
-            if (Math.abs(alignmentOffset.getLocation().convertToUnits(LengthUnit.Millimeters).getLinearDistanceTo(0.,
-                    0.)) > 19.999) {
-                throw new Exception("Offset too big");
-            }
-            nozzle.moveTo(cameraLocation.subtractWithRotation(alignmentOffset.getLocation()));
+            Location centeredLocation = cameraLocation.subtractWithRotation(alignmentOffset.getLocation());
+            nozzle.moveTo(centeredLocation);
             return;
         }
 

--- a/src/main/java/org/openpnp/machine/reference/vision/wizards/FiducialVisionSettingsConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/vision/wizards/FiducialVisionSettingsConfigurationWizard.java
@@ -16,7 +16,7 @@ import javax.swing.border.LineBorder;
 import javax.swing.border.TitledBorder;
 
 import org.jdesktop.beansbinding.AutoBinding.UpdateStrategy;
-import org.openpnp.gui.components.PipelinePanel;
+import org.openpnp.gui.components.PipelineControls;
 import org.openpnp.gui.support.AbstractConfigurationWizard;
 import org.openpnp.machine.reference.vision.ReferenceFiducialLocator;
 import org.openpnp.model.AbstractVisionSettings;
@@ -52,7 +52,7 @@ public class FiducialVisionSettingsConfigurationWizard extends AbstractConfigura
 
     private JButton btnSpecializeSetting;
     private JButton btnGeneralizeSettings;
-    private PipelinePanel pipelinePanel;
+    private PipelineControls pipelinePanel;
 
     public FiducialVisionSettingsConfigurationWizard(FiducialVisionSettings visionSettings, 
             PartSettingsHolder settingsHolder) {
@@ -194,7 +194,7 @@ public class FiducialVisionSettingsConfigurationWizard extends AbstractConfigura
         enabledCheckbox = new JCheckBox("");
         panel.add(enabledCheckbox, "4, 8");
 
-        pipelinePanel = new PipelinePanel() {
+        pipelinePanel = new PipelineControls() {
 
             @Override
             public void configurePipeline(CvPipeline pipeline, Map<String, Object> pipelineParameterAssignments, boolean edit) throws Exception {

--- a/src/main/java/org/openpnp/machine/reference/wizards/ReferenceCameraPositionConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/wizards/ReferenceCameraPositionConfigurationWizard.java
@@ -1,11 +1,9 @@
 package org.openpnp.machine.reference.wizards;
 
-import java.awt.Color;
-
+import javax.swing.JComboBox;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JTextField;
-import javax.swing.border.EtchedBorder;
 import javax.swing.border.TitledBorder;
 
 import org.jdesktop.beansbinding.AutoBinding.UpdateStrategy;
@@ -14,7 +12,6 @@ import org.openpnp.gui.components.LocationButtonsPanel;
 import org.openpnp.gui.support.AbstractConfigurationWizard;
 import org.openpnp.gui.support.AxesComboBoxModel;
 import org.openpnp.gui.support.DoubleConverter;
-import org.openpnp.gui.support.IntegerConverter;
 import org.openpnp.gui.support.LengthConverter;
 import org.openpnp.gui.support.MutableLocationProxy;
 import org.openpnp.gui.support.NamedConverter;
@@ -28,7 +25,6 @@ import com.jgoodies.forms.layout.ColumnSpec;
 import com.jgoodies.forms.layout.FormLayout;
 import com.jgoodies.forms.layout.FormSpecs;
 import com.jgoodies.forms.layout.RowSpec;
-import javax.swing.JComboBox;
 
 @SuppressWarnings("serial")
 public class ReferenceCameraPositionConfigurationWizard extends AbstractConfigurationWizard {
@@ -57,6 +53,9 @@ public class ReferenceCameraPositionConfigurationWizard extends AbstractConfigur
     private JComboBox axisRotation;
     private JLabel lblRotation;
     private JTextField textFieldOffRotation;
+    private JLabel lblLocation;
+    private JLabel lblRoamingRadius;
+    private JTextField roamingRadius;
 
 
     public ReferenceCameraPositionConfigurationWizard(AbstractMachine machine, ReferenceCamera referenceCamera) {
@@ -68,7 +67,7 @@ public class ReferenceCameraPositionConfigurationWizard extends AbstractConfigur
                 "Coordinate System", TitledBorder.LEADING, TitledBorder.TOP, null));
         panelOffsets.setLayout(new FormLayout(new ColumnSpec[] {
                 FormSpecs.RELATED_GAP_COLSPEC,
-                FormSpecs.DEFAULT_COLSPEC,
+                ColumnSpec.decode("max(70dlu;default)"),
                 FormSpecs.RELATED_GAP_COLSPEC,
                 FormSpecs.DEFAULT_COLSPEC,
                 FormSpecs.RELATED_GAP_COLSPEC,
@@ -78,6 +77,10 @@ public class ReferenceCameraPositionConfigurationWizard extends AbstractConfigur
                 FormSpecs.RELATED_GAP_COLSPEC,
                 FormSpecs.DEFAULT_COLSPEC,},
             new RowSpec[] {
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
                 FormSpecs.RELATED_GAP_ROWSPEC,
                 FormSpecs.DEFAULT_ROWSPEC,
                 FormSpecs.RELATED_GAP_ROWSPEC,
@@ -118,35 +121,26 @@ public class ReferenceCameraPositionConfigurationWizard extends AbstractConfigur
 
         textFieldOffX = new JTextField();
         panelOffsets.add(textFieldOffX, "4, 6");
-        textFieldOffX.setColumns(8);
+        textFieldOffX.setColumns(10);
 
         textFieldOffY = new JTextField();
         panelOffsets.add(textFieldOffY, "6, 6");
-        textFieldOffY.setColumns(8);
+        textFieldOffY.setColumns(10);
 
         textFieldOffZ = new JTextField();
         panelOffsets.add(textFieldOffZ, "8, 6");
-        textFieldOffZ.setColumns(8);
-        
+        textFieldOffZ.setColumns(10);
+
         textFieldOffRotation = new JTextField();
         panelOffsets.add(textFieldOffRotation, "10, 6, fill, default");
         textFieldOffRotation.setColumns(10);
 
-        JPanel panelSafeZ = new JPanel();
-        panelSafeZ.setBorder(new TitledBorder(null, "Safe Z", TitledBorder.LEADING,
-                TitledBorder.TOP, null, null));
-        contentPanel.add(panelSafeZ);
-        panelSafeZ.setLayout(new FormLayout(
-                new ColumnSpec[] {FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,
-                        FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,},
-                new RowSpec[] {FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,}));
-
         JLabel lblSafeZ = new JLabel("Safe Z");
-        panelSafeZ.add(lblSafeZ, "2, 2, right, default");
+        panelOffsets.add(lblSafeZ, "2, 10, right, default");
 
         textFieldSafeZ = new JTextField();
+        panelOffsets.add(textFieldSafeZ, "8, 10");
         textFieldSafeZ.setEditable(false);
-        panelSafeZ.add(textFieldSafeZ, "4, 2, fill, default");
         textFieldSafeZ.setColumns(10);
 
         panelLocation = new JPanel();
@@ -155,7 +149,7 @@ public class ReferenceCameraPositionConfigurationWizard extends AbstractConfigur
         contentPanel.add(panelLocation);
         panelLocation.setLayout(new FormLayout(new ColumnSpec[] {
                 FormSpecs.RELATED_GAP_COLSPEC,
-                FormSpecs.DEFAULT_COLSPEC,
+                ColumnSpec.decode("max(70dlu;default)"),
                 FormSpecs.RELATED_GAP_COLSPEC,
                 FormSpecs.DEFAULT_COLSPEC,
                 FormSpecs.RELATED_GAP_COLSPEC,
@@ -163,50 +157,63 @@ public class ReferenceCameraPositionConfigurationWizard extends AbstractConfigur
                 FormSpecs.RELATED_GAP_COLSPEC,
                 FormSpecs.DEFAULT_COLSPEC,
                 FormSpecs.RELATED_GAP_COLSPEC,
-                ColumnSpec.decode("default:grow"),},
+                FormSpecs.DEFAULT_COLSPEC,
+                FormSpecs.RELATED_GAP_COLSPEC,
+                ColumnSpec.decode("left:default"),},
             new RowSpec[] {
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
                 FormSpecs.RELATED_GAP_ROWSPEC,
                 FormSpecs.DEFAULT_ROWSPEC,
                 FormSpecs.RELATED_GAP_ROWSPEC,
                 FormSpecs.DEFAULT_ROWSPEC,}));
 
         lblX = new JLabel("X");
-        panelLocation.add(lblX, "2, 2");
+        panelLocation.add(lblX, "4, 2");
 
         lblY = new JLabel("Y");
-        panelLocation.add(lblY, "4, 2");
+        panelLocation.add(lblY, "6, 2");
 
         lblZ = new JLabel("Z");
-        panelLocation.add(lblZ, "6, 2");
+        panelLocation.add(lblZ, "8, 2");
 
         lblRotation_1 = new JLabel("Rotation");
-        panelLocation.add(lblRotation_1, "8, 2");
+        panelLocation.add(lblRotation_1, "10, 2");
+        
+        lblLocation = new JLabel("Location");
+        panelLocation.add(lblLocation, "2, 4, right, default");
 
         textFieldLocationX = new JTextField();
-        panelLocation.add(textFieldLocationX, "2, 4, fill, default");
-        textFieldLocationX.setColumns(8);
+        panelLocation.add(textFieldLocationX, "4, 4, fill, default");
+        textFieldLocationX.setColumns(10);
 
         textFieldLocationY = new JTextField();
-        panelLocation.add(textFieldLocationY, "4, 4, fill, default");
-        textFieldLocationY.setColumns(8);
+        panelLocation.add(textFieldLocationY, "6, 4, fill, default");
+        textFieldLocationY.setColumns(10);
 
         textFieldLocationZ = new JTextField();
-        panelLocation.add(textFieldLocationZ, "6, 4, fill, default");
-        textFieldLocationZ.setColumns(8);
+        panelLocation.add(textFieldLocationZ, "8, 4, fill, default");
+        textFieldLocationZ.setColumns(10);
 
         textFieldLocationRotation = new JTextField();
-        panelLocation.add(textFieldLocationRotation, "8, 4, fill, default");
-        textFieldLocationRotation.setColumns(8);
-
+        panelLocation.add(textFieldLocationRotation, "10, 4, fill, default");
+        textFieldLocationRotation.setColumns(10);
+        
+        lblRoamingRadius = new JLabel("Roaming Radius");
+        lblRoamingRadius.setToolTipText("<html>\r\n<p>The maximum <em>nominal</em> roaming radius over the camera<br/>\r\nwhich also indicates the largest part diagonal that can be<br/>\r\nsupported.</p>\r\n<br/>\r\n<p>If set to zero, this switches off multi-shot vision<br/> \r\n(see package <strong>Vision Compositing</strong>).</p> \r\n<br/>\r\n<p>During bottom vision, the nozzle movement will be <br/>\r\nrestricted, taking into consideration the following:</p>\r\n<ul>\r\n<li>The distance of the nozzle from the camera <br/>\r\ncenter.</li>\r\n<li>How much the part footprint is portruding <br/>\r\nfrom there (approximated by octogonal hull).</li>\r\n</ul>\r\n<p>Inside the roaming radius, the nozzle will also be <br/>\r\nfreely moved at camera Z, i.e. without going to Safe Z.</p> \r\n<p>Note, this is the <em>nominal</em> radius, i.e. there must be<br/>\r\nextra space available for pick offsets and other <br/>\r\ndeviations.</p>\r\n<br/>\r\n<p><strong color=\"red\">Caution:</strong> the roaming radius is not enforced \r\nwhen jogging.</p>\r\n</html>");
+        panelLocation.add(lblRoamingRadius, "2, 6, right, default");
+        
+        roamingRadius = new JTextField();
+        panelLocation.add(roamingRadius, "4, 6, fill, default");
+        roamingRadius.setColumns(10);
+        locationButtonsPanel = new LocationButtonsPanel(textFieldLocationX,
+                textFieldLocationY, textFieldLocationZ, textFieldLocationRotation);
+        panelLocation.add(locationButtonsPanel, "12, 4, fill, fill");
         try {
             // Causes WindowBuilder to fail, so just throw away the error.
             if (referenceCamera.getHead() == null) {
                 // Fixed camera, add the location fields and buttons and turn off offsets.
-                locationButtonsPanel = new LocationButtonsPanel(textFieldLocationX,
-                        textFieldLocationY, textFieldLocationZ, textFieldLocationRotation);
-                panelLocation.add(locationButtonsPanel, "10, 4, fill, fill");
                 panelOffsets.setVisible(false);    
-                panelSafeZ.setVisible(false);
             }
             else {
                 // Moving camera, hide location and show only offsets.
@@ -254,6 +261,7 @@ public class ReferenceCameraPositionConfigurationWizard extends AbstractConfigur
             
             addWrappedBinding(referenceCamera, "safeZ", textFieldSafeZ, "text", lengthConverter);
         }
+        addWrappedBinding(referenceCamera, "roamingRadius", roamingRadius, "text", lengthConverter);
 
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldOffX);
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldOffY);
@@ -264,6 +272,7 @@ public class ReferenceCameraPositionConfigurationWizard extends AbstractConfigur
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldLocationY);
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldLocationZ);
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldLocationRotation);
+        ComponentDecorators.decorateWithAutoSelectAndLengthConversion(roamingRadius);
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldSafeZ);
     }
 }

--- a/src/main/java/org/openpnp/machine/reference/wizards/ReferenceNozzleConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/wizards/ReferenceNozzleConfigurationWizard.java
@@ -79,6 +79,8 @@ public class ReferenceNozzleConfigurationWizard extends AbstractConfigurationWiz
     private JLabel lblOffset;
     private JLabel lblRotationMode;
     private JComboBox rotationMode;
+    private JLabel lblAlignWithPart;
+    private JCheckBox aligningRotationMode;
 
     public ReferenceNozzleConfigurationWizard(AbstractMachine machine, ReferenceNozzle nozzle) {
         this.nozzle = nozzle;
@@ -181,6 +183,13 @@ public class ReferenceNozzleConfigurationWizard extends AbstractConfigurationWiz
         
         rotationMode = new JComboBox(RotationMode.values());
         panelOffsets.add(rotationMode, "4, 10, fill, default");
+        
+        lblAlignWithPart = new JLabel("Align with Part?");
+        lblAlignWithPart.setToolTipText("<html>\n<p>After bottom vision part alignment, make the nozzle Rotation Mode offset<br/>\nalign with the part rotation.</p>\n<br/>\n<p>This will make sure the nozzle coordinates as indicated in the reticle (cross-hairs),<br/>\nin the DRO etc. match the detected rotation of the part.</p>\n<br/>\n<p>After placing/discarding the part, the nozzle snaps back to indicating the original <br/>\naxis rotation.</p>\n</html>");
+        panelOffsets.add(lblAlignWithPart, "6, 10, right, default");
+        
+        aligningRotationMode = new JCheckBox("");
+        panelOffsets.add(aligningRotationMode, "8, 10");
 
         JPanel panelSafeZ = new JPanel();
         panelSafeZ.setBorder(new TitledBorder(null, "Safe Z", TitledBorder.LEADING,
@@ -273,6 +282,8 @@ public class ReferenceNozzleConfigurationWizard extends AbstractConfigurationWiz
         addWrappedBinding(nozzle, "axisZ", axisZ, "selectedItem", axisConverter);
         addWrappedBinding(nozzle, "axisRotation", axisRotation, "selectedItem", axisConverter);
         addWrappedBinding(nozzle, "rotationMode", rotationMode, "selectedItem");
+        addWrappedBinding(nozzle, "aligningRotationMode", aligningRotationMode, "selected");
+        
 
         MutableLocationProxy headOffsets = new MutableLocationProxy();
         bind(UpdateStrategy.READ_WRITE, nozzle, "headOffsets", headOffsets, "location");

--- a/src/main/java/org/openpnp/model/Footprint.java
+++ b/src/main/java/org/openpnp/model/Footprint.java
@@ -22,6 +22,7 @@ package org.openpnp.model;
 import java.awt.Shape;
 import java.awt.geom.AffineTransform;
 import java.awt.geom.Path2D;
+import java.awt.geom.Rectangle2D;
 import java.awt.geom.RoundRectangle2D;
 import java.util.ArrayList;
 import java.util.List;
@@ -63,6 +64,12 @@ public class Footprint extends AbstractModelObject{
 
     @Attribute(required = false)
     private double padRoundness;
+    
+    public enum Generator {
+        Dual,
+        Quad,
+        Bga;
+    }
 
     public Shape getShape() {
         Path2D.Double shape = new Path2D.Double();
@@ -223,7 +230,7 @@ public class Footprint extends AbstractModelObject{
         private double rotation = 0;
 
         /**
-         * Roundness as a percentage of the width and height. 0 is square, 100 is round.
+         * Roundness as a percentage of the lesser of width and height. 0 is square, 100 is round.
          */
         @Attribute(required = false)
         private double roundness = 0;
@@ -284,13 +291,211 @@ public class Footprint extends AbstractModelObject{
             this.roundness = roundness;
         }
 
+        public String toString() {
+            return x+", "+y+" "+width+" x "+height+" "+rotation+"°";
+        }
+
         public Shape getShape() {
-            Shape shape = new RoundRectangle2D.Double(-width / 2, -height / 2, width, height,
-                    width / 100.0 * roundness, height / 100.0 * roundness);
+            double r = Math.min(width, height)*roundness/100;
+            Shape shape;
+            if (r < 0) {
+                // one-sided roundness.
+                java.awt.geom.Area area = new java.awt.geom.Area(new RoundRectangle2D.Double(-width / 2, -height / 2, width, height,
+                        -r, -r));
+                area.add(new java.awt.geom.Area(new Rectangle2D.Double(0, -height / 2, width/2, height)));
+                shape = area;
+            }
+            else {
+                shape = new RoundRectangle2D.Double(-width / 2, -height / 2, width, height,
+                    r, r);
+            }
             AffineTransform tx = new AffineTransform();
             tx.translate(x, -y);
             tx.rotate(Math.toRadians(-rotation));
             return tx.createTransformedShape(shape);
+        }
+
+        /**
+         * @return The corner points of the pad, starting from the upper left (pin 1) corner,
+         * and going counter-clockwise. Roundness is ignored.
+         */
+        public Point[] corners() {
+            Point[] points = new Point[4];
+            points[0] = new Point(x - width/2, y + height/2);
+            points[1] = new Point(x - width/2, y - height/2);
+            points[2] = new Point(x + width/2, y - height/2);
+            points[3] = new Point(x + width/2, y + height/2);
+            // Rotate
+            double s = Math.sin(Math.toRadians(rotation));
+            double c = Math.cos(Math.toRadians(rotation));
+            int i = 0;
+            for (Point pt : points) {
+                points[i++] = new Point(c*pt.x - s*pt.y, s*pt.x + c*pt.y);
+            }
+            return points;
+        }
+
+        public Pad boundingBox() {
+            double x0 = Double.POSITIVE_INFINITY;
+            double x1 = Double.NEGATIVE_INFINITY;
+            double y0 = Double.POSITIVE_INFINITY;
+            double y1 = Double.NEGATIVE_INFINITY;
+            for (Point pt : corners()) {
+                x0 = Math.min(pt.x, x0);
+                x1 = Math.max(pt.x, x1);
+                y0 = Math.min(pt.y, y0);
+                y1 = Math.max(pt.y, y1);
+            }
+            // Create the unrotated bounding pad from it.
+            Pad pad = new Pad();
+            pad.setName(name);
+            pad.setWidth(x1 - x0);
+            pad.setHeight(y1 - y0);
+            pad.setX(x);
+            pad.setY(y);
+            return pad;
+        }
+    }
+
+    public void generate(Footprint.Generator type) throws Exception {
+        double outerDimension = getOuterDimension();
+        double innerDimension = getInnerDimension();
+        int padCount = getPadCount();
+        double padAcross = getPadAcross();
+        double padPitch = getPadPitch();
+        double padRoundness = getPadRoundness();
+        switch (type) {
+            case Dual: 
+            {
+                if (padCount % 2 != 0 || padCount <= 0) {
+                    throw new Exception("For Dual form factor, the pad count must be positive multiples of 2.");
+                }
+                double padLength = (outerDimension - innerDimension)/2;
+                double x = (outerDimension + innerDimension)/4;
+                int padNr = 0;
+                // Left side.
+                for (; padNr < padCount/2; padNr++) {
+                    Pad pad = new Pad();
+                    pad.setName(String.valueOf(padNr+1));
+                    pad.setWidth(padLength);
+                    pad.setHeight(padAcross);
+                    pad.setRotation(180); // strictly speaking
+                    pad.setX(-x);
+                    pad.setY((padCount/4.0 - padNr - 0.5)*padPitch);
+                    pad.setRoundness(padRoundness);
+                    addPad(pad);
+                }
+                // Right side.
+                for (; padNr < padCount; padNr++) {
+                    Pad pad = new Pad();
+                    pad.setName(String.valueOf(padNr+1));
+                    pad.setWidth(padLength);
+                    pad.setHeight(padAcross);
+                    pad.setRotation(0);
+                    pad.setX(x);
+                    pad.setY((padNr - padCount*3/4.0 + 0.5)*padPitch);
+                    pad.setRoundness(padRoundness);
+                    addPad(pad);
+                }
+                if (bodyWidth == 0 && bodyHeight == 0) {
+                    setBodyWidth(innerDimension);
+                    setBodyHeight(padCount/2*padPitch);
+                }
+                break;
+            }
+            case Quad:
+            {
+                if (padCount % 4 != 0 || padCount <= 0) {
+                    throw new Exception("For Quad form factor, the pad count must be positive multiples of 4.");
+                }
+                double padLength = (outerDimension - innerDimension)/2;
+                double d = (outerDimension + innerDimension)/4;
+                int padNr = 0;
+                // Left side.
+                for (; padNr < padCount*1/4; padNr++) {
+                    Pad pad = new Pad();
+                    pad.setName(String.valueOf(padNr+1));
+                    pad.setWidth(padLength);
+                    pad.setHeight(padAcross);
+                    pad.setRotation(180); // strictly speaking
+                    pad.setX(-d);
+                    pad.setY((padCount/8.0 - padNr - 0.5)*padPitch);
+                    pad.setRoundness(padRoundness);
+                    addPad(pad);
+                }
+                // Bottom side.
+                for (; padNr < padCount*2/4; padNr++) {
+                    Pad pad = new Pad();
+                    pad.setName(String.valueOf(padNr+1));
+                    pad.setWidth(padLength);
+                    pad.setHeight(padAcross);
+                    pad.setRotation(-90); 
+                    pad.setX((padNr - padCount*3/8.0 + 0.5)*padPitch);
+                    pad.setY(-d);
+                    pad.setRoundness(padRoundness);
+                    addPad(pad);
+                }
+                // Right side.
+                for (; padNr < padCount*3/4; padNr++) {
+                    Pad pad = new Pad();
+                    pad.setName(String.valueOf(padNr+1));
+                    pad.setWidth(padLength);
+                    pad.setHeight(padAcross);
+                    pad.setRotation(0);
+                    pad.setX(d);
+                    pad.setY((padNr - padCount*5/8.0 + 0.5)*padPitch);
+                    pad.setRoundness(padRoundness);
+                    addPad(pad);
+                }
+                // Top side.
+                for (; padNr < padCount*4/4; padNr++) {
+                    Pad pad = new Pad();
+                    pad.setName(String.valueOf(padNr+1));
+                    pad.setWidth(padLength);
+                    pad.setHeight(padAcross);
+                    pad.setRotation(90); 
+                    pad.setX((padCount*7/8.0 - padNr - 0.5)*padPitch);
+                    pad.setY(d);
+                    pad.setRoundness(padRoundness);
+                    addPad(pad);
+                }
+                if (bodyWidth == 0 && bodyHeight == 0) {
+                    setBodyWidth(innerDimension);
+                    setBodyHeight(innerDimension);
+                }
+                break;
+            }
+            case Bga:
+            {
+                int cols = (int)Math.sqrt(padCount);
+                int rows = cols;
+                if (Math.pow(rows, 2) != padCount) {
+                    throw new Exception("For PGA, the pad count must be a square number.");
+                }
+                double d = (outerDimension + innerDimension)/4;
+                for (int row = 0; row < rows; row++) {
+                    for (int col = 0; col < cols; col++) {
+                        double x = (col - cols/2.0 + 0.5)*padPitch;
+                        double y = (rows/2.0 - row - 0.5)*padPitch;
+                        if (Math.abs(x) > innerDimension/2 || Math.abs(y) > innerDimension/2) {
+                            Pad pad = new Pad();
+                            pad.setName(String.valueOf((char)('A'+row))+String.valueOf(col));
+                            pad.setWidth(padAcross);
+                            pad.setHeight(padAcross);
+                            pad.setX(x);
+                            pad.setY(y);
+                            pad.setRoundness(padRoundness);
+                            addPad(pad);
+                        }
+                    }
+                }
+                setOuterDimension((rows - 1)*padPitch + padAcross);
+                if (bodyWidth == 0 && bodyHeight == 0) {
+                    setBodyWidth(outerDimension+padPitch);
+                    setBodyHeight(outerDimension+padPitch);
+                }
+                break;
+            }
         }
     }
 }

--- a/src/main/java/org/openpnp/model/Package.java
+++ b/src/main/java/org/openpnp/model/Package.java
@@ -54,6 +54,9 @@ public class Package extends AbstractPartSettingsHolder {
     @Element(required = false)
     private Footprint footprint;
     
+    @Element(required = false)
+    private VisionCompositing visionCompositing;
+    
     @ElementList(required = false)
     protected List<String> compatibleNozzleTipIds = new ArrayList<>();
 
@@ -133,6 +136,23 @@ public class Package extends AbstractPartSettingsHolder {
         Object oldValue = this.footprint;
         this.footprint = footprint;
         firePropertyChange("footprint", oldValue, footprint);
+    }
+
+    public void fireFootprintChanged() {
+        firePropertyChange("footprint", null, footprint); 
+     }
+
+    public VisionCompositing getVisionCompositing() {
+        if (visionCompositing == null) {
+            visionCompositing = new VisionCompositing();
+        }
+        return visionCompositing;
+    }
+
+    public void setVisionCompositing(VisionCompositing visionCompositing) {
+        Object oldValue = this.visionCompositing;
+        this.visionCompositing = visionCompositing;
+        firePropertyChange("visionCompositing", oldValue, visionCompositing);
     }
 
     @Override

--- a/src/main/java/org/openpnp/model/Point.java
+++ b/src/main/java/org/openpnp/model/Point.java
@@ -54,8 +54,24 @@ public class Point {
         this.y = y;
     }
 
+    public Point add(Point p) {
+        return new Point(x + p.x, y + p.y);
+    }
+
     public Point subtract(Point p) {
         return new Point(x - p.x, y - p.y);
+    }
+
+    public Point multiply(double f) {
+        return new Point(x*f, y*f);
+    }
+
+    public Point divide(double f) {
+        return new Point(x/f, y/f);
+    }
+
+    public double distance() {
+        return Math.hypot(x, y);
     }
 
     public static Point fromOpencv(org.opencv.core.Point p) {

--- a/src/main/java/org/openpnp/model/VisionCompositing.java
+++ b/src/main/java/org/openpnp/model/VisionCompositing.java
@@ -1,0 +1,1514 @@
+/*
+ * Copyright (C) 2022 <mark@makr.zone>
+ * inspired and based on work
+ * Copyright (C) 2011 Jason von Nieda <jason@vonnieda.org>
+ * 
+ * This file is part of OpenPnP.
+ * 
+ * OpenPnP is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * OpenPnP is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License along with OpenPnP. If not, see
+ * <http://www.gnu.org/licenses/>.
+ * 
+ * For more information about OpenPnP visit http://openpnp.org
+ */
+
+package org.openpnp.model;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map.Entry;
+import java.util.TreeSet;
+
+import org.opencv.core.RotatedRect;
+import org.openpnp.model.Footprint.Pad;
+import org.openpnp.spi.Camera;
+import org.openpnp.spi.Nozzle;
+import org.openpnp.spi.NozzleTip;
+import org.openpnp.util.NanosecondTime;
+import org.openpnp.util.TravellingSalesman;
+import org.openpnp.util.Utils2D;
+import org.openpnp.util.VisionUtils;
+import org.simpleframework.xml.Attribute;
+import org.simpleframework.xml.Element;
+
+/**
+ * A Footprint is a group of SMD pads along with length unit information. Footprints can be rendered
+ * to a Shape for easy display using 2D primitives.
+ */
+public class VisionCompositing extends AbstractModelObject{
+    public enum CompositingMethod {
+        None,
+        Restricted,
+        Automatic,
+        SingleCorners;
+
+        public boolean isEnforced() {
+            return this == Automatic || this == SingleCorners;
+        }
+    }
+
+    public enum CompositingSolution {
+        Square,
+        Box,
+        Z,
+        Arrow,
+        Figure7,
+        Angle,
+        Trapezoid, 
+        Small, 
+        VisionOffsets,
+        NoFootprint,
+        NoCameraRoaming,
+        RestrictedCameraRoaming,
+        Invalid;
+
+        public boolean isAdvanced() {
+            return ordinal() < Small.ordinal();
+        }
+        public boolean isInvalid() {
+            return ordinal() >= NoCameraRoaming.ordinal();
+        }
+    }
+
+    public enum ShotConfiguration {
+        Square,
+        Box,
+        MirrorX,
+        MirrorY,
+        Corner,
+        Unknown;
+
+        boolean isDiagonal() {
+            return this == Square || this == Box;
+        }
+    }
+
+    @Attribute
+    private CompositingMethod compositingMethod = CompositingMethod.Restricted;
+
+    @Element(required = false)
+    private Length maxPickTolerance = new Length(0, LengthUnit.Millimeters);
+
+    @Attribute(required = false)
+    private double minLeverageFactor = 0.2; 
+
+    @Attribute(required = false)
+    private int extraShots = 0;
+
+    @Attribute(required = false)
+    private boolean allowInside = true;
+
+    private static final double minCameraRadiusOverlap = 0.02; // 2% overlap, ~7 pixels at 720p/2
+
+    private static final double eps = 1e-5;
+
+    public CompositingMethod getCompositingMethod() {
+        return compositingMethod;
+    }
+
+    public void setCompositingMethod(CompositingMethod compositingMethod) {
+        Object oldValue = this.compositingMethod;
+        this.compositingMethod = compositingMethod;
+        firePropertyChange("compositingMethod", oldValue, compositingMethod);
+    }
+
+    public Length getMaxPickTolerance() {
+        return maxPickTolerance;
+    }
+
+    public void setMaxPickTolerance(Length maxPickTolerance) {
+        Object oldValue = this.maxPickTolerance;
+        this.maxPickTolerance = maxPickTolerance;
+        firePropertyChange("maxPickTolerance", oldValue, maxPickTolerance);
+    }
+
+    public double getMinLeverageFactor() {
+        return minLeverageFactor;
+    }
+
+    public void setMinLeverageFactor(double minLeverageFactor) {
+        Object oldValue = this.minLeverageFactor;
+        this.minLeverageFactor = minLeverageFactor;
+        firePropertyChange("minLeverageFactor", oldValue, minLeverageFactor);
+    }
+
+    public boolean isAllowInside() {
+        return allowInside;
+    }
+
+    public void setAllowInside(boolean allowInside) {
+        Object oldValue = this.allowInside;
+        this.allowInside = allowInside;
+        firePropertyChange("allowInside", oldValue, allowInside);
+    }
+
+    public int getExtraShots() {
+        return extraShots;
+    }
+
+    public void setExtraShots(int extraShots) {
+        Object oldValue = this.extraShots;
+        this.extraShots = extraShots;
+        firePropertyChange("extraShots", oldValue, extraShots);
+    }
+
+    public Camera getCamera() {
+        try {
+            return VisionUtils.getBottomVisionCamera();
+        }
+        catch (Exception e) {
+        }
+        return null;
+    }
+
+    public static class Shot {
+        private ArrayList<Corner> corners;
+        private double x;
+        private double y;
+        private double width;
+        private double height;
+        private double minMaskRadius;
+        private double maxMaskRadius;
+        private boolean optional;
+        ShotConfiguration configuration;
+
+        public Shot(ArrayList<Corner> corners, 
+                double x, double y, 
+                double width, double height,
+                double minMaskRadius, double maxMaskRadius, boolean optional, 
+                ShotConfiguration configuration) {
+            super();
+            this.corners = corners;
+            this.x = x;
+            this.y = y;
+            this.width = width;
+            this.height = height;
+            this.minMaskRadius = minMaskRadius;
+            this.maxMaskRadius = maxMaskRadius;
+            this.optional = optional;
+            this.configuration = configuration;
+        }
+
+        public Shot(ArrayList<Corner> corners,double minMaskRadius, double maxMaskRadius,
+                double tolerance, ShotConfiguration configuration) {
+            super();
+            this.corners = corners;
+            double x0 = 0;
+            double y0 = 0;
+            double x1 = 0;
+            double y1 = 0;
+            double x = 0;
+            double y = 0;
+            int n = 0;
+            boolean optional = true;
+            for (Corner corner : corners) {
+                x0 = Math.min(x0,  corner.getX());
+                x1 = Math.max(x1,  corner.getX());
+                y0 = Math.min(y0,  corner.getY());
+                y1 = Math.max(y1,  corner.getY());
+                x += corner.getX();  
+                y += corner.getY();
+                n++;
+                if (!corner.isOptional()) {
+                    optional = false;
+                }
+            }
+            this.x = x/n;
+            this.y = y/n;
+            this.width = x1 - x0 + tolerance*2;
+            this.height= y1 - y0 + tolerance*2;
+            this.minMaskRadius = minMaskRadius;
+            this.maxMaskRadius = maxMaskRadius;
+            this.optional = optional;
+            this.configuration = configuration;
+        }
+
+        public List<Corner> getCorners() {
+            if (corners == null) {
+                corners = new ArrayList<>();
+            }
+            return Collections.unmodifiableList(corners);
+        }
+
+        public double getX() {
+            return x;
+        }
+
+        public double getY() {
+            return y;
+        }
+
+        public double getWidth() {
+            return width;
+        }
+
+        public double getHeight() {
+            return height;
+        }
+
+        public double getMinMaskRadius() {
+            return minMaskRadius;
+        }
+
+        public double getMaxMaskRadius() {
+            return maxMaskRadius;
+        }
+
+        public boolean isOptional() {
+            return optional;
+        }
+
+        public ShotConfiguration getConfiguration() {
+            return configuration;
+        }
+
+        private boolean hasEdge(int num) {
+            if (corners == null) {
+                return true;
+            }
+            for (Corner corner : corners) {
+                if (num == 0 && corner.getXSign() < 0) {
+                    return true;
+                }
+                if (num == 1 && corner.getXSign() > 0) {
+                    return true;
+                }
+                if (num == 2 && corner.getYSign() > 0) {
+                    return true;
+                }
+                if (num == 3 && corner.getYSign() < 0) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        public boolean hasLeftEdge() {
+            return hasEdge(0);
+        }
+        public boolean hasRightEdge() {
+            return hasEdge(1);
+        }
+        public boolean hasTopEdge() {
+            return hasEdge(2);
+        }
+        public boolean hasBottomEdge() {
+            return hasEdge(3);
+        }
+    }
+
+    public static class Corner implements Comparable<Corner> {
+        private double x;
+        private double y;
+        private double minMaskRadius;
+        private double maxMaskRadius;
+        private int xSign;
+        private int ySign;
+        private boolean optional;
+
+        private int rating;
+        private boolean square;
+        private CompositingSolution compositeSolution;
+
+        private Corner diagonalBuddy;
+        private Corner xAlignedBuddy;
+        private Corner yAlignedBuddy;
+        private Corner xSymmetricBuddy;
+        private Corner ySymmetricBuddy;
+        private Corner xMirrorBuddy;
+        private Corner yMirrorBuddy;
+
+        public Corner(double x, double y, 
+                double minMaskRadius, double maxMaskRadius,
+                int xSign, int ySign) {
+            this.x = x;
+            this.y = y;
+            this.minMaskRadius = minMaskRadius;
+            this.maxMaskRadius = maxMaskRadius;
+            this.xSign = xSign;
+            this.ySign = ySign;
+        }
+
+        public int getRating() {
+            return rating;
+        }
+
+        public double getX() {
+            return x;
+        }
+
+        public double getY() {
+            return y;
+        }
+
+        public double getMinMaskRadius() {
+            return minMaskRadius;
+        }
+
+        public double getMaxMaskRadius() {
+            return maxMaskRadius;
+        }
+
+        public int getXSign() {
+            return xSign;
+        }
+
+        public int getYSign() {
+            return ySign;
+        }
+
+        public boolean isOptional() {
+            return optional;
+        }
+
+        public CompositingSolution getCompositeSolution() {
+            return compositeSolution;
+        }
+
+        public ArrayList<Corner> computeBuddies(ArrayList<Corner> corners, double minAlignDistance, double minSymmetryDistance, int pass) {
+            for (Corner corner2 : corners) {
+                if (this != corner2) {
+                    boolean xSymmetric = (getXSign() == -corner2.getXSign()
+                            && Math.abs(getX() + corner2.getX()) < eps
+                            && Math.abs(getX() - corner2.getX()) > minSymmetryDistance);
+                    boolean ySymmetric = (getYSign() == -corner2.getYSign()
+                            && Math.abs(getY() + corner2.getY()) < eps
+                            && Math.abs(getY() - corner2.getY()) > minSymmetryDistance);
+                    boolean xAligned = (getXSign() == corner2.getXSign()
+                            && Math.abs(getX() - corner2.getX()) < eps
+                            && Math.abs(getY() - corner2.getY()) > minAlignDistance);
+                    boolean yAligned = (getYSign() == corner2.getYSign()
+                            && Math.abs(getY() - corner2.getY()) < eps
+                            && Math.abs(getX() - corner2.getX()) > minAlignDistance);
+                    boolean square = (xSymmetric && ySymmetric 
+                            && Math.abs(Math.abs(getX()) - Math.abs(getY())) < eps);
+                    if (pass > 0) {
+                        if (xSymmetric && corner2.yMirrorBuddy != null){
+                            if (xSymmetricBuddy == null || 
+                                    getYDistance(xSymmetricBuddy.yMirrorBuddy) < getYDistance(corner2.yMirrorBuddy)) {
+                                xSymmetricBuddy = corner2;
+                            }
+                        }
+                        if (ySymmetric && corner2.xMirrorBuddy != null){
+                            if (ySymmetricBuddy == null || 
+                                    getXDistance(ySymmetricBuddy.xMirrorBuddy) < getXDistance(corner2.xMirrorBuddy)) {
+                                ySymmetricBuddy = corner2;
+                            }
+                        }
+                    }
+                    if (xAligned){
+                        if (xAlignedBuddy == null || 
+                                getYDistance(xAlignedBuddy) < getYDistance(corner2)) {
+                            xAlignedBuddy = corner2;
+                        }
+                    }
+                    if (yAligned){
+                        if (yAlignedBuddy == null || 
+                                getXDistance(yAlignedBuddy) < getXDistance(corner2)) {
+                            yAlignedBuddy = corner2;
+                        }
+                    }
+                    if (xSymmetric && ySymmetric) {
+                        diagonalBuddy = corner2;
+                        if (square) {
+                            this.square = true;
+                        }
+                    }
+                    if (xSymmetric && yAligned) {
+                        xMirrorBuddy = corner2;
+                    }
+                    if (ySymmetric && xAligned) {
+                        yMirrorBuddy = corner2;
+                    }
+                }
+            }
+            ArrayList<Corner> group = null;
+            if (pass > 0) {
+                group = computeCornerSolution();
+            }
+            return group;
+        }
+
+        boolean pairsInOneShotWith(Corner corner2) {
+            // To pair in one shot, the signs must be outwards.
+            if (corner2 == null) {
+                return false;
+            }
+            if (Math.abs(getX() - corner2.getX()) > eps ) { 
+                if (getXSign() == corner2.getXSign()
+                        || getXSign()*(getX() - corner2.getX()) < eps) {
+                    return false;
+                }
+            }
+            else {
+                if (getXSign() != corner2.getXSign()) {
+                    return false;
+                }
+            }
+            if (Math.abs(getY() - corner2.getY()) > eps ) { 
+                if (getYSign() == corner2.getYSign()
+                        || getYSign()*(getY() - corner2.getY()) < eps) {
+                    return false;
+                }
+            }
+            else {
+                if (getYSign() != corner2.getYSign()) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        private ArrayList<Corner> computeCornerSolution() {
+            ArrayList<Corner> solution = null;
+            rating = 0;
+            int minCorners = 0;
+            if (square) {
+                // Gives us both symmetric position and symmetric angle with just two corners.
+                minCorners = 2;
+                rating = 7;
+                solution = new ArrayList<>();
+                solution.add(this);
+                solution.add(diagonalBuddy);
+                if (xMirrorBuddy != null) {
+                    solution.add(xMirrorBuddy);
+                    rating++;
+                }
+                if (yMirrorBuddy != null) {
+                    solution.add(yMirrorBuddy);
+                    rating++;
+                }
+                compositeSolution = CompositingSolution.Square;
+            }
+            else if (diagonalBuddy != null && xMirrorBuddy != null && yMirrorBuddy != null) {
+                // Gives us symmetric position and asymmetric angle with three corners, non-square box and X configuration.
+                minCorners = 3;
+                rating = 6;
+                solution = new ArrayList<>();
+                solution.add(this);
+                solution.add(diagonalBuddy);
+                if (getXDistance(xMirrorBuddy) > getYDistance(yMirrorBuddy) - eps) {
+                    solution.add(xMirrorBuddy);
+                    solution.add(yMirrorBuddy);
+                }
+                else {
+                    solution.add(yMirrorBuddy);
+                    solution.add(xMirrorBuddy);
+                }
+                compositeSolution = CompositingSolution.Box;
+            }
+            else if (diagonalBuddy != null && (xAlignedBuddy != null || yAlignedBuddy != null)) {
+                // Gives us symmetric position and asymmetric angle with three corners.
+                minCorners = 3;
+                rating = 4;
+                solution = new ArrayList<>();
+                solution.add(this);
+                solution.add(diagonalBuddy);
+                if (yAlignedBuddy == null) {
+                    solution.add(xAlignedBuddy);
+                    if (diagonalBuddy.xAlignedBuddy != null) {
+                        // Z configuration
+                        solution.add(diagonalBuddy.xAlignedBuddy);
+                        rating++;
+                        compositeSolution = CompositingSolution.Z;
+                    }
+                    else {
+                        compositeSolution = CompositingSolution.Figure7;
+                    }
+                }
+                else if (xAlignedBuddy == null) {
+                    solution.add(yAlignedBuddy);
+                    if (diagonalBuddy.yAlignedBuddy != null) {
+                        // Z configuration
+                        solution.add(diagonalBuddy.yAlignedBuddy);
+                        rating++;
+                        compositeSolution = CompositingSolution.Z;
+                    }
+                    else {
+                        compositeSolution = CompositingSolution.Figure7;
+                    }
+                }
+                else if (getYDistance(xAlignedBuddy) > getXDistance(yAlignedBuddy) - eps) {
+                    solution.add(xAlignedBuddy);
+                    rating++;
+                    if (diagonalBuddy.xAlignedBuddy != null
+                            && getXDistance(yAlignedBuddy) - eps < diagonalBuddy.getYDistance(diagonalBuddy.xAlignedBuddy) - eps) {
+                        // Z configuration
+                        solution.add(diagonalBuddy.xAlignedBuddy);
+                        compositeSolution = CompositingSolution.Z;
+                    }
+                    else {
+                        solution.add(yAlignedBuddy);
+                        compositeSolution = CompositingSolution.Arrow;
+                    }
+                }
+                else {
+                    solution.add(yAlignedBuddy);
+                    rating++;
+                    if (diagonalBuddy.yAlignedBuddy != null
+                            && getXDistance(xAlignedBuddy) - eps < diagonalBuddy.getXDistance(diagonalBuddy.yAlignedBuddy) - eps) {
+                        // Z configuration
+                        solution.add(diagonalBuddy.yAlignedBuddy);
+                        compositeSolution = CompositingSolution.Z;
+                    }
+                    else {
+                        solution.add(xAlignedBuddy);
+                        compositeSolution = CompositingSolution.Arrow;
+                    }
+                }
+            }
+            else if (xMirrorBuddy != null && yMirrorBuddy != null) {
+                // Gives us asymmetric position and asymmetric angle with three corners.
+                minCorners = 3;
+                rating = 3;
+                solution = new ArrayList<>();
+                solution.add(this);
+                solution.add(xMirrorBuddy);
+                solution.add(yMirrorBuddy);
+                compositeSolution = CompositingSolution.Angle;
+            }
+            else if (xMirrorBuddy != null && ySymmetricBuddy != null) {
+                // Gives us trapezoidal position and angle with four corners.
+                minCorners = 4;
+                rating = 2;
+                solution = new ArrayList<>();
+                solution.add(this);
+                solution.add(xMirrorBuddy);
+                solution.add(ySymmetricBuddy);
+                solution.add(ySymmetricBuddy.xMirrorBuddy);
+                compositeSolution = CompositingSolution.Trapezoid;
+            }
+            else if (yMirrorBuddy != null && xSymmetricBuddy != null) {
+                // Gives us trapezoidal position and angle with four corners.
+                minCorners = 4;
+                rating = 2;
+                solution = new ArrayList<>();
+                solution.add(this);
+                solution.add(yMirrorBuddy);
+                solution.add(xSymmetricBuddy);
+                solution.add(xSymmetricBuddy.yMirrorBuddy);
+                compositeSolution = CompositingSolution.Trapezoid;
+            }
+            if (solution != null) { 
+                int i = 0;
+                for (Corner corner : solution) {
+                    corner.optional = (++i > minCorners);
+                }
+            }
+            return solution;
+        }
+
+        private double getXDistance(Corner shot2) {
+            return Math.abs(x - shot2.x);
+        }
+
+        private double getYDistance(Corner shot2) {
+            return Math.abs(y - shot2.y);
+        }
+
+        @Override
+        public int compareTo(Corner corner2) {
+            // By rating, reversed.
+            int diff = getRating() - corner2.getRating();
+            if (diff != 0) { 
+                return -diff;
+            }
+            // By distance from center, reversed.
+            double d1 = Math.hypot(getX(), getY());
+            double d2 = Math.hypot(corner2.getX(), corner2.getY());
+            if (Math.abs(d1 - d2) > eps) {
+                return d1 > d2 ? -1 : 1;
+            }
+            // By angle from pin1 (rotated 270°), counter-clockwise.
+            double a1 = Math.atan2(getX(), -getY());
+            double a2 = Math.atan2(corner2.getX(), -corner2.getY());
+            return Double.compare(a1, a2);
+        }
+    }
+
+    public class Composite { 
+        // Basic parameters.
+        final private Package pkg;
+        final private BottomVisionSettings visionSettings;
+        final private Footprint footprint;
+        final private LengthUnit units;
+        final private Camera camera; 
+        private Location upp;
+        final private Nozzle nozzle;
+        final private NozzleTip nozzleTip;
+        final private Location locationAndRotation;
+
+        // Computation results
+        private double tolerance;
+        private double cameraViewRadius;
+        private double expectedAngle;
+        private TreeSet<Double> leftEdges;
+        private TreeSet<Double> rightEdges;
+        private TreeSet<Double> topEdges;
+        private TreeSet<Double> bottomEdges;
+        private ArrayList<Shot> compositeShots;
+        private CompositingSolution compositingSolution;
+        private List<Shot> shotsTravel;
+
+        // Gathered pipeline results.
+        private HashMap<Corner, Point> cornerMap = new HashMap<>();
+
+        // Final detection results.
+        private Point detectedCenter;
+        private double detectedAngle;
+        private Point detectedScale;
+        private Point detectedSize;
+        private RotatedRect detectedRotatedRect;
+        private double maxCornerRadius;
+        private ArrayList<Footprint.Pad> rectifiedPads;
+        private int outOfRoamingCandidates;
+        private double computeTime;
+
+        public Composite(org.openpnp.model.Package pkg, BottomVisionSettings visionSettings,
+                Nozzle nozzle, NozzleTip nozzleTip, Camera camera, Location locationAndRotation) throws Exception {
+            this.pkg = pkg;
+            this.visionSettings = visionSettings;
+            this.footprint = pkg.getFootprint();
+            this.units = footprint.getUnits();
+            this.camera = camera;
+            this.nozzle = nozzle;
+            this.nozzleTip = nozzleTip;
+            this.locationAndRotation = locationAndRotation.convertToUnits(units);
+            this.expectedAngle = locationAndRotation.getRotation();
+            double t0 = NanosecondTime.getRuntimeSeconds();
+            // Compute the solution.
+            compute();
+            this.computeTime = NanosecondTime.getRuntimeSeconds() - t0;
+        }
+
+        public Package getPackage() {
+            return pkg;
+        }
+
+        public Footprint getFootprint() {
+            return footprint;
+        }
+
+        public LengthUnit getUnits() {
+            return units;
+        }
+
+        public Camera getCamera() {
+            return camera;
+        }
+
+        public Nozzle getNozzle() {
+            return nozzle;
+        }
+
+        protected NozzleTip getNozzleTip() {
+            return nozzleTip;
+        }
+
+        public double getComputeTime() {
+            return computeTime;
+        }
+
+        public ArrayList<Shot> getCompositeShots() {
+            return compositeShots;
+        }
+
+        public CompositingSolution getCompositingSolution() {
+            return compositingSolution;
+        }
+
+        public VisionCompositing getParent() {
+            return VisionCompositing.this;
+        }
+
+        public Location getLocationAndRotation() {
+            return locationAndRotation;
+        }
+
+        public List<Footprint.Pad> getRectifiedPads() {
+            if (rectifiedPads == null) {
+                return null;
+            }
+            return Collections.unmodifiableList(rectifiedPads);
+        }
+
+        public List<Shot> getShotsTravel() {
+            prepareTravel();
+            return shotsTravel;
+        }
+
+        public double getTolerance() {
+            return tolerance;
+        }
+
+        public double getExpectedAngle() {
+            return expectedAngle;
+        }
+
+        public double getMaxCornerRadius() {
+            return maxCornerRadius;
+        }
+
+        public Point getDetectedCenter() {
+            return detectedCenter;
+        }
+
+        public double getDetectedAngle() {
+            return detectedAngle;
+        }
+
+        public Point getDetectedScale() {
+            return detectedScale;
+        }
+
+        public Point getDetectedSize() {
+            return detectedSize;
+        }
+
+        public RotatedRect getDetectedRotatedRect() {
+            return detectedRotatedRect;
+        }
+        private final double invHypot = 1/Math.hypot(1, 1); 
+        private final double[] xOctogonalHullSign = new double[] { -invHypot,  0, +invHypot, -1, +1, -invHypot,  0, +invHypot };
+        private final double[] yOctogonalHullSign = new double[] { -invHypot, -1, -invHypot,  0,  0, +invHypot, +1, +invHypot };
+        
+        private double octogonalHull[] = new double[8]; 
+
+        /**
+         * Compute the needed compositing solution for the given package footprint. 
+         * 
+         * @param pkg
+         * @return
+         * @throws Exception
+         */
+        public void compute() throws Exception {
+            // Compute some lengths.
+            tolerance = maxPickTolerance.convertToUnits(units).getValue();
+            if (tolerance <= 0) {
+                tolerance = nozzleTip
+                        .getMaxPickTolerance()
+                        .convertToUnits(units).getValue();
+            }
+            upp = camera.getUnitsPerPixel().convertToUnits(units);
+            cameraViewRadius = Math.min(camera.getWidth()*upp.getX(), camera.getHeight()*upp.getY()) / 2; 
+            double maxPartDiameter = nozzleTip.getMaxPartDiameter().convertToUnits(units).getValue();
+            if (footprint.getPads().isEmpty() 
+                    || visionSettings.getVisionOffset().isInitialized()
+                    || !camera.getRoamingRadius().isInitialized()) {
+                // No footprint, or vision offsets present, or no roaming radius set.
+                // Resort to classic single shot.
+                compositeShots = new ArrayList<>();
+                compositeShots.add(new Shot(null, 0, 0, 
+                        maxPartDiameter, maxPartDiameter, maxPartDiameter/2, maxPartDiameter/2, false, ShotConfiguration.Unknown));
+                if (visionSettings.getVisionOffset().isInitialized()) {
+                    compositingSolution = CompositingSolution.VisionOffsets;
+                }
+                else if (!camera.getRoamingRadius().isInitialized()) {
+                    compositingSolution = CompositingSolution.NoCameraRoaming;
+                }
+                else {
+                    compositingSolution = CompositingSolution.NoFootprint;
+                }
+                return;
+            }
+            // Add the body to the octogonal hull.
+            Pad body = new Pad();
+            body.setWidth(footprint.getBodyWidth());
+            body.setHeight(footprint.getBodyHeight());
+            addPadToOctogalHull(body);
+            // Rectify and fuse pads.
+            // As a heuristic, we assume pads are ordered in lines. If not, it will be less performant bus still ok.  
+            ArrayList<Footprint.Pad> rectPads = new ArrayList<>();
+            for (Footprint.Pad pad : footprint.getPads()) {
+                if (Math.abs(pad.getRotation() % 90) > eps) {
+                    if (compositingMethod.isEnforced()) { 
+                        throw new Exception("Package "+pkg.getId()+" pad "+pad.getName()+" not at 90° step angle.");
+                    }
+                }
+                Pad rectifiedPad = pad.boundingBox();
+                rectPads.add(rectifiedPad);
+            }
+            // Call it twice for column/row fusing in BGAs.
+            ArrayList<Footprint.Pad> fusedPads = rectPads;
+            fusedPads = fusedPads(fusedPads);
+            fusedPads = fusedPads(fusedPads);
+            rectifiedPads = fusedPads;
+            // Calculate the octogonal hull.
+            for (Footprint.Pad pad : rectifiedPads) {
+                addPadToOctogalHull(pad);
+            }
+
+            // Create the pad edges.
+            leftEdges = new TreeSet<>();
+            rightEdges = new TreeSet<>();
+            topEdges = new TreeSet<>();
+            bottomEdges = new TreeSet<>();
+            for (Footprint.Pad pad : rectifiedPads) {
+                if (allowInside || pad.getX() - pad.getWidth()/2 < 0) {
+                    addCoordinate(leftEdges, pad.getX() - pad.getWidth()/2);
+                }
+                if (allowInside || pad.getY() - pad.getHeight()/2 < 0) {
+                    addCoordinate(bottomEdges, pad.getY() - pad.getHeight()/2);
+                }
+                if (allowInside || pad.getX() + pad.getWidth()/2 > 0) {
+                    addCoordinate(rightEdges, pad.getX() + pad.getWidth()/2);
+                }
+                if (allowInside || pad.getY() + pad.getHeight()/2 > 0) {
+                    addCoordinate(topEdges, pad.getY() + pad.getHeight()/2);
+                }
+            }
+            double overallWidth = rightEdges.last() - leftEdges.first();
+            double overallHeight = topEdges.last() - bottomEdges.first();
+            double overallDiagonal = Math.hypot(overallWidth, overallHeight);
+            boolean isSymmetric = Math.abs(rightEdges.last() + leftEdges.first()) < eps
+                    && Math.abs(topEdges.last() + bottomEdges.first()) < eps;
+
+            // By combining X, Y edges, find eligible corners, including those out in the "air".
+            ArrayList<Corner> corners = new ArrayList<>();
+            findEligibleCorners(leftEdges,  bottomEdges, -1, -1, corners);
+            findEligibleCorners(leftEdges,  topEdges,    -1, +1, corners);
+            findEligibleCorners(rightEdges, bottomEdges, +1, -1, corners);
+            findEligibleCorners(rightEdges, topEdges,    +1, +1, corners);
+
+            // Compute the corner buddy solutions.
+            ArrayList<Corner> cornerSolution = null;
+            double minLeverage = Math.min(overallWidth, overallHeight)*minLeverageFactor;
+            int count = computeBuddies(minLeverage, corners);
+            CompositingSolution compositeSolution = CompositingSolution.Small;
+            if (count > 0) {
+                // Sort by rating etc.
+                Collections.sort(corners);
+                // Store the best solution.
+                Corner mainCorner = corners.get(0);
+                cornerSolution = mainCorner.computeCornerSolution();
+                compositeSolution = mainCorner.getCompositeSolution();
+            }
+            // Start composing results.
+            compositeShots = new ArrayList<>();
+            double minRadius = overallDiagonal/2 + tolerance;
+            double cameraRoamingRadius = camera.getRoamingRadius().convertToUnits(units).getValue()/2;
+            if (compositingMethod == CompositingMethod.None 
+                    || (isSymmetric && minRadius < cameraViewRadius && !compositingMethod.isEnforced())) {
+                // Whole footprint fits in camera.
+                compositeShots.add(new Shot(cornerSolution, 0, 0, 
+                        overallWidth+2*tolerance, overallHeight+2*tolerance, 
+                        overallDiagonal+2*tolerance, overallDiagonal+2*tolerance,
+                        false, ShotConfiguration.Unknown));
+                compositeSolution = (minRadius < cameraViewRadius ? 
+                        CompositingSolution.Small : CompositingSolution.RestrictedCameraRoaming);
+            }
+            else if (cornerSolution != null){
+                // Compose shots from corners.
+                composeShots(cornerSolution);
+            }
+            if (compositeShots.size() == 0) {
+                // No solution, resort to single shot, but mark it invalid
+                compositeShots.add(new Shot(corners, 0, 0, 
+                        overallWidth+2*tolerance, overallHeight+2*tolerance, 
+                        overallDiagonal+2*tolerance, overallDiagonal+2*tolerance,
+                        false, ShotConfiguration.Unknown));
+                if (outOfRoamingCandidates > 0) {
+                    compositeSolution = CompositingSolution.RestrictedCameraRoaming;
+                }
+                else {
+                    compositeSolution = CompositingSolution.Invalid;
+                }
+            }
+            this.compositingSolution = compositeSolution;
+        }
+
+        /**
+         * Fuses the pads that are very close together (tolerance). This greatly reduces the computing cost.
+         * 
+         * @param pads
+         * @return
+         */
+        protected ArrayList<Footprint.Pad> fusedPads(ArrayList<Footprint.Pad> pads) {
+            ArrayList<Footprint.Pad> fusedPads = new ArrayList<>();
+            Footprint.Pad runningPad = null;
+            for (Footprint.Pad pad : pads) {
+                if (runningPad != null) {
+                    Footprint.Pad fusedPad = null;
+                    if (Math.abs(runningPad.getY() - pad.getY()) < eps && Math.abs(runningPad.getHeight() - pad.getHeight()) < eps) {
+                        if (Math.abs(runningPad.getX() - pad.getX()) < runningPad.getWidth()/2  + pad.getWidth()/2 + tolerance) {
+                            // fuse left-right
+                            fusedPad = new Footprint.Pad();
+                            double x0 = Math.min(runningPad.getX() - runningPad.getWidth()/2, pad.getX() - pad.getWidth()/2);
+                            double x1 = Math.max(runningPad.getX() + runningPad.getWidth()/2, pad.getX() + pad.getWidth()/2);
+                            fusedPad.setX((x0 + x1)/2);
+                            fusedPad.setWidth(x1 - x0);
+                            fusedPad.setY(runningPad.getY());
+                            fusedPad.setHeight(runningPad.getHeight());
+                        }
+                    }
+                    else if (Math.abs(runningPad.getX() - pad.getX()) < eps && Math.abs(runningPad.getWidth() - pad.getWidth()) < eps) {
+                        if (Math.abs(runningPad.getY() - pad.getY()) < runningPad.getHeight()/2  + pad.getHeight()/2 + tolerance) {
+                            // fuse top-bottom
+                            fusedPad = new Footprint.Pad();
+                            double y0 = Math.min(runningPad.getY() - runningPad.getHeight()/2, pad.getY() - pad.getHeight()/2);
+                            double y1 = Math.max(runningPad.getY() + runningPad.getHeight()/2, pad.getY() + pad.getHeight()/2);
+                            fusedPad.setX(runningPad.getX());
+                            fusedPad.setWidth(runningPad.getWidth());
+                            fusedPad.setY((y0 + y1)/2);
+                            fusedPad.setHeight(y1 - y0);
+                        }
+                    }
+                    if (fusedPad == null) {
+                        fusedPads.add(runningPad);
+                        runningPad = pad;
+                    }
+                    else {
+                        runningPad = fusedPad;
+                    }
+                }
+                else {
+                    runningPad = pad;
+                }
+            }
+            if (runningPad != null) {
+                fusedPads.add(runningPad);
+            }
+            return fusedPads;
+        }
+
+        /**
+         * @param pad
+         */
+        protected void addPadToOctogalHull(Footprint.Pad pad) {
+            for (int i = 0; i < 8; i++) {
+                double h = pad.getX()*xOctogonalHullSign[i] + pad.getWidth()*Math.abs(xOctogonalHullSign[i])*0.5
+                         + pad.getY()*yOctogonalHullSign[i] + pad.getHeight()*Math.abs(yOctogonalHullSign[i])*0.5;
+                if (octogonalHull[i] < h) {
+                    octogonalHull[i] = h;
+                }
+            }
+        }
+
+        private void composeShots(ArrayList<Corner> solution) {
+            maxCornerRadius = 0; 
+            for (Corner corner : solution) {
+                double x = corner.getX();
+                double y = corner.getY();
+                double r = Math.hypot(x, y);
+                if (maxCornerRadius < r) {
+                    maxCornerRadius = r;
+                }
+            }
+            while (solution.size() > 0) {
+                Corner corner = solution.get(0);
+                solution.remove(corner);
+                double bestDistance = Double.NEGATIVE_INFINITY;
+                double bestOverreach = 0;
+                ShotConfiguration bestConfig = null;
+                Corner bestBuddy = null;
+                Corner bestBuddy2 = null;
+                Corner bestBuddy3 = null;
+                if (compositingMethod != CompositingMethod.SingleCorners) {
+                    for (Corner buddy : solution) {
+                        if (corner.pairsInOneShotWith(buddy)) {
+                            ShotConfiguration config = null;
+                            Corner buddy2 = null;
+                            Corner buddy3 = null;
+                            if (corner.diagonalBuddy == buddy) {
+                                if (corner.pairsInOneShotWith(corner.xMirrorBuddy)) {
+                                    if (solution.contains(corner.xMirrorBuddy)) {
+                                        buddy2 = corner.xMirrorBuddy;
+                                    }
+                                }
+                                if (corner.pairsInOneShotWith(corner.yMirrorBuddy)) {
+                                    if (solution.contains(corner.yMirrorBuddy)) {
+                                        buddy3 = corner.yMirrorBuddy;
+                                    }
+                                }
+                                if (corner.square) {
+                                    config = ShotConfiguration.Square;
+                                }
+                                else if (buddy2 != null || buddy3 != null) {
+                                    config = ShotConfiguration.Box;
+                                }
+                            }
+                            else if (corner.xMirrorBuddy == buddy) {
+                                config = ShotConfiguration.MirrorY;
+                            }
+                            else if (corner.yMirrorBuddy == buddy) {
+                                config = ShotConfiguration.MirrorY;
+                            }
+                            if (config != null) {
+                                double distance = Math.hypot(
+                                        corner.getXDistance(buddy),
+                                        corner.getYDistance(buddy));
+                                double overreach = Math.min(Math.min(
+                                        (cameraViewRadius - tolerance)*2 - distance,
+                                        corner.getMaxMaskRadius() - distance), 
+                                        buddy.getMaxMaskRadius() - distance);
+                                double minOverreach = 0;
+                                if (!config.isDiagonal()) {
+                                    // With a horizontal/vertical buddy we must also test whether min mask radius is covered.
+                                    // This is not needed for a square/box config, where the radius goes all around.
+                                    double minMaskRadius = Math.max(corner.getMinMaskRadius(), buddy.getMinMaskRadius());
+                                    double minRadius = Math.hypot(minMaskRadius, distance/2);
+                                    minOverreach = minRadius - distance/2;
+                                }
+                                if (overreach > minOverreach + tolerance) {
+                                    // Corners can reach each other. 
+                                    if (bestConfig == null 
+                                            || bestConfig.ordinal() > config.ordinal() 
+                                            || (bestConfig == config && bestDistance < distance)) {
+                                        bestDistance = distance;
+                                        bestOverreach = overreach;
+                                        bestConfig = config;
+                                        bestBuddy = buddy;
+                                        bestBuddy2 = buddy2;
+                                        bestBuddy3 = buddy3;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                ArrayList<Corner> shotCorners = new ArrayList<>();
+                shotCorners.add(corner);
+                if (bestBuddy != null) {
+                    // buddy shot
+                    solution.remove(bestBuddy);
+                    shotCorners.add(bestBuddy);
+                    if (bestBuddy2 != null) {
+                        solution.remove(bestBuddy2);
+                        shotCorners.add(bestBuddy2);
+                    }
+                    if (bestBuddy3 != null) {
+                        solution.remove(bestBuddy3);
+                        shotCorners.add(bestBuddy3);
+                    }
+                    compositeShots.add(new Shot(shotCorners,
+                            bestDistance/2 + tolerance,
+                            Math.min(cameraViewRadius, bestDistance/2 + bestOverreach),
+                            tolerance, bestConfig));
+                }
+                else {
+                    compositeShots.add(new Shot(shotCorners, 
+                            corner.getMinMaskRadius(),
+                            Math.min(cameraViewRadius, corner.getMaxMaskRadius()),
+                            tolerance, ShotConfiguration.Corner));
+                }
+            }
+        }
+
+        private double requiredRoamingRadius(double xCorner, double yCorner) {
+            double requiredRoamingRadius = 0;
+            for (int i = 0; i < 8; i++) {
+                double h = xCorner*xOctogonalHullSign[i]
+                         + yCorner*yOctogonalHullSign[i];
+                double r = octogonalHull[i] - h;
+                if (requiredRoamingRadius < r) {
+                    requiredRoamingRadius = r;
+                }
+            }
+            return requiredRoamingRadius;
+        }
+
+        private int computeBuddies(double minLeverage, ArrayList<Corner> corners) {
+            int solutionCount = 0;
+            for (int pass = 0; pass < 2; pass++) {
+                for (Corner corner : corners) {
+                    if (corner.computeBuddies(corners, minLeverage, minLeverage/2, pass) != null) {
+                        solutionCount++;
+                    }
+                }
+            }
+            return solutionCount; 
+        }
+
+        private void findEligibleCorners(TreeSet<Double> xEdges, TreeSet<Double> yEdges, int xSign, int ySign, 
+                ArrayList<Corner> corners) {
+            double maxRoamingRadius = camera.getRoamingRadius().convertToUnits(units).getValue();
+            // Try all combos of edges in X, Y.
+            for (double yEdge : yEdges) {
+                for (double xEdge : xEdges) {
+                    if (requiredRoamingRadius(xEdge, yEdge) > maxRoamingRadius) {
+                        outOfRoamingCandidates++;
+                        continue; // Out of the questions, as we can't move the part that far.
+                    }
+
+                    // Test the pads in the vicinity.
+                    double nearestOutsidePadDistance = cameraViewRadius*2;
+                    double nearestEdgePadDistanceX = Double.POSITIVE_INFINITY;
+                    double nearestEdgePadDistanceY = Double.POSITIVE_INFINITY;
+                    ArrayList<Footprint.Pad> edgeXPads = new ArrayList<>();
+                    ArrayList<Footprint.Pad> edgeYPads = new ArrayList<>();
+                    for (Footprint.Pad pad : rectifiedPads) {
+                        double x = pad.getX() + xSign*pad.getWidth()/2; 
+                        double y = pad.getY() + ySign*pad.getHeight()/2;
+                        if (xSign*(x - xEdge) > eps || ySign*(y - yEdge) > eps) {
+                            // Pad is outside the corner. Records its distance. 
+                            double distance = getPadDistance(xEdge, yEdge, pad);
+                            if (nearestOutsidePadDistance > distance) {
+                                nearestOutsidePadDistance = distance;
+                            }
+                        }
+                        else { 
+                            if (Math.abs(x - xEdge) < eps) {
+                                // Pad is on our X edge(s).
+                                double distance = getPadDistance(xEdge, yEdge, pad);
+                                if (nearestEdgePadDistanceX > distance) {
+                                    nearestEdgePadDistanceX = distance;
+                                }
+                                edgeXPads.add(pad);
+                            }
+                            if (Math.abs(y - yEdge) < eps) {
+                                // Pad is on our Y edge(s).
+                                double distance = getPadDistance(xEdge, yEdge, pad);
+                                if (nearestEdgePadDistanceY > distance) {
+                                    nearestEdgePadDistanceY = distance;
+                                }
+                                edgeYPads.add(pad);
+                            }
+                        }
+                    }
+                    // Find edge pads that define the edge sufficiently.
+                    // Note, if the corner is not right at the pads (like with a Quad package) the the edge
+                    // defined by the pads must be must be at least as long as the distance to the first pad, 
+                    // i.e. the overlap distance must be x2 or more (extended to next pad). Otherwise the 
+                    // MinAreaRect might find a diagonal bounding box with less area. The wedge gain in X 
+                    // obtained by going diagonal must always be less that the loss in Y and vice versa.
+                    //
+                    //           x2
+                    //   |<------|------> > >
+                    // ..:....... _   _   _
+                    //   :   ____| |_| |_| |
+                    //   :  |
+                    //   :__| 
+                    //   |__
+                    //    __|
+                    //   |__
+                    //    __|
+                    //   |__
+
+                    double minOverlap = cameraViewRadius*minCameraRadiusOverlap;
+                    double edgePadDistance = Math.max(nearestEdgePadDistanceX, nearestEdgePadDistanceY);
+                    // Distances in X along the Y edge.
+                    double wantedDistanceX = edgePadDistance*2 + minOverlap;
+                    double overlapEdgePadDistanceX = Double.POSITIVE_INFINITY;
+                    for (Footprint.Pad pad : edgeYPads) {
+                        double distance = getPadDistance(xEdge, yEdge, pad);
+                        if (distance + minOverlap > wantedDistanceX) {
+                            // Pad is beyond, must extend overlap.
+                            if (overlapEdgePadDistanceX > distance + minOverlap) {
+                                overlapEdgePadDistanceX = distance + minOverlap;
+                            }
+                        }
+                        else if (wantedDistanceX < distance + pad.getWidth()) {
+                            // Pad is across, take exactly the wanted distance.
+                            if (overlapEdgePadDistanceX > wantedDistanceX) {
+                                overlapEdgePadDistanceX = wantedDistanceX;
+                                break; // can't get any better
+                            }
+                        }
+                    }
+                    // Distances in Y along the X edge.
+                    double wantedDistanceY = edgePadDistance*2 + minOverlap;
+                    double overlapEdgePadDistanceY = Double.POSITIVE_INFINITY;
+                    for (Footprint.Pad pad : edgeXPads) {
+                        double distance = getPadDistance(xEdge, yEdge, pad);
+                        if (distance + minOverlap > wantedDistanceY) {
+                            // Pad is beyond, must extend overlap.
+                            if (overlapEdgePadDistanceY > distance + minOverlap) {
+                                overlapEdgePadDistanceY = distance + minOverlap;
+                            }
+                        }
+                        else if (wantedDistanceY < distance + pad.getHeight()) {
+                            // Pad is across, take exactly the wanted distance.
+                            if (overlapEdgePadDistanceY > wantedDistanceY) {
+                                overlapEdgePadDistanceY = wantedDistanceY;
+                                break; // can't get any better
+                            }
+                        }
+                    }
+                    double overlapEdgePadDistance = Math.max(overlapEdgePadDistanceX, overlapEdgePadDistanceY);
+                    if (overlapEdgePadDistance + tolerance < nearestOutsidePadDistance - tolerance 
+                            && overlapEdgePadDistance + tolerance < cameraViewRadius) {
+                        // This guy is eligible.
+                        corners.add(new Corner(xEdge, yEdge, 
+                                overlapEdgePadDistance + tolerance, 
+                                nearestOutsidePadDistance - tolerance,
+                                xSign, ySign));
+                    }
+                }
+            }
+        }
+
+        private double getPadDistance(double x, double y, Footprint.Pad pad) {
+            double dx;
+            if (pad.getX() - pad.getWidth()/2 > x) {
+                dx = pad.getX() - pad.getWidth()/2 - x;
+            }
+            else if (pad.getX() + pad.getWidth()/2 < x) {
+                dx = pad.getX() + pad.getWidth()/2 - x;
+            }
+            else {
+                dx = 0;
+            }
+            double dy;
+            if (pad.getY() - pad.getHeight()/2 > y) {
+                dy = pad.getY() - pad.getHeight()/2 - y;
+            }
+            else if (pad.getY() + pad.getHeight()/2 < y) {
+                dy = pad.getY() + pad.getHeight()/2 - y;
+            }
+            else {
+                dy = 0;
+            }
+            return Math.hypot(dx,  dy);
+        }
+
+        private void addCoordinate(TreeSet<Double> edges, double coordinate) {
+            Double nearest = getNearest(edges, coordinate);
+            if (nearest == null || Math.abs(nearest - coordinate) > eps) {
+                edges.add(coordinate);
+            }
+        }
+
+        private Double getNearest(TreeSet<Double> set, double coordinate) {
+            Double nearest0 = set.lower(coordinate);
+            Double nearest1 = set.higher(coordinate);
+            if (nearest0 != null 
+                    && (nearest1 == null || coordinate - nearest0 < nearest1 - coordinate)) {
+                return nearest0;
+            }
+            else {
+                return nearest1;
+            }
+        }
+
+        public void prepareTravel() {
+            ArrayList<Shot> visitedShots = new ArrayList<>();
+            int extraShots = 0;
+            for (Shot shot : compositeShots) {
+                if (shot.isOptional()) {
+                    if (extraShots < getParent().getExtraShots()) {
+                        visitedShots.add(shot);
+                        extraShots++;
+                    }
+                }
+                else {
+                    visitedShots.add(shot);
+                }
+            }
+            // Use a traveling salesman algorithm to optimize the path to visit the placements
+            Location start = nozzle.getLocation().convertToUnits(getUnits());
+            TravellingSalesman<Shot> tsm = new TravellingSalesman<>(
+                    visitedShots, 
+                    new TravellingSalesman.Locator<Shot>() { 
+                        @Override
+                        public Location getLocation(Shot locatable) {
+                            return getShotLocation(locatable);
+                        }
+                    }, 
+                    // start from current location
+                    start,
+                    // leave open
+                    null);
+
+            // Solve it using the default heuristics.
+            tsm.solve();
+            shotsTravel = tsm.getTravel();
+        }
+
+        public Location getShotLocation(Shot shot) {
+            // Note, we move the nozzle, not the camera, so it is inverted.
+            Location location = new Location(units,
+                    -shot.getX(), -shot.getY(), 0, 0);
+            location = location.rotateXy(locationAndRotation.getRotation());
+            location = location.addWithRotation(locationAndRotation);
+            return location;
+        }
+
+        public Point[] convertToPoints(Shot shot, RotatedRect rect) {
+            rect = Utils2D.rotateToExpectedAngle(rect, expectedAngle);
+            // Convert to points. We don't use RotatedRect.point() as it does not document an order and might change in the future.
+            double angle = VisionUtils.getPixelAngle(camera, rect.angle);
+            Location center = VisionUtils.getPixelCenterOffsets(camera, rect.center.x, rect.center.y).convertToUnits(units);
+            Location size = new Location(units, rect.size.width*upp.getX(), rect.size.height*upp.getY(), 0, 0);
+            double s = Math.sin(Math.toRadians(angle));
+            double c = Math.cos(Math.toRadians(angle));
+            double sinHalfW = s*size.getX()/2;
+            double sinHalfH = s*size.getY()/2;
+            double cosHalfW = c*size.getX()/2;
+            double cosHalfH = c*size.getY()/2;
+            double ec = Math.cos(Math.toRadians(expectedAngle));
+            double es = Math.sin(Math.toRadians(expectedAngle));
+            double cx = center.getX() + ec*shot.getX() - es*shot.getY();
+            double cy = center.getY() + es*shot.getX() + ec*shot.getY();
+            // Row, then column sorting.
+            Point[] points = new Point[4];
+            // Upper left.
+            points[0] = new Point(
+                    cx - cosHalfW - sinHalfH, 
+                    cy - sinHalfW + cosHalfH);
+            // Upper Right.
+            points[1] = new Point(
+                    cx + cosHalfW - sinHalfH, 
+                    cy + sinHalfW + cosHalfH);
+            // Lower left.
+            points[2] = new Point(
+                    cx - cosHalfW + sinHalfH, 
+                    cy - sinHalfW - cosHalfH);
+            // Lower Right.
+            points[3] = new Point(
+                    cx + cosHalfW + sinHalfH, 
+                    cy + sinHalfW - cosHalfH);
+            return points;
+        }
+
+        public void accumulateShotDetection(Shot shot, RotatedRect rect) {
+            if (!compositingSolution.isAdvanced()) {
+                detectedRotatedRect = rect;
+            }
+            else {
+                Point[] points = convertToPoints(shot, rect);
+                for (Corner corner : shot.getCorners()) {
+                    int idx = (corner.getXSign() < 0 ? 0 : 1)
+                            + (corner.getYSign() > 0 ? 0 : 2);
+                    cornerMap.put(corner, points[idx]);
+                }
+            }
+        }
+
+        public void interpret() {
+            if (!compositingSolution.isAdvanced()) {
+                return;
+            }
+            // Find the center and angle.
+            Point centerSum = new Point(0, 0);
+            int centerWeights = 0;
+            double angleSum = 0;
+            int angleWeights = 0;
+            double xScaleSum = 0;
+            double xScaleWeights = 0;
+            double yScaleSum = 0;
+            double yScaleWeights = 0;
+            // Note, the same configurations will be computed many times over in 
+            // mirrored or rotated counter-parts. We just don't care.
+            for (Entry<Corner, Point> entry : cornerMap.entrySet()) {
+                Corner corner = entry.getKey();
+                Point point1 = entry.getValue();
+                // Diagonal
+                if (corner.diagonalBuddy != null) {
+                    Point point2 = cornerMap.get(corner.diagonalBuddy);
+                    if (point2 != null) {
+                        // We got the center point.
+                        centerSum = centerSum
+                                .add(point1)
+                                .add(point2);
+                        centerWeights += 2;
+                        if (corner.square) {
+                            // Diagonal of a square, gives us the angle too (at 45°).
+                            Point diff = point2.subtract(point1);
+                            double angle = Math.toDegrees(Math.atan2(diff.y, diff.x)) - 45;
+                            angle += Math.round((expectedAngle - angle)/90)*90;
+                            angleSum += angle;
+                            angleWeights++;
+                            // We got a scale indication
+                            double distance = diff.distance();
+                            double dx = Math.abs(corner.diagonalBuddy.getX() - corner.getX());
+                            double dy = Math.abs(corner.diagonalBuddy.getY() - corner.getY());
+                            xScaleSum += distance;
+                            xScaleWeights += dx;
+                            yScaleSum += distance;
+                            yScaleWeights += dy;
+                        }
+                    }
+                }
+                // Pair of mirrors in Y
+                if (corner.ySymmetricBuddy != null) {
+                    Point point2 = cornerMap.get(corner.xMirrorBuddy);
+                    Point point3 = cornerMap.get(corner.ySymmetricBuddy);
+                    Point point4 = cornerMap.get(corner.ySymmetricBuddy.xMirrorBuddy);
+                    if (point2 != null && point3 != null && point4 != null) {
+                        // We got the center point.
+                        centerSum = centerSum
+                                .add(point1)
+                                .add(point2)
+                                .add(point3)
+                                .add(point4);
+                        centerWeights += 4;
+                    }
+                }
+                // Pair of mirrors in X
+                if (corner.xSymmetricBuddy != null) {
+                    Point point2 = cornerMap.get(corner.yMirrorBuddy);
+                    Point point3 = cornerMap.get(corner.xSymmetricBuddy);
+                    Point point4 = cornerMap.get(corner.xSymmetricBuddy.yMirrorBuddy);
+                    if (point2 != null && point3 != null && point4 != null) {
+                        // We got the center point.
+                        centerSum = centerSum
+                                .add(point1)
+                                .add(point2)
+                                .add(point3)
+                                .add(point4);
+                        centerWeights += 4;
+                    }
+                }
+                // Aligned in X
+                for (Corner buddy : new Corner[] { 
+                        corner.xAlignedBuddy, 
+                        corner.yAlignedBuddy, 
+                        corner.xMirrorBuddy, 
+                        corner.yMirrorBuddy, 
+                }) {
+                    if (buddy != null) {
+                        Point point2 = cornerMap.get(buddy);
+                        if (point2 != null) {
+                            // We got an angle indication.
+                            Point diff = point2.subtract(point1);
+                            double angle = Math.toDegrees(Math.atan2(diff.y, diff.x));
+                            angle += Math.round((expectedAngle - angle)/90)*90;
+                            angleSum += angle;
+                            angleWeights++;
+                            // We got a scale indication
+                            double distance = diff.distance();
+                            double dx = Math.abs(buddy.getX() - corner.getX());
+                            double dy = Math.abs(buddy.getY() - corner.getY());
+                            if (dx > dy) {
+                                xScaleSum += distance;
+                                xScaleWeights += dx;
+                            }
+                            else {
+                                yScaleSum += distance;
+                                yScaleWeights += dy;
+                            }
+                        }
+                    }
+                }
+            }
+            // Evaluate the stats.
+            detectedCenter = centerSum.divide(centerWeights);
+            detectedAngle = angleSum/angleWeights;
+            detectedAngle += Math.round((expectedAngle - detectedAngle)/90)*90;
+            detectedScale = new Point(
+                    xScaleSum/xScaleWeights, 
+                    yScaleSum/yScaleWeights); 
+            detectedSize = new Point(
+                    detectedScale.x*Math.max(-leftEdges.first(), rightEdges.last())*2,
+                    detectedScale.y*Math.max(-bottomEdges.first(), topEdges.last())*2);
+            // For pipeline result compatibility, make the RotatedRect in OpenCv pixel coordinates. 
+            double angle = VisionUtils.getPixelAngle(camera, detectedAngle);
+            org.opencv.core.Point center = new org.opencv.core.Point(
+                    camera.getWidth()*0.5 + detectedCenter.x/upp.getX(), 
+                    camera.getHeight()*0.5 - detectedCenter.y/upp.getY());
+            org.opencv.core.Size size = new org.opencv.core.Size(
+                    detectedSize.x/upp.getX(), 
+                    detectedSize.y/upp.getY());
+            detectedRotatedRect = new RotatedRect(center, size, angle);
+        }
+    }
+}

--- a/src/main/java/org/openpnp/spi/Camera.java
+++ b/src/main/java/org/openpnp/spi/Camera.java
@@ -230,4 +230,12 @@ public interface Camera extends HeadMountable, WizardConfigurable,
     boolean isShownInMultiCameraView();
 
     public FocusProvider getFocusProvider();
+
+    /**
+     * @return The bottom camera roaming radius within which a part is allowed to be positioned at camera Z.
+     * It includes moving the nozzle around to take different shots of the parts, and the part extent itself.  
+     * It does not include pick offsets and other deviations that may occur during practical operation, a 
+     * physical camera "pit" must allow for some extra wiggle space, on to of this nominal radius.   
+     */
+    public Length getRoamingRadius();
 }

--- a/src/main/java/org/openpnp/spi/Nozzle.java
+++ b/src/main/java/org/openpnp/spi/Nozzle.java
@@ -51,6 +51,12 @@ public interface Nozzle
     public RotationMode getRotationMode();
 
     /**
+     * @return Whether the bottom vision aligment of parts adjust the Rotation Mode of the nozzle to include the 
+     * alignment rotation offset.
+     */
+    public boolean isAligningRotationMode();
+
+    /**
      * Prepare the Nozzle for the next placement rotation. This will apply a rotation offset to the Nozzle 
      * that implements the {@link RotationMode} and is subject to articulation limits, if present.
      * 

--- a/src/main/java/org/openpnp/spi/NozzleTip.java
+++ b/src/main/java/org/openpnp/spi/NozzleTip.java
@@ -30,7 +30,24 @@ public interface NozzleTip extends Identifiable, Named, Solutions.Subject, Wizar
     void home() throws Exception;
 
     /**
-     * @return the Nozzle where this tip is currently loaded, or null.
+     * @return The Nozzle where this tip is currently loaded, or null.
      */
     Nozzle getNozzleWhereLoaded();
+
+    /**
+     * @return The maximum part height to be allowed on this nozzle tip. 
+     */
+    Length getMaxPartHeight();
+    /**
+     * @return The maximum part diameter to be allowed on this nozzle tip.
+     */
+    Length getMaxPartDiameter();
+    /**
+     * @return The minimum part diameter to be allowed on this nozzle tip.
+     */
+    Length getMinPartDiameter();
+    /**
+     * @return The maximum pick tolerance on this nozzle tip. This can be overridden in the Package. 
+     */
+    Length getMaxPickTolerance();
 }

--- a/src/main/java/org/openpnp/spi/base/AbstractCamera.java
+++ b/src/main/java/org/openpnp/spi/base/AbstractCamera.java
@@ -122,6 +122,9 @@ public abstract class AbstractCamera extends AbstractHeadMountable implements Ca
     @Element(required = false)
     protected VisionProvider visionProvider;
 
+    @Element(required = false)
+    protected Length roamingRadius = new Length(0, LengthUnit.Millimeters);
+
     public enum SettleMethod {
         FixedTime,
         Maximum,
@@ -510,6 +513,15 @@ public abstract class AbstractCamera extends AbstractHeadMountable implements Ca
 
     public void setCameraSecondaryZ(Length cameraSecondaryZ) {
         this.cameraSecondaryZ = cameraSecondaryZ;
+    }
+
+    @Override
+    public Length getRoamingRadius() {
+        return roamingRadius;
+    }
+
+    public void setRoamingRadius(Length roamingRadius) {
+        this.roamingRadius = roamingRadius;
     }
 
     /**

--- a/src/main/java/org/openpnp/spi/base/AbstractNozzle.java
+++ b/src/main/java/org/openpnp/spi/base/AbstractNozzle.java
@@ -36,6 +36,9 @@ public abstract class AbstractNozzle extends AbstractHeadMountable implements No
     @Attribute(required = false)
     protected RotationMode rotationMode = RotationMode.AbsolutePartAngle;
 
+    @Attribute(required = false)
+    protected boolean aligningRotationMode = false;
+
     /**
      * Under limited angular articulation, the nozzle must be prepared for a pick-and-place cycle, including
      * any angular tolerances in the pick (for feeders with vision) and in the alignment (bottom vision).
@@ -104,7 +107,7 @@ public abstract class AbstractNozzle extends AbstractHeadMountable implements No
         Object oldValue = this.part;
         this.part = part;
         if (rotationModeOffset != null && part == null) {
-            rotationModeOffset = null;
+            setRotationModeOffset(null);
             getMachine().fireMachineHeadActivity(head);
         }
         firePropertyChange("part", oldValue, part);
@@ -121,7 +124,20 @@ public abstract class AbstractNozzle extends AbstractHeadMountable implements No
     }
 
     public void setRotationMode(RotationMode rotationMode) {
+        Object oldValue = this.rotationMode;
         this.rotationMode = rotationMode;
+        firePropertyChange("rotationMode", oldValue, rotationMode);
+    }
+
+    @Override
+    public boolean isAligningRotationMode() {
+        return aligningRotationMode;
+    }
+
+    public void setAligningRotationMode(boolean aligningRotationMode) {
+        Object oldValue = this.aligningRotationMode;
+        this.aligningRotationMode = aligningRotationMode;
+        firePropertyChange("aligningRotationMode", oldValue, aligningRotationMode);
     }
 
     public double[] getRotationModeLimits() throws Exception {

--- a/src/main/java/org/openpnp/util/Utils2D.java
+++ b/src/main/java/org/openpnp/util/Utils2D.java
@@ -30,6 +30,8 @@ import org.apache.commons.math3.linear.LUDecomposition;
 import org.apache.commons.math3.linear.MatrixUtils;
 import org.apache.commons.math3.linear.RealMatrix;
 import org.apache.commons.math3.linear.SingularValueDecomposition;
+import org.opencv.core.RotatedRect;
+import org.opencv.core.Size;
 import org.openpnp.model.Board.Side;
 import org.openpnp.model.BoardLocation;
 import org.openpnp.model.Length;
@@ -365,7 +367,48 @@ public class Utils2D {
         }
         return angle;
     }
-    
+
+    public static double angleNorm(double val, double lim) {
+        double clip = lim * 2;
+        while (Math.abs(val) > lim) {
+            val += (val < 0.) ? clip : -clip;
+        }
+        return val;
+    }
+
+    public static double angleNorm(double val) {
+        return angleNorm(val, 45.);
+    }
+
+    /**
+     * Rotate the given RotatedRect nearest to the expectedAngle in 90° steps, i.e., it will have the same shape
+     * but be ±45° within expectedAngle. 
+     * 
+     * @param r
+     * @param expectedAngle Note, the angle given here is right-handed, unlike the one 
+     *                      stored in the RotatedRect.
+     * @return
+     */
+    public static RotatedRect rotateToExpectedAngle(RotatedRect r, double expectedAngle) {
+        int steps90 = (int) Math.round((expectedAngle + r.angle)/90);
+        if (steps90 != 0) {
+            if ((steps90 & 1) != 0) {
+                // Odd 90° rotation, must swap size
+                r = new RotatedRect(
+                        r.center, 
+                        new Size(r.size.height, r.size.width), 
+                        Utils2D.angleNorm(r.angle - steps90*90, 180));
+            }
+            else {
+                r = new RotatedRect(
+                        r.center, 
+                        r.size, 
+                        Utils2D.angleNorm(r.angle - steps90*90, 180));
+            }
+        }
+        return r;
+    }
+
     /**
      * Calculate the Location along the line formed by a and b with distance from a.
      * @param a
@@ -647,17 +690,5 @@ public class Utils2D {
         results.add(maxA);
         results.add(maxB);
         return results;
-    }
-
-    public static double angleNorm(double val, double lim) {
-        double clip = lim * 2;
-        while (Math.abs(val) > lim) {
-            val += (val < 0.) ? clip : -clip;
-        }
-        return val;
-    }
-
-    public static double angleNorm(double val) {
-        return angleNorm(val, 45.);
     }
 }

--- a/src/main/java/org/openpnp/util/VisionUtils.java
+++ b/src/main/java/org/openpnp/util/VisionUtils.java
@@ -57,14 +57,26 @@ public class VisionUtils {
         // Calculate the difference between the center of the image to the
         // center of the match.
         double offsetX = x - (imageWidth / 2);
-        double offsetY = (imageHeight / 2) - y;
+        double offsetY = y - (imageHeight / 2);
 
-        // And convert pixels to units
+        return getPixelOffsets(camera, offsetX, offsetY);
+    }
+
+    /**
+     * Given pixel offset coordinates, get the same offsets in Camera space and units.
+     * 
+     * @param camera
+     * @param offsetX
+     * @param offsetY
+     * @return
+     */
+    public static Location getPixelOffsets(Camera camera, double offsetX, double offsetY) {
+        // Convert pixels to units
         Location unitsPerPixel = camera.getUnitsPerPixelAtZ();
         offsetX *= unitsPerPixel.getX();
         offsetY *= unitsPerPixel.getY();
-
-        return new Location(unitsPerPixel.getUnits(), offsetX, offsetY, 0, 0);
+        // Convert to right-handed.
+        return new Location(unitsPerPixel.getUnits(), offsetX, -offsetY, 0, 0);
     }
 
     /**

--- a/src/main/java/org/openpnp/vision/pipeline/ui/PipelinePanel.java
+++ b/src/main/java/org/openpnp/vision/pipeline/ui/PipelinePanel.java
@@ -38,6 +38,7 @@ import org.openpnp.gui.support.Icons;
 import org.openpnp.gui.support.MessageBoxes;
 import org.openpnp.spi.Camera;
 import org.openpnp.util.MovableUtils;
+import org.openpnp.util.UiUtils;
 import org.openpnp.util.VisionUtils;
 import org.openpnp.vision.pipeline.CvPipeline;
 import org.openpnp.vision.pipeline.CvStage;
@@ -53,6 +54,7 @@ public class PipelinePanel extends JPanel {
     private JTable stagesTable;
     private StagesTableModel stagesTableModel;
     private PropertySheetPanel propertySheetPanel;
+    private JEditorPane descriptionTa;
     private PipelinePropertySheetTable pipelinePropertySheetTable;
 
     public PipelinePanel(CvPipelineEditor editor) {
@@ -75,6 +77,13 @@ public class PipelinePanel extends JPanel {
         JButton refreshButton = new JButton(refreshAction);
         refreshButton.setHideActionText(true);
         toolbar.add(refreshButton);
+
+        if (editor.getPipeline() != null 
+                && editor.getPipeline().getPipelineShotsCount() > 1) {
+            JButton stepNextButton = new JButton(stepNextShotAction);
+            stepNextButton.setHideActionText(true);
+            toolbar.add(stepNextButton);
+        }
 
         JButton btnAdd = new JButton(newStageAction);
         btnAdd.setHideActionText(true);
@@ -354,5 +363,20 @@ public class PipelinePanel extends JPanel {
             editor.process();
         }
     };
-    private JEditorPane descriptionTa;
+
+    public final Action stepNextShotAction = new AbstractAction() {
+        {
+            putValue(SMALL_ICON, Icons.step);
+            putValue(NAME, "Step to the next shot.");
+            putValue(SHORT_DESCRIPTION, "Step to the next shot.");
+        }
+
+        @Override
+        public void actionPerformed(ActionEvent arg0) {
+            UiUtils.messageBoxOnException(() -> {
+                editor.getPipeline().stepToNextPipelineShot();
+                editor.process();
+            });
+        }
+    };
 }

--- a/src/test/java/ReferenceBottomVisionOffsetTest.java
+++ b/src/test/java/ReferenceBottomVisionOffsetTest.java
@@ -19,6 +19,7 @@ import org.openpnp.model.Length;
 import org.openpnp.model.LengthUnit;
 import org.openpnp.model.Location;
 import org.openpnp.model.Part;
+import org.openpnp.model.VisionCompositing.CompositingMethod;
 import org.openpnp.spi.Machine;
 import org.openpnp.spi.Nozzle;
 import org.openpnp.spi.NozzleTip;
@@ -204,6 +205,8 @@ public class ReferenceBottomVisionOffsetTest {
        
         Part part = Configuration.get().getPart("DoubleAsymPart");
         BottomVisionSettings bottomVisionSettings = bottomVision.getInheritedVisionSettings(part);
+        // Need to suppress vision compositing, as it complains about asymmetric parts.
+        part.getPackage().getVisionCompositing().setCompositingMethod(CompositingMethod.None);
         
         BoardLocation boardLocation = new BoardLocation(new Board());
         boardLocation.setLocation(new Location(LengthUnit.Millimeters, 0, 0, -10, 0));
@@ -246,6 +249,8 @@ public class ReferenceBottomVisionOffsetTest {
         Nozzle nozzle = machine.getDefaultHead().getDefaultNozzle();
        
         Part part = Configuration.get().getPart("DoubleAsymPart");
+        // Need to suppress vision compositing, as it complains about asymmetric parts.
+        part.getPackage().getVisionCompositing().setCompositingMethod(CompositingMethod.None);
         BottomVisionSettings bottomVisionSettings = bottomVision.getInheritedVisionSettings(part);
         
         BoardLocation boardLocation = new BoardLocation(new Board());

--- a/src/test/java/ReferenceBottomVisionTest.java
+++ b/src/test/java/ReferenceBottomVisionTest.java
@@ -24,12 +24,12 @@ import com.google.common.io.Files;
 public class ReferenceBottomVisionTest {
     @Test
     public void testPositiveAngle() throws Exception {
-        testError(new Location(LengthUnit.Millimeters, 1, 2, 0, 13));
+        testError(new Location(LengthUnit.Millimeters, 0.25, 0.75, 0, 13));
     }
     
     @Test
     public void testNegativeAngle() throws Exception {
-        testError(new Location(LengthUnit.Millimeters, 1, 2, 0, -13));
+        testError(new Location(LengthUnit.Millimeters, 0.25, 0.75, 0, -13));
     }
     
     public static void testError(Location error) throws Exception {
@@ -59,7 +59,7 @@ public class ReferenceBottomVisionTest {
 
         // Set nozzle tip pick tolerances for large offsets.
         for (NozzleTip tip : Configuration.get().getMachine().getNozzleTips()) {
-            ((ReferenceNozzleTip) tip).setMaxPickTolerance(new Length(3, LengthUnit.Millimeters));
+            ((ReferenceNozzleTip) tip).setMaxPickTolerance(new Length(1, LengthUnit.Millimeters));
         }
 
         camera.setErrorOffsets(error);

--- a/src/test/java/VisionCompositingTest.java
+++ b/src/test/java/VisionCompositingTest.java
@@ -1,0 +1,224 @@
+/*
+ * Copyright (C) 2022 <mark@makr.zone>
+ * inspired and based on work
+ * Copyright (C) 2011 Jason von Nieda <jason@vonnieda.org>
+ * 
+ * This file is part of OpenPnP.
+ * 
+ * OpenPnP is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * OpenPnP is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License along with OpenPnP. If not, see
+ * <http://www.gnu.org/licenses/>.
+ * 
+ * For more information about OpenPnP visit http://openpnp.org
+ */
+
+import java.io.File;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.openpnp.model.Configuration;
+
+import com.google.common.io.Files;
+
+
+public class VisionCompositingTest {
+
+    @BeforeEach
+    public void before() throws Exception {
+        /**
+         * Create a new config directory and load the default configuration.
+         */
+        File workingDirectory = Files.createTempDir();
+        workingDirectory = new File(workingDirectory, ".openpnp");
+        System.out.println("Configuration directory: " + workingDirectory);
+        Configuration.initialize(workingDirectory);
+        Configuration.get().load();
+
+    }
+
+
+    @Test
+    public void testPackageSolutions() throws Exception {
+        /*
+        SimulatedUpCamera camera = (SimulatedUpCamera)VisionUtils.getBottomVisionCamera();
+        NozzleTip nt = Configuration.get().getMachine().getNozzleTips().get(0); 
+        org.openpnp.model.Package pkg;
+        Footprint footprint;
+        Pad pad;
+        pkg = new org.openpnp.model.Package("PASSIVE");
+        pkg.addCompatibleNozzleTip(nt);
+        footprint = pkg.getFootprint();
+        footprint.setOuterDimension(3);
+        footprint.setInnerDimension(2);
+        footprint.setPadAcross(2);
+        footprint.setPadCount(2);
+        footprint.generate(Generator.Dual);
+        pkg.getVisionCompositing().computeCompositeShots(pkg, camera);
+        assertEquals(pkg.getVisionCompositing().getMinCorners(), 3);
+        assertEquals(pkg.getVisionCompositing().getCompositeCorners().size(), 4);
+        assertEquals(pkg.getVisionCompositing().getCompositeCorners().get(0).getRating(), 6); // non-square box and X configuration.
+
+        pkg = new org.openpnp.model.Package("DUAL"); // SOIC
+        pkg.addCompatibleNozzleTip(nt);
+        footprint = pkg.getFootprint();
+        footprint.setOuterDimension(6.2);
+        footprint.setInnerDimension(3.8);
+        footprint.setPadAcross(0.5);
+        footprint.setPadPitch(1.27);
+        footprint.setPadCount(24);
+        footprint.generate(Generator.Dual);
+        pkg.getVisionCompositing().computeCompositeShots(pkg, camera);
+        assertEquals(pkg.getVisionCompositing().getMinCorners(), 3);
+        assertEquals(pkg.getVisionCompositing().getCompositeCorners().size(), 4);
+        assertEquals(pkg.getVisionCompositing().getCompositeCorners().get(0).getRating(), 6); // non-square box and X configuration.
+
+        pkg = new org.openpnp.model.Package("QUAD");
+        pkg.addCompatibleNozzleTip(nt);
+        footprint = pkg.getFootprint();
+        footprint.setOuterDimension(4);
+        footprint.setInnerDimension(2);
+        footprint.setPadAcross(0.2);
+        footprint.setPadPitch(0.5);
+        footprint.setPadCount(16);
+        footprint.generate(Generator.Quad);
+        pkg.getVisionCompositing().computeCompositeShots(pkg, camera);
+        assertEquals(pkg.getVisionCompositing().getMinCorners(), 2);
+        assertEquals(pkg.getVisionCompositing().getCompositeCorners().size(), 4);
+        assertEquals(pkg.getVisionCompositing().getCompositeCorners().get(0).getRating(), 9); // full square
+
+        pkg = new org.openpnp.model.Package("BGA");
+        pkg.addCompatibleNozzleTip(nt);
+        footprint = pkg.getFootprint();
+        footprint.setPadAcross(0.2);
+        footprint.setPadPitch(0.5);
+        footprint.setPadCount(64);
+        footprint.setPadRoundness(100);
+        footprint.generate(Generator.Bga);
+        pkg.getVisionCompositing().computeCompositeShots(pkg, camera);
+        assertEquals(pkg.getVisionCompositing().getMinCorners(), 2);
+        assertEquals(pkg.getVisionCompositing().getCompositeCorners().size(), 4);
+        assertEquals(pkg.getVisionCompositing().getCompositeCorners().get(0).getRating(), 9); // full square
+
+        pkg = new org.openpnp.model.Package("HEADPHONE");
+        pkg.addCompatibleNozzleTip(nt);
+        footprint = pkg.getFootprint();
+        pad = new Pad();            //  [1]
+        pad.setX(-3);               //       [4]
+        pad.setY(6);                //
+        pad.setWidth(2);            //
+        pad.setHeight(2);           //  [2]
+        pad.setName("1");           //       [3]
+        footprint.addPad(pad);      //
+        pad = new Pad();            // Staggered pads.
+        pad.setX(-3);
+        pad.setY(-4);
+        pad.setWidth(2);
+        pad.setHeight(2);
+        pad.setName("2");
+        footprint.addPad(pad);
+        pad = new Pad();
+        pad.setX(3);
+        pad.setY(-6);
+        pad.setWidth(2);
+        pad.setHeight(2);
+        pad.setName("3");
+        footprint.addPad(pad);
+        pad = new Pad();
+        pad.setX(3);
+        pad.setY(4);
+        pad.setWidth(2);
+        pad.setHeight(2);
+        pad.setName("4");
+        footprint.addPad(pad);
+        pkg.getVisionCompositing().computeCompositeShots(pkg, camera);
+        assertEquals(pkg.getVisionCompositing().getMinCorners(), 3);
+        assertEquals(pkg.getVisionCompositing().getCompositeCorners().size(), 4);
+        assertEquals(pkg.getVisionCompositing().getCompositeCorners().get(0).getX(), -4); // upper left corner of 1st pad is lead
+        assertEquals(pkg.getVisionCompositing().getCompositeCorners().get(0).getY(), 7); 
+        assertEquals(pkg.getVisionCompositing().getCompositeCorners().get(0).getRating(), 5); // Z configuration
+
+        pkg = new org.openpnp.model.Package("HEADPHONE2");
+        pkg.addCompatibleNozzleTip(nt);
+        footprint = pkg.getFootprint();
+        pad = new Pad();            //       [4]
+        pad.setX(-3);               //  [1]
+        pad.setY(4);                //
+        pad.setWidth(2);            //
+        pad.setHeight(2);           //       [3]
+        pad.setName("1");           //  [2]
+        footprint.addPad(pad);      //
+        pad = new Pad();            // Staggered pads.
+        pad.setX(-3);
+        pad.setY(-6);
+        pad.setWidth(2);
+        pad.setHeight(2);
+        pad.setName("2");
+        footprint.addPad(pad);
+        pad = new Pad();
+        pad.setX(3);
+        pad.setY(-4);
+        pad.setWidth(2);
+        pad.setHeight(2);
+        pad.setName("3");
+        footprint.addPad(pad);
+        pad = new Pad();
+        pad.setX(3);
+        pad.setY(6);
+        pad.setWidth(2);
+        pad.setHeight(2);
+        pad.setName("4");
+        footprint.addPad(pad);
+        pkg.getVisionCompositing().computeCompositeShots(pkg, camera);
+        assertEquals(pkg.getVisionCompositing().getMinCorners(), 3);
+        assertEquals(pkg.getVisionCompositing().getCompositeCorners().size(), 4);
+        assertEquals(pkg.getVisionCompositing().getCompositeCorners().get(0).getX(), -4); // lower left corner of 2nd pad is lead
+        assertEquals(pkg.getVisionCompositing().getCompositeCorners().get(0).getY(), -7); 
+        assertEquals(pkg.getVisionCompositing().getCompositeCorners().get(0).getRating(), 5); // Z configuration
+
+        pkg = new org.openpnp.model.Package("PWR_FET");
+        pkg.addCompatibleNozzleTip(nt);
+        footprint = pkg.getFootprint();
+        pad = new Pad();            //  [  1  ]
+        pad.setX(-3);               //              [     ]  
+        pad.setY(1);                //              [     ]
+        pad.setWidth(4);            //  [  2  ]     [  4  ]
+        pad.setHeight(0.5);         //              [     ]
+        pad.setName("1");           //              [     ]
+        footprint.addPad(pad);      //  [  3  ]
+        pad = new Pad();            //
+        pad.setX(-3);               // Power-FET, left-right asymmetrical.
+        pad.setY(0);
+        pad.setWidth(4);
+        pad.setHeight(0.5);
+        pad.setName("2");
+        footprint.addPad(pad);
+        pad = new Pad();
+        pad.setX(-3);
+        pad.setY(-1);
+        pad.setWidth(4);
+        pad.setHeight(0.5);
+        pad.setName("3");
+        footprint.addPad(pad);
+        pad = new Pad();
+        pad.setX(3);
+        pad.setY(0);
+        pad.setWidth(4);
+        pad.setHeight(2);
+        pad.setName("4");
+        footprint.addPad(pad);
+        pkg.getVisionCompositing().computeCompositeShots(pkg, camera);
+        assertEquals(pkg.getVisionCompositing().getMinCorners(), 4);
+        assertEquals(pkg.getVisionCompositing().getCompositeCorners().size(), 4);
+        assertEquals(pkg.getVisionCompositing().getCompositeCorners().get(0).getX(), -5); // upper left corner of 1st pad is lead
+        assertEquals(pkg.getVisionCompositing().getCompositeCorners().get(0).getY(), 1.25); 
+        assertEquals(pkg.getVisionCompositing().getCompositeCorners().get(0).getRating(), 2); // Trapezoid configuration
+        */
+    }
+}

--- a/src/test/java/VisionUtilsTest.java
+++ b/src/test/java/VisionUtilsTest.java
@@ -1,3 +1,5 @@
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.IOException;
@@ -26,8 +28,6 @@ import org.openpnp.spi.base.AbstractHeadMountable;
 import org.openpnp.util.VisionUtils;
 
 import com.google.common.io.Files;
-
-import static org.junit.jupiter.api.Assertions.*;
 
 
 public class VisionUtilsTest {
@@ -281,6 +281,11 @@ public class VisionUtilsTest {
         @Override
         public FocusProvider getFocusProvider() {
             return null;
+        }
+
+        @Override
+        public Length getRoamingRadius() {
+            return new Length(10, LengthUnit.Millimeters);
         }
     }
 }


### PR DESCRIPTION
# Description
Adds Vision Compositing, i.e. multi-shot bottom vision, where multiple corners of a part can be aligned individually and then combined into the whole-part alignment. 

![multi-shot](https://user-images.githubusercontent.com/9963310/178464287-c1100a86-b81e-40f3-b11d-b736822f7e1c.gif)

The following features are included:

- Align packages that are larger than the camera view.
- Align packages that are not rectangular in their overall shape. 
- Improve accuracy by detecting in the camera center, avoiding errors from parallax, viewing & lighting side angles, and residual lens distortion. 
- Align packages based on pad corners facing inwards, i.e. parts that are asymmetric on the outside, or so large you can't capture their outside corners.
- Enable the Pipeline Editor to cycle through multiple shots.
- Use the nozzle Rotation Mode offset (see #1309) to align the nozzle rotation with the aligned part. 

# Justification
Between tiny 0201/0402 passives and enormous LQFP-256 packages, it is quite hard to get the bottom camera view right. One has to trade resolution against view size. Attempting to escape this dilemma by using a higher resolution camera comes at a significant additional cost in processing power, more lighting required, more compression artifacts, or (worse) reduced frame rate (fps) and additional camera lag. 

Wanting a large camera view also adds constraints to the machine build. The ideal camera has a long focal length ("telephoto") lens to minimize parallax errors, which means it has to be far away from the subject. However, this usually means building a taller machine, especially for table-top design. Consequently, designers often use (very) wide-angle lenses, which are detrimental to alignment accuracy (see the parallax error illustration further below). 

Ironically, the very large parts are often quite rare in projects, just the _one_ MCU, for example. The overwhelming majority of parts are rather small. It hurts to make poor tradeoffs for the few exotic parts.  

Vision Compositing helps with all these problems. 

Cameras can now be optimized to the brunt of the work with medium and small sized parts. You can use medium resolution cameras with high fps, longish focal length lenses and still get a reasonable compact table-top design. A narrower view means more accuracy, and faster convergence on multi-pass alignment. 

The few large parts can then still be aligned with multiple shots. Obviously, there is an extra cost in alignment time, which may or may not be compensated by the avoided tradeoffs overall (more fps, less lag, faster convergence on multi-pass alignment). 

As an independent benefit, multi-shot alignment increases accuracy, particularly for very large parts. In some cases it might actually be the key to successful placement, regardless of the package actually being too large for the camera view. 

Finally, the multi-shot feature also enables alignment of non-rectangular parts (best see the video for examples). 

# Instructions for Use

For an easy overview, [please watch the video](https://youtu.be/P-ZudS7QQeE).

## Camera Roaming Radius

A **Camera Roaming Radius** of zero (default) effectively switches off Vision Compositing.

A **Camera Roaming Radius** of more than zero allows Vision Compositing. The nozzle is allowed to hold the part anywhere within this radius of the bottom camera location. 

![Camera Roaming Radius](https://user-images.githubusercontent.com/9963310/178479776-158df3f9-e5f1-45a0-8b17-c9bf554d4a57.png)

Within the **Camera Roaming Radius**, the nozzle is allowed to move freely in X, Y, i.e. without going to Safe Z first. This is also used to optimize in-camera drag-jogging. However, this is **not** a soft-limit, you still have to be careful not to bump your nozzle and/or part into any obstacles near your camera. 

The radius must accommodate both the nozzle distance from the camera center, and the part protruding from the nozzle. This is automatically observed during Vision Compositing, taking the the hull of the package footprint into consideration. Because the part is typically held in its center, and because the corners are the package's obvious multi-shot targets, this means that part sizes are more or less constrained to _those with diameters smaller than the **Camera Roaming Radius**_. 

The following illustrates an LQFP-144 package within a 30mm camera roaming radius: 

![Roaming as a limit](https://user-images.githubusercontent.com/9963310/178480317-770b6801-9625-42cf-b4f1-723c55e08caa.png)

**CAUTION**: Your camera "pit" must physically provide this freedom of movement, when the nozzle tip and part is at Camera Z (focal plane), and with the worst pick tolerances and other deviations to spare. 

## Other Machine Preparation

It is recommended to enable the **Align with Part?** option on the nozzles:

![Align with part switch](https://user-images.githubusercontent.com/9963310/178480834-200e20d4-8640-46c4-8143-14903fdadc3d.png)

It offsets the nozzle rotation coordinate to match that of the part, once the part is aligned. This means that the cross-hairs and the DRO are nicely aligned with the part. This is especially useful in the multi-shot scenario, where you often only see a fraction of the whole part, and the reticle (cross-hairs, grid etc.) provides valuable visual feedback, 

## Package Footprint

In order for Multi-Shot Bottom Vision to work, the footprint must be defined. Most common footprints can easily be generated from very few datasheet parameters, right inside OpenPnP:

![Footprint generator](https://user-images.githubusercontent.com/9963310/178484759-bdcc34c4-feba-48d2-8b79-9dd87338d8ec.png)

Note: the Eagle E-CAD importer can also import the pads along with the packages. 

## Package Vision Compositing

Basic operation should be automatic. Given the **Camera Roaming Radius**, the multi-shot is enabled. It will automatically be employed with parts nearly as large as the camera view. 

The package **Vision Compositing** tab can give a quick preview of the footprint and its treatment by bottom vision:

![Vision-Compositing-Tab](https://user-images.githubusercontent.com/9963310/178488589-01a1725a-2af1-4182-b73d-b069dac64e2d.gif)

You can hover your mouse over the shots, indicated by corner marker and masking radius. It then indicates the camera view rectangle according to your camera size. The thick red/dashed circle around the package indicates the **Camera Roaming Radius**, i.e. where the nozzle and part can be.

You can press the mouse to see how the pads are fused together, where they are too close to isolate. Only the outside corners of these blocks can be considered as shot locations. But even these are subject to many more constraints.

### Compositing Settings

**Method** determines how the footprint is treated:

![Compositing Method Drop-Down](https://user-images.githubusercontent.com/9963310/178490264-70c62247-3998-4e9f-ad26-5e393393df3f.png)

- **None**: the part is aligned with one shot, even if its size or other properties of the footprint would suggest otherwise. This can be used to basically enforce the old behavior. It might be a way to tell OpenPnP to still align select packages with one shot, even if the footprint (plus tolerances) are actually overlapping the camera central circle. Or when pre-rotate is switched off and the part just happens to fit inside the rectangular camera view.
- **Restricted**: the part is always aligned with one shot if it fits inside the camera view (central circle), regardless of other properties of the footprint, like convex pad patterns. This is the default method, intended to provide continuity for the majority of packages. 
- **Automatic**: the part is aligned with one shot if it fits inside the camera view (central circle), and if its corners are understood to be symmetric and convex, to be capture as one bounding rectangle. If this is not the case, a multi-shot is automatically performed. It might combine pairs of corners into "brackets" or "diagonals" shots.
- **SingleCorners**: every isolated corner is shot individually. This can be used for the best accuracy, for the following reasons: 
  - Only the camera center , i.e. a perpendicular "ray" up Z will provide positional information. 
  - Parallax as well as view and light side angle errors are minimized. 
  - Multiple shots reduce random errors, staticstically.

**Extra Shots** determines how many extra shots are taken for this package. The minimum is automatically computed from the geometry of the pads. For example, a square package shape can be aligned with just two corners shots, but the opposing two corners are made available as extra shots, to improve accuracy.

**Max. Pick Tolerance**: determines by how much a package, or rather its corners, can deviate after the pick. When set to zero, the analog setting on the nozzle tip is taken. If non-zero, this value overrides the nozzle tip's. The larger this tolerance, the more the corners must be isolated from other, obstructing corners, or from the limits of the camera view. Finding a solution can therefore fail, if tolerance are too large. 

**Min. Angle Leverage**: determines how far away two corners have to be, in order to define the detected angle of the package, _relative_ to the dimension of the package (the lesser of width and height). A setting of 0.5 means that the corners must be half-way apart across the package. 

**Allow inside corner?**: determines if inside corners are allowed. For very large parts, where even the **Camera Roaming Radius** is not enough to position the part to its corners, the alignment might still be gleaned from the inside corners of large pads.

![Inside corners](https://user-images.githubusercontent.com/9963310/178497553-a355b84d-40ad-4462-9e3d-8402c38ca6c4.png)

## Improving Accuracy

The following illustration (exaggerated) shows how a slightly tilted nozzle might result in large placments errors (red) due to large parallax errors in (very) wide angle lenses:

![illu](https://user-images.githubusercontent.com/9963310/178497746-51f0a470-8410-4cfd-b95e-0bb22a44c74a.png)

Detecting the same corners using two shots reduces these errors to nothing, as the parallax is negligible when looking straight up from the camera center, and even what little remains, is symmetric left and right, and cancels itself out.

Similar effects might come from viewing pins from the side, and/or having asymmetric lighting. Or from residual lens distortions.

# Implementation Details
1. Tested extensively in simulation and some machine tests.
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. Changes in the `org.openpnp.spi` or `org.openpnp.model` packages are: elevating nozzle tip part dimension  properties to the model. Introducing the VisionCompositing model. Adding the Camera Roaming Radius. Moving the Footprint generator into the model. Adding missing `add(),multiply(), divide()` to the Point model.
4. Successful `mvn test` before submitting the Pull Request. 

Known TODOs for a later PR; the `VisionCompositingTest` unit test is unfinished. I would like to base it on a custom `packages.xml` file, ideally with my own but also problematic footprints from the testing round. 
