### PR TITLE
Limit low value of speed slider to 1 %

### DIFF
--- a/src/main/java/org/openpnp/gui/JogControlsPanel.java
+++ b/src/main/java/org/openpnp/gui/JogControlsPanel.java
@@ -364,15 +364,7 @@ public class JogControlsPanel extends JPanel {
         speedSlider.setMajorTickSpacing(25);
         speedSlider.setSnapToTicks(true);
         speedSlider.setPaintLabels(true);
-        speedSlider.setMinimum(1);
         speedSlider.setOrientation(SwingConstants.VERTICAL);
-        Hashtable<Integer, JLabel> speedSliderLabels = new Hashtable<Integer, JLabel>();
-        speedSliderLabels.put(1, new JLabel("1"));
-        speedSliderLabels.put(25, new JLabel("25"));
-        speedSliderLabels.put(50, new JLabel("50"));
-        speedSliderLabels.put(75, new JLabel("75"));
-        speedSliderLabels.put(100, new JLabel("100"));
-        speedSlider.setLabelTable(speedSliderLabels);
         panelControls.add(speedSlider, "20, 4, 1, 9"); //$NON-NLS-1$
         speedSlider.addChangeListener(new ChangeListener() {
             @Override

--- a/src/main/java/org/openpnp/gui/JogControlsPanel.java
+++ b/src/main/java/org/openpnp/gui/JogControlsPanel.java
@@ -364,7 +364,15 @@ public class JogControlsPanel extends JPanel {
         speedSlider.setMajorTickSpacing(25);
         speedSlider.setSnapToTicks(true);
         speedSlider.setPaintLabels(true);
+        speedSlider.setMinimum(1);
         speedSlider.setOrientation(SwingConstants.VERTICAL);
+        Hashtable<Integer, JLabel> speedSliderLabels = new Hashtable<Integer, JLabel>();
+        speedSliderLabels.put(1, new JLabel("1"));
+        speedSliderLabels.put(25, new JLabel("25"));
+        speedSliderLabels.put(50, new JLabel("50"));
+        speedSliderLabels.put(75, new JLabel("75"));
+        speedSliderLabels.put(100, new JLabel("100"));
+        speedSlider.setLabelTable(speedSliderLabels);
         panelControls.add(speedSlider, "20, 4, 1, 9"); //$NON-NLS-1$
         speedSlider.addChangeListener(new ChangeListener() {
             @Override

--- a/src/main/java/org/openpnp/gui/JogControlsPanel.java
+++ b/src/main/java/org/openpnp/gui/JogControlsPanel.java
@@ -369,9 +369,14 @@ public class JogControlsPanel extends JPanel {
         speedSlider.addChangeListener(new ChangeListener() {
             @Override
             public void stateChanged(ChangeEvent e) {
-                Configuration.get()
-                .getMachine()
-                .setSpeed(speedSlider.getValue() * 0.01);
+                try {
+                    Configuration.get()
+                    .getMachine()
+                    .setSpeed(speedSlider.getValue() * 0.01);
+                }
+                catch (Exception ex) {
+                    // TODO: I don't like this
+                };
             }
         });
 
@@ -768,6 +773,8 @@ public class JogControlsPanel extends JPanel {
         @Override
         public void configurationComplete(Configuration configuration) throws Exception {
             setUnits(configuration.getSystemUnits());
+            speedSlider.setMinimum((int) (configuration.getMachine().getSpeedLimitLow() * 100));
+            speedSlider.setMaximum((int) (configuration.getMachine().getSpeedLimitHigh() * 100));
             speedSlider.setValue((int) (configuration.getMachine()
                     .getSpeed()
                     * 100));

--- a/src/main/java/org/openpnp/machine/reference/wizards/ReferenceMachineConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/wizards/ReferenceMachineConfigurationWizard.java
@@ -16,6 +16,7 @@ import org.openpnp.gui.support.AbstractConfigurationWizard;
 import org.openpnp.gui.support.DoubleConverter;
 import org.openpnp.gui.support.LengthConverter;
 import org.openpnp.gui.support.MutableLocationProxy;
+import org.openpnp.gui.support.PercentConverter;
 import org.openpnp.machine.reference.ReferenceMachine;
 import org.openpnp.model.Configuration;
 import org.openpnp.spi.MotionPlanner;
@@ -41,6 +42,8 @@ public class ReferenceMachineConfigurationWizard extends AbstractConfigurationWi
     private JTextField unsafeZRoamingDistance;
     private JCheckBox parkAfterHomed;
     private JCheckBox poolScriptingEngines;
+    private JTextField speedLimitLow;
+    private JTextField speedLimitHigh;
 
     public ReferenceMachineConfigurationWizard(ReferenceMachine machine) {
         this.machine = machine;
@@ -57,6 +60,10 @@ public class ReferenceMachineConfigurationWizard extends AbstractConfigurationWi
                 FormSpecs.RELATED_GAP_COLSPEC,
                 FormSpecs.DEFAULT_COLSPEC,},
             new RowSpec[] {
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
                 FormSpecs.RELATED_GAP_ROWSPEC,
                 FormSpecs.DEFAULT_ROWSPEC,
                 FormSpecs.RELATED_GAP_ROWSPEC,
@@ -122,6 +129,20 @@ public class ReferenceMachineConfigurationWizard extends AbstractConfigurationWi
 
         poolScriptingEngines = new JCheckBox("");
         panelGeneral.add(poolScriptingEngines, "4, 18");
+
+        JLabel lblSpeedLimitLow = new JLabel("Speed limit low");
+        panelGeneral.add(lblSpeedLimitLow, "2, 20, right, default");
+        
+        speedLimitLow = new JTextField("");
+        panelGeneral.add(speedLimitLow, "4, 20, fill, default");
+        speedLimitLow.setColumns(10);
+
+        JLabel lblSpeedLimitHigh = new JLabel("Speed limit high");
+        panelGeneral.add(lblSpeedLimitHigh, "2, 22, right, default");
+        
+        speedLimitHigh = new JTextField("");
+        panelGeneral.add(speedLimitHigh, "4, 22, fill, default");
+        speedLimitHigh.setColumns(10);
 
                 JPanel panelLocations = new JPanel();
         panelLocations.setBorder(new TitledBorder(null, "Locations", TitledBorder.LEADING,
@@ -191,6 +212,7 @@ public class ReferenceMachineConfigurationWizard extends AbstractConfigurationWi
         DoubleConverter doubleConverter =
                 new DoubleConverter(Configuration.get().getLengthDisplayFormat());
         LengthConverter lengthConverter = new LengthConverter();
+        PercentConverter percentConverter = new PercentConverter();
 
         addWrappedBinding(machine, "homeAfterEnabled", checkBoxHomeAfterEnabled, "selected");
         addWrappedBinding(machine, "parkAfterHomed", parkAfterHomed, "selected");
@@ -202,6 +224,8 @@ public class ReferenceMachineConfigurationWizard extends AbstractConfigurationWi
         addWrappedBinding(this, "motionPlannerClassName", motionPlannerClass, "selectedItem");
 
         addWrappedBinding(machine, "poolScriptingEngines", poolScriptingEngines, "selected");
+        addWrappedBinding(machine, "speedLimitLow", speedLimitLow, "text", percentConverter);
+        addWrappedBinding(machine, "speedLimitHigh", speedLimitHigh, "text", percentConverter);
 
         MutableLocationProxy discardLocation = new MutableLocationProxy();
         bind(UpdateStrategy.READ_WRITE, machine, "discardLocation", discardLocation, "location");

--- a/src/main/java/org/openpnp/spi/Machine.java
+++ b/src/main/java/org/openpnp/spi/Machine.java
@@ -330,9 +330,17 @@ public interface Machine extends WizardConfigurable, PropertySheetHolder, Closea
 
     public Location getDiscardLocation();
 
-    public void setSpeed(double speed);
+    public void setSpeed(double speed) throws Exception;
 
     public double getSpeed();
+
+    public void setSpeedLimitLow(double speed);
+
+    public double getSpeedLimitLow();
+
+    public void setSpeedLimitHigh(double speed);
+
+    public double getSpeedLimitHigh();
     
     public Object getProperty(String name);
     

--- a/src/main/java/org/openpnp/spi/base/AbstractMachine.java
+++ b/src/main/java/org/openpnp/spi/base/AbstractMachine.java
@@ -93,6 +93,12 @@ public abstract class AbstractMachine extends AbstractModelObject implements Mac
 
     @Attribute(required = false)
     protected double speed = 1.0D;
+
+    @Attribute(required = false)
+    protected double speedLimitLow = 0.05D;
+
+    @Attribute(required = false)
+    protected double speedLimitHigh = 1.0D;
     
     @ElementMap(required = false)
     protected HashMap<String, Object> properties = new HashMap<>();
@@ -733,13 +739,44 @@ public abstract class AbstractMachine extends AbstractModelObject implements Mac
     }
 
     @Override
-    public void setSpeed(double speed) {
+    public void setSpeed(double speed) throws Exception {
+        if (speed < speedLimitLow) {
+            throw new Exception("A speed lower than the low speed limit cannot be set.");
+        }
+        else if (speed > speedLimitHigh) {
+            throw new Exception("A speed higher than the high speed limit cannot be set.");
+        }
+
         this.speed = speed;
     }
 
     @Override
     public double getSpeed() {
         return speed;
+    }
+
+    @Override
+    public void setSpeedLimitLow(double speedLimitLowPercent) {
+        // if (speedLimitLowPercent < 0 || speedLimitLowPercent > speedLimitHighPercent) {
+        //     throw new Exception("The lower speed limit is invalid.");
+        // }
+
+        this.speedLimitLow = speedLimitLowPercent;
+    }
+
+    @Override
+    public double getSpeedLimitLow() {
+        return speedLimitLow;
+    }
+
+    @Override
+    public void setSpeedLimitHigh(double speedLimitHighPercent) {
+        this.speedLimitHigh = speedLimitHighPercent;
+    }
+
+    @Override
+    public double getSpeedLimitHigh() {
+        return speedLimitHigh;
     }
 
     @Override


### PR DESCRIPTION
Moving a machine with 0 % speed doesn't seem to provide a lot of value.
Ticks are kept at 1, 25, 50, 75, 100 %.

# Description
Speed slider range is now limited to 1 % at the bottom, but labels are kept tidy as they are set manually.

# Justification
I don't think that normal usage of the UI should trigger an exception if there is nothing exceptional to report.

# Instructions for Use
No instructions required.
1. How did you test the change?
=> Loading OpenPnP demo machine, checking correct debug log speed info from 0.01 - 1 while jogging.
2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)?
=> Yes.
3. If you made changes in the org.openpnp.spi or org.openpnp.model packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing.
=> No changes
4. Be sure to run mvn test before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted. 
=> Done, passed
