### PR TITLE
Fix / ReferencePushPullFeeder: Preview Vision Features detects uninitialized sprocket holes

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/feeder/ReferencePushPullFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/ReferencePushPullFeeder.java
@@ -1538,7 +1538,8 @@ public class ReferencePushPullFeeder extends ReferenceFeeder {
                             }
                         });
 
-                        if (autoSetupMode  == FindFeaturesMode.FromPickLocationGetHoles) {
+                        if (autoSetupMode == FindFeaturesMode.FromPickLocationGetHoles
+                                || (autoSetupMode == null && !(getHole1Location().isInitialized() && getHole2Location().isInitialized()))) {
                             // because we sorted the holes by distance, the first two are our holes 1 and 2
                             if (holes.size() < 2) {
                                 throw new Exception("At least two sprocket holes need to be recognized"); 


### PR DESCRIPTION
# Description
If not yet set up, show the detected sprocket holes in Show Features.

# Justification
User request:
https://groups.google.com/g/openpnp/c/-nQ09SWl_nk/m/kRap3zEhBgAJ

# Instructions for Use
Just press the **Preview Vision Features** button when the sprocket holes are not yet initialized. 

See the Wiki:
https://github.com/openpnp/openpnp/wiki/ReferencePushPullFeeder#locations

# Implementation Details
1. No tests. Code change deemed trivial. Testing branch.
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. No sense for `mvn test` before submitting the Pull Request. 
