### PR TITLE
Feature / Vacuum Pump Control

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/ReferenceNozzle.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceNozzle.java
@@ -1023,38 +1023,20 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
         blowOffActuatorName = (actuator != null ? actuator.getName() : null);
     }
 
-    protected boolean hasPartOnAnyOtherNozzle() {
-        for (Nozzle nozzle : getHead().getNozzles()) {
-            if (nozzle != this ) {
-                if (nozzle.getPart() != null) {
-                    return true;
-                }
-            }
-        }
-        return false;
-    }
-
-    protected void actuatePump(boolean on) throws Exception {
-        Actuator pump = getHead().getPumpActuator();
-        if (pump != null && !hasPartOnAnyOtherNozzle()) {
-            pump.actuate(on);
-        }
-    }
-    
     protected void actuateVacuumValve(boolean on) throws Exception {
         if (on) {
-            actuatePump(true);
+            getHead().actuatePumpRequest(this, true);
         }
 
         getExpectedVacuumActuator().actuate(on);
 
         if (! on) {
-            actuatePump(false);
+            getHead().actuatePumpRequest(this, false);
         }
     }
 
     protected void actuateVacuumValve(double value) throws Exception {
-        actuatePump(true);
+        getHead().actuatePumpRequest(this, true);
 
         getExpectedVacuumActuator().actuate(value);
     }
@@ -1062,7 +1044,7 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
     protected void actuateBlowValve(double value) throws Exception {
         getExpectedBlowOffActuator().actuate(value);
 
-        actuatePump(false);
+        getHead().actuatePumpRequest(this, false);
     }
 
     public double readVacuumLevel() throws Exception {

--- a/src/main/java/org/openpnp/spi/Head.java
+++ b/src/main/java/org/openpnp/spi/Head.java
@@ -170,4 +170,14 @@ public interface Head extends Identifiable, Named, WizardConfigurable, PropertyS
     public Actuator getzProbeActuator(); 
     
     public Actuator getPumpActuator(); 
+
+    /**
+     * Request a pump actuation. It will be subject to pump control method, the presence of parts on other nozzles etc., 
+     * whether the pump will actually be actuated.
+     *  
+     * @param nozzle
+     * @param on
+     * @throws Exception 
+     */
+    public void actuatePumpRequest(Nozzle nozzle, boolean on) throws Exception;
 }


### PR DESCRIPTION
# Description
Introducing a selection of simple vacuum pump control methods. Provides alternatives to the rapid on/off when parts are picked and placed. The new methods allow keeping the pump going longer, perhaps establishing a more constant vacuum level and [shorter dwell times/faster established level](https://github.com/openpnp/openpnp/wiki/Setup-and-Calibration%3A-Vacuum-Sensing#dwell-times--establish-level) on picks. 

Furthermore, these methods allow for seamless "[sniffle probing](https://github.com/openpnp/openpnp/wiki/Contact-Probing-Nozzle#method-selection)" ([watch video](https://youtu.be/9uFxV1-vnXw?t=50)).

![Control Methods](https://user-images.githubusercontent.com/9963310/181920613-9a05ac18-bd80-4afe-b01f-da8d0448002c.png)

Switching control to **None** allows the pump actuator to be configured as such (assigned to the head) without also getting the control forced on you. This is useful for those machines (including mine) that use external control, like [a controller-side hysteresis](https://makr.zone/vacuum-sensor/192/). 

The PR also introduces a wait time for the pump to be ready when first switched on. For those methods that keep the pump running longer, this time can then effectively be subtracted from the pick dwell times, i.e. it is then only incurred _once_. 

More in the **Instructions for Use**.

# Justification
It is planned to handle the pump actuator in upcoming extensions to Issues & Solutions. The ability for alternative ways of control (including **None**) is essential. 

# Instructions for Use

![Vacuum Pump](https://user-images.githubusercontent.com/9963310/181920168-facf1355-300d-405f-8bff-2f2d359a993b.png)

**Pump Control** determines how the pump on/off state is controlled:
- **None** the pump is controlled manually or outside of OpenPnP. Use this for a controller-side hysteresis control, for instance.
- **PartOn**: the pump is switched on when a part is about to be picked, it is switched off when no part is on any nozzle.
- **TaskDuration**: the pump is switched on when a part is about to be picked, it is only switched off when queued tasks (e.g. the running job) is finished, given no part is on any nozzle.
- **KeepRunning**: the pump is switched on when a part is about to be picked, it is kept running until explicitly switched off, or until the machine is being disabled.

**Pump On Wait [ms]** sets the wait time used to give the pump a chance to establish the proper vacuum level.

# Implementation Details
1. Tested in simulation (log).
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. Added `Head.actuatePumpRequest(Nozzle, boolean)` (`spi`) to encapsulate the pump control logic on the head, and no longer on the single nozzle.
4. Successful `mvn test` before submitting the Pull Request. 
