### PR TITLE
Fix ReferenceLeverFeeder Feed Start Location Z Height Ignored

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/feeder/ReferenceLeverFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/ReferenceLeverFeeder.java
@@ -148,6 +148,7 @@ public class ReferenceLeverFeeder extends ReferenceFeeder {
 		    
 	            // Move the actuator to the feed start location.
 	            actuator.moveTo(feedStartLocation.derive(null, null, Double.NaN, Double.NaN));
+	            actuator.moveTo(feedStartLocation);
 		    
 	            // enable actuator (may do nothing)
 		    	actuator.actuate(true);
@@ -160,7 +161,7 @@ public class ReferenceLeverFeeder extends ReferenceFeeder {
 		    		peelOffActuator.actuate(true);
 		    	}
 	            // Now move back to the start location to move the tape.
-	            actuator.moveTo(feedStartLocation.derive(null, null, Double.NaN, Double.NaN));
+	            actuator.moveTo(feedStartLocation);
 		    
 			    // Stop the take up actuator
 		    	if (peelOffActuator != null) {

--- a/src/main/java/org/openpnp/machine/reference/feeder/ReferenceLeverFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/ReferenceLeverFeeder.java
@@ -144,12 +144,13 @@ public class ReferenceLeverFeeder extends ReferenceFeeder {
             Location feedStartLocation = this.feedStartLocation;
             Location feedEndLocation = this.feedEndLocation;
 
+            // Move the actuator to the feed start location, at a safe height.
+            actuator.moveTo(feedStartLocation.derive(null, null, Double.NaN, Double.NaN));
+
+            // Move the actuator to the actual feed start location height.
+            actuator.moveTo(feedStartLocation);
+
 		    for (double i = partPitch.convertToUnits(LengthUnit.Millimeters).getValue(); i > 0; i=i-4) {  // perform multiple feeds if required
-		    
-	            // Move the actuator to the feed start location.
-	            actuator.moveTo(feedStartLocation.derive(null, null, Double.NaN, Double.NaN));
-	            actuator.moveTo(feedStartLocation);
-		    
 	            // enable actuator (may do nothing)
 		    	actuator.actuate(true);
 		    


### PR DESCRIPTION
# Description
The ReferenceLeverFeeder currently throws away the Z height of the Feed Start Location, instead using the safe Z height configured in the Z axis.  This causes two main problems.  First of all, you can't set the start height to anything other than the Z axis safe height.  Not a huge issue, but still a bug.  Second though, because a lever feeder will often be actuated with a pure up-down motion of the Z axis, this means that the "return to start" move becomes a no-op, causing the actuator to be turned off before the lever arm has properly returned to its starting height.  This results in a very sudden snap-back motion, which can lead to parts jumping, or just additional wear and tear on the lever arm.  You can see the result very clearly by slowing down the feed speed and noting that the actuator turns off before the lever arm has a chance to be returned to its starting position, as shown here:

https://youtu.be/Ma-H7PO320E

# Justification
This fixes a bug.

# Instructions for Use
Add a ReferenceLeverFeeder to your machine, and configure the Feed Start Location to a Z height other than your Z Safe Height, and/or with a functional feed actuator configured.  Perform a feed operation, and note that prior to this fix, the Feed Start Location did not respect the configured Z height, and the actuator will turn off before the lever is returned to its start height.

# Implementation Details
I chose to break the initial move to the Feed Start Location into two moves, starting with an XY-only move at the Safe Z Height, as the current implementation already does, because it seems prudent to make that move at a safe height, not knowing where the head might be prior to initiating the feed command.  The code already issues a head.moveToSafeZ() before moving to the pick location, so it's not necessary to add that after the return to start position.
