### PR TITLE
Fix/Fiducial Locator Default Package for Pipeline Editing

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/vision/ReferenceFiducialLocator.java
+++ b/src/main/java/org/openpnp/machine/reference/vision/ReferenceFiducialLocator.java
@@ -404,30 +404,31 @@ public class ReferenceFiducialLocator extends AbstractPartSettingsHolder impleme
             PartSettingsHolder partSettingsHolder) throws Exception {
         org.openpnp.model.Package pkg = null;
         Footprint footprint = null;
-        if (partSettingsHolder != null) {
-            if (partSettingsHolder instanceof Part) {
-                pkg = ((Part) partSettingsHolder).getPackage();
-            }
-            else if (partSettingsHolder instanceof org.openpnp.model.Package) {
-                pkg = (org.openpnp.model.Package) partSettingsHolder;
-            }
-            if (pkg == null) {
-                throw new Exception(
-                        String.format("%s %s does not have a valid package associated.", partSettingsHolder.getClass().getSimpleName(), partSettingsHolder.getShortName()));
-            }
+        if (partSettingsHolder instanceof Part) {
+            pkg = ((Part) partSettingsHolder).getPackage();
+        }
+        else if (partSettingsHolder instanceof org.openpnp.model.Package) {
+            pkg = (org.openpnp.model.Package) partSettingsHolder;
+        }
+        if (pkg == null) {
+            // If we're editing non-specific vision settings, i.e. when we are not on the Parts or Packages tab,
+            // use the FIDUCIAL-HOME as the stand-in package for pipeline editing. Defaults to a 1mm circular fiducial
+            // if it does not exist yet.
+            pkg = VisionUtils.readyHomingFiducialWithDiameter(new Length(1, LengthUnit.Millimeters), false)
+                    .getPackage();
+        }
 
-            footprint = pkg.getFootprint();
-            if (footprint == null) {
-                throw new Exception(String.format(
-                        "Package %s does not have a valid footprint. See https://github.com/openpnp/openpnp/wiki/Fiducials.",
-                        pkg.getId()));
-            }
+        footprint = pkg.getFootprint();
+        if (footprint == null) {
+            throw new Exception(String.format(
+                    "Package %s does not have a valid footprint. See https://github.com/openpnp/openpnp/wiki/Fiducials.",
+                    pkg.getId()));
+        }
 
-            if (footprint.getShape() == null) {
-                throw new Exception(String.format(
-                        "Package %s has an invalid or empty footprint.  See https://github.com/openpnp/openpnp/wiki/Fiducials.",
-                        pkg.getId()));
-            }
+        if (footprint.getShape() == null) {
+            throw new Exception(String.format(
+                    "Package %s has an invalid or empty footprint.  See https://github.com/openpnp/openpnp/wiki/Fiducials.",
+                    pkg.getId()));
         }
         pipeline.setProperty("camera", camera);
         pipeline.setProperty("part", partSettingsHolder);

--- a/src/main/java/org/openpnp/util/UiUtils.java
+++ b/src/main/java/org/openpnp/util/UiUtils.java
@@ -189,7 +189,11 @@ public class UiUtils {
             final Thrunnable actionThrunnable) {
     
         messageBoxOnException(() -> {
-            if (Configuration.get().getMachine().isEnabled()) {
+            if (moveBeforeActionDescription == null) {
+                // No motion given.
+                actionThrunnable.thrun();
+            }
+            else if (Configuration.get().getMachine().isEnabled()) {
                 // We need to move there, ask the user to confirm.
                 int result;
                 if (allowWithoutMove) {

--- a/src/main/java/org/openpnp/util/VisionUtils.java
+++ b/src/main/java/org/openpnp/util/VisionUtils.java
@@ -2,25 +2,34 @@ package org.openpnp.util;
 
 import java.awt.Color;
 import java.awt.image.BufferedImage;
+import java.io.IOException;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.commons.io.IOUtils;
+import org.openpnp.machine.reference.vision.ReferenceBottomVision;
+import org.openpnp.machine.reference.vision.ReferenceFiducialLocator;
 import org.openpnp.model.Area;
 import org.openpnp.model.AreaUnit;
 import org.openpnp.model.BoardLocation;
 import org.openpnp.model.Configuration;
+import org.openpnp.model.FiducialVisionSettings;
+import org.openpnp.model.Footprint;
 import org.openpnp.model.Length;
 import org.openpnp.model.Location;
+import org.openpnp.model.Package;
 import org.openpnp.model.Part;
 import org.openpnp.model.Point;
+import org.openpnp.model.Footprint.Pad;
 import org.openpnp.spi.Camera;
 import org.openpnp.spi.HeadMountable;
 import org.openpnp.spi.Nozzle;
 import org.openpnp.spi.PartAlignment;
 import org.openpnp.spi.PartAlignment.PartAlignmentOffset;
+import org.openpnp.vision.pipeline.CvPipeline;
 
 import com.google.zxing.BinaryBitmap;
 import com.google.zxing.MultiFormatReader;
@@ -317,5 +326,67 @@ public class VisionUtils {
             }
         }
         return histogram;
+    }
+
+    /**
+     * Ready the FIDUCIAL-HOME, either by returning the existing part or creating a new
+     * part with the given circular fiducialDiameter.
+     * 
+     * @param fiducialDiameter 
+     * @param overwrite If the FIDUCIAL-HOME already exists, overwrite it and make sure it has the given fiducialDiameter
+     * and circular shape.
+     * @return The FIDUCIAL-HOME part.
+     * @throws Exception 
+     */
+    static public Part readyHomingFiducialWithDiameter(Length fiducialDiameter, boolean overwrite) throws Exception {
+        Configuration configuration = Configuration.get();
+        Part part = configuration.getPart("FIDUCIAL-HOME");
+        if (part == null) {
+            part = new Part("FIDUCIAL-HOME");
+            configuration.addPart(part);
+        }
+        else if (!overwrite) {
+            return part;
+        }
+        org.openpnp.model.Package pkg = configuration.getPackage("FIDUCIAL-HOME");
+        if (pkg == null) {
+            pkg = new org.openpnp.model.Package("FIDUCIAL-HOME");
+            configuration.addPackage(pkg);
+        }
+        part.setPackage(pkg);
+        Footprint footprint = new Footprint();
+        footprint.setUnits(fiducialDiameter.getUnits());
+        Pad pad = new Pad();
+        pad.setName("FID");
+        pad.setWidth(fiducialDiameter.getValue());
+        pad.setHeight(fiducialDiameter.getValue());
+        pad.setRoundness(100.0);
+        footprint.addPad(pad);
+        pkg.setFootprint(footprint);
+        ReferenceFiducialLocator fiducialLocator = ReferenceFiducialLocator.getDefault();
+        String xmlPipeline = IOUtils.toString(ReferenceBottomVision.class
+                .getResource("ReferenceFiducialLocator-DefaultPipeline.xml"));
+        CvPipeline pipeline = new CvPipeline(xmlPipeline);
+        FiducialVisionSettings visionSettings = fiducialLocator.getInheritedVisionSettings(part);
+        if (pipeline.equals(visionSettings.getPipeline())) {
+            // Already the right vision settings.
+        }
+        else {
+            if (visionSettings.getUsedFiducialVisionIn().size() == 1 
+                    && visionSettings.getUsedFiducialVisionIn().get(0) == part) {
+                // Already a special setting on the part. Modify it.
+            }
+            else {
+                // Needs new settings (likely means the default was changed by the user).
+                FiducialVisionSettings newSettings = new FiducialVisionSettings();
+                newSettings.setValues(visionSettings);
+                newSettings.setName(part.getShortName());
+                part.setFiducialVisionSettings(newSettings);
+                Configuration.get().addVisionSettings(newSettings);
+                visionSettings = newSettings;
+            }
+            visionSettings.setPipeline(pipeline);
+        }
+        return part;
     }
 }

--- a/src/main/java/org/openpnp/vision/pipeline/CvPipeline.java
+++ b/src/main/java/org/openpnp/vision/pipeline/CvPipeline.java
@@ -406,6 +406,22 @@ public class CvPipeline implements AutoCloseable {
         }
     }
 
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        else if (other instanceof CvPipeline) {
+            try {
+                return toXmlString().equals(((CvPipeline) other).toXmlString());
+            }
+            catch (Exception e) {
+                //ignore
+            }
+        }
+        return false;
+    }
+
     private String generateUniqueName() {
         for (int i = 0;; i++) {
             String name = "" + i;


### PR DESCRIPTION
# Description

The fiducial locator needs a package, or more specifically its footprint, to parametrize the pipeline for the right shape and size. Pipeline parameters are now handled more strictly, therefore a missing package will result in an exception. 

![Exception](https://user-images.githubusercontent.com/9963310/205699509-4b705062-b5f6-4e90-a47b-02d2039b76f4.png)
_Image by DG_

When a user is on the **Parts** or **Packages** tab, the associated package can be determined. But this is not the case when you are on the **Vision** or **Machine Setup** tab.

This PR fixes this by defaulting to the homing fiducial as the test case for editing the pipeline. 

- Defaults the fiducial locator to the `FIDUCIAL-HOME` package for pipeline editing.
- Readying the `FIDUCIAL-HOME` part was refactored to `VisionUtils` (formerly a part of `VisionSolutions`).
- `FIDUCIAL-HOME` vision-settings are now _inherited_ when the pipeline already matches the stock pipeline (which is usually the case on new machines).
- Introduced `equals()` for `CvPipeline`, comparing them by freshly generated XML.
- Bonus: Fixed bug where the pipeline editor asked to confirm a `null` motion prior to editing the pipeline.

# Justification
User report:
https://groups.google.com/g/openpnp/c/Ov4_Cr9qE5Q/m/zeHEZtpBAQAJ

# Instructions for Use
The pipeline **Edit** button on **Fiducial Vision Settings** now becomes usable on the **Vision** and **Machine Setup** tab.

# Implementation Details
1. Tested pipeline editing, readying `FIDUCIAL-HOME` from various initial states, pipeline comparison, bugfix. 
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. Successful `mvn test` before submitting the Pull Request. 
