### PR TITLE
ReferenceLoosePartFeeder - Human Vision Fallback

### DIFF
--- a/src/main/java/org/openpnp/gui/JobPanel.java
+++ b/src/main/java/org/openpnp/gui/JobPanel.java
@@ -103,7 +103,7 @@ import com.google.common.eventbus.Subscribe;
 
 @SuppressWarnings("serial")
 public class JobPanel extends JPanel {
-    enum State {
+	public enum State {
         Stopped,
         Paused,
         Running,
@@ -747,6 +747,10 @@ public class JobPanel extends JPanel {
         return true;
     }
 
+    public State getJobState() {
+    	return state;
+    }
+
     public void importBoard(Class<? extends BoardImporter> boardImporterClass) {
         if (!checkJobStopped()) {
             return;
@@ -1042,13 +1046,13 @@ public class JobPanel extends JPanel {
         }
     };
 
-    public void PauseJob() {
+    public void pauseJob() {
     	if (state == State.Running) {
             setState(State.Pausing);
     	}
     }
 
-    public void ResumeJob() {
+    public void resumeJob() {
     	 if (state == State.Paused) {
              setState(State.Running);
              jobRun();

--- a/src/main/java/org/openpnp/gui/JobPanel.java
+++ b/src/main/java/org/openpnp/gui/JobPanel.java
@@ -1042,6 +1042,19 @@ public class JobPanel extends JPanel {
         }
     };
 
+    public void PauseJob() {
+    	if (state == State.Running) {
+            setState(State.Pausing);
+    	}
+    }
+
+    public void ResumeJob() {
+    	 if (state == State.Paused) {
+             setState(State.Running);
+             jobRun();
+    	 }
+    }
+
     public final Action stepJobAction = new AbstractAction() {
         {
             putValue(SMALL_ICON, Icons.step);

--- a/src/main/java/org/openpnp/gui/components/reticle/FootprintReticle.java
+++ b/src/main/java/org/openpnp/gui/components/reticle/FootprintReticle.java
@@ -48,7 +48,7 @@ public class FootprintReticle implements Reticle {
         g2d.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
         g2d.setColor(color);
 
-        Shape shape = footprint.getPadsShape();
+        Shape shape = footprint.getShape();	// Draw Body too. getPadsShape();
         if (shape == null) {
             return;
         }

--- a/src/main/java/org/openpnp/machine/reference/ReferencePnpJobProcessor.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferencePnpJobProcessor.java
@@ -30,6 +30,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.openpnp.gui.support.Wizard;
+import org.openpnp.machine.index.exceptions.FeedFailureException;
 import org.openpnp.machine.reference.vision.AbstractPartAlignment;
 import org.openpnp.machine.reference.wizards.ReferencePnpJobProcessorConfigurationWizard;
 import org.openpnp.model.BoardLocation;
@@ -610,6 +611,9 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
                 try {
                     feed(feeder, nozzle);
                 }
+                catch (FeedFailureException e) {	// for immediate user intervention via Instructions Pane
+                	throw new JobProcessorException(null, e);
+                }
                 catch (JobProcessorException jpe) {
                     lastException = jpe;
                     continue;
@@ -646,7 +650,7 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
             throw lastException;
         }
         
-        private void feed(Feeder feeder, Nozzle nozzle) throws JobProcessorException {
+        private void feed(Feeder feeder, Nozzle nozzle) throws JobProcessorException, FeedFailureException {
             Exception lastException = null;
             for (int i = 0; i < 1 + feeder.getFeedRetryCount(); i++) {
                 try {
@@ -654,6 +658,9 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
                     
                     feeder.feed(nozzle);
                     return;
+                }
+                catch (FeedFailureException e) {	// for immediate user intervention via Instructions Pane
+                    throw e;
                 }
                 catch (Exception e) {
                     lastException = e;

--- a/src/main/java/org/openpnp/util/VisionUtils.java
+++ b/src/main/java/org/openpnp/util/VisionUtils.java
@@ -31,6 +31,8 @@ import com.google.zxing.common.HybridBinarizer;
 public class VisionUtils {
     final public static String PIPELINE_RESULTS_NAME = "results";
     final public static String PIPELINE_CONTROL_PROPERTY_NAME = "propertyName";
+    final public static String HUMAN_VISION_FALLBACK = "CV Failed. Fallback to Human Vision";	// hack for error processing.
+    private boolean humanVision = false;
 
     /**
      * Given pixel coordinates within the frame of the Camera's image, get the offsets from Camera
@@ -57,26 +59,14 @@ public class VisionUtils {
         // Calculate the difference between the center of the image to the
         // center of the match.
         double offsetX = x - (imageWidth / 2);
-        double offsetY = y - (imageHeight / 2);
+        double offsetY = (imageHeight / 2) - y;
 
-        return getPixelOffsets(camera, offsetX, offsetY);
-    }
-
-    /**
-     * Given pixel offset coordinates, get the same offsets in Camera space and units.
-     * 
-     * @param camera
-     * @param offsetX
-     * @param offsetY
-     * @return
-     */
-    public static Location getPixelOffsets(Camera camera, double offsetX, double offsetY) {
-        // Convert pixels to units
+        // And convert pixels to units
         Location unitsPerPixel = camera.getUnitsPerPixelAtZ();
         offsetX *= unitsPerPixel.getX();
         offsetY *= unitsPerPixel.getY();
-        // Convert to right-handed.
-        return new Location(unitsPerPixel.getUnits(), offsetX, -offsetY, 0, 0);
+
+        return new Location(unitsPerPixel.getUnits(), offsetX, offsetY, 0, 0);
     }
 
     /**
@@ -270,7 +260,7 @@ public class VisionUtils {
             Configuration.get().getScripting().on("Vision.PartAlignment.After", globals);
         }
     }
-
+    
     /**
      * Compute an RGB histogram over the provided image.
      * 
@@ -294,10 +284,10 @@ public class VisionUtils {
     }
 
     /**
-     * Compute an HSV histogram over the provided image.
+     * Compute an RGB histogram over the provided image.
      * 
      * @param image
-     * @return the histogram as long[channel][value] with channel 0=Hue 1=Saturation 2=Value and value 0...255.
+     * @return the histogram as long[channel][value] with channel 0=Red 1=Green 2=Blue and value 0...255.
      */
     public static long[][] computeImageHistogramHsv(BufferedImage image) {
         long[][] histogram = new long[3][256];


### PR DESCRIPTION
# Description
In ReferenceLoosePartFeeder when computer vision fails, the user get stuck and has to tweak CV settings which is often hindering especially in the middle of a job. An option to manually jog to the parts pick location could be time saving.

# Instructions for Use
When CV fails, the "Instructions Panel" shows up. The current job is paused. The user has to manually jog to the parts pick location and click "Accept" The job resumes.

# Implementation Details
1. How did you test the change? Tested in simulation.
