### PR TITLE
Fix / ReferencePushPullFeeder: Exclude Typed Pipeline In Secondary Clone

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/feeder/wizards/ReferencePushPullFeederConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/wizards/ReferencePushPullFeederConfigurationWizard.java
@@ -871,7 +871,7 @@ extends AbstractReferenceFeederConfigurationWizard {
                             checkBoxCloneLocationSettings.isSelected(),
                             checkBoxCloneTapeSettings.isSelected(), 
                             checkBoxClonePushPullSettings.isSelected(),
-                            checkBoxCloneVisionSettings.isSelected());
+                            checkBoxCloneVisionSettings.isSelected(), checkBoxCloneVisionSettings.isSelected());
                 }
             });
         }
@@ -910,7 +910,7 @@ extends AbstractReferenceFeederConfigurationWizard {
                                 checkBoxCloneLocationSettings.isSelected(),
                                 checkBoxCloneTapeSettings.isSelected(), 
                                 checkBoxClonePushPullSettings.isSelected(),
-                                checkBoxCloneVisionSettings.isSelected(),
+                                checkBoxCloneVisionSettings.isSelected(), checkBoxCloneVisionSettings.isSelected(),
                                 feeder);
                     }
                 }


### PR DESCRIPTION
# Description
In Auto-Setup, if there are other `ReferencePushPullFeeder`s, it will try to clone settings over from just a very generic template (there is nothing yet known about the part or tape, so "smart" template selection is not possible). Once vision is successful, it might have identified a part using OCR, so it performs a secondary clone, as the template selection might now be (more) accurate. 

However, since #1450 the Auto-Setup performs an automatic pipeline _type_ selection (ColorKeyed or CircularSymmetry). So the secondary clone might just _undo_ that selection, by cloning the _wrong type_ pipeline from another, likely not yet or wrongly configured `ReferencePushPullFeeder`. 

Therefore, this fix _excludes_ the pipeline from the secondary clone, _if_ the pipeline was _typed_. 

Also adds better logging for easier diagnostics if this still fails (can't test this properly on my side). 

# Justification
User cases:
https://groups.google.com/g/openpnp/c/ESOWIXfZpmE/m/yGopTKOnAgAJ

# Instructions for Use
No change, see #1450.

# Implementation Details
1. Tested in simulation (limited). User must really test this again.
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. Successful `mvn test` before submitting the Pull Request. 
