### PR TITLE
Feature / ReferencePushPullFeeder smarter Auto-Setup

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/feeder/ReferencePushPullFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/ReferencePushPullFeeder.java
@@ -189,8 +189,21 @@ public class ReferencePushPullFeeder extends ReferenceFeeder {
     @Attribute(required = false)
     private long feedCount = 0;
 
+    public enum PipelineType {
+        ColorKeyed("Default"),
+        CircularSymmetry("CircularSymmetry");
+
+        private String tag;
+
+        PipelineType(String tag) {
+            this.tag = tag; 
+        }
+    }
+
     @Element(required = false)
-    private CvPipeline pipeline = createDefaultPipeline();
+    private CvPipeline pipeline = createDefaultPipeline(PipelineType.ColorKeyed);
+    @Attribute(required = false)
+    protected PipelineType pipelineType = PipelineType.ColorKeyed;
 
     @Attribute(required = false)
     protected String ocrFontName = "Liberation Mono";
@@ -1167,6 +1180,16 @@ public class ReferencePushPullFeeder extends ReferenceFeeder {
         this.pipeline = pipeline;
     }
 
+    public PipelineType getPipelineType() {
+        return pipelineType;
+    }
+
+    public void setPipelineType(PipelineType pipelineType) {
+        Object oldValue = this.pipelineType;
+        this.pipelineType = pipelineType;
+        firePropertyChange("pipelineType", oldValue, pipelineType);
+    }
+
     public Location getVisionOffset() {
         if (isVisionEnabled() && visionOffset != null) {
             return visionOffset;
@@ -1184,8 +1207,9 @@ public class ReferencePushPullFeeder extends ReferenceFeeder {
         setVisionOffset(null);
     }
 
-    public void resetPipeline() {
-        pipeline = createDefaultPipeline();
+    public void resetPipeline(PipelineType type) {
+        pipeline = createDefaultPipeline(type);
+        setPipelineType(type);
     }
 
     public Location getNominalVisionLocation() throws Exception {
@@ -1261,10 +1285,10 @@ public class ReferencePushPullFeeder extends ReferenceFeeder {
         }
     }
 
-    private static CvPipeline createDefaultPipeline() {
+    private static CvPipeline createDefaultPipeline(PipelineType type) {
         try {
             String xml = IOUtils.toString(BlindsFeeder.class
-                    .getResource("ReferencePushPullFeeder-DefaultPipeline.xml"));
+                    .getResource("ReferencePushPullFeeder-"+type.tag+"Pipeline.xml"));
             return new CvPipeline(xml);
         }
         catch (Exception e) {
@@ -1516,14 +1540,17 @@ public class ReferencePushPullFeeder extends ReferenceFeeder {
                                 - sprocketHoleToleranceMm;
                         double maxDistanceMm = (autoSetupMode == FindFeaturesMode.CalibrateHoles ? 
                                 calibrationToleranceMm : bestDistanceMm);
+
                         if (distanceMm >= minDistanceMm && distanceMm < maxDistanceMm) {
                             // Take the first line that is close enough, as the lines are ordered by length (descending).
                             // In autoSetupMode take the closest line.
                             bestLine = line;
                             bestUnitVector = aLocation.unitVectorTo(bLocation);
                             bestDistanceMm = distanceMm;
-                            lines.add(bestLine);
-                            break;
+                            lines.add(line);
+                        }
+                        else if (autoSetupMode == null) {
+                            lines.add(line);
                         }
                     }
 
@@ -1532,6 +1559,7 @@ public class ReferencePushPullFeeder extends ReferenceFeeder {
                             throw new Exception("No line of sprocket holes can be recognized"); 
                         }
                     }
+
                     if (bestLine != null) {
                         // Filter the circles by distance from the resulting line
                         for (Result.Circle circle : results) {
@@ -1688,6 +1716,12 @@ public class ReferencePushPullFeeder extends ReferenceFeeder {
                     drawLines(resultMat, getLines(), new Color(0, 0, 255));
                     drawPartNumbers(resultMat, Color.orange);
                     drawOcrText(resultMat, Color.orange);
+                    if (getHoles().isEmpty()) {
+                        Imgproc.line(resultMat, new Point(0, 0), new Point(resultMat.cols()-1, resultMat.rows()-1), 
+                                FluentCv.colorToScalar(Color.red), 2);
+                        Imgproc.line(resultMat, new Point(0, resultMat.rows()-1), new Point(resultMat.cols()-1, 0), 
+                                FluentCv.colorToScalar(Color.red), 2);
+                    }
 
                     if (Logger.getLevel() == org.pmw.tinylog.Level.DEBUG || Logger.getLevel() == org.pmw.tinylog.Level.TRACE) {
                         File file = Configuration.get().createResourceFile(getClass(), "push-pull-feeder", ".png");
@@ -1729,6 +1763,26 @@ public class ReferencePushPullFeeder extends ReferenceFeeder {
         }
 
         ensureCameraZ(camera);
+        // Try with cloned pipeline.
+        if (autoSetupPipeline(camera, null) != null) {
+            // Failed, try with pipeline type defaults.
+            Exception e = null;
+            for (PipelineType type : PipelineType.values()) {
+               e = autoSetupPipeline(camera, type);
+               if (e == null) {
+                   // Success.
+                   return;
+               }
+            }
+            // Still no luck, throw.
+            throw e;
+        }
+    }
+
+    protected Exception autoSetupPipeline(Camera camera, PipelineType type) {
+        if (type != null) {
+            resetPipeline(type);
+        }
         try (CvPipeline pipeline = getCvPipeline(camera, true, true, true)) {
             // Process vision and get some features 
             pipeline.process();
@@ -1751,6 +1805,10 @@ public class ReferencePushPullFeeder extends ReferenceFeeder {
             // Move the camera back to the pick location
             MovableUtils.moveToLocationAtSafeZ(camera, getLocation());
             MovableUtils.fireTargetedUserAction(camera);
+            return null;
+        }
+        catch (Exception e) {
+            return e;
         }
     }
 
@@ -2049,6 +2107,7 @@ public class ReferencePushPullFeeder extends ReferenceFeeder {
             setFeedCount(0);
             // clone the pipeline
             setPipeline(templateFeeder.getPipeline().clone());
+            setPipelineType(templateFeeder.getPipelineType());
         }
         // now transform over all the locations
         setFeederLocation(getTransform(null), false, true, true, templateFeeder);

--- a/src/main/resources/org/openpnp/machine/reference/feeder/ReferencePushPullFeeder-CircularSymmetryPipeline.xml
+++ b/src/main/resources/org/openpnp/machine/reference/feeder/ReferencePushPullFeeder-CircularSymmetryPipeline.xml
@@ -1,0 +1,17 @@
+<cv-pipeline>
+   <stages>
+      <cv-stage class="org.openpnp.vision.pipeline.stages.ImageCapture" name="0" enabled="true" default-light="true" settle-first="true" count="1"/>
+      <cv-stage class="org.openpnp.vision.pipeline.stages.ImageWriteDebug" name="deb0" enabled="false" prefix="push_pull_" suffix=".png"/>
+      <cv-stage class="org.openpnp.vision.pipeline.stages.BlurGaussian" name="1" enabled="true" kernel-size="5"/>
+      <cv-stage class="org.openpnp.vision.pipeline.stages.AffineWarp" name="2" enabled="true" length-unit="Millimeters" x-0="0.0" y-0="0.0" x-1="0.0" y-1="0.0" x-2="0.0" y-2="0.0" scale="1.0" rectify="true" region-of-interest-property="regionOfInterest"/>
+      <cv-stage class="org.openpnp.vision.pipeline.stages.ConvertColor" name="3" enabled="true" conversion="Bgr2Gray"/>
+      <cv-stage class="org.openpnp.vision.pipeline.stages.SimpleOcr" name="OCR" enabled="true" alphabet="0123456789.-+_RCLDQYXJIVAFH%GMKkmuµnp" font-name="Liberation Mono" font-size-pt="7.0" font-max-pixel-size="20" auto-detect-size="false" threshold="0.75" draw-style="OverOriginalImage" debug="false"/>
+      <cv-stage class="org.openpnp.vision.pipeline.stages.ImageRecall" name="5" enabled="true" image-stage-name="0"/>
+      <cv-stage class="org.openpnp.vision.pipeline.stages.DetectCircularSymmetry" name="results" enabled="true" min-diameter="10" max-diameter="100" max-distance="100" max-target-count="10" min-symmetry="1.2" corr-symmetry="0.2" property-name="sprocketHole" outer-margin="0.2" inner-margin="0.2" sub-sampling="8" super-sampling="1" diagnostics="false"/>
+      <cv-stage class="org.openpnp.vision.pipeline.stages.ImageRecall" name="7" enabled="false" image-stage-name="0"/>
+      <cv-stage class="org.openpnp.vision.pipeline.stages.DrawCircles" name="8" enabled="false" circles-stage-name="results" thickness="1">
+         <color r="255" g="0" b="0" a="255"/>
+      </cv-stage>
+      <cv-stage class="org.openpnp.vision.pipeline.stages.ImageWriteDebug" name="deb1" enabled="false" prefix="push_pull_result_" suffix=".png"/>
+   </stages>
+</cv-pipeline>


### PR DESCRIPTION
# Description
With help from **Jan** and **vespaman** from the discussion list, the `ReferencePushPullFeeder` pipeline handling and **Auto-Setup** was improved. 

1. There are now two stock pipelines shipped, the classic one for color-keyed feeders ("green-screening") and a new one that tries to detect the sprocket holes using the circular symmetry stage.
2. The pipeline type is automatically selected in **Auto-Setup** (tries types until successful).
3. The user can also manually select and reset to the pipeline type in the Wizard.
4. The pipeline type is cloned along with the pipeline.
5. Auto-Setup now suppresses detected hole lines that are too close to the pick location. If the stage mistakenly detects the pockets as sprocket holes (which can happen with 0402 pockets, which have an unfortunate "tangential" likeness), this line is robustly rejected (by EIA-481 the sprocket line must nominally be at least 3.5mm away from the pick location, this is checked with tolerance).
6. A bug in the selection loop was fixed, now the closest (remaining) line is robustly favored, i.e. neighboring feeders' sprocket holes will be rejected.
7. Vision failure is indicated with a crossed-out result view. Therefore, pressing **Vision Preview** will now always give feedback.

# Justification
`ReferencePushPullFeeder`  is increasingly used for drag feeders, mostly on CHMT machines, where the feeders aren't color-keyed. Auto-Setup did not work out of the box, users needed to copy and paste a special pipeline, and then it still mistook pockets as sprocket holes, as shown here (image by vespaman):

![grafik](https://user-images.githubusercontent.com/9963310/180604942-be633c91-16d3-4252-a103-010115e35b6e.png)


See this discussion:
https://groups.google.com/g/openpnp/c/N6IVhO_xbrw/m/vw-xOUtzBQAJ

# Instructions for Use
The Wiki has been updated, see:

- https://github.com/openpnp/openpnp/wiki/ReferencePushPullFeeder#locations-auto-setup
- https://github.com/openpnp/openpnp/wiki/ReferencePushPullFeeder#vision--edit-pipeline

![Vision Type Tooltip](https://user-images.githubusercontent.com/9963310/180604882-6a028f3c-d6b6-4a1d-9270-db7f46f38fbb.png)


# Implementation Details
1. Tested in simulation.
8. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
9. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
10. Successful `mvn test` before submitting the Pull Request. 
