### PR TITLE
Fix / Respect Max. Part Diameter in Vision Compositing

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/SimulationModeMachine.java
+++ b/src/main/java/org/openpnp/machine/reference/SimulationModeMachine.java
@@ -376,7 +376,8 @@ public class SimulationModeMachine extends ReferenceMachine {
                                             }
                                         }
                                         if (nozzle instanceof AbstractNozzle) {
-                                            rotationModeOffsetAtPick.put(nozzle, ((AbstractNozzle) nozzle).getRotationModeOffset());
+                                            Double rotationModeOffset = ((AbstractNozzle) nozzle).getRotationModeOffset();
+                                            rotationModeOffsetAtPick.put(nozzle, rotationModeOffset == null ? 0.0 : rotationModeOffset);
                                         }
                                     }
                                     else {

--- a/src/main/java/org/openpnp/machine/reference/solutions/NozzleTipSolutions.java
+++ b/src/main/java/org/openpnp/machine/reference/solutions/NozzleTipSolutions.java
@@ -179,7 +179,7 @@ public class NozzleTipSolutions implements Solutions.Subject  {
                 @Override 
                 public String getExtendedDescription() {
                     return "<html>"
-                            + "<p>It is recommended to enable nozzle tip calibration for run-out, offsets and background calibration. "
+                            + "<p>It is recommended to enable nozzle tip calibration for run-out and precision camera offsets. "
                             + "For more information, press the blue Info button (below) to open the Wiki.</p><br/>"
                             + (nozzleTip != nozzle.getNozzleTip() ?
                                     "<p>Load nozzle tip "+nozzleTip.getName()+" to nozzle "+nozzle.getName() + ".</p><br/>"

--- a/src/main/java/org/openpnp/machine/reference/wizards/ReferenceNozzleTipConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/wizards/ReferenceNozzleTipConfigurationWizard.java
@@ -208,7 +208,7 @@ public class ReferenceNozzleTipConfigurationWizard extends AbstractConfiguration
 
         lblMaxPartDiameter = new JLabel("Max. Part Diameter");
         lblMaxPartDiameter.setToolTipText(
-                "<html>\nMaximum diameter/diagonal of parts picked with this nozzle tip, <br/>\nincluding tolerances.\n</html>\n");
+                "<html>\nMaximum diameter/diagonal of parts picked with this nozzle tip.<br/>\n<br/>\nNote, when using Vision Compositing (bottom vision multi-shot), this does<br/>\nnot limit the parts size, but rather the size of a single shot (mask diameter).\n</html>\n");
         panelPartDimensions.add(lblMaxPartDiameter, "2, 4, right, default");
 
         maxPartDiameter = new JTextField();


### PR DESCRIPTION
# Description
The **Max. Part Diameter** property on the nozzle tip has become an important setting for multiple interconnected functions. It determines how large a part can be, when it is loaded on said nozzle tip. More specifically it determines the camera view diameter that is considered active in bottom vision. Some computer vision pipeline stages are parametrized to limit their detection to that area (for speed). The same diameter is used by [Background Calibration](https://github.com/openpnp/openpnp/wiki/Nozzle-Tip-Background-Calibration) to limit the background area considered active. Anything outside that area is assumed to be masked. Ultimately, a MaskCircle stage in the pipeline is parametrized to apply this mask.

The mask is effectively used to eliminate peripheral camera view elements that might disrupt computer vision. To quote the user that reported the issue:

> "some random light reflections around the outer edge of my bottom camera view"

With Vision Compositing (a.k.a. multi-shot bottom vision) from #1440 this was previously ignored. The algorithms used the whole camera view (largest diameter fitting inside) as they liked. 

This PR fixes this, taking the  **Max. Part Diameter** as the largest allowed diameter:

![image](https://user-images.githubusercontent.com/9963310/184549830-8ec31e3b-e6a9-4a17-a624-ef5d5bada39e.png)

This also works when doing multiple corner shots, i.e. the  **Max. Part Diameter** is then rather a "max. part corner shot diameter":

![image](https://user-images.githubusercontent.com/9963310/184549893-c8f8987d-87d4-4fa0-87cd-1366a1f6d9ee.png)

## Feature List

- Vision compositing must respect **Max. Part Diameter** of nozzle tip.
- Adds 2 x **Pick Tolerance** to **Max. Part Diameter** as it should have. 
- Background calibration does now [match the masks applied for any type of bottom vision](https://github.com/openpnp/openpnp/wiki/Nozzle-Tip-Background-Calibration#calibration-pipeline-control).
- Update the Wizard tooltip for **Max. Part Diameter**.
- Improve the description in nozzle tip vs. background calibration solution.
- Fix bug in simulation machine, where rotation mode offset was not working when previously null, i.e. when applied on machine _without_ limited articulation.

# Justification
User feedback, own testing:
https://groups.google.com/g/openpnp/c/Bad16-17f7g/m/kn7vnk9ODAAJ

# Instructions for Use
No change in use. See existing Wiki:
https://github.com/openpnp/openpnp/wiki/Vision-Compositing
https://github.com/openpnp/openpnp/wiki/Nozzle-Tip-Background-Calibration#calibration-pipeline-control

# Implementation Details
1. Tested in simulation.
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. Successful `mvn test` before submitting the Pull Request.
