### PR TITLE
Feature / ReferencePushPullFeeder Auto-Setup More Robust.

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/feeder/ReferencePushPullFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/ReferencePushPullFeeder.java
@@ -1514,7 +1514,8 @@ public class ReferencePushPullFeeder extends ReferenceFeeder {
                     for (Result.Circle circle : results) {
                         points.add(new Point(circle.x, circle.y));
                     }
-                    List<Ransac.Line> ransacLines = Ransac.ransac(points, 100, sprocketHoleTolerancePx, sprocketHolePitchPx, sprocketHoleTolerancePx);
+                    List<Ransac.Line> ransacLines = Ransac.ransac(points, 100, sprocketHoleTolerancePx, 
+                            sprocketHolePitchPx, sprocketHoleTolerancePx, false);
                     // Get the best line within the calibration tolerance
                     Ransac.Line bestLine = null;
                     Location bestUnitVector = null;

--- a/src/main/java/org/openpnp/machine/reference/feeder/wizards/ReferenceStripFeederConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/wizards/ReferenceStripFeederConfigurationWizard.java
@@ -788,7 +788,7 @@ public class ReferenceStripFeederConfigurationWizard extends AbstractConfigurati
                 points.add(new Point(circle.x, circle.y));
             }
 
-            lines = Ransac.ransac(points, 100, maxDistanceToLine, holePitchPx, holePitchPx - minHolePitchPx);
+            lines = Ransac.ransac(points, 100, maxDistanceToLine, holePitchPx, holePitchPx - minHolePitchPx, true);
 
             bestLine = null;
             for (Ransac.Line line : lines) {

--- a/src/main/java/org/openpnp/util/UiUtils.java
+++ b/src/main/java/org/openpnp/util/UiUtils.java
@@ -193,9 +193,14 @@ public class UiUtils {
                 // We need to move there, ask the user to confirm.
                 int result;
                 if (allowWithoutMove) {
-                    result = JOptionPane.showConfirmDialog(parentComponent,
-                            "Do you want to "+moveBeforeActionDescription+"?\n",
-                                    null, JOptionPane.YES_NO_CANCEL_OPTION, JOptionPane.QUESTION_MESSAGE);
+                    if (moveBeforeActionDescription != null) {
+                        result = JOptionPane.showConfirmDialog(parentComponent,
+                                "Do you want to "+moveBeforeActionDescription+"?\n",
+                                null, JOptionPane.YES_NO_CANCEL_OPTION, JOptionPane.QUESTION_MESSAGE);
+                    }
+                    else {
+                        result = JOptionPane.NO_OPTION;
+                    }
                 }
                 else {
                     result = JOptionPane.showConfirmDialog(parentComponent,

--- a/src/main/resources/org/openpnp/machine/reference/feeder/ReferencePushPullFeeder-CircularSymmetryPipeline.xml
+++ b/src/main/resources/org/openpnp/machine/reference/feeder/ReferencePushPullFeeder-CircularSymmetryPipeline.xml
@@ -7,7 +7,7 @@
       <cv-stage class="org.openpnp.vision.pipeline.stages.ConvertColor" name="3" enabled="true" conversion="Bgr2Gray"/>
       <cv-stage class="org.openpnp.vision.pipeline.stages.SimpleOcr" name="OCR" enabled="true" alphabet="0123456789.-+_RCLDQYXJIVAFH%GMKkmuµnp" font-name="Liberation Mono" font-size-pt="7.0" font-max-pixel-size="20" auto-detect-size="false" threshold="0.75" draw-style="OverOriginalImage" debug="false"/>
       <cv-stage class="org.openpnp.vision.pipeline.stages.ImageRecall" name="5" enabled="true" image-stage-name="0"/>
-      <cv-stage class="org.openpnp.vision.pipeline.stages.DetectCircularSymmetry" name="results" enabled="true" min-diameter="10" max-diameter="100" max-distance="100" max-target-count="10" min-symmetry="1.2" corr-symmetry="0.2" property-name="sprocketHole" outer-margin="0.2" inner-margin="0.2" sub-sampling="8" super-sampling="1" diagnostics="false"/>
+      <cv-stage class="org.openpnp.vision.pipeline.stages.DetectCircularSymmetry" name="results" enabled="true" min-diameter="10" max-diameter="100" max-distance="100" max-target-count="10" min-symmetry="1.2" corr-symmetry="0.2" property-name="sprocketHole" outer-margin="0.3" inner-margin="0.1" sub-sampling="8" super-sampling="1" symmetry-score="RingMedianVarianceVsRingVarianceSum" diagnostics="false"/>
       <cv-stage class="org.openpnp.vision.pipeline.stages.ImageRecall" name="7" enabled="false" image-stage-name="0"/>
       <cv-stage class="org.openpnp.vision.pipeline.stages.DrawCircles" name="8" enabled="false" circles-stage-name="results" thickness="1">
          <color r="255" g="0" b="0" a="255"/>


### PR DESCRIPTION
# Description
- Make `ReferencePushPullFeeder` Auto-Setup more robust by allowing interrupted sprocket hole lines.
- Option for `Ransac` to search for interrupted lines.
- Improve the stock `ReferencePushPullFeeder` circular symmetry pipeline to use #1456.
- Bonus: Fixed a bug in the fiducial test pipeline editing handler (Asking _"Do you want to null?"_ and pressing _Yes_ would throw).

# Justification
See discussion:
https://groups.google.com/g/openpnp/c/N6IVhO_xbrw/m/PSOT0qaaAQAJ

# Instructions for Use
See #1450 for usage. See also #1456 for _inside_ details.

![push-pull-feeder1659133317901680400](https://user-images.githubusercontent.com/9963310/181853969-464fbee4-6171-432f-b9b7-857a9022adcd.png)

# Implementation Details

1. Tested with user images.
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. Successful `mvn test` before submitting the Pull Request.
