### PR TITLE
Fix / Remove Nozzle Move from `feedFeederAction`

### DIFF
--- a/src/main/java/org/openpnp/gui/FeedersPanel.java
+++ b/src/main/java/org/openpnp/gui/FeedersPanel.java
@@ -578,13 +578,6 @@ public class FeedersPanel extends JPanel implements WizardContainer {
                 Feeder feeder = getSelection();
                 // Do the feed and get the nozzle that would be used for the subsequent pick. 
                 Nozzle nozzle = feedFeeder(feeder);
-
-                // Note, we do not use nozzle.moveToPickLocation(feeder) as this might involve 
-                // probing, which we don't want to happen here. Instead we need to simulate a preliminary 
-                // pick location. 
-                Location pickLocation = preliminaryPickLocation(feeder, nozzle);
-                MovableUtils.moveToLocationAtSafeZ(nozzle, pickLocation);
-                MovableUtils.fireTargetedUserAction(nozzle);
             });
         }
     };


### PR DESCRIPTION
# Description
Remove the nozzle move to pick location from the `FeedersPanel`'s `feedFeederAction`.

# Justification
User broke nozzle tip, because he rightly did not expect the move to pick location when he pressed the **feed** button on a drag feeder:

https://groups.google.com/g/openpnp/c/qOlRCwZeIWw/m/HlDPTYjqAAAJ

# Instructions for Use
Use the **feed** button just for the feed:

![Feed button](https://user-images.githubusercontent.com/9963310/180573710-e93345c0-d709-4118-857e-810da93eba46.png)

If you want to position the nozzle as well, use the **position nozzle** button _explicitly_:

![Position button](https://user-images.githubusercontent.com/9963310/180574045-546051d7-f378-4769-a202-4d549ce26c1d.png)

# Implementation Details
1. Tested in simulation.
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. Successful `mvn test` before submitting the Pull Request.
