### PR TITLE
Fix / ReferenceDragFeeder: Remove redundant `pickLocation` variable.

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/feeder/ReferenceDragFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/ReferenceDragFeeder.java
@@ -89,8 +89,6 @@ public class ReferenceDragFeeder extends ReferenceFeeder {
     @Element(required = false)
     protected Length backoffDistance = new Length(0, LengthUnit.Millimeters);    
 
-    protected Location pickLocation;
-
     private double feededCount = 0;
     private double partsPitchX = -2; //-2mm for 0402
     private double partsPitchY = 0;
@@ -106,9 +104,7 @@ public class ReferenceDragFeeder extends ReferenceFeeder {
 
     @Override
     public Location getPickLocation() throws Exception {
-        if (pickLocation == null) {
-            pickLocation = location;
-        }
+        Location pickLocation = location;
 
         if (partPitch.convertToUnits(LengthUnit.Millimeters).getValue() == 2 && partPick != null) {
 			pickLocation = pickLocation.add(partPick);
@@ -177,10 +173,7 @@ public class ReferenceDragFeeder extends ReferenceFeeder {
 
         // Now we have visionOffsets (if we're using them) so we
         // need to create a local, offset version of the feedStartLocation,
-        // feedEndLocation and pickLocation. pickLocation will be saved
-        // for the pick operation while feed start and end are used
-        // here and then discarded.
-        pickLocation = this.location;
+        // feedEndLocation.
 
         if (feededCount == 0) {
             Location feedStartLocation = this.feedStartLocation;
@@ -250,7 +243,7 @@ public class ReferenceDragFeeder extends ReferenceFeeder {
 
             Logger.debug("final visionOffsets " + visionOffset);
 
-            Logger.debug("Modified pickLocation {}", pickLocation.subtract(visionOffset));
+            Logger.debug("Modified pickLocation {}", location.subtract(visionOffset));
         }
     }
 


### PR DESCRIPTION

# Description
Remove the redundant `pickLocation` variable on the `ReferenceDragFeeder`, using the `location` directly. 

# Justification
The unnecessary copy may lead to a stale pick location, as described in the #1016 discussion.

# Instructions for Use
No change.

# Implementation Details
1. It will hopefully be tested in the testing version (ongoing discussion).
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. Successful `mvn test` before submitting the Pull Request.
