### PR TITLE
parsing new additional comment (optional) field when import csv (NamedCsvImporter)

### DIFF
--- a/src/main/java/org/openpnp/gui/importer/NamedCSVImporter.java
+++ b/src/main/java/org/openpnp/gui/importer/NamedCSVImporter.java
@@ -120,8 +120,9 @@ public class NamedCSVImporter implements BoardImporter {
     private static final String Rots[] = {"ROTATION", "ROT", "ROTATE", "SYM_ROTATE"};
     private static final String TBs[] = {"LAYER", "SIDE", "TB", "SYM_MIRROR"};
     private static final String Heights[] = {"HEIGHT", "HEIGHT(MIL)", "HEIGHT(MM)"};
+    private static final String Comments[] = {"ADDCOMMENT"};
     //////////////////////////////////////////////////////////
-    static private int Ref = -1, Val = -1, Pack = -1, X = -1, Y = -1, Rot = -1, TB = -1, HT = -1,
+    static private int Ref = -1, Val = -1, Pack = -1, X = -1, Y = -1, Rot = -1, TB = -1, HT = -1, Comment = -1,
             Len = 0;
     static private int units_mils_x = 0, units_mils_y = 0, units_mils_height = 0; // set if units
                                                                                   // are in mils not
@@ -171,6 +172,7 @@ public class NamedCSVImporter implements BoardImporter {
             // the following fields are optional
             HT = checkCSV(Heights, str); // optional height field
             TB = checkCSV(TBs, str); // optional top/bottom layer field
+            Comment = checkCSV(Comments, str); // optional comment field
 
             Len = Ref <= Len ? Len : Ref;
             Len = Val <= Len ? Len : Val;
@@ -191,6 +193,7 @@ public class NamedCSVImporter implements BoardImporter {
         Logger.trace("checkCSV: Rot = " + Rot);
         Logger.trace("checkCSV: TB = " + TB);
         Logger.trace("checkCSV: HT = " + HT);
+        Logger.trace("checkCSV: Comment = " + Comment);
         Ref = -1;
         Val = -1;
         Pack = -1;
@@ -199,6 +202,7 @@ public class NamedCSVImporter implements BoardImporter {
         Rot = -1;
         TB = -1;
         HT = -1;
+        Comment = -1;
         Len = 0;
         return false;
     }
@@ -362,6 +366,10 @@ public class NamedCSVImporter implements BoardImporter {
                     }
                     placement.setPart(part);
 
+                }
+
+                if(Comment != -1) {
+                    placement.setComments(as[Comment]);
                 }
 
                 char c = 0;


### PR DESCRIPTION
# Description
Feature  in NamedCsvImporter for parsing new field (additional comments) for add to column `comments` in `Placements` section.

# Justification
Useful feature for insert comments to board from own cad design:
https://groups.google.com/g/openpnp/c/0ARswEbQ1m8

# Instructions for Use
In csv file add field named: "Addcomment" (additional comment)
![image](https://user-images.githubusercontent.com/9434930/188248266-a9da4272-6bff-4ec8-89a4-18c893042346.png)
so when import to openpnp, column comments will be populated
![image](https://user-images.githubusercontent.com/9434930/188248322-1cf82997-2783-4b24-8282-8c5b8a0e93d2.png)

# Implementation Details
1. Tested in real environment
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. Successfull `mvn test` before submitting the Pull Request.
