### PR TITLE
PushPullFeeder ocr read offset

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/feeder/wizards/ReferencePushPullFeederConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/wizards/ReferencePushPullFeederConfigurationWizard.java
@@ -412,6 +412,14 @@ extends AbstractReferenceFeederConfigurationWizard {
         panelVisionEnabled.add(textFieldFontSizePt, "10, 10");
         textFieldFontSizePt.setColumns(10);
 
+        lblOcrOffset = new JLabel("OCR Offset");
+        lblOcrOffset.setToolTipText("OCR Camera offset along tape direction.");
+        panelVisionEnabled.add(lblOcrOffset, "8, 12, right, default");
+
+        textFieldOcrOffset = new JTextField();
+        panelVisionEnabled.add(textFieldOcrOffset, "10, 12");
+        textFieldOcrOffset.setColumns(10);
+
         btnEditPipeline = new JButton(editPipelineAction);
         btnEditPipeline.addActionListener(new ActionListener() {
             public void actionPerformed(ActionEvent e) {
@@ -602,6 +610,7 @@ extends AbstractReferenceFeederConfigurationWizard {
         addWrappedBinding(feeder, "ocrDiscoverOnJobStart", checkBoxDiscoverOnJobStart, "selected");
         addWrappedBinding(feeder, "ocrFontName", comboBoxFontName, "selectedItem");
         addWrappedBinding(feeder, "ocrFontSizePt", textFieldFontSizePt, "text", doubleConverter);
+        addWrappedBinding(feeder, "ocrOffset", textFieldOcrOffset, "text", doubleConverter);
         addWrappedBinding(feeder, "pipelineType", pipelineType, "selectedItem");
 
         addWrappedBinding(feeder, "cloneTemplateStatus", textPaneCloneTemplateStatus, "text");
@@ -617,6 +626,7 @@ extends AbstractReferenceFeederConfigurationWizard {
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldPartPitch);
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldFeedPitch);
         ComponentDecorators.decorateWithAutoSelect(textFieldFontSizePt);
+        ComponentDecorators.decorateWithAutoSelect(textFieldOcrOffset);
     }
 
     private Action editPipelineAction =
@@ -800,7 +810,7 @@ extends AbstractReferenceFeederConfigurationWizard {
         public void actionPerformed(ActionEvent e) {
             applyAction.actionPerformed(e);
             UiUtils.submitUiMachineTask(() -> {
-                MovableUtils.moveToLocationAtSafeZ(feeder.getCamera(), feeder.getNominalVisionLocation());
+                MovableUtils.moveToLocationAtSafeZ(feeder.getCamera(), feeder.getOcrVisionLocation());
                 MovableUtils.fireTargetedUserAction(feeder.getCamera());
                 SwingUtilities.invokeAndWait(() -> {
                     UiUtils.messageBoxOnException(() -> {
@@ -1011,6 +1021,8 @@ extends AbstractReferenceFeederConfigurationWizard {
     private JComboBox comboBoxFontName;
     private JLabel lblFontSizept;
     private JTextField textFieldFontSizePt;
+    private JLabel lblOcrOffset;
+    private JTextField textFieldOcrOffset;
     private JLabel lblOcrWrongPart;
     private JComboBox comboBoxWrongPartAction;
     private JLabel lblDiscoverOnJobStart;


### PR DESCRIPTION
# Description
Adds an option to move the OCR identification position along the axis of the feeder.
Moves the OCR part check to before the new position of alignment holes is submitted to the feeder.  This avoids new hole alignment being applied to the wrong feeder.

# Justification
A camera that has limited scope on the machine y-axis can't see both the tape holes and a position to read OCR or QRCode.  The OCR read position needs to be offset.

# Instructions for Use
On PushPullFeeder configuration tab use the "OCR offset" value.  Positive offset is away from the feeder.  Negative offset is towards the feeder.
A zero offset results in default behavior where the OCR is checked at the mid tape hole location together with the first tape hole position check.  A non zero offset results in the OCR being checked just after the first tape hole position check.
Use "Setup OCR region" to pick an new region of interest at the new offset location.  The region moves relative to the OCR offset.  If the offset changes then the region may need to be changed.
Selecting "Part by OCR" results in the camera moving to the new position before OCR check.
Feeding results in the additional OCR check only as required.

# Implementation Details
1. How did you test the change?
Zero offset shows no additional camera movement or image capture to check OCR.
Non zero offset moves the camera along the feeder axis.  This has only been tested with a feeder mounted at one side.
Feeder direction is derived from the direction between tape hole 1 and 2.
Using a feeder with offset as a template results in the offset being copied.

2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)?   
  With luck yes.
3. No changes to `org.openpnp.spi` or `org.openpnp.model` packages 
4. `mvn test` passed
