### PR TITLE
Fix/Roundup Testing

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/camera/AbstractBroadcastingCamera.java
+++ b/src/main/java/org/openpnp/machine/reference/camera/AbstractBroadcastingCamera.java
@@ -364,9 +364,6 @@ public abstract class AbstractBroadcastingCamera extends AbstractSettlingCamera 
     }
 
     public boolean isPreviewSuspended() {
-        if (cameraViewDirty) {
-            return false;
-        }
         return (suspendPreviewInTasks && Configuration.get().getMachine().isBusy());
     }
 }

--- a/src/main/java/org/openpnp/machine/reference/camera/SwitcherCamera.java
+++ b/src/main/java/org/openpnp/machine/reference/camera/SwitcherCamera.java
@@ -22,7 +22,10 @@ package org.openpnp.machine.reference.camera;
 import java.awt.image.BufferedImage;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 
 import org.openpnp.gui.support.Wizard;
 import org.openpnp.machine.reference.camera.wizards.SwitcherCameraConfigurationWizard;
@@ -32,6 +35,7 @@ import org.openpnp.spi.Camera;
 import org.openpnp.spi.Machine;
 import org.openpnp.spi.PropertySheetHolder;
 import org.openpnp.spi.base.AbstractActuator;
+import org.pmw.tinylog.Logger;
 import org.simpleframework.xml.Attribute;
 
 public class SwitcherCamera extends ReferenceCamera {
@@ -50,8 +54,7 @@ public class SwitcherCamera extends ReferenceCamera {
     @Attribute(required=false)
     private long actuatorDelayMillis = 500;
 
-    private boolean switching = false;
-    
+    private static ReentrantLock switchingLock = new ReentrantLock();
     private static Map<Integer, Camera> switchers = new HashMap<>();
     
     protected int getCaptureTryCount() {
@@ -60,29 +63,42 @@ public class SwitcherCamera extends ReferenceCamera {
 
     @Override
     public void notifyCapture() {
-        if (switching) {
-            // While switching, do not notifyCapture(), it would potentially create 
-            // endless recursion. The notifyCapture() will still be done by 
-            // setLastTransformedImage() when the capture that is the initiator of the 
-            // present switching is done.
-            return;
-        }
-        // If we're in a machine task already, take the opportunity to switch the camera over, if necessary.
-        // Note if we'd just let the notified camera thread do the actuator switching, it would timeout and 
-        // produce an ugly error frame, because our machine thread is likely still running.
-        Machine machine = Configuration.get().getMachine();
-        if (machine.isTask(Thread.currentThread())) {
-            synchronized (switchers) {
-                if (switchers.get(switcher) != this) {
-                    // Need to switch the camera over, provoke by capturing. 
-                    captureTransformed();
-                    // Note, captureTransformed() will do another notifyCapture() for us when the 
-                    // frame was captured, this time no switching needed. 
+        if (switchingLock.tryLock()) {
+            // Got the switching lock immediately.
+            try {
+                if (switchingLock.getHoldCount() > 1) {
+                    // Prevent reentrance. See the end of this function for comments. 
                     return;
                 }
+                if (switchers.get(switcher) != this) {
+                    // If we're in a machine task already, take the opportunity to switch the camera over, if necessary.
+                    // Note if we'd just let the notified camera thread do the actuator switching, it would timeout and 
+                    // produce an ugly error frame, because our machine thread is likely still running.
+                    Machine machine = Configuration.get().getMachine();
+                    if (machine.isTask(Thread.currentThread())) {
+                        // Need to switch the camera over, provoke by capturing. 
+                        captureTransformed();
+                        // Note, captureTransformed() will do another notifyCapture() for us when the 
+                        // frame was captured. Therefore return without super call.
+                        return;
+                    }
+                }
+                // Do the actual notify.
+                super.notifyCapture();
+            }
+            finally {
+                // Never forget to unlock.
+                switchingLock.unlock();
             }
         }
-        super.notifyCapture();
+        // When we do not get the switching lock immediately and non-reentrantly, swallow the notifyCapture(), 
+        // it would potentially create endless recursion. The notifyCapture() will later be done by setLastTransformedImage() 
+        // when the current holder of the lock is done. 
+        // Note that notifications from functional (machine task) captures will always already own the (reentrant) 
+        // switchingLock from internalCapture() and therefore never be in this situation. Conversely, for mere "refresh" 
+        // captures it is ok to drop frames, even for different cameras.
+
+        // Therefore return without super call.
     }
 
     @Override
@@ -90,50 +106,59 @@ public class SwitcherCamera extends ReferenceCamera {
         if (!ensureOpen()) {
             return null;
         }
-        synchronized (switchers) {
-            if (switchers.get(switcher) != this) {
+        try {
+            if (switchingLock.tryLock(actuatorDelayMillis, TimeUnit.MILLISECONDS)) {
                 try {
-                    // Flag the transition to prevent endless recursion through notifyCapture()
-                    // which is called by the switching actuator through fireHeadActivity().
-                    switching = true;
-                    // The switching is subject to fail, so make the state indeterminate.
-                    switchers.put(switcher, null);
-                    // Make sure this happens within a machine task, but wait for it.
-                    Camera switchedCamera = Configuration.get().getMachine().execute(() -> {
+                    if (switchers.get(switcher) != this) {
+                        // The switching is subject to fail, so make the state indeterminate.
+                        switchers.put(switcher, null);
+                        // Make sure actuator switching happens within a machine task, but wait for it.
+                        Camera switchedCamera = Configuration.get().getMachine().execute(() -> {
                             getActuator().actuate(actuatorDoubleValue);
                             return this;
                         }, 
-                        true,                   // Execute only if the Machine is enabled. 
-                        actuatorDelayMillis,    // Max wait for machine to be idle.
-                        actuatorDelayMillis     // Max wait for it to finish, which prevents deadlock through static SwitcherCamera.switchers. 
-                                                // Note, because of the switcher actuator and machine task involvement, deadlocks cannot be excluded 
-                                                // in general .
-                    );
-                    if (this != switchedCamera) {
-                        return null;
+                                true,                   // Execute only if the Machine is enabled. 
+                                actuatorDelayMillis,    // Max wait for machine to be idle.
+                                actuatorDelayMillis     // Max wait for it to finish, which prevents deadlock through static SwitcherCamera.switchers. 
+                                // Note, because of the switcher actuator and machine task involvement, deadlocks cannot be excluded 
+                                // in general .
+                                );
+                        if (this != switchedCamera) {
+                            return null;
+                        }
+                        Thread.sleep(actuatorDelayMillis);
+                        // Succeeded, set the new state.
+                        switchers.put(switcher, this);
                     }
-                    Thread.sleep(actuatorDelayMillis);
-                    // Succeeded, set the new state.
-                    switchers.put(switcher, this);
+                    // Note, the target camera is actually a capture device with multiple analog cameras connected via multiplexer. 
+                    // Each analog camera can have a different lens attached and may be subject to different mounting imperfections, 
+                    // therefore each SwitcherCamera must have its own set of lens calibration and transforms. 
+                    // The target camera device however must not apply any calibration or transform, hence the raw capture.  
+                    return getCamera().captureRaw();
                 }
                 catch (TimeoutException e) {
                     // If the machine is busy we can't switch, so we should return a null image.
+                    Logger.debug("SwitcherCamera "+getName()+" failed to actuate "+getActuator().getName()+" with timeout.");
                     return null;
                 }
                 catch (Exception e) {
-                    e.printStackTrace();
+                    Logger.warn(e, "SwitcherCamera "+getName()+" failed to actuate "+getActuator().getName()+" with exception.");
                     return null;
                 }
                 finally {
-                    switching = false;
+                    // Never forget to unlock.
+                    switchingLock.unlock();
                 }
             }
+            else {
+                Logger.debug("SwitcherCamera "+getName()+" failed to obtain switcher lock within timeout.");
+                return null;
+            }
         }
-        // Note, the target camera is actually a capture device with multiple analog cameras connected via multiplexer. 
-        // Each analog camera can have a different lens attached and may be subject to different mounting imperfections, 
-        // therefore each SwitcherCamera must have its own set of lens calibration and transforms. 
-        // The target camera device however must not apply any calibration or transform, hence the raw capture.  
-        return getCamera().captureRaw();
+        catch (InterruptedException e) {
+            Logger.debug("SwitcherCamera "+getName()+" was interrupted trying to obtain switcher lock.");
+            return null;
+        }
     }
 
     @Override
@@ -141,13 +166,23 @@ public class SwitcherCamera extends ReferenceCamera {
         if (!isOpen()) {
             return false;
         }
-        synchronized (switchers) {
-            if (switchers.get(switcher) != this) {
-                // Always assume an off-switched camera has a new frame.
-                return true;
+        if (switchingLock.tryLock()) {
+            // Got the switching lock immediately.
+            try {
+                Camera switchedCamera = switchers.get(switcher);
+                if (switchedCamera != this && switchedCamera != null) {
+                    // Always assume an off-switched camera has a new frame.
+                    return false;
+                }
+                return getCamera().hasNewFrame();
+            }
+            finally {
+                // Never forget to unlock.
+                switchingLock.unlock();
             }
         }
-        return getCamera().hasNewFrame();
+        // Always assume a camera that is currently switching has no new frame (yet).
+        return false;
     }
 
     @Override

--- a/src/main/java/org/openpnp/machine/reference/camera/SwitcherCamera.java
+++ b/src/main/java/org/openpnp/machine/reference/camera/SwitcherCamera.java
@@ -107,7 +107,7 @@ public class SwitcherCamera extends ReferenceCamera {
             return null;
         }
         try {
-            if (switchingLock.tryLock(actuatorDelayMillis, TimeUnit.MILLISECONDS)) {
+            if (switchingLock.tryLock(actuatorDelayMillis*4, TimeUnit.MILLISECONDS)) {
                 try {
                     if (switchers.get(switcher) != this) {
                         // The switching is subject to fail, so make the state indeterminate.
@@ -120,8 +120,7 @@ public class SwitcherCamera extends ReferenceCamera {
                                 true,                   // Execute only if the Machine is enabled. 
                                 actuatorDelayMillis,    // Max wait for machine to be idle.
                                 actuatorDelayMillis     // Max wait for it to finish, which prevents deadlock through static SwitcherCamera.switchers. 
-                                // Note, because of the switcher actuator and machine task involvement, deadlocks cannot be excluded 
-                                // in general .
+                                // Note, because of the switcher actuator and machine task involvement, deadlocks cannot be excluded in general .
                                 );
                         if (this != switchedCamera) {
                             return null;

--- a/src/main/java/org/openpnp/machine/reference/driver/wizards/AbstractReferenceDriverConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/wizards/AbstractReferenceDriverConfigurationWizard.java
@@ -187,9 +187,13 @@ public class AbstractReferenceDriverConfigurationWizard extends AbstractConfigur
         panelSerial.add(comboBoxBaud, "4, 4, fill, default");
 
         comboBoxBaud.addItem(new Integer(110));
+        comboBoxBaud.addItem(new Integer(134));
+        comboBoxBaud.addItem(new Integer(150));
+        comboBoxBaud.addItem(new Integer(200));
         comboBoxBaud.addItem(new Integer(300));
         comboBoxBaud.addItem(new Integer(600));
         comboBoxBaud.addItem(new Integer(1200));
+        comboBoxBaud.addItem(new Integer(1800));
         comboBoxBaud.addItem(new Integer(2400));
         comboBoxBaud.addItem(new Integer(4800));
         comboBoxBaud.addItem(new Integer(9600));
@@ -198,14 +202,27 @@ public class AbstractReferenceDriverConfigurationWizard extends AbstractConfigur
         comboBoxBaud.addItem(new Integer(38400));
         comboBoxBaud.addItem(new Integer(56000));
         comboBoxBaud.addItem(new Integer(57600));
+        comboBoxBaud.addItem(new Integer(76800));
         comboBoxBaud.addItem(new Integer(115200));
         comboBoxBaud.addItem(new Integer(128000));
         comboBoxBaud.addItem(new Integer(153600));
         comboBoxBaud.addItem(new Integer(230400));
         comboBoxBaud.addItem(new Integer(250000));
         comboBoxBaud.addItem(new Integer(256000));
+        comboBoxBaud.addItem(new Integer(307200));
         comboBoxBaud.addItem(new Integer(460800));
+        comboBoxBaud.addItem(new Integer(500000));
+        comboBoxBaud.addItem(new Integer(576000));
+        comboBoxBaud.addItem(new Integer(614400));
         comboBoxBaud.addItem(new Integer(921600));
+        comboBoxBaud.addItem(new Integer(1000000));
+        comboBoxBaud.addItem(new Integer(1152000));
+        comboBoxBaud.addItem(new Integer(1500000));
+        comboBoxBaud.addItem(new Integer(2000000));
+        comboBoxBaud.addItem(new Integer(2500000));
+        comboBoxBaud.addItem(new Integer(3000000));
+        comboBoxBaud.addItem(new Integer(3500000));
+        comboBoxBaud.addItem(new Integer(4000000));
 
         JLabel lblParity = new JLabel(Translations.getString(
                 "AbstractReferenceDriverConfigurationWizard.CommunicationMethodPanel.ParityLabel.text")); //$NON-NLS-1$

--- a/src/main/java/org/openpnp/machine/reference/solutions/VisionSolutions.java
+++ b/src/main/java/org/openpnp/machine/reference/solutions/VisionSolutions.java
@@ -1554,6 +1554,7 @@ public class VisionSolutions implements Solutions.Subject {
         Location fiducialLocation = head.getCalibrationPrimaryFiducialLocation();
         return fiducialLocation.getLengthX().isInitialized()
                && fiducialLocation.getLengthY().isInitialized()
+               && head.getCalibrationPrimaryFiducialDiameter() != null
                && head.getCalibrationPrimaryFiducialDiameter().isInitialized();
     }
 
@@ -1576,6 +1577,7 @@ public class VisionSolutions implements Solutions.Subject {
         Location fiducialLocation = head.getCalibrationSecondaryFiducialLocation();
         return fiducialLocation.getLengthX().isInitialized()
                && fiducialLocation.getLengthY().isInitialized()
+               && head.getCalibrationSecondaryFiducialDiameter() != null
                && head.getCalibrationSecondaryFiducialDiameter().isInitialized();
     }
 


### PR DESCRIPTION
# Description
This is a roundup of small fixes/adjustments in the testing round.

## Primary / Secondary Fiducial Diameter Null Pointer

In case a primary/secondary fiducial location X, Y was set _manually_, but the diameter was not (still null), it resulted in a NullPointerException (see user report in the Justification). 

Note, this never happens when these are setup through **Issues & Solutions** (as is recommended). 

## Add Fast Baud-Rates for Serial Connections

Adds missing (high) baud-rates for serial connections (drivers). The missing baud-rates were taken from the jSerial "posix" implementation. 

![Fast Baud-rates](https://user-images.githubusercontent.com/9963310/209374267-1d004bef-7d8f-4876-b48e-e705d58c079c.png)

Note: some baud-rates were already in there that are not in the "posix" list, i.e. those will (still) not work on *ix OSes, but may work on Windows, these are:

- 14400
- 56000
- 128000
- 250000
- 256000

## SwitcherCameras Revisited 

Due to problems still reported after #1500 and #1503, a new approach to the SwitcherCamera was implemented: 

- SwitcherCameras may now have **Preview FPS** > 0, i.e., they can show a live image.
- However, they will no longer switch due to FPS or other frame notifications, i.e., the currently switched-to camera will remain live, the other frozen.
- Only explicit capture through user action or machine tasks will now switch a camera. 
- **Issues & Solutions** issues for **Preview FPS** have been removed, accordingly. 
- Locking in the SwitcherCamera is now very defensive, i.e. instead of using `synchronized` on the `switcher` map, which will always at least potentially be prone to deadlocks, we use a `ReentrantLock` and defensive `tryLock()`.
- **Preview FPS** or other frame notifications will always `tryLock()` and back down immediately (preview frames may be dropped, but deadlocks prevented). 
- Explicit capture will `tryLock()` with a timeout, so deadlock should be excluded even there. The timeout is four times the **Actuator Delay**, so any normal congestion should be covered, but the deadlock then resolved. The capture will then fail and deliver a "red x" frame.

## Camera Exposure Device Settings

It seems that ELP cameras have difficulty reporting the exposure setting right on Linux. Consequently, OpenPnpCaptureCamera reports a 1 to 5000 range. The range behaves non-linear, exposure is all over the place. When the Issues & Solutions static exposure calibration is run, it therefore "never" finishes. This fixes it by just spacing out a maximum of 32 probes. Tests show it still finds a reasonable value.

# Justification

Related user group discussions:

- https://groups.google.com/g/openpnp/c/eM8ISf0dbqc/m/MWTN3aBmAgAJ
- https://groups.google.com/g/openpnp/c/N_C2meRUCC4/m/fbkApNZMAgAJ
- https://groups.google.com/g/openpnp/c/wDe4JqmM7cI/m/iIWIGqBxAQAJ
- https://groups.google.com/g/openpnp/c/SpkC2XxB_jk/m/giIKoFwkAwAJ

# Instructions for Use

A SwitcherCamera may now have a **Preview FPS**  > 0 so it can remain live when switched-to.

Conversely, it is recommended to set the **Preview FPS** of the capture device to a very low value or 0, as those preview frames are snatched away from the SwitcherCamera.

# Implementation Details
1. Test with real camera and GcodeServer simulated switcher actuator.
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. Successful `mvn test` before submitting the Pull Request. 
