### PR TITLE
Feature / Better Blow-Off Control

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/ReferenceNozzle.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceNozzle.java
@@ -983,6 +983,14 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
         blowOffActuator = actuator;
     }
 
+    public boolean isBlowOffClosingValve() {
+        return blowOffClosingValve;
+    }
+
+    public void setBlowOffClosingValve(boolean blowOffClosingValve) {
+        this.blowOffClosingValve = blowOffClosingValve;
+    }
+
     protected void actuateVacuumValve(boolean on) throws Exception {
         if (on) {
             getHead().actuatePumpRequest(this, true);

--- a/src/main/java/org/openpnp/machine/reference/ReferenceNozzle.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceNozzle.java
@@ -91,6 +91,9 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
     private String blowOffActuatorName;
 
     @Attribute(required = false)
+    private boolean blowOffClosingValve;
+
+    @Attribute(required = false)
     private int version; // the OpenPnP target version/migration status (version x 100)
 
     @Deprecated
@@ -390,12 +393,14 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
         // if the method needs it, store one measurement up front
         storeBeforePlaceVacuumLevel();
 
-        if (getPart() != null) {
-            double placeBlowLevel = getPart().getPackage().getPlaceBlowOffLevel();
-            if (Double.compare(placeBlowLevel, Double.valueOf(0.0)) != 0) {
-                actuateBlowValve(placeBlowLevel);
-            } 
-            else {
+        double placeBlowLevel = nozzleTip.getPlaceBlowOffLevel();
+        if (getPart() != null 
+                && getPart().getPackage().getPlaceBlowOffLevel() != 0) {
+            placeBlowLevel = getPart().getPackage().getPlaceBlowOffLevel();
+        }
+        if (placeBlowLevel != 0) {
+            actuateBlowValve(placeBlowLevel);
+            if (!blowOffClosingValve) {
                 actuateVacuumValve(false);
             }
         }

--- a/src/main/java/org/openpnp/machine/reference/ReferenceNozzle.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceNozzle.java
@@ -91,7 +91,7 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
     private String blowOffActuatorName;
 
     @Attribute(required = false)
-    private boolean blowOffClosingValve;
+    private boolean blowOffClosingValve = true;
 
     @Attribute(required = false)
     private int version; // the OpenPnP target version/migration status (version x 100)

--- a/src/main/java/org/openpnp/machine/reference/ReferenceNozzleTip.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceNozzleTip.java
@@ -54,6 +54,9 @@ public class ReferenceNozzleTip extends AbstractNozzleTip {
     @Attribute(required = false)
     private int placeDwellMilliseconds;
 
+    @Attribute(required = false)
+    private double placeBlowOffLevel;
+
     @Element(required = false)
     private Location changerStartLocation = new Location(LengthUnit.Millimeters);
 
@@ -393,6 +396,14 @@ public class ReferenceNozzleTip extends AbstractNozzleTip {
 
     public void setPlaceDwellMilliseconds(int placeDwellMilliseconds) {
         this.placeDwellMilliseconds = placeDwellMilliseconds;
+    }
+
+    public double getPlaceBlowOffLevel() {
+        return placeBlowOffLevel;
+    }
+
+    public void setPlaceBlowOffLevel(double placeBlowOffLevel) {
+        this.placeBlowOffLevel = placeBlowOffLevel;
     }
 
     public Location getChangerStartLocation() {

--- a/src/main/java/org/openpnp/machine/reference/solutions/CalibrationSolutions.java
+++ b/src/main/java/org/openpnp/machine/reference/solutions/CalibrationSolutions.java
@@ -1101,10 +1101,14 @@ public class CalibrationSolutions implements Solutions.Subject {
             throws Exception {
         try {
             // Create a pseudo part, package and feeder to enable pick and place.
-            Part testPart = new Part("TEST-OBJECT");
-            testPart.setHeight(new Length(0.01, LengthUnit.Millimeters));
-            Package packag = new Package("TEST-OBJECT-PACKAGE");
-            testPart.setPackage(packag);
+            Part testPart = Configuration.get().getPart("TEST-OBJECT");
+            if (testPart == null) {
+                // No predefined part, create one temporarily 
+                testPart = new Part("TEST-OBJECT");
+                testPart.setHeight(new Length(0.01, LengthUnit.Millimeters));
+                Package packag = new Package("TEST-OBJECT-PACKAGE");
+                testPart.setPackage(packag);
+            }
             ReferenceTubeFeeder feeder = new ReferenceTubeFeeder();
             feeder.setPart(testPart);
             // Get the initial precise test object location. It must lay on the primary fiducial. 

--- a/src/main/java/org/openpnp/machine/reference/wizards/ReferenceNozzleTipConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/wizards/ReferenceNozzleTipConfigurationWizard.java
@@ -19,6 +19,7 @@
 
 package org.openpnp.machine.reference.wizards;
 
+import java.awt.Color;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -26,15 +27,18 @@ import javax.swing.JCheckBox;
 import javax.swing.JComponent;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
+import javax.swing.JTextArea;
 import javax.swing.JTextField;
 import javax.swing.UIManager;
 import javax.swing.border.TitledBorder;
 
 import org.openpnp.gui.components.ComponentDecorators;
 import org.openpnp.gui.support.AbstractConfigurationWizard;
+import org.openpnp.gui.support.DoubleConverter;
 import org.openpnp.gui.support.IntegerConverter;
 import org.openpnp.gui.support.LengthConverter;
 import org.openpnp.machine.reference.ReferenceNozzleTip;
+import org.openpnp.model.Configuration;
 
 import com.jgoodies.forms.layout.CellConstraints;
 import com.jgoodies.forms.layout.ColumnSpec;
@@ -44,10 +48,10 @@ import com.jgoodies.forms.layout.RowSpec;
 
 public class ReferenceNozzleTipConfigurationWizard extends AbstractConfigurationWizard {
     private final ReferenceNozzleTip nozzleTip;
-    private JPanel panelDwellTime;
+    private JPanel panelPickAndPlace;
     private JLabel lblPickDwellTime;
     private JLabel lblPlaceDwellTime;
-    private JLabel lblDwellTime;
+    private JTextArea lblDwellTime;
     private JTextField pickDwellTf;
     private JTextField placeDwellTf;
 
@@ -69,6 +73,8 @@ public class ReferenceNozzleTipConfigurationWizard extends AbstractConfiguration
     private JTextField minPartDiameter;
     private JLabel lblMaxPickTolerance;
     private JTextField maxPickTolerance;
+    private JLabel lblPlaceBlowoffLevel;
+    private JTextField placeBlowOffLevel;
 
 
     public ReferenceNozzleTipConfigurationWizard(ReferenceNozzleTip nozzleTip) {
@@ -93,17 +99,19 @@ public class ReferenceNozzleTipConfigurationWizard extends AbstractConfiguration
         panel.add(nameTf, "4, 2, fill, default");
         nameTf.setColumns(10);
         
-        panelDwellTime = new JPanel();
-        panelDwellTime.setBorder(new TitledBorder(null, "Dwell Times", TitledBorder.LEADING, TitledBorder.TOP, null, null));
-        contentPanel.add(panelDwellTime);
-        panelDwellTime.setLayout(new FormLayout(new ColumnSpec[] {
+        panelPickAndPlace = new JPanel();
+        panelPickAndPlace.setBorder(new TitledBorder(UIManager.getBorder("TitledBorder.border"), "Pick & Place", TitledBorder.LEADING, TitledBorder.TOP, null, new Color(0, 0, 0)));
+        contentPanel.add(panelPickAndPlace);
+        panelPickAndPlace.setLayout(new FormLayout(new ColumnSpec[] {
                 FormSpecs.RELATED_GAP_COLSPEC,
                 ColumnSpec.decode("max(70dlu;default)"),
                 FormSpecs.RELATED_GAP_COLSPEC,
                 FormSpecs.DEFAULT_COLSPEC,
                 FormSpecs.RELATED_GAP_COLSPEC,
-                ColumnSpec.decode("default:grow"),},
+                ColumnSpec.decode("min(100dlu;pref):grow"),},
             new RowSpec[] {
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
                 FormSpecs.RELATED_GAP_ROWSPEC,
                 FormSpecs.DEFAULT_ROWSPEC,
                 FormSpecs.RELATED_GAP_ROWSPEC,
@@ -112,22 +120,36 @@ public class ReferenceNozzleTipConfigurationWizard extends AbstractConfiguration
                 FormSpecs.DEFAULT_ROWSPEC,}));
           
         lblPickDwellTime = new JLabel("Pick Dwell Time (ms)");
-        panelDwellTime.add(lblPickDwellTime, "2, 2, right, default");
+        panelPickAndPlace.add(lblPickDwellTime, "2, 2, right, default");
         
         pickDwellTf = new JTextField();
-        panelDwellTime.add(pickDwellTf, "4, 2");
+        panelPickAndPlace.add(pickDwellTf, "4, 2");
         pickDwellTf.setColumns(10);
+        lblDwellTime = new JTextArea ("Note: Total Dwell Time is the sum of Nozzle Dwell Time plus the Nozzle Tip Dwell Time.");
+        lblDwellTime.setBackground(UIManager.getColor("Label.background"));
+        lblDwellTime.setForeground(UIManager.getColor("Label.foreground"));
+        lblDwellTime.setFont(UIManager.getFont("Label.font"));
+        lblDwellTime.setWrapStyleWord(true);
+        lblDwellTime.setLineWrap(true);
+        lblDwellTime.setEditable(false);
+        panelPickAndPlace.add(lblDwellTime, "6, 2, 1, 3, fill, center");
         
         lblPlaceDwellTime = new JLabel("Place Dwell Time (ms)");
-        panelDwellTime.add(lblPlaceDwellTime, "2, 4, right, default");
+        panelPickAndPlace.add(lblPlaceDwellTime, "2, 4, right, default");
         
         placeDwellTf = new JTextField();
-        panelDwellTime.add(placeDwellTf, "4, 4");
+        panelPickAndPlace.add(placeDwellTf, "4, 4");
         placeDwellTf.setColumns(10);
         
         CellConstraints cc = new CellConstraints();
-        lblDwellTime = new JLabel("Note: Total Dwell Time is the sum of Nozzle Dwell Time plus the Nozzle Tip Dwell Time.");
-        panelDwellTime.add(lblDwellTime, cc.xywh(2, 6, 5, 1));
+        
+        lblPlaceBlowoffLevel = new JLabel("Place Blow-Off Level");
+        lblPlaceBlowoffLevel.setToolTipText("Default placement blow-off level, if none is given on the Package. ");
+        panelPickAndPlace.add(lblPlaceBlowoffLevel, "2, 8, right, default");
+        
+        placeBlowOffLevel = new JTextField();
+        panelPickAndPlace.add(placeBlowOffLevel, "4, 8, fill, default");
+        placeBlowOffLevel.setColumns(10);
 
         panelPushAndDrag = new JPanel();
         panelPushAndDrag.setBorder(new TitledBorder(UIManager.getBorder("TitledBorder.border"), "Push and Drag Usage", TitledBorder.LEADING, TitledBorder.TOP, null));
@@ -238,11 +260,13 @@ public class ReferenceNozzleTipConfigurationWizard extends AbstractConfiguration
     public void createBindings() {
         IntegerConverter intConverter = new IntegerConverter();
         LengthConverter lengthConverter = new LengthConverter();
-
+        DoubleConverter doubleConverter = new DoubleConverter(Configuration.get().getLengthDisplayFormat());
+        
         addWrappedBinding(nozzleTip, "name", nameTf, "text");
 
         addWrappedBinding(nozzleTip, "pickDwellMilliseconds", pickDwellTf, "text", intConverter);
         addWrappedBinding(nozzleTip, "placeDwellMilliseconds", placeDwellTf, "text", intConverter);
+        addWrappedBinding(nozzleTip, "placeBlowOffLevel", placeBlowOffLevel, "text", doubleConverter);
 
         addWrappedBinding(nozzleTip, "diameterLow", textFieldLowDiameter, "text", lengthConverter);
 

--- a/src/main/java/org/openpnp/machine/reference/wizards/ReferenceNozzleVacuumWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/wizards/ReferenceNozzleVacuumWizard.java
@@ -21,6 +21,7 @@ package org.openpnp.machine.reference.wizards;
 
 import java.awt.BorderLayout;
 
+import javax.swing.JCheckBox;
 import javax.swing.JComboBox;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
@@ -46,6 +47,8 @@ public class ReferenceNozzleVacuumWizard extends AbstractConfigurationWizard {
     private JComboBox blowOffComboBoxActuator;
     private JLabel lblSensingActuator;
     private JComboBox vacuumSenseActuator;
+    private JLabel lblClosingValve;
+    private JCheckBox blowOffClosingValve;
 
     public ReferenceNozzleVacuumWizard(ReferenceNozzle nozzle) {
         this.nozzle = nozzle;
@@ -61,9 +64,11 @@ public class ReferenceNozzleVacuumWizard extends AbstractConfigurationWizard {
         contentPanel.add(panel);
         panel.setLayout(new FormLayout(new ColumnSpec[] {
                 FormSpecs.RELATED_GAP_COLSPEC,
-                FormSpecs.DEFAULT_COLSPEC,
+                ColumnSpec.decode("max(70dlu;default)"),
                 FormSpecs.RELATED_GAP_COLSPEC,
                 FormSpecs.DEFAULT_COLSPEC,
+                FormSpecs.RELATED_GAP_COLSPEC,
+                ColumnSpec.decode("max(50dlu;default)"),
                 FormSpecs.RELATED_GAP_COLSPEC,
                 FormSpecs.DEFAULT_COLSPEC,},
             new RowSpec[] {
@@ -88,6 +93,13 @@ public class ReferenceNozzleVacuumWizard extends AbstractConfigurationWizard {
         blowOffComboBoxActuator.setMaximumRowCount(15);
         blowOffComboBoxActuator.setModel(new ActuatorsComboBoxModel(nozzle.getHead()));
         panel.add(blowOffComboBoxActuator, "4, 4");
+        
+        lblClosingValve = new JLabel("Closes Vacuum Actuator?");
+        lblClosingValve.setToolTipText("<html>\r\nActuating the Blow-Off actuator also <em>implicitly</em> actuates the Vacuum actuator off.<br/>\r\nIf this is enabled, the <em>explicit</em> Off-actuation of the Vacuum actuator is ommitted.\r\n</html>");
+        panel.add(lblClosingValve, "6, 4, right, default");
+        
+        blowOffClosingValve = new JCheckBox("");
+        panel.add(blowOffClosingValve, "8, 4");
         lblSensingActuator = new JLabel("Sensing Actuator");
         panel.add(lblSensingActuator, "2, 6, right, default");
 
@@ -102,5 +114,6 @@ public class ReferenceNozzleVacuumWizard extends AbstractConfigurationWizard {
         addWrappedBinding(nozzle, "vacuumActuator", vacuumComboBoxActuator, "selectedItem", actuatorConverter);
         addWrappedBinding(nozzle, "blowOffActuator", blowOffComboBoxActuator, "selectedItem", actuatorConverter);
         addWrappedBinding(nozzle, "vacuumSenseActuator", vacuumSenseActuator, "selectedItem", actuatorConverter);
+        addWrappedBinding(nozzle, "blowOffClosingValve", blowOffClosingValve, "selected");
     }
 }


### PR DESCRIPTION
# Description
Some machines can perform a blow-off air pulse when parts are placed. This PR improves the handling of this:

- So far one had to define a blow-off level on each package, which is too much work. This PR adds a default blow-off level on the nozzle tip for a more central configuration:
  ![Default blow-off level](https://user-images.githubusercontent.com/9963310/188926762-42a0e566-e65d-436f-b01d-02ec39c4f0ad.png)
- For some machines it is assumed that the blow-off command happens to implicitly close the vacuum valve too, i.e. the valve has a sort of _three-state operation_. For this behavior one can enable the **Closes Vacuum Actuator?** option on the nozzle (default is _enabled_, to get the same behavior as before):
   ![Blow-off closes valve](https://user-images.githubusercontent.com/9963310/188930917-1169c0d2-e94e-4a37-9868-d49bd5d5eb73.png)
- Otherwise, the place operation now closes the vacuum valve, even if a blow-off value is set. This also allows for actuators on different drivers/controllers (previously impossible).  

- The Issues & Solutions nozzle offsets calibration a.k.a. "Confetti Test", now looks for a part with ID `TEST-OBJECT` to use for the calibration. Users can now create such a part in order to set a custom part height and package specific blow-off value, if needed. 
- This is [documented in the Wiki](https://github.com/openpnp/openpnp/wiki/Calibration-Solutions#calibrating-precision-camera-to-nozzle-offsets), linked from the Issues & Solutions, item (which explicitly tells the user to read the Wiki). 

# Justification
See discussion:
https://groups.google.com/g/openpnp/c/P2-vgP8-6qo/m/yagtfRQ7CQAJ

# Instructions for Use
See the Description.

# Implementation Details
1. No explicit testing was done (no such a blow-off valve on my machine, no simulation implemented). It is assumed this is done quickly by the reporting user in the testing version.
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. Successful `mvn test` before submitting the Pull Request.
