### PR TITLE
fix(sec): upgrade commons-codec to 1.13

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
 		<dependency>
 			<groupId>commons-codec</groupId>
 			<artifactId>commons-codec</artifactId>
-			<version>1.6</version>
+			<version>1.13</version>
 		</dependency>
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
Upgrade commons-codec from 1.6 to 1.13 for vulnerability fix:
- [MPS-2022-11853](https://www.oscs1024.com/hd/MPS-2022-11853)
