### PR TITLE
Move Camera to Pick Location

### DIFF
--- a/src/main/java/org/openpnp/gui/FeedersPanel.java
+++ b/src/main/java/org/openpnp/gui/FeedersPanel.java
@@ -578,39 +578,14 @@ public class FeedersPanel extends JPanel implements WizardContainer {
                 Feeder feeder = getSelection();
                 // Do the feed and get the nozzle that would be used for the subsequent pick. 
                 Nozzle nozzle = feedFeeder(feeder);
+		feeder.postPick(nozzle);	// moveCameraToPickLocation BUG. Until distinct Increment FeedCount is implemented.
 
 		// Tracking with camera rather than nozzle
-                /*
-		// Note, we do not use nozzle.moveToPickLocation(feeder) as this might involve 
-                // probing, which we don't want to happen here. Instead we need to simulate a preliminary 
-                // pick location. 
-                Location pickLocation = preliminaryPickLocation(feeder, nozzle);
-                MovableUtils.moveToLocationAtSafeZ(nozzle, pickLocation);
-                MovableUtils.fireTargetedUserAction(nozzle);
-		*/
-		    
              	Camera camera = MainFrame.get().getMachineControls().getSelectedTool().getHead()
                         .getDefaultCamera();
                 Location pickLocation = preliminaryPickLocation(feeder, nozzle);
                 MovableUtils.moveToLocationAtSafeZ(camera, pickLocation);
                 MovableUtils.fireTargetedUserAction(camera);
-            });
-        }
-    };
-
-    public Action pickFeederAction = new AbstractAction() {
-        {
-            putValue(SMALL_ICON, Icons.pick);
-            putValue(NAME, "Pick");
-            putValue(SHORT_DESCRIPTION, "Perform a feed and pick on the selected feeder.");
-        }
-
-        @Override
-        public void actionPerformed(ActionEvent arg0) {
-            UiUtils.submitUiMachineTask(() -> {
-                Feeder feeder = getSelection();
-
-                pickFeeder(feeder);
             });
         }
     };
@@ -642,9 +617,25 @@ public class FeedersPanel extends JPanel implements WizardContainer {
         // Perform the feed.
         nozzle.moveToSafeZ();
         feeder.feed(nozzle);
-	feeder.postPick(nozzle);	// moveCameraToPickLocation BUG. Execute postPick if implemented
         return nozzle;
     }
+	
+    public Action pickFeederAction = new AbstractAction() {
+        {
+            putValue(SMALL_ICON, Icons.pick);
+            putValue(NAME, "Pick");
+            putValue(SHORT_DESCRIPTION, "Perform a feed and pick on the selected feeder.");
+        }
+
+        @Override
+        public void actionPerformed(ActionEvent arg0) {
+            UiUtils.submitUiMachineTask(() -> {
+                Feeder feeder = getSelection();
+
+                pickFeeder(feeder);
+            });
+        }
+    };
 
     /**
      * Perform a job-like feed and pick operations sequence. 
@@ -720,7 +711,7 @@ public class FeedersPanel extends JPanel implements WizardContainer {
         }
         // Check the nozzle tip package compatibility.
         Nozzle nozzle = MainFrame.get().getMachineControls().getSelectedNozzle();
-        org.openpnp.model.Package packag = feeder.getPart().getPackage();
+        org.openpnp.model.Package packag = feeder.getPart().getPackage();d
         if (nozzle.getNozzleTip() == null || 
                 !packag.getCompatibleNozzleTips().contains(nozzle.getNozzleTip())) {
             // Wrong nozzle tip, try find one that works.

--- a/src/main/java/org/openpnp/gui/FeedersPanel.java
+++ b/src/main/java/org/openpnp/gui/FeedersPanel.java
@@ -579,12 +579,21 @@ public class FeedersPanel extends JPanel implements WizardContainer {
                 // Do the feed and get the nozzle that would be used for the subsequent pick. 
                 Nozzle nozzle = feedFeeder(feeder);
 
-                // Note, we do not use nozzle.moveToPickLocation(feeder) as this might involve 
+		// Tracking with camera rather than nozzle
+                /*
+		// Note, we do not use nozzle.moveToPickLocation(feeder) as this might involve 
                 // probing, which we don't want to happen here. Instead we need to simulate a preliminary 
                 // pick location. 
                 Location pickLocation = preliminaryPickLocation(feeder, nozzle);
                 MovableUtils.moveToLocationAtSafeZ(nozzle, pickLocation);
                 MovableUtils.fireTargetedUserAction(nozzle);
+		*/
+		    
+             	Camera camera = MainFrame.get().getMachineControls().getSelectedTool().getHead()
+                        .getDefaultCamera();
+                Location pickLocation = preliminaryPickLocation(feeder, nozzle);
+                MovableUtils.moveToLocationAtSafeZ(camera, pickLocation);
+                MovableUtils.fireTargetedUserAction(camera);
             });
         }
     };
@@ -633,6 +642,7 @@ public class FeedersPanel extends JPanel implements WizardContainer {
         // Perform the feed.
         nozzle.moveToSafeZ();
         feeder.feed(nozzle);
+	feeder.postPick(nozzle);	// moveCameraToPickLocation BUG. Execute postPick if implemented
         return nozzle;
     }
 

--- a/src/main/java/org/openpnp/gui/FeedersPanel.java
+++ b/src/main/java/org/openpnp/gui/FeedersPanel.java
@@ -711,7 +711,7 @@ public class FeedersPanel extends JPanel implements WizardContainer {
         }
         // Check the nozzle tip package compatibility.
         Nozzle nozzle = MainFrame.get().getMachineControls().getSelectedNozzle();
-        org.openpnp.model.Package packag = feeder.getPart().getPackage();d
+        org.openpnp.model.Package packag = feeder.getPart().getPackage();
         if (nozzle.getNozzleTip() == null || 
                 !packag.getCompatibleNozzleTips().contains(nozzle.getNozzleTip())) {
             // Wrong nozzle tip, try find one that works.

--- a/src/main/java/org/openpnp/machine/reference/ReferencePnpJobProcessor.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferencePnpJobProcessor.java
@@ -685,8 +685,8 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
             for (int i = 0; i < 1 + feeder.getPickRetryCount(); i++) {
                 try {
                     pick(nozzle, feeder, jobPlacement, part);
-                    postPick(feeder, nozzle);
                     checkPartOn(nozzle);
+                    postPick(feeder, nozzle);
                     return;
                 }
                 catch (Exception e) {

--- a/src/main/java/org/openpnp/machine/reference/feeder/ReferenceStripFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/ReferenceStripFeeder.java
@@ -378,7 +378,10 @@ public class ReferenceStripFeeder extends ReferenceFeeder {
             throw new UnsupportedOperationException("Feeder: " + getName() + " - Currently no free slot. Can not take back the part.");
         }
         
-        // ok, now put the part back on the location of the last pick
+        // change FeedCount
+        setFeedCount(getFeedCount() - 1);
+	    
+	// ok, now put the part back on the location of the last pick
         nozzle.moveToPickLocation(this);
         // put the part back
         nozzle.place();
@@ -386,11 +389,8 @@ public class ReferenceStripFeeder extends ReferenceFeeder {
         if (nozzle.isPartOffEnabled(Nozzle.PartOffStep.AfterPlace) && !nozzle.isPartOff()) {
             throw new Exception("Feeder: " + getName() + " - Putting part back failed, check nozzle tip");
         }
-        // change FeedCount
-        setFeedCount(getFeedCount() - 1);
     }
-        
-    
+   
     public CvPipeline getPipeline() {
         return pipeline;
     }

--- a/src/main/java/org/openpnp/machine/reference/feeder/ReferenceStripFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/ReferenceStripFeeder.java
@@ -160,9 +160,11 @@ public class ReferenceStripFeeder extends ReferenceFeeder {
          * as if the feeder had been fed. This keeps us from returning a pick location
          * that is off the edge of the strip.
          */
-        if (feedCount == 0) {
-            feedCount = 1;
-        }
+	// moveCameraToPickLocation BUG. No special handling. feedCount is incremented post pick.
+        //if (feedCount == 0) {
+        //    feedCount = 1;
+        //}
+	    
         // Find the location of the part linearly along the tape
         Location[] lineLocations = getIdealLineLocations();
         // 20160608 - ldpgh/lutz_dd
@@ -186,8 +188,12 @@ public class ReferenceStripFeeder extends ReferenceFeeder {
         	partPitchAdjusted = holePitch.getValue();
         }
         	
-        Location l = Utils2D.getPointAlongLine(lineLocations[0], lineLocations[1],
-                new Length((feedCount - 1) * partPitchAdjusted, partPitch.getUnits()));
+        // moveCameraToPickLocation BUG
+	//    Location l = Utils2D.getPointAlongLine(lineLocations[0], lineLocations[1],
+        //        new Length((feedCount - 1) * partPitchAdjusted, partPitch.getUnits()));
+	Location l = Utils2D.getPointAlongLine(lineLocations[0], lineLocations[1],
+                new Length(feedCount * partPitchAdjusted, partPitch.getUnits()));
+	    
         // Create the offsets that are required to go from a reference hole
         // to the part in the tape
         Length x = getHoleToPartLateral().convertToUnits(l.getUnits());
@@ -237,7 +243,8 @@ public class ReferenceStripFeeder extends ReferenceFeeder {
     }
 
     public void feed(Nozzle nozzle) throws Exception {
-        setFeedCount(getFeedCount() + 1);
+        // moveCameraToPickLocation BUG. feedCount is incremented post pick
+	// setFeedCount(getFeedCount() + 1);
 
         // Throw an exception when the feeder runs out of parts
         if ((maxFeedCount > 0) && (feedCount > maxFeedCount)) {
@@ -245,6 +252,11 @@ public class ReferenceStripFeeder extends ReferenceFeeder {
 		}
 
         updateVisionOffsets(nozzle);
+    }
+	
+    public void postPick(Nozzle nozzle) throws Exception {
+    	// moveCameraToPickLocation BUG. FeedCount is incremented here (post pick)
+    	setFeedCount(getFeedCount() + 1);
     }
 
     private void updateVisionOffsets(Nozzle nozzle) throws Exception {

--- a/src/main/java/org/openpnp/machine/reference/feeder/ReferenceStripFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/ReferenceStripFeeder.java
@@ -251,7 +251,12 @@ public class ReferenceStripFeeder extends ReferenceFeeder {
 			throw new Exception("Tried to feed part: " + part.getId() + "  Feeder " + name + " empty.");
 		}
 
-        updateVisionOffsets(nozzle);
+        try {
+		updateVisionOffsets(nozzle);
+	} catch (Exception e) {
+		setFeedCount(getFeedCount() + 1);
+		throw e;
+	}
     }
 	
     public void postPick(Nozzle nozzle) throws Exception {


### PR DESCRIPTION
# Description
"Move Camera to Pick Location" button in the Feeders tab moves the camera to an empty position except when Feed Count is 0, making this behavior not very useful to the me - an ordinary user.

# Justification
This is a long standing BUG. Also Feed Feeder was moving the nozzle. Moving the camera would be a more useful activity.


# Implementation Details
1. Moved increment of FeedCount to a Post Pick routine. Removed special handling when FeedCount was zero.