### PR TITLE
Fix / Atomic ReferenceDriverCommunications.writeLine()

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/driver/ReferenceDriverCommunications.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/ReferenceDriverCommunications.java
@@ -22,6 +22,8 @@ package org.openpnp.machine.reference.driver;
 import java.io.IOException;
 import java.util.concurrent.TimeoutException;
 
+import org.jfree.chart.util.ArrayUtils;
+import org.openpnp.util.Collect;
 import org.openpnp.util.GcodeServer;
 import org.simpleframework.xml.Attribute;
 
@@ -73,8 +75,8 @@ public abstract class ReferenceDriverCommunications {
     }
 
     public void writeLine(String data) throws IOException {
-        writeBytes(data.getBytes());
-        writeBytes(getLineEndingType().getLineEnding().getBytes());
+        byte [] line = Collect.concat(data.getBytes(), getLineEndingType().getLineEnding().getBytes());
+        writeBytes(line);
     }
 
     /**

--- a/src/main/java/org/openpnp/util/Collect.java
+++ b/src/main/java/org/openpnp/util/Collect.java
@@ -59,4 +59,17 @@ public class Collect {
         System.arraycopy(second, 0, result, first.length, second.length);
         return result;
     }
+
+    /**
+     * Concatenate two byte arrays. 
+     * 
+     * @param first
+     * @param second
+     * @return
+     */
+    public static byte[] concat(byte[] first, byte[] second) {
+        byte[] result = Arrays.copyOf(first, first.length + second.length);
+        System.arraycopy(second, 0, result, first.length, second.length);
+        return result;
+    }
 }


### PR DESCRIPTION
# Description
The OpenPnP driver's `ReferenceDriverCommunications.writeLine()` should work as _one_ underlying call to `writeBytes()` to prevent any breaking up of USB packets etc. 

Added needed `byte[]` implementation of `Collect.concat()`, as Java [does not seem](https://stackoverflow.com/questions/41060384/java-template-with-primitivedata-types-as-c-templates) to support primitive data types for `T` in templates.

# Justification
Breaking up of packets was reported here:
https://groups.google.com/g/openpnp/c/eM8ISf0dbqc/m/2WBtaRQkBQAJ

# Instructions for Use
No change for the user.

# Implementation Details
1. Tested in simulation with the GcodeServer (socket vs. serial is irrelevant, because `writeLine()` is case class code).
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. Successful `mvn test` before submitting the Pull Request.
