### PR TITLE
Feature / Motion Detect Settle Method

### DIFF
--- a/src/main/java/org/openpnp/gui/wizards/CameraVisionConfigurationWizard.java
+++ b/src/main/java/org/openpnp/gui/wizards/CameraVisionConfigurationWizard.java
@@ -36,6 +36,7 @@ import javax.swing.JLabel;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.JTextField;
+import javax.swing.SwingUtilities;
 import javax.swing.border.TitledBorder;
 
 import org.openpnp.gui.MainFrame;
@@ -355,13 +356,16 @@ public class CameraVisionConfigurationWizard extends AbstractConfigurationWizard
                 }
                 initialJogWarningDisplayed = true;
             }
-            UiUtils.submitUiMachineTask(() -> {
-                if (jogTool instanceof Camera) {
-                    camera.moveToSafeZ();
-                }
-                MainFrame.get().getMachineControls().getJogControlsPanel().jogTool(x, y, 0, c, jogTool);
-                MainFrame.get().getMachineControls().getJogControlsPanel().jogTool(-x, -y, 0, -c, jogTool);
-                camera.lightSettleAndCapture();
+            SwingUtilities.invokeLater(() -> {
+                // There is some strange redraw related race, so do this later.
+                UiUtils.submitUiMachineTask(() -> {
+                    if (jogTool instanceof Camera) {
+                        camera.moveToSafeZ();
+                    }
+                    MainFrame.get().getMachineControls().getJogControlsPanel().jogTool(x, y, 0, c, jogTool);
+                    MainFrame.get().getMachineControls().getJogControlsPanel().jogTool(-x, -y, 0, -c, jogTool);
+                    camera.lightSettleAndCapture();
+                });
             });
         });
     }
@@ -456,8 +460,8 @@ public class CameraVisionConfigurationWizard extends AbstractConfigurationWizard
         }
         @Override
         public void actionPerformed(ActionEvent e) {
+            applyAction.actionPerformed(e);
             UiUtils.messageBoxOnException(() -> {
-                applyAction.actionPerformed(e);
                 camera.lightSettleAndCapture();
                 MovableUtils.fireTargetedUserAction(camera);
             });

--- a/src/main/java/org/openpnp/machine/reference/camera/calibration/AdvancedCalibration.java
+++ b/src/main/java/org/openpnp/machine/reference/camera/calibration/AdvancedCalibration.java
@@ -38,7 +38,9 @@ import org.openpnp.machine.reference.camera.ReferenceCamera;
 import org.openpnp.model.Length;
 import org.openpnp.model.LengthUnit;
 import org.openpnp.model.Location;
+import org.openpnp.spi.Camera.SettleOption;
 import org.openpnp.vision.pipeline.CvPipeline;
+import org.openpnp.vision.pipeline.stages.ImageCapture;
 import org.pmw.tinylog.Logger;
 import org.simpleframework.xml.Attribute;
 import org.simpleframework.xml.Element;
@@ -53,7 +55,8 @@ public class AdvancedCalibration extends LensCalibrationParams {
     // tangential distortion correction by default.
     // Moving to version 1.3 - version 1.2 accidentally disabled all distortion correction by 
     // default rather than only tangential distortion correction.
-    private static final Double LATEST_VERSION = 1.3;
+    // Moving to version 1.4 - modify the pipeline for camera full frame settling.
+    private static final Double LATEST_VERSION = 1.4;
     
     @Attribute(required = false)
     private boolean overridingOldTransformsAndDistortionCorrectionSettings = false;
@@ -65,14 +68,18 @@ public class AdvancedCalibration extends LensCalibrationParams {
     private Boolean dataAvailable = false;
     
     @Element(required = false)
-    private CvPipeline pipeline = new CvPipeline(
-            "<cv-pipeline>" +
-                "<stages>" +
-                    "<cv-stage class=\"org.openpnp.vision.pipeline.stages.ImageCapture\" name=\"image\" enabled=\"true\" default-light=\"true\" settle-first=\"true\" count=\"1\"/>" +
-                    "<cv-stage class=\"org.openpnp.vision.pipeline.stages.DetectCircularSymmetry\" name=\"detect_circle\" enabled=\"true\" min-diameter=\"18\" max-diameter=\"25\" max-distance=\"100\" search-width=\"0\" search-height=\"0\" max-target-count=\"1\" min-symmetry=\"1.2\" corr-symmetry=\"0.0\" property-name=\"DetectCircularSymmetry\" outer-margin=\"0.1\" inner-margin=\"0.1\" sub-sampling=\"8\" super-sampling=\"8\" diagnostics=\"false\" heat-map=\"false\"/>" +
-                    "<cv-stage class=\"org.openpnp.vision.pipeline.stages.ConvertModelToKeyPoints\" name=\"results\" enabled=\"true\" model-stage-name=\"detect_circle\"/>" +
-                "</stages>" +
-             "</cv-pipeline>");
+    private CvPipeline pipeline = createDefaultPipeline();
+
+    protected static CvPipeline createDefaultPipeline() {
+        return new CvPipeline(
+                "<cv-pipeline>" +
+                    "<stages>" +
+                        "<cv-stage class=\"org.openpnp.vision.pipeline.stages.ImageCapture\" name=\"image\" enabled=\"true\" default-light=\"true\" settle-option=\"SettleFullArea\" count=\"1\"/>" +
+                        "<cv-stage class=\"org.openpnp.vision.pipeline.stages.DetectCircularSymmetry\" name=\"detect_circle\" enabled=\"true\" min-diameter=\"18\" max-diameter=\"25\" max-distance=\"100\" search-width=\"0\" search-height=\"0\" max-target-count=\"1\" min-symmetry=\"1.2\" corr-symmetry=\"0.0\" property-name=\"DetectCircularSymmetry\" outer-margin=\"0.1\" inner-margin=\"0.1\" sub-sampling=\"8\" super-sampling=\"8\" diagnostics=\"false\" heat-map=\"false\"/>" +
+                        "<cv-stage class=\"org.openpnp.vision.pipeline.stages.ConvertModelToKeyPoints\" name=\"results\" enabled=\"true\" model-stage-name=\"detect_circle\"/>" +
+                    "</stages>" +
+                 "</cv-pipeline>");
+    }
 
     @Element(name = "virtualCameraMatrix", required = false)
     private double[] virtualCameraMatrixArr = new double[9];
@@ -277,6 +284,16 @@ public class AdvancedCalibration extends LensCalibrationParams {
             //Fix version 1.2 where the initial values of these two were accidentally swapped
             disableDistortionCorrection = false;
             disableTangentialDistortionCorrection = true;
+        }
+        if (version == null || version <= 1.3) {
+            try {
+                Logger.info("Upgrading AdvancedCalibration.pipeline");
+                ((ImageCapture) pipeline.getStage("image")).setSettleOption(SettleOption.SettleFullArea);
+            }
+            catch (Exception e) {
+                Logger.warn(e, "Falling back to assigning default AdvancedCalibration.pipeline.");
+                pipeline = createDefaultPipeline();
+            }
         }
     }
     

--- a/src/main/java/org/openpnp/spi/Camera.java
+++ b/src/main/java/org/openpnp/spi/Camera.java
@@ -119,14 +119,30 @@ public interface Camera extends HeadMountable, WizardConfigurable,
     public BufferedImage captureTransformed();
     
     public BufferedImage captureRaw();
-    
+
+    public enum SettleOption {
+        Skip,
+        Settle,
+        SettleFullArea;
+    }
+
     /**
      * Same as capture() but settles the camera before capturing.
+     * @param settleOption Determines how thorough the settling is.
      * 
      * @return
      * @throws Exception
      */
-    public BufferedImage settleAndCapture() throws Exception;
+    public BufferedImage settleAndCapture(SettleOption settleOption) throws Exception;
+
+    /**
+     * Same as capture() but settles the camera before capturing.
+     * @return
+     * @throws Exception
+     */
+    public default BufferedImage settleAndCapture() throws Exception {
+        return settleAndCapture(SettleOption.Settle);
+    }
 
     /**
      * Same as capture(), but lights and settles the camera before capturing. Uses default lighting.

--- a/src/main/java/org/openpnp/util/NanosecondTime.java
+++ b/src/main/java/org/openpnp/util/NanosecondTime.java
@@ -46,7 +46,10 @@ public class NanosecondTime implements Comparable<NanosecondTime> {
     public static double getRuntimeSeconds() {
         return (double) getRuntime()*1e-9;
     }
-    
+    public static long getRuntimeMilliseconds() {
+        return getRuntime()/1000000;
+    }
+
     private static NanosecondTime systemStartTime = null;
     public static NanosecondTime get() {
         if (systemStartTime == null) {

--- a/src/test/java/VisionUtilsTest.java
+++ b/src/test/java/VisionUtilsTest.java
@@ -215,7 +215,7 @@ public class VisionUtilsTest {
         }
 
         @Override
-        public BufferedImage settleAndCapture() throws Exception {
+        public BufferedImage settleAndCapture(SettleOption settleOption) throws Exception {
             return null;
         }
 


### PR DESCRIPTION
# Description

## Background 
[Camera Settling](https://github.com/openpnp/openpnp/wiki/Camera-Settling) already contains various methods to detect whether a camera image has settled down, i.e. whether all motion and vibration has ceased in the potentially lagging video stream. 

There is a passive **FixedTime** wait method, as well as advanced methods based on frame comparison. The latter have the advantage of being _adaptive_, i.e. only after aggressive machine motion will the camera settling take longer, whereas for little adjustment motion (like in typical vision iteration) it will be much faster. Unlike with **FixedTime** we don't have to settle (literally) for the worst case. 

Frame comparison is done pixel-by-pixel, i.e. moving edges are detected _indirectly_ because their displacement changes a pixel value from one frame to the other. Roughly speaking, the more a frame is still "in motion", the more pixels change, and to a larger degree. We should be able to set a settling _threshold_ based on the amount and nature of cumulative or maximum pixel changes. 

## Problems

However, pixel change also depends on image contents. The amount of structure, texture, brightness and contrasts distributions, steepness of gradients, etc., all influence how abundantly and how strongly pixels change when a certain motion is present. 

In practice, I have observed that setting a universal threshold is difficult, especially on the down-looking camera, where the variety of subjects and lighting situations is large. Whenever I thought, I now have a setting that is covers all use cases, while still being quite fast, along came a new scene where it failed, i.e. where settling was accepted too early. I ended up setting more and more conservative settings, which resulted in excessive settle times elsewhere, sometimes even failure to settle at all (timeout). 

Not so _adaptive_ after all!

## Motion Based Method

Enter the new motion based method. Instead of comparing pixels, it actually tries to detect the amount of motion from frame to frame. The settling threshold can now be based on the detected **pixel distance**, which is directly the objective criteria, we are actually interested in for accurate computer vision. 

Using [OpenCV Template Match](https://docs.opencv.org/3.4/d4/dc6/tutorial_py_template_matching.html), it will equally lock onto sparse, out-of-focus, low-contrast, bright, dark images. The method is using a scalar product and is normed to image contents: as long as there is a discernible non-repetitive structure, and the motion from frame to frame is basically a shift, it will nail it.

The matching is optimized for the final stabilization phase, with little residual motion, but where setting a robust threshold is critical.  

Conversely, in the early frames, the motion might actually be too large to find a match, either because the shift is too large, or due to motion blur, rolling shutter skew and other effects. If there is no match, the method will max out at the largest displacement, i.e. it waits for better frames. 

Due to its nature of matching up the image (almost) as a whole, the method will only work for largely planar subjects. However, it is assumed that small parallaxes from shallow "3D" structures won't matter much in the final settling phase. Even if there are deep 3D structures, chances are that these are out-of-focus (soft-gradient) and/or dark, so they become insignificant compared to the actual in-focus and well-lit subject at the surface. 

## Pros

- Measures the pixel displacement distance between frames, the ideal criterion for camera settling. 
- Much easier to understand and set as a threshold value. 
- Very much independent of image contents, lighting etc.

## Cons

- Computation time is orders of magnitudes higher than the simple frame comparison. Tuning settings can help, but tens of milliseconds are to be expected. 
- Will not work if there are deep 3D structures well visible behind the actual subject. 
- A diffuser (or other structures fixed with the camera) must not be visible in the camera view (or masked away). For the bottom camera, even background shading is needed. 

## Dismissed Method

I first tried another, more flexible method, using [calcOpticalFlowFarneback](https://docs.opencv.org/3.4/dc/d6b/group__video__track.html#ga5d10ebbd59fe09c5f650289ec0ece5af). But it turned out prohibitively slow (200 ... 300ms per frame).

## Related Changes

- The **Mask** setting can now be overridden by a settle option.
- The new `settleOption` was added to the `ImageCapture` pipeline stage. The **SettleFullArea** option overrides the **Mask** on the Camera Settling (if set).
    ![Settle Option](https://user-images.githubusercontent.com/9963310/180622766-004f1e67-a8c6-4863-97f5-43570cfbed33.png)
- The built-in pipeline in `AdvancedCalibration` was modified to use full frame settling. This is needed, as it moves the detection subject to the very periphery of the camera view.

# Justification
See section **Problems** above.

# Instructions for Use

Must be used in the context of the [Camera Settling](https://github.com/openpnp/openpnp/wiki/Camera-Settling) Wiki page.

Specifically see here:
https://github.com/openpnp/openpnp/wiki/Camera-Settling#motion

![settle-method-motion](https://user-images.githubusercontent.com/9963310/180622943-a72b1a70-5802-44c4-87de-7949a4910e1d.gif)

# Implementation Details
1. Tested in simulation
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. The `SettleOption` was added to the `Camera` in `org.openpnp.spi` package.
4. Successful `mvn test` before submitting the Pull Request. 
