### PR TITLE
Fix / ImageUtils.emulateCameraCapture() Odd Pixel Adjustment

### DIFF
--- a/src/main/java/org/openpnp/util/ImageUtils.java
+++ b/src/main/java/org/openpnp/util/ImageUtils.java
@@ -105,10 +105,10 @@ public class ImageUtils {
             fy = upp.getLengthY().divide(uppCamera.getLengthY());
         }
         Imgproc.resize(image, image, new Size(), fx, fy, Imgproc.INTER_LANCZOS4);
-        int bx = Math.max(0, camera.getWidth() - image.cols())/2;
-        int by = Math.max(0, camera.getHeight() - image.rows())/2;
+        int bx = Math.max(0, camera.getWidth() - image.cols());
+        int by = Math.max(0, camera.getHeight() - image.rows());
         if (bx > 0 || by > 0) {
-            Core.copyMakeBorder(image, image, by, by, bx, bx, Core.BORDER_CONSTANT);
+            Core.copyMakeBorder(image, image, by/2, (by+1)/2, bx/2, (bx+1)/2, Core.BORDER_CONSTANT);
         }
         int cx = Math.max(0, image.cols() - camera.getWidth())/2;
         int cy = Math.max(0, image.rows() - camera.getHeight())/2;


### PR DESCRIPTION
# Description
The `ImageUtils.emulateCameraCapture()` function adapts a source image to the native camera resolution and dimension, i.e. the image is presented as if captured. This optionally uses an `upp.txt` file stored side-by-side to the source image, to adjust for true scale. The function is used in the `ImageRead` pipeline stage, so one can test camera images from other users with true scale, while having one's own camera setup. 

Because of integer math (rounding), this failed if the dimensions of the camera frame vs. source image differed by an odd (not divisible by two) pixel number. This PR fixes that, by making the left/right, upper/lower border different by one pixel.

# Justification
Bug.

# Instructions for Use
No change.

# Implementation Details
1. Tested with an actual user image (where this was discovered)
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. Successful `mvn test` before submitting the Pull Request. 
