### PR TITLE
Feature / Jobs: Step to Next Machine Motion

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/ReferencePnpJobProcessor.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferencePnpJobProcessor.java
@@ -80,7 +80,7 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
     protected int maxVisionRetries = 3;
     
     @Attribute(required = false)
-    boolean steppingToNextMotion;
+    boolean steppingToNextMotion = true;
 
     @Element(required = false)
     public PnpJobPlanner planner = new SimplePnpJobPlanner();

--- a/src/main/java/org/openpnp/machine/reference/ReferencePnpJobProcessor.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferencePnpJobProcessor.java
@@ -78,6 +78,9 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
 
     @Attribute(required = false)
     protected int maxVisionRetries = 3;
+    
+    @Attribute(required = false)
+    boolean steppingToNextMotion;
 
     @Element(required = false)
     public PnpJobPlanner planner = new SimplePnpJobPlanner();
@@ -1150,6 +1153,15 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
 
     public void setMaxVisionRetries(int maxVisionRetries) {
         this.maxVisionRetries = maxVisionRetries;
+    }
+
+    @Override
+    public boolean isSteppingToNextMotion() {
+        return steppingToNextMotion;
+    }
+
+    public void setSteppingToNextMotion(boolean steppingToNextMotion) {
+        this.steppingToNextMotion = steppingToNextMotion;
     }
 
     protected abstract class PlannedPlacementStep implements Step {

--- a/src/main/java/org/openpnp/machine/reference/driver/AbstractMotionPlanner.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/AbstractMotionPlanner.java
@@ -706,6 +706,18 @@ public abstract class AbstractMotionPlanner extends AbstractModelObject implemen
     }
 
     @Override
+    public synchronized Motion getLastMotion() {
+        for (Map.Entry<Double, Motion> entry : motionPlan.descendingMap().entrySet()) {
+            Motion motion = entry.getValue();
+            if (!motion.getLocation0().matches(motion.getLocation1())) {
+                // Got a real move.
+                return motion;
+            }
+        }
+        return null;
+    }
+
+    @Override
     public void waitForCompletion(HeadMountable hm, CompletionType completionType)
             throws Exception {
         // Now is high time to plan and execute the queued motion commands. 

--- a/src/main/java/org/openpnp/machine/reference/wizards/ReferencePnpJobProcessorConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/wizards/ReferencePnpJobProcessorConfigurationWizard.java
@@ -20,6 +20,7 @@
 package org.openpnp.machine.reference.wizards;
 
 import javax.swing.BoxLayout;
+import javax.swing.JCheckBox;
 import javax.swing.JComboBox;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
@@ -43,6 +44,7 @@ public class ReferencePnpJobProcessorConfigurationWizard extends AbstractConfigu
     private final ReferencePnpJobProcessor jobProcessor;
     private JComboBox comboBoxJobOrder;
     private JTextField maxVisionRetriesTextField;
+    private JCheckBox steppingToNextMotion;
 
     public ReferencePnpJobProcessorConfigurationWizard(ReferencePnpJobProcessor jobProcessor) {
         this.jobProcessor = jobProcessor;
@@ -57,10 +59,15 @@ public class ReferencePnpJobProcessorConfigurationWizard extends AbstractConfigu
                 FormSpecs.DEFAULT_COLSPEC,
                 FormSpecs.RELATED_GAP_COLSPEC,
                 FormSpecs.DEFAULT_COLSPEC,},
-            new RowSpec[] {
-                FormSpecs.RELATED_GAP_ROWSPEC,
-                FormSpecs.DEFAULT_ROWSPEC,
-                FormSpecs.DEFAULT_ROWSPEC,}));
+                new RowSpec[] {
+                        FormSpecs.RELATED_GAP_ROWSPEC,
+                        FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC,
+                        FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC,
+                        FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC,
+                        FormSpecs.DEFAULT_ROWSPEC,}));
 
         JLabel lblJobOrder = new JLabel(Translations.getString("MachineSetup.JobProcessors.ReferencePnpJobProcessor.Label.JobOrder"));
         panelGeneral.add(lblJobOrder, "2, 2, right, default");
@@ -69,11 +76,18 @@ public class ReferencePnpJobProcessorConfigurationWizard extends AbstractConfigu
         panelGeneral.add(comboBoxJobOrder, "4, 2");
 
         JLabel lblMaxVisionRetries = new JLabel(Translations.getString("MachineSetup.JobProcessors.ReferencePnpJobProcessor.Label.MaxVisionRetries"));
-        panelGeneral.add(lblMaxVisionRetries, "2, 3, right, default");
+        panelGeneral.add(lblMaxVisionRetries, "2, 4, right, default");
 
         maxVisionRetriesTextField = new JTextField();
-        panelGeneral.add(maxVisionRetriesTextField, "4, 3");
+        panelGeneral.add(maxVisionRetriesTextField, "4, 4");
         maxVisionRetriesTextField.setColumns(10);
+
+        JLabel lblStepsMotion = new JLabel(Translations.getString("ReferencePnpJobProcessorConfigurationWizard.lblStepsMotion.text")); //$NON-NLS-1$
+        lblStepsMotion.setToolTipText(Translations.getString("ReferencePnpJobProcessorConfigurationWizard.lblStepsMotion.toolTipText")); //$NON-NLS-1$
+        panelGeneral.add(lblStepsMotion, "2, 6, right, default");
+
+        steppingToNextMotion = new JCheckBox(); 
+        panelGeneral.add(steppingToNextMotion, "4, 6");
     }
 
     @Override
@@ -82,7 +96,8 @@ public class ReferencePnpJobProcessorConfigurationWizard extends AbstractConfigu
 
         addWrappedBinding(jobProcessor, "jobOrder", comboBoxJobOrder, "selectedItem");
         addWrappedBinding(jobProcessor, "maxVisionRetries", maxVisionRetriesTextField, "text", intConverter);
-
+        addWrappedBinding(jobProcessor, "steppingToNextMotion", steppingToNextMotion, "selected");
+        
         ComponentDecorators.decorateWithAutoSelect(maxVisionRetriesTextField);
     }
 }

--- a/src/main/java/org/openpnp/spi/JobProcessor.java
+++ b/src/main/java/org/openpnp/spi/JobProcessor.java
@@ -11,9 +11,11 @@ public interface JobProcessor extends PropertySheetHolder, WizardConfigurable {
     }
 
     public void initialize(Job job) throws Exception;
-    
+
     public boolean next() throws JobProcessorException;
-    
+
+    boolean isSteppingToNextMotion();
+
     public void abort() throws JobProcessorException;    
 
     public void addTextStatusListener(TextStatusListener listener);

--- a/src/main/java/org/openpnp/spi/MotionPlanner.java
+++ b/src/main/java/org/openpnp/spi/MotionPlanner.java
@@ -188,6 +188,12 @@ public interface MotionPlanner extends PropertySheetHolder, Solutions.Subject {
      */
     Motion getMomentaryMotion(double time);
 
+    /**
+     * Get the last planned motion with displacement of axes. 
+     * @return 
+     */
+    Motion getLastMotion();
+
      /**
      * Clear the motion planning older than the given real-time from the history of the motion planner. The 
      * MotionPlanner is free to do its own house-keeping and get rid of past planning data before this is called. 

--- a/src/main/resources/org/openpnp/translations.properties
+++ b/src/main/resources/org/openpnp/translations.properties
@@ -118,3 +118,5 @@ Theme.Section.User=User Themes
 Theme.Default=(Default)
 ThemeSettingsPanel.chckbxAlternatingRows.text=Alternating Rows Style
 Menu.View.TablesLinked=Selections in Tables
+ReferencePnpJobProcessorConfigurationWizard.lblStepsMotion.text=Step Next Motion
+ReferencePnpJobProcessorConfigurationWizard.lblStepsMotion.toolTipText=Stepping will only stop at the next step with motion


### PR DESCRIPTION
# Description
When stepping through a Job, the JobPanel would pause after each steps of the JobProcessor, including some steps that result in no machine motion, either because they are purely logical (like planning the Job), or because a step action is conditional (like loading a compatible nozzle tip when one is already loaded). 

From an operator's perspective, these "empty" steps are confusing, the processor should only pause after the next visible machine motion happened. 

However, from a debugging perspective, when looking at the log, the single steps might still be important. 

The new **Step Next Motion** option on the JobProcessor can switch between the two behaviors. After testing, I concluded the new experience is much more likely what users expect, the new option was _enabled_ by default. 

# Justification
See #1342.

# Instructions for Use

Go to Machine Setup / JobProcessors / ReferenceJobProcessor:

![Step motion option](https://user-images.githubusercontent.com/9963310/178746459-fd742590-0d15-4be6-9761-1aecb4cdebfe.png)

**Step Next Motion**: determines that the ![Step](https://user-images.githubusercontent.com/9963310/178748374-3d5a5298-62b5-4a61-92cd-1e335fd226cb.png) button should not pause until the next machine motion was detected. 

![JopPanel](https://user-images.githubusercontent.com/9963310/178748661-f7bfa5d6-e11c-4922-bf06-96e8cd784a63.png)

# Implementation Details
1. Tested in simulation
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. The spi methods `org.openpnp.spi.JobProcessor.isSteppingToNextMotion()` and `org.openpnp.spi.MotionPlanner.getLastMotion()` were added to address the new functionality.
4. Successful `mvn test` before submitting the Pull Request. 
