### PR TITLE
Fix/Machine Tasks Cleanup On Exceptions

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -10,7 +10,7 @@ jobs:
     name: Java ${{ matrix.java }}
     strategy:
       matrix:
-        java: [8, 9, 10, 11, 12, 13, 14, 15]
+        java: [8, 9, 11, 12, 13, 14, 15]
 
     steps:
       - name: Checkout Repo

--- a/src/main/java/org/openpnp/gui/support/NozzleItem.java
+++ b/src/main/java/org/openpnp/gui/support/NozzleItem.java
@@ -24,7 +24,7 @@ import org.openpnp.spi.Nozzle;
 public class NozzleItem extends HeadMountableItem {
 
     public NozzleItem(Nozzle nozzle) {
-    	super(nozzle);
+        super(nozzle);
     }
 
     public Nozzle getNozzle() {
@@ -33,10 +33,11 @@ public class NozzleItem extends HeadMountableItem {
 
     @Override
     public String toString() {
-    	Nozzle nozzle = (Nozzle)hm;
-    	
-        return String.format("Nozzle: %s - %s %s", nozzle.getName(),
-        		nozzle.getNozzleTip() != null ? nozzle.getNozzleTip().getName() : "No Nozzle Tip", 
-        		nozzle.getHead() != null ? String.format("(Head: %s)", nozzle.getHead().getName()) : "");
+        Nozzle nozzle = (Nozzle)hm;
+
+        return String.format("Nozzle: %s - %s%s %s", nozzle.getName(),
+                nozzle.getNozzleTip() != null ? nozzle.getNozzleTip().getName() : "No Nozzle Tip", 
+                nozzle.getPart() != null ? String.format(" - %s", nozzle.getPart().getId()) : "", 
+                nozzle.getHead() != null ? String.format("(Head: %s)", nozzle.getHead().getName()) : "");
     }
 }

--- a/src/main/java/org/openpnp/machine/reference/solutions/CalibrationSolutions.java
+++ b/src/main/java/org/openpnp/machine/reference/solutions/CalibrationSolutions.java
@@ -402,10 +402,11 @@ public class CalibrationSolutions implements Solutions.Subject {
                                     + "<table>"
                                     + "<tr><td align=\"right\">Detected Nozzle Head Offsets:</td>"
                                     + "<td>"+nozzle.getHeadOffsets()+"</td></tr>"
-                                    + "<tr><td align=\"right\">Previous Nozzle Head Offsets:</td>"
-                                    + "<td>"+oldNozzleOffsets+"</td></tr>"
-                                    + "<tr><td align=\"right\">Difference:</td>"
-                                    + "<td>"+nozzle.getHeadOffsets().subtract(oldNozzleOffsets)+"</td></tr>"
+                                    + (oldNozzleOffsets == null ? "" : 
+                                        "<tr><td align=\"right\">Previous Nozzle Head Offsets:</td>"
+                                        + "<td>"+oldNozzleOffsets+"</td></tr>"
+                                        + "<tr><td align=\"right\">Difference:</td>"
+                                        + "<td>"+nozzle.getHeadOffsets().subtract(oldNozzleOffsets)+"</td></tr>")
                                     + "</table>" 
                                     : "")
                             + "</html>";

--- a/src/main/java/org/openpnp/spi/base/AbstractMachine.java
+++ b/src/main/java/org/openpnp/spi/base/AbstractMachine.java
@@ -1,5 +1,7 @@
 package org.openpnp.spi.base;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -44,6 +46,7 @@ import org.simpleframework.xml.ElementList;
 import org.simpleframework.xml.ElementMap;
 import org.simpleframework.xml.core.Commit;
 
+import com.google.common.collect.Lists;
 import com.google.common.util.concurrent.FutureCallback;
 
 public abstract class AbstractMachine extends AbstractModelObject implements Machine {
@@ -539,6 +542,10 @@ public abstract class AbstractMachine extends AbstractModelObject implements Mac
         return submit(callable, callback, false);
     }
 
+    private synchronized boolean isQueueEmpty() {
+        return executor == null || executor.isShutdown() || executor.getQueue().isEmpty();
+    }
+
     @Override
     public <T> Future<T> submit(final Callable<T> callable, final FutureCallback<T> callback,
             final boolean ignoreEnabled) {
@@ -551,9 +558,10 @@ public abstract class AbstractMachine extends AbstractModelObject implements Mac
 
         Callable<T> wrapper = new Callable<T>() {
             public T call() throws Exception {
+                Exception exception = null;
                 try {
                     boolean isBusy = isBusy();
-                    // TODO: this should also lock drivers
+                    // Note, this also locks drivers (busy).
                     setTaskThread(Thread.currentThread());
 
                     if (!isBusy) {
@@ -563,7 +571,6 @@ public abstract class AbstractMachine extends AbstractModelObject implements Mac
 
                     // Call the task, storing the result and exception if any
                     T result = null;
-                    Exception exception = null;
                     try {
                         if (!ignoreEnabled && !isEnabled()) {
                             throw new Exception("Machine has not been started.");
@@ -596,9 +603,21 @@ public abstract class AbstractMachine extends AbstractModelObject implements Mac
                         }
                     }
 
-                    // If there was an error cancel all pending tasks.
+                    // If there was an exception, cancel all pending tasks.
                     if (exception != null) {
-                        executor.shutdownNow();
+                        synchronized (this) {
+                            if (executor != null) {
+                                // Remove all pending tasks from the queue. Note, we no longer use executor.shutdownNow() here,
+                                // as this introduces a potential race conditions where a new task submitted could be run in 
+                                // parallel with this task still finishing up. Furthermore, this task may still need to function 
+                                // nominally in its onSuccess(), onFailure(), and fireMachineBusy(false)
+                                // handlers, i.e. it must not be subject to any Thread.interrupt() calls causing InterruptedException. 
+                                // After finishing up, there will still be a call to executor.shutdownNow() (see further below).
+                                for (Runnable runnable : new ArrayList<>(executor.getQueue())) {
+                                    executor.remove(runnable);
+                                }
+                            }
+                        }
                     }
 
                     // If a callback was supplied, call it with the results
@@ -621,10 +640,18 @@ public abstract class AbstractMachine extends AbstractModelObject implements Mac
                 finally {
                     // If no more tasks are scheduled notify listeners that
                     // the machine is no longer busy
-                    if (executor.getQueue().isEmpty()) {
-                        // TODO: this should also unlock drivers
+                    if (isQueueEmpty()) {
+                        Logger.trace("Machine entering idle state.");
                         fireMachineBusy(false);
+                        // Note, this also unlocks drivers (idle).
                         setTaskThread(null);
+                    }
+                    if (exception != null) {
+                        synchronized (this) {
+                            if (executor != null) {
+                                executor.shutdownNow();
+                            }
+                        }
                     }
                 }
             }


### PR DESCRIPTION
# Description
This PR fixes these issues and bugs:

1. Indicates the part on the nozzle in Machine Controls (explains the state of the vacuum pump/need for a "discard" action).
   
   ![Screenshot_20221128_173842](https://user-images.githubusercontent.com/9963310/204397799-aa669b36-e4d0-4843-93ac-5c05fdc04595.png)

1. Remove race conditions in the machine task finishing phase, in case of exception. Cleanup handlers must still be able to execute driver actions, no `Thread.interrupt()` must yet be pending.
1. Issues & Solutions: Prevent a null pointer exception when there is no `oldNozzleOffset`, because the solution was reopened.

# Justification
User reports.

Regarding 1. and 2.: See https://groups.google.com/g/openpnp/c/eUylM0_tFns/m/1GCbFgo-AwAJ
Regarding 3: See https://groups.google.com/g/openpnp/c/2KL7a3vKqyQ/m/0ch23yA4AwAJ

# Instructions for Use
No change in use.

# Implementation Details
1. Tested by provoking exceptions in queued tasks. Final test must be reproduced on user machine.
5. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
6. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
7. Successful `mvn test` before submitting the Pull Request. 
