### PR TITLE
Fix / ContactProbeNozzle.convertToContactProbe(ReferenceNozzle)

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/ContactProbeNozzle.java
+++ b/src/main/java/org/openpnp/machine/reference/ContactProbeNozzle.java
@@ -370,10 +370,12 @@ public class ContactProbeNozzle extends ReferenceNozzle {
         }
     }
 
-    @Override 
-    protected void loaded(Configuration configuration) {
-        super.loaded(configuration);
-        contactProbeActuator = getHead().getActuatorByName(contactProbeActuatorName);
+    @Override
+    public void applyConfiguration(Configuration configuration) {
+        super.applyConfiguration(configuration);
+        if (getHead() != null) {
+            contactProbeActuator = getHead().getActuatorByName(contactProbeActuatorName);
+        }
     }
     @Override
     protected void persist() {
@@ -1035,8 +1037,8 @@ public class ContactProbeNozzle extends ReferenceNozzle {
         Serializer serIn = XmlSerialize.createSerializer();
         StringReader sr = new StringReader(serialized);
         ContactProbeNozzle contactProbeNozzle = serIn.read(ContactProbeNozzle.class, sr);
-        contactProbeNozzle.applyConfiguration(Configuration.get());
         contactProbeNozzle.setHead(nozzle.getHead());
+        contactProbeNozzle.applyConfiguration(Configuration.get());
         contactProbeNozzle.setNozzleTip(nozzle.nozzleTip);
         return contactProbeNozzle;
     }
@@ -1064,8 +1066,8 @@ public class ContactProbeNozzle extends ReferenceNozzle {
         Serializer serIn = XmlSerialize.createSerializer();
         StringReader sr = new StringReader(serialized);
         ReferenceNozzle referenceNozzle = serIn.read(ReferenceNozzle.class, sr);
-        referenceNozzle.applyConfiguration(Configuration.get());
         referenceNozzle.setHead(nozzle.getHead());
+        referenceNozzle.applyConfiguration(Configuration.get());
         referenceNozzle.setNozzleTip(nozzle.nozzleTip);
         return referenceNozzle;
     }

--- a/src/main/java/org/openpnp/machine/reference/ReferenceNozzle.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceNozzle.java
@@ -9,7 +9,6 @@ import javax.swing.AbstractAction;
 import javax.swing.Action;
 import javax.swing.JOptionPane;
 
-import org.openpnp.ConfigurationListener;
 import org.openpnp.gui.MainFrame;
 import org.openpnp.gui.support.Icons;
 import org.openpnp.gui.support.MessageBoxes;
@@ -105,20 +104,16 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
     protected ReferenceNozzleTip nozzleTip;
 
     public ReferenceNozzle() {
-        Configuration.get().addListener(new ConfigurationListener.Adapter() {
-            @Override
-            public void configurationLoaded(Configuration configuration) throws Exception {
-                loaded(configuration);
-            }
-        });
+        super();
     }
-
     public ReferenceNozzle(String id) {
         this();
         this.id = id;
     }
 
-    protected void loaded(Configuration configuration) {
+    @Override
+    public void applyConfiguration(Configuration configuration) {
+        super.applyConfiguration(configuration);
         // When brand new nozzles are created rather than loaded from configuration, configurationLoaded() is also 
         // triggered. Therefore we need to check for the presence of the head. 
         if (getHead() !=  null) {


### PR DESCRIPTION
# Description
Fixes using the XML serializer to convert nozzles to contact probe nozzles after the persisting of actuators was changed in 4c537b5bb2385c2a99787af7ae8e5e19e6346c9a.

The `loaded()` handler should check for `head != null` and it must be called again _after_ assigning the head. 

The `loaded()` handler was consolidated with the already existing `AbstractHeadMountable.applyConfiguration(Configuration)`.

# Justification
User error report.
https://groups.google.com/g/openpnp/c/9yuV0pyEnks/m/RQtMQB2VAgAJ

# Instructions for Use
No change.

# Implementation Details
1. Tested with reported user `machine.xml`
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. Successful `mvn test` before submitting the Pull Request.
