### PR TITLE
Fix / Bottom Vision Pipeline Configuration: Report Missing Part, Nozzle Tip

### DIFF
--- a/src/main/java/org/openpnp/gui/PackagesPanel.java
+++ b/src/main/java/org/openpnp/gui/PackagesPanel.java
@@ -242,7 +242,7 @@ public class PackagesPanel extends JPanel implements WizardContainer {
         });
     }
 
-    private Package getSelection() {
+    public Package getSelectedPackage() {
         List<Package> selections = getSelections();
         if (selections.size() != 1) {
             return null;
@@ -349,7 +349,7 @@ public class PackagesPanel extends JPanel implements WizardContainer {
 
         @Override
         public void actionPerformed(ActionEvent arg0) {
-            Package pkg = getSelection();
+            Package pkg = getSelectedPackage();
             if (pkg == null) {
                 return;
             }
@@ -423,7 +423,7 @@ public class PackagesPanel extends JPanel implements WizardContainer {
             singleSelectionActionGroup.setEnabled(!selections.isEmpty());
         }
 
-        Package selectedPackage = getSelection();
+        Package selectedPackage = getSelectedPackage();
         if (selectedPackage != null) {
             this.selectedPackage = selectedPackage; 
         }
@@ -473,7 +473,7 @@ public class PackagesPanel extends JPanel implements WizardContainer {
     }
 
     public void selectPackageInTable(Package packag) {
-        if (getSelection() != packag) {
+        if (getSelectedPackage() != packag) {
             Helpers.selectObjectTableRow(table, packag);
         }
     }

--- a/src/main/java/org/openpnp/gui/PartsPanel.java
+++ b/src/main/java/org/openpnp/gui/PartsPanel.java
@@ -240,7 +240,7 @@ public class PartsPanel extends JPanel implements WizardContainer {
         });
     }
 
-    private Part getSelection() {
+    public Part getSelectedPart() {
         List<Part> selections = getSelections();
         if (selections.size() != 1) {
             return null;
@@ -344,7 +344,7 @@ public class PartsPanel extends JPanel implements WizardContainer {
         @Override
         public void actionPerformed(ActionEvent arg0) {
             UiUtils.submitUiMachineTask(() -> {
-                Part part = getSelection();
+                Part part = getSelectedPart();
                 Feeder feeder = null;
                 // find a feeder to feed
                 for (Feeder f : Configuration.get().getMachine().getFeeders()) {
@@ -371,7 +371,7 @@ public class PartsPanel extends JPanel implements WizardContainer {
 
         @Override
         public void actionPerformed(ActionEvent arg0) {
-            Part part = getSelection();
+            Part part = getSelectedPart();
             if (part == null) {
                 return;
             }
@@ -439,7 +439,7 @@ public class PartsPanel extends JPanel implements WizardContainer {
             singleSelectionActionGroup.setEnabled(!selections.isEmpty());
         }
 
-        Part selectedPart = getSelection();
+        Part selectedPart = getSelectedPart();
         if (selectedPart != null) {
             this.selectedPart = selectedPart;
         }
@@ -492,7 +492,7 @@ public class PartsPanel extends JPanel implements WizardContainer {
     }
 
     public void selectPartInTable(Part part) {
-        if (getSelection() != part) {
+        if (getSelectedPart() != part) {
             Helpers.selectObjectTableRow(table, part);
         }
     }


### PR DESCRIPTION
# Description
In  #1440 the bottom vision pipeline configuration was extended to support multiple shots etc. For this purpose, it has become necessary to designate the package and the nozzle tip to be used for the vision operation. These contain properties affecting how the multi-shot and other pipeline properties are controlled. 

In normal operational use, including testing pick/align cycles through UI buttons, these are always present, i.e. the part picked on the nozzle gives the package, and a nozzle tip is also always guaranteed to be loaded, while a part is on the nozzle. 

However, when trying to directly edit a pipeline (without prior pick), a missing package or nozzle tip are not handled correctly, a null pointer exception is thrown.

This PR fixes this and also provides an alternative.

# Justification
See user report:
https://groups.google.com/g/openpnp/c/pPkd5CZpVno/m/w2eCx91SCAAJ

# Instructions for Use
The pipeline configuration has been extended to designate the package in the following order:

1. It tries to use the part on the nozzle (as before). 
2. It checks if we are on a part's vision settings wizard, then the current part is taken.
3. It checks if we are on a package's vision settings wizard, then the current package is taken.
4. It uses the single selected part on the Parts tab.
5. It uses the single selected package on the Packages tab.
6. If all the above fails, it reports an error.

It should be clear that editing a bottom vision pipeline against an empty nozzle is unusual, however it might be useful to test what happens after a mispick.

![Package missing error](https://user-images.githubusercontent.com/9963310/180003745-45bd0246-2a69-48c5-931e-e5b591011927.png)

Likewise, a missing nozzle tip is reported:

![Nozzle tip missing](https://user-images.githubusercontent.com/9963310/180003969-c429fee1-44bd-4764-b8cf-e510267ad4bc.png)


# Implementation Details
1. Tested in simulation.
7. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
8. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
9. Successful `mvn test` before submitting the Pull Request. 
