### PR TITLE
Feature / Anti-Aliased OpenCV Drawing.

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/feeder/BlindsFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/BlindsFeeder.java
@@ -576,7 +576,7 @@ public class BlindsFeeder extends ReferenceFeeder {
                 double x = rect.center.x;
                 double y = rect.center.y;
                 FluentCv.drawRotatedRect(mat, rect, color, 3);
-                Imgproc.circle(mat, new org.opencv.core.Point(x, y), 2, FluentCv.colorToScalar(centerColor), 3);
+                Imgproc.circle(mat, new org.opencv.core.Point(x, y), 2, FluentCv.colorToScalar(centerColor), 3, Imgproc.LINE_AA);
             }
         }
 

--- a/src/main/java/org/openpnp/machine/reference/feeder/ReferencePushPullFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/ReferencePushPullFeeder.java
@@ -1336,8 +1336,8 @@ public class ReferencePushPullFeeder extends ReferenceFeeder {
             }
             for (Result.Circle circle : features) {
                 org.opencv.core.Point c =  new org.opencv.core.Point(circle.x, circle.y);
-                Imgproc.circle(mat, c, (int) (circle.diameter+0.5)/2, FluentCv.colorToScalar(color), 2);
-                Imgproc.circle(mat, c, 2, FluentCv.colorToScalar(color), 3);
+                Imgproc.circle(mat, c, (int) (circle.diameter+0.5)/2, FluentCv.colorToScalar(color), 2, Imgproc.LINE_AA);
+                Imgproc.circle(mat, c, 1, FluentCv.colorToScalar(color), 3, Imgproc.LINE_AA);
             }
         }
 
@@ -1346,7 +1346,7 @@ public class ReferencePushPullFeeder extends ReferenceFeeder {
                 return;
             }
             for (Line line : lines) {
-                Imgproc.line(mat, line.a, line.b, FluentCv.colorToScalar(color), 2);
+                Imgproc.line(mat, line.a, line.b, FluentCv.colorToScalar(color), 2, Imgproc.LINE_AA);
             }
         }
 
@@ -1718,9 +1718,9 @@ public class ReferencePushPullFeeder extends ReferenceFeeder {
                     drawOcrText(resultMat, Color.orange);
                     if (getHoles().isEmpty()) {
                         Imgproc.line(resultMat, new Point(0, 0), new Point(resultMat.cols()-1, resultMat.rows()-1), 
-                                FluentCv.colorToScalar(Color.red), 2);
+                                FluentCv.colorToScalar(Color.red), 2, Imgproc.LINE_AA);
                         Imgproc.line(resultMat, new Point(0, resultMat.rows()-1), new Point(resultMat.cols()-1, 0), 
-                                FluentCv.colorToScalar(Color.red), 2);
+                                FluentCv.colorToScalar(Color.red), 2, Imgproc.LINE_AA);
                     }
 
                     if (Logger.getLevel() == org.pmw.tinylog.Level.DEBUG || Logger.getLevel() == org.pmw.tinylog.Level.TRACE) {

--- a/src/main/java/org/openpnp/machine/reference/feeder/wizards/ReferenceStripFeederConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/wizards/ReferenceStripFeederConfigurationWizard.java
@@ -881,8 +881,8 @@ public class ReferenceStripFeederConfigurationWizard extends AbstractConfigurati
             double x = circle.x;
             double y = circle.y;
             double radius = circle.diameter / 2.0;
-            Imgproc.circle(mat, new Point(x, y), (int) radius, FluentCv.colorToScalar(color), 2);
-            Imgproc.circle(mat, new Point(x, y), 1, FluentCv.colorToScalar(centerColor), 2);
+            Imgproc.circle(mat, new Point(x, y), (int) radius, FluentCv.colorToScalar(color), 2, Imgproc.LINE_AA);
+            Imgproc.circle(mat, new Point(x, y), 1, FluentCv.colorToScalar(centerColor), 2, Imgproc.LINE_AA);
         }
     }
 

--- a/src/main/java/org/openpnp/util/OpenCvUtils.java
+++ b/src/main/java/org/openpnp/util/OpenCvUtils.java
@@ -282,8 +282,8 @@ public class OpenCvUtils {
             double x = circle[0];
             double y = circle[1];
             double radius = circle[2];
-            Imgproc.circle(mat, new Point(x, y), (int) radius, new Scalar(0, 0, 255, 255), 2);
-            Imgproc.circle(mat, new Point(x, y), 1, new Scalar(0, 255, 0, 255), 2);
+            Imgproc.circle(mat, new Point(x, y), (int) radius, new Scalar(0, 0, 255, 255), 2, Imgproc.LINE_AA);
+            Imgproc.circle(mat, new Point(x, y), 1, new Scalar(0, 255, 0, 255), 2, Imgproc.LINE_AA);
         }
         return mat;
     }

--- a/src/main/java/org/openpnp/vision/FluentCv.java
+++ b/src/main/java/org/openpnp/vision/FluentCv.java
@@ -777,7 +777,7 @@ public class FluentCv {
         rect.points(points);
         Scalar color_ = colorToScalar(color);
         for (int j = 0; j < 4; ++j) {
-            Imgproc.line(mat, points[j], points[(j + 1) % 4], color_, thickness);
+            Imgproc.line(mat, points[j], points[(j + 1) % 4], color_, thickness, Imgproc.LINE_AA);
         }
     }
 

--- a/src/main/java/org/openpnp/vision/pipeline/stages/DrawCircles.java
+++ b/src/main/java/org/openpnp/vision/pipeline/stages/DrawCircles.java
@@ -82,9 +82,9 @@ public class DrawCircles extends CvStage {
             Color centerColor = this.centerColor == null ? new HslColor(color).getComplementary()
                     : this.centerColor;
             Imgproc.circle(mat, new Point(circle.x, circle.y), (int) (circle.diameter / 2),
-                    FluentCv.colorToScalar(color), thickness);
+                    FluentCv.colorToScalar(color), thickness,  Imgproc.LINE_AA);
             Imgproc.circle(mat, new Point(circle.x, circle.y), 1, FluentCv.colorToScalar(centerColor),
-                    2);
+                    2, Imgproc.LINE_AA);
         }
         return null;
     }

--- a/src/main/java/org/openpnp/vision/pipeline/stages/DrawEllipses.java
+++ b/src/main/java/org/openpnp/vision/pipeline/stages/DrawEllipses.java
@@ -5,9 +5,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.opencv.core.Mat;
-import org.opencv.core.Point;
 import org.opencv.core.RotatedRect;
-import org.opencv.core.Scalar;
 import org.opencv.core.Size;
 import org.opencv.imgproc.Imgproc;
 import org.openpnp.vision.FluentCv;
@@ -84,7 +82,7 @@ public class DrawEllipses extends CvStage {
             Color thecolor = (color == null ? FluentCv.indexedColor(i) : color);
             Size axes = new Size(rect.size.width*0.5, rect.size.height*0.5);
             //public static void ellipse(Mat img, Point center, Size axes, double angle, double startAngle, double endAngle, Scalar color, int thickness)
-            Imgproc.ellipse(mat, rect.center, axes, rect.angle, 0, 360, FluentCv.colorToScalar(thecolor), thickness);
+            Imgproc.ellipse(mat, rect.center, axes, rect.angle, 0, 360, FluentCv.colorToScalar(thecolor), thickness,  Imgproc.LINE_AA);
         }
         return new Result(null, rects);
     }

--- a/src/main/java/org/openpnp/vision/pipeline/stages/DrawRotatedRects.java
+++ b/src/main/java/org/openpnp/vision/pipeline/stages/DrawRotatedRects.java
@@ -100,7 +100,7 @@ public class DrawRotatedRects extends CvStage {
         Imgproc.line(image, rrect.center,
                 new Point(rrect.center.x + 1.2 * rrect.size.height / 2.0 * Math.cos(markAngle),
                         rrect.center.y + 1.2 * rrect.size.height / 2.0 * Math.sin(markAngle)),
-                color, Math.abs(thickness));
+                color, Math.abs(thickness), Imgproc.LINE_AA);
     }
 
     @Override
@@ -128,7 +128,7 @@ public class DrawRotatedRects extends CvStage {
             FluentCv.drawRotatedRect(mat, rect, thecolor, thickness);
             if (drawRectCenter) {
                 Imgproc.circle(mat, rect.center, rectCenterRadius, FluentCv.colorToScalar(thecolor),
-                        thickness);
+                        thickness, Imgproc.LINE_AA);
             }
             if (showOrientation) {
                 drawOrientationMark(mat, rect, FluentCv.colorToScalar(thecolor), thickness);


### PR DESCRIPTION

# Description
Use anti-aliased OpenCV drawing on circles and lines, where appropriate.

Before:
![Before](https://user-images.githubusercontent.com/9963310/181841412-26a0a1ac-f2f1-4116-8512-ff76cf05a865.png)
After:
![After](https://user-images.githubusercontent.com/9963310/181841438-ef5ed32c-9180-4f7b-8554-9441173058e8.png)


Note: anti-aliasing was not used on mask drawing where a binary pixel mask is required. 

# Justification
Better looking results.

# Instructions for Use
No change.

# Implementation Details
1. Tested in simulation.
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. Successful `mvn test` before submitting the Pull Request. 
