### PR TITLE
Fix / SwitcherCamera deadlocks

### DIFF
--- a/src/main/java/org/openpnp/spi/Machine.java
+++ b/src/main/java/org/openpnp/spi/Machine.java
@@ -277,16 +277,25 @@ public interface Machine extends WizardConfigurable, PropertySheetHolder, Closea
      * @param onlyIfEnabled True if the task must only be executed if the machine is enabled.
      * @param busyTimeout If the machine is busy executing other submitted task, the execution 
      * will be rejected when the timeout (in milliseconds) expires, throwing a TimeoutException. 
-     * This will typically happen, when a long-running operation like a Job is pending.  
+     * This will typically happen, when a long-running operation like a Job is pending.
+     * @param executeTimeout If the execution takes longer than this time (in milliseconds) the 
+     * method throws a TimeoutException. Note the callable will still continue after that.    
      * @return
      * @throws Exception
      */
-    public <T> T execute(Callable<T> callable, boolean onlyIfEnabled, long busyTimeout) throws Exception;
+    public <T> T execute(Callable<T> callable, boolean onlyIfEnabled, long busyTimeout, long executeTimeout) throws Exception;
+
+    /**
+     * Calls {@link #execute(Callable, boolean, long, long)} with default busy timeout. 
+     */
+    public default <T> T execute(Callable<T> callable, boolean onlyIfEnabled, long busyTimeout) throws Exception {
+        return execute(callable, onlyIfEnabled, busyTimeout, -1);
+    }
 
     public long DEFAULT_TASK_BUSY_TIMEOUT_MS = 1000;
 
     /**
-     * Calls {@link #execute(Callable, boolean, long)} with default busy timeout. 
+     * Calls {@link #execute(Callable, boolean, long, long)} with default busy timeout. 
      * 
      * @param <T>
      * @param callable
@@ -298,7 +307,8 @@ public interface Machine extends WizardConfigurable, PropertySheetHolder, Closea
     }
 
     /**
-     * Same as execute() but the task is only executed if the Machine is enabled. 
+     * Same as {@link #execute(Callable, boolean, long, long)} but the task is only executed 
+     * if the Machine is enabled. 
      * 
      * @param <T>
      * @param callable


### PR DESCRIPTION
# Description
Fixes deadlocks in the SwitcherCamera. 

For some time now, it is no longer admissible to actuate actuators on the UI thread, therefore a `machine.execute()` future is needed in the `SwitcherCamera`'s `internalCapture()` method . In some circumstances this can create a deadlock through the static `switcher` map shared by all switcher cameras. 

The `notifyCapture()` method normally wakes up the camera thread to broadcast a frame, either one already captured before, or a fresh one. On a `SwitcherCamera` that is currently not switched-to, this will provoke an actuator switch, which again must execute on the machine thread. If we notify the camera from a machine thread, the camera thread will likely create a busy timeout on the `machine.execute()`, as the original machine thread is still running. It is better to directly capture from the machine thread, so it can switch the actuator directly. The captured frame is then _implicitly_ notified to the camera thread and the broadcast still done.  

Details were documented in the source code, see the changes.

The solution needed a new `executeTimeout` parameter for `machine.execute()` to provide an execution timeout, resolving any deadlock situation. In this case the camera will produce an error (red x) frame. This was added "just in case", i.e. the known sources of deadlocks should now be eliminated.

# Justification
User report:
https://groups.google.com/g/openpnp/c/wDe4JqmM7cI/m/twL6E6Q6AgAJ

# Instructions for Use
No change.

# Implementation Details
1. Tested in simulation with GcodeServer.
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. Change in the `org.openpnp.spi` package `Machine.execute(Callable, boolean, long, long)`. Added new `executeTimeout` parameter.
4. Successful `mvn test` before submitting the Pull Request. 
