### PR TITLE
Feature / More Robust CIrcular Symmetry Detection

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/solutions/VisionSolutions.java
+++ b/src/main/java/org/openpnp/machine/reference/solutions/VisionSolutions.java
@@ -77,6 +77,7 @@ import org.openpnp.vision.pipeline.CvPipeline;
 import org.openpnp.vision.pipeline.CvStage.Result.Circle;
 import org.openpnp.vision.pipeline.stages.DetectCircularSymmetry;
 import org.openpnp.vision.pipeline.stages.DetectCircularSymmetry.ScoreRange;
+import org.openpnp.vision.pipeline.stages.DetectCircularSymmetry.SymmetryScore;
 import org.pmw.tinylog.Logger;
 import org.simpleframework.xml.Attribute;
 import org.simpleframework.xml.Element;
@@ -96,6 +97,8 @@ public class VisionSolutions implements Solutions.Subject {
     private int subSampling = 4;
     @Attribute(required = false)
     private int superSampling = 8;
+    @Attribute(required = false)
+    private DetectCircularSymmetry.SymmetryScore symmetryScore = SymmetryScore.OverallVarianceVsRingVarianceSum;
 
     @Attribute(required = false)
     protected long diagnosticsMilliseconds = 4000;
@@ -1404,7 +1407,7 @@ public class VisionSolutions implements Solutions.Subject {
         List<Circle> results = DetectCircularSymmetry.findCircularSymmetry(image, 
                 expectedX, expectedY, 
                 minDiameter, maxDiameter, maxDistance, maxDistance, maxDistance, 1,
-                minSymmetry, 0.0, subSampling, superSampling, diagnostics != null, false, scoreRange);
+                minSymmetry, 0.0, subSampling, superSampling, symmetryScore, diagnostics != null, false, scoreRange);
         if (diagnostics != null) {
             if (LogUtils.isDebugEnabled()) {
                 File file = Configuration.get().createResourceFile(getClass(), "loc_", ".png");


### PR DESCRIPTION
# Description
The [DetectCircularSymmetry stage and method](https://github.com/openpnp/openpnp/wiki/DetectCircularSymmetry) has become very successful as a tuning-free and robust way to detect circular features such as fiducials and nozzle tips in computer vision. 

However, it has shown some limits when it has to compete with other nearby features that happen to have an (interrupted) tangential match with the wanted circular diameters. As a typical example: on paper carrier tapes 0402 pockets are confused with sprocket holes. Another example are texture patterns that happen to have a circular weight either randomly or from LED reflection highlights etc. (for both examples see the animation below).

The new **SymmetryScore** method selection provides alternative score functions to reject partial/interrupted ring edges. By either taking the average or median value of ring pixels/segments, the comparison variance is reduced when rings are interrupted, making a candidate less favorable.

Features:

1. Introduce the `DetectCircularSymmetry.SymmetryScore` method selection.
2. Create a 2D polar coordinates histogram over the image in one go, instead of sampling rings individually.
3. On coarse sub-sampling, the preliminary results may not match symmetry criteria yet, allow them to iterate anyway.
4. Make the heat map more adaptive, to accommodate the different score characteristics of the methods.

# Justification
Robustly reject non-circular (rectangular) shapes, even if some of their edges tangentially match the inner (minimum) or outer (maximum) diameter of the searched feature. Used for upcoming better `ReferencePushPullFeeder` vision, but also usable for `ReferenceStripFeeder` (see example animation below). 

The old score method is still available and remains the default. 

# Instructions for Use
The new **SymmetryScore** method selection provides alternative score functions to reject partial/interrupted ring edges: 

![circular-symmetry-score](https://user-images.githubusercontent.com/9963310/181843949-0becc703-8f96-485e-8b3c-15d1dac2ffd7.gif)

- **Overall variance vs. ring variance sum** (default): tolerant circular symmetry score. Matches partial/scattered circular patterns.
- **Ring ageraged variance vs. ring variance sum**: stricter circular symmetry score. The rings must be quite uniform to match.
- **Ring median variance vs. ring variance sum**: even stricter circular symmetry score. Rejects interrupted rings, e.g. from tangential non-circular edges.

# Implementation Details
1. Tested on user sample images.
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. Successful `mvn test` before submitting the Pull Request.
