### PR TITLE
Fix/Camera Properties

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/camera/OpenPnpCaptureCamera.java
+++ b/src/main/java/org/openpnp/machine/reference/camera/OpenPnpCaptureCamera.java
@@ -90,6 +90,9 @@ public class OpenPnpCaptureCamera extends ReferenceCamera implements Runnable {
     @Element(required = false)
     private CapturePropertyHolder zoom = new CapturePropertyHolder(CaptureProperty.Zoom);
 
+    @Attribute(required = false)
+    private boolean freezeProperties = false;
+
     public List<CaptureDevice> getCaptureDevices() {
         return capture.getDevices();
     }
@@ -427,6 +430,7 @@ public class OpenPnpCaptureCamera extends ReferenceCamera implements Runnable {
         @Attribute(required = false)
         private Boolean auto;
 
+        private OpenPnpCaptureCamera camera;
         private CaptureStream stream;
 
         public CapturePropertyHolder(CaptureProperty property) {
@@ -438,6 +442,7 @@ public class OpenPnpCaptureCamera extends ReferenceCamera implements Runnable {
         }
 
         public void setCamera(OpenPnpCaptureCamera camera) {
+            this.camera = camera;
             camera.addPropertyChangeListener("device", e -> {
                 firePropertyChange("supported", null, isSupported());
             });
@@ -498,7 +503,12 @@ public class OpenPnpCaptureCamera extends ReferenceCamera implements Runnable {
 
         public boolean isAuto() {
             try {
-                return this.auto = stream.getAutoProperty(property);
+                if (this.auto == null || !this.camera.isFreezeProperties()) {
+                    return this.auto = stream.getAutoProperty(property);
+                }
+                else {
+                    return this.auto;
+                }
             }
             catch (Exception e) {
                 return false;
@@ -527,7 +537,12 @@ public class OpenPnpCaptureCamera extends ReferenceCamera implements Runnable {
 
         public int getValue() {
             try {
-                return this.value = stream.getProperty(property);
+                if (this.value == null || !this.camera.isFreezeProperties()) {
+                    return this.value = stream.getProperty(property);
+                }
+                else {
+                    return this.value;
+                }
             }
             catch (Exception e) {
                 return 0;
@@ -553,5 +568,23 @@ public class OpenPnpCaptureCamera extends ReferenceCamera implements Runnable {
                 return false;
             }
         }
+    }
+
+    public boolean isFreezeProperties() {
+        return freezeProperties;
+    }
+
+    public void setFreezeProperties(boolean freezeProperties) {
+        Object oldValue = this.freezeProperties;
+        this.freezeProperties = freezeProperties;
+        if (! freezeProperties) {
+            // Unfrozen properties might be read back different. 
+            reapplyProperties();
+        }
+        firePropertyChange("freezeProperties", oldValue, freezeProperties);
+    }
+
+    public void reapplyProperties() {
+        setPropertiesStream(stream);
     }
 }

--- a/src/main/java/org/openpnp/machine/reference/camera/wizards/OpenPnpCaptureCameraConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/camera/wizards/OpenPnpCaptureCameraConfigurationWizard.java
@@ -44,12 +44,18 @@ import org.openpnp.gui.support.DoubleConverter;
 import org.openpnp.gui.support.IntegerConverter;
 import org.openpnp.machine.reference.camera.OpenPnpCaptureCamera;
 import org.openpnp.model.Configuration;
+import org.openpnp.util.MovableUtils;
 import org.openpnp.util.UiUtils;
 
 import com.jgoodies.forms.layout.ColumnSpec;
 import com.jgoodies.forms.layout.FormLayout;
 import com.jgoodies.forms.layout.FormSpecs;
 import com.jgoodies.forms.layout.RowSpec;
+import org.jdesktop.beansbinding.BeanProperty;
+import org.jdesktop.beansbinding.AutoBinding;
+import org.jdesktop.beansbinding.Bindings;
+import javax.swing.AbstractAction;
+import javax.swing.Action;
 
 @SuppressWarnings("serial")
 public class OpenPnpCaptureCameraConfigurationWizard extends AbstractConfigurationWizard {
@@ -160,7 +166,20 @@ public class OpenPnpCaptureCameraConfigurationWizard extends AbstractConfigurati
     private JLabel lblCaptureFps;
     private JTextField nativeFps;
     private JButton btnTest;
-
+    private JLabel lblFreezeProperties;
+    private JCheckBox freezeProperties;
+    private JButton btnReapplyToCamera;
+    private final Action reapplyPropertiesToCameraAction = new AbstractAction() {
+        {
+            putValue(NAME, "Reapply to Camera");
+            putValue(SHORT_DESCRIPTION, "Reapply the frozen properties to the camera.");
+        }
+        public void actionPerformed(ActionEvent e) {
+            camera.reapplyProperties();
+            MovableUtils.fireTargetedUserAction(camera);
+        }
+    };
+    
     public OpenPnpCaptureCameraConfigurationWizard(OpenPnpCaptureCamera camera) {
         this.camera = camera;
         createUi();
@@ -283,6 +302,10 @@ public class OpenPnpCaptureCameraConfigurationWizard extends AbstractConfigurati
                 FormSpecs.RELATED_GAP_ROWSPEC,
                 FormSpecs.DEFAULT_ROWSPEC,
                 FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
                 FormSpecs.DEFAULT_ROWSPEC,}));
 
         lblAuto = new JLabel("Auto");
@@ -304,7 +327,7 @@ public class OpenPnpCaptureCameraConfigurationWizard extends AbstractConfigurati
         panelProperties.add(brightness, "2, 4, right, default");
 
         brightnessAuto = new JCheckBox("");
-        panelProperties.add(brightnessAuto, "4, 4");
+        panelProperties.add(brightnessAuto, "4, 4, center, default");
 
         brightnessMin = new JLabel("min");
         panelProperties.add(brightnessMin, "8, 4");
@@ -312,7 +335,7 @@ public class OpenPnpCaptureCameraConfigurationWizard extends AbstractConfigurati
         brightnessSlider = new JSlider();
         brightnessSlider.setPaintTicks(true);
         brightnessSlider.setPaintLabels(true);
-        panelProperties.add(brightnessSlider, "12, 4");
+        panelProperties.add(brightnessSlider, "12, 4, fill, default");
 
         brightnessValue = new JTextField();
         brightnessValue.setText("00000");
@@ -329,7 +352,7 @@ public class OpenPnpCaptureCameraConfigurationWizard extends AbstractConfigurati
         panelProperties.add(backLightCompensation, "2, 6, right, default");
         
         backLightCompensationAuto = new JCheckBox("");
-        panelProperties.add(backLightCompensationAuto, "4, 6");
+        panelProperties.add(backLightCompensationAuto, "4, 6, center, default");
         
         backLightCompensationMin = new JLabel("min");
         panelProperties.add(backLightCompensationMin, "8, 6");
@@ -337,7 +360,7 @@ public class OpenPnpCaptureCameraConfigurationWizard extends AbstractConfigurati
         backLightCompensationSlider = new JSlider();
         backLightCompensationSlider.setPaintTicks(true);
         backLightCompensationSlider.setPaintLabels(true);
-        panelProperties.add(backLightCompensationSlider, "12, 6");
+        panelProperties.add(backLightCompensationSlider, "12, 6, fill, default");
         
         backLightCompensationValue = new JTextField();
         backLightCompensationValue.setText("00000");
@@ -354,7 +377,7 @@ public class OpenPnpCaptureCameraConfigurationWizard extends AbstractConfigurati
         panelProperties.add(contrast, "2, 8, right, default");
 
         contrastAuto = new JCheckBox("");
-        panelProperties.add(contrastAuto, "4, 8");
+        panelProperties.add(contrastAuto, "4, 8, center, default");
 
         contrastMin = new JLabel("min");
         panelProperties.add(contrastMin, "8, 8");
@@ -362,7 +385,7 @@ public class OpenPnpCaptureCameraConfigurationWizard extends AbstractConfigurati
         contrastSlider = new JSlider();
         contrastSlider.setPaintTicks(true);
         contrastSlider.setPaintLabels(true);
-        panelProperties.add(contrastSlider, "12, 8");
+        panelProperties.add(contrastSlider, "12, 8, fill, default");
 
         contrastValue = new JTextField();
         contrastValue.setText("00000");
@@ -387,7 +410,7 @@ public class OpenPnpCaptureCameraConfigurationWizard extends AbstractConfigurati
         exposureSlider = new JSlider();
         exposureSlider.setPaintLabels(true);
         exposureSlider.setPaintTicks(true);
-        panelProperties.add(exposureSlider, "12, 10, center, default");
+        panelProperties.add(exposureSlider, "12, 10, fill, default");
 
         exposureValue = new JTextField();
         exposureValue.setText("00000");
@@ -410,7 +433,7 @@ public class OpenPnpCaptureCameraConfigurationWizard extends AbstractConfigurati
         panelProperties.add(gamma, "2, 16, right, default");
 
         gammaAuto = new JCheckBox("");
-        panelProperties.add(gammaAuto, "4, 16");
+        panelProperties.add(gammaAuto, "4, 16, center, default");
 
         gammaMin = new JLabel("min");
         panelProperties.add(gammaMin, "8, 16");
@@ -418,7 +441,7 @@ public class OpenPnpCaptureCameraConfigurationWizard extends AbstractConfigurati
         gammaSlider = new JSlider();
         gammaSlider.setPaintTicks(true);
         gammaSlider.setPaintLabels(true);
-        panelProperties.add(gammaSlider, "12, 16");
+        panelProperties.add(gammaSlider, "12, 16, fill, default");
 
         gammaValue = new JTextField();
         gammaValue.setText("00000");
@@ -435,7 +458,7 @@ public class OpenPnpCaptureCameraConfigurationWizard extends AbstractConfigurati
         panelProperties.add(hue, "2, 18, right, default");
         
         hueAuto = new JCheckBox("");
-        panelProperties.add(hueAuto, "4, 18");
+        panelProperties.add(hueAuto, "4, 18, center, default");
         
         hueMin = new JLabel("min");
         panelProperties.add(hueMin, "8, 18");
@@ -443,7 +466,7 @@ public class OpenPnpCaptureCameraConfigurationWizard extends AbstractConfigurati
         hueSlider = new JSlider();
         hueSlider.setPaintTicks(true);
         hueSlider.setPaintLabels(true);
-        panelProperties.add(hueSlider, "12, 18");
+        panelProperties.add(hueSlider, "12, 18, fill, default");
         
         hueValue = new JTextField();
         hueValue.setText("00000");
@@ -460,7 +483,7 @@ public class OpenPnpCaptureCameraConfigurationWizard extends AbstractConfigurati
         panelProperties.add(powerLineFrequency, "2, 20, right, default");
         
         powerLineFrequencyAuto = new JCheckBox("");
-        panelProperties.add(powerLineFrequencyAuto, "4, 20");
+        panelProperties.add(powerLineFrequencyAuto, "4, 20, center, default");
         
         powerLineFrequencyMin = new JLabel("min");
         panelProperties.add(powerLineFrequencyMin, "8, 20");
@@ -468,7 +491,7 @@ public class OpenPnpCaptureCameraConfigurationWizard extends AbstractConfigurati
         powerLineFrequencySlider = new JSlider();
         powerLineFrequencySlider.setPaintTicks(true);
         powerLineFrequencySlider.setPaintLabels(true);
-        panelProperties.add(powerLineFrequencySlider, "12, 20");
+        panelProperties.add(powerLineFrequencySlider, "12, 20, fill, default");
         
         powerLineFrequencyValue = new JTextField();
         powerLineFrequencyValue.setText("00000");
@@ -485,7 +508,7 @@ public class OpenPnpCaptureCameraConfigurationWizard extends AbstractConfigurati
         panelProperties.add(saturation, "2, 22, right, default");
 
         saturationAuto = new JCheckBox("");
-        panelProperties.add(saturationAuto, "4, 22");
+        panelProperties.add(saturationAuto, "4, 22, center, default");
 
         saturationMin = new JLabel("min");
         panelProperties.add(saturationMin, "8, 22");
@@ -493,7 +516,7 @@ public class OpenPnpCaptureCameraConfigurationWizard extends AbstractConfigurati
         saturationSlider = new JSlider();
         saturationSlider.setPaintTicks(true);
         saturationSlider.setPaintLabels(true);
-        panelProperties.add(saturationSlider, "12, 22");
+        panelProperties.add(saturationSlider, "12, 22, fill, default");
 
         saturationValue = new JTextField();
         saturationValue.setText("00000");
@@ -510,7 +533,7 @@ public class OpenPnpCaptureCameraConfigurationWizard extends AbstractConfigurati
         panelProperties.add(sharpness, "2, 24, right, default");
         
         sharpnessAuto = new JCheckBox("");
-        panelProperties.add(sharpnessAuto, "4, 24");
+        panelProperties.add(sharpnessAuto, "4, 24, center, default");
         
         sharpnessMin = new JLabel("min");
         panelProperties.add(sharpnessMin, "8, 24");
@@ -518,7 +541,7 @@ public class OpenPnpCaptureCameraConfigurationWizard extends AbstractConfigurati
         sharpnessSlider = new JSlider();
         sharpnessSlider.setPaintTicks(true);
         sharpnessSlider.setPaintLabels(true);
-        panelProperties.add(sharpnessSlider, "12, 24");
+        panelProperties.add(sharpnessSlider, "12, 24, fill, default");
         
         sharpnessValue = new JTextField();
         sharpnessValue.setText("00000");
@@ -543,7 +566,7 @@ public class OpenPnpCaptureCameraConfigurationWizard extends AbstractConfigurati
         whiteBalanceSlider = new JSlider();
         whiteBalanceSlider.setPaintTicks(true);
         whiteBalanceSlider.setPaintLabels(true);
-        panelProperties.add(whiteBalanceSlider, "12, 26, center, default");
+        panelProperties.add(whiteBalanceSlider, "12, 26, fill, default");
 
         whiteBalanceValue = new JTextField();
         whiteBalanceValue.setText("00000");
@@ -565,7 +588,7 @@ public class OpenPnpCaptureCameraConfigurationWizard extends AbstractConfigurati
         focusSlider = new JSlider();
         focusSlider.setPaintTicks(true);
         focusSlider.setPaintLabels(true);
-        panelProperties.add(focusSlider, "12, 12, center, default");
+        panelProperties.add(focusSlider, "12, 12, fill, default");
 
         focusValue = new JTextField();
         focusValue.setText("00000");
@@ -590,7 +613,7 @@ public class OpenPnpCaptureCameraConfigurationWizard extends AbstractConfigurati
         zoomSlider = new JSlider();
         zoomSlider.setPaintTicks(true);
         zoomSlider.setPaintLabels(true);
-        panelProperties.add(zoomSlider, "12, 28, center, default");
+        panelProperties.add(zoomSlider, "12, 28, fill, default");
 
         zoomValue = new JTextField();
         zoomValue.setText("00000");
@@ -612,7 +635,7 @@ public class OpenPnpCaptureCameraConfigurationWizard extends AbstractConfigurati
         gainSlider = new JSlider();
         gainSlider.setPaintTicks(true);
         gainSlider.setPaintLabels(true);
-        panelProperties.add(gainSlider, "12, 14, center, default");
+        panelProperties.add(gainSlider, "12, 14, fill, default");
 
         gainValue = new JTextField();
         gainValue.setText("00000");
@@ -624,10 +647,21 @@ public class OpenPnpCaptureCameraConfigurationWizard extends AbstractConfigurati
 
         zoomDefault = new JLabel("def");
         panelProperties.add(zoomDefault, "22, 28");
+        
+        lblFreezeProperties = new JLabel("Freeze Properties?");
+        lblFreezeProperties.setToolTipText("<html>\n<p>Freeze properties as applied, and reapply them to the camera<br/>\nwhenever reopened. Never query properties back from the camera.<p/>\n<p>Use this when properties are not properly persisted by the camera<p/>\ndriver, or when you use this camera in different configurations <p/>\nor apps.\n</html>");
+        panelProperties.add(lblFreezeProperties, "2, 32, right, default");
+        
+        freezeProperties = new JCheckBox("");
+        panelProperties.add(freezeProperties, "4, 32, center, default");
+        
+        btnReapplyToCamera = new JButton(reapplyPropertiesToCameraAction);
+        panelProperties.add(btnReapplyToCamera, "12, 32");
 
         for (CaptureDevice dev : camera.getCaptureDevices()) {
             deviceCb.addItem(dev);
         }
+        initDataBindings();
     }
 
     @Override
@@ -662,6 +696,8 @@ public class OpenPnpCaptureCameraConfigurationWizard extends AbstractConfigurati
         bindProperty("whiteBalance", whiteBalanceAuto, whiteBalanceMin, whiteBalanceMax,
                 whiteBalanceSlider, whiteBalance, whiteBalanceValue, whiteBalanceDefault);
         bindProperty("zoom", zoomAuto, zoomMin, zoomMax, zoomSlider, zoom, zoomValue, zoomDefault);
+
+        addWrappedBinding(camera, "freezeProperties", freezeProperties, "selected");
     }
 
     private void bindProperty(String property, JCheckBox auto, JLabel min, JLabel max,
@@ -721,5 +757,11 @@ public class OpenPnpCaptureCameraConfigurationWizard extends AbstractConfigurati
         public Boolean convertReverse(Boolean arg0) {
             return !arg0;
         }
+    }
+    protected void initDataBindings() {
+        BeanProperty<JCheckBox, Boolean> jCheckBoxBeanProperty = BeanProperty.create("selected");
+        BeanProperty<JButton, Boolean> jButtonBeanProperty = BeanProperty.create("enabled");
+        AutoBinding<JCheckBox, Boolean, JButton, Boolean> autoBinding = Bindings.createAutoBinding(UpdateStrategy.READ, freezeProperties, jCheckBoxBeanProperty, btnReapplyToCamera, jButtonBeanProperty);
+        autoBinding.bind();
     }
 }

--- a/src/main/java/org/openpnp/machine/reference/solutions/GcodeDriverSolutions.java
+++ b/src/main/java/org/openpnp/machine/reference/solutions/GcodeDriverSolutions.java
@@ -255,7 +255,8 @@ public class GcodeDriverSolutions implements Solutions.Subject {
                 if (gcodeDriver.getFirmwareProperty("FIRMWARE_NAME", "").contains("Smoothieware")) {
                     firmware = (gcodeDriver.getFirmwareProperty("X-GRBL_MODE", "").contains("1"))? 
                             FirmwareType.SmoothiewareGrblSyntax : 
-                                gcodeDriver.getFirmwareProperty("FIRMWARE_VERSION", "").contains("chmt-")?
+                                (gcodeDriver.getFirmwareProperty("FIRMWARE_VERSION", "").contains("chmt-")
+                                        || gcodeDriver.getFirmwareProperty("X-HARDWARE", "").contains("CHMT"))?
                                         FirmwareType.SmoothiewareChmt : FirmwareType.Smoothieware;
                     firmwareAxesCount = Integer.valueOf(gcodeDriver.getFirmwareProperty("X-AXES", "0"));
                     if (firmware == FirmwareType.SmoothiewareChmt) {


### PR DESCRIPTION
# Description
Fixes/improvements contained in this PR:

- New option to freeze OpenPnpCaptureCamera properties, so they will be reapplied to the camera after reopening the device. Properties not persisted correctly, or changed in other OpenPnP configurations, or other web cam applications will be restored. Connecting the wrong cameras will no longer overwrite configured property settings.
- Fixes some layout inconsistencies on the camera Device Properties form. 
- Improves the stepping through static exposure probing by Issues & Solutions. A maximum of 64 probes will be done, probes are properly stretched over the full range (no need to be a integer step size multiple).
- Fix a threading issue where the Issues & Solutions apply method would compete for the camera lighting/switching actuator, which will trigger an error message ("Machine still busy after timeout expired, task rejected"). 
- Stowaway: Support a new detection method for Smoothieware on CHMT controllers using the `X-HARDWARE` property.

# Justification
Various user reports and own tests on Linux.
- https://groups.google.com/g/openpnp/c/SpkC2XxB_jk/m/wy-fmdb9AwAJ
- https://groups.google.com/g/openpnp/c/RT9uaZO82w0/m/dqEozDd-BQAJ

# Instructions for Use

![Camera Properties, Frozen](https://user-images.githubusercontent.com/9963310/210006199-d9f0ba49-6dd2-47a2-aed8-bbb0fd2e9212.png)

The new **Freeze Properties?** determines how camera properties are handled: 

- If **disabled** (default), the camera device driver will store the properties (**Auto** and **Value**). They are queried from the camera whenever it is reopened. 
- If **enabled** (new), the OpenPnP configuration (`machine.xml`) will store all the currently set properties (**Auto** and **Value**). They are reapplied to the camera whenever it is later reopened. They can still be changed through the UI, but settings will never be overwritten from the camera device. 

Use the **Reapply to Camera** button, to reapply properties to the camera at any time. If this is required, i.e. if the camera is arbitrarily not accepting or losing its properties, please report to the [discussion group](http://groups.google.com/group/openpnp).

Enable **Freeze Properties?** when you want repeatable settings stored with the OpenPnP configuration. You can then switch between configurations or even between different applications using the web cam with no harm. The configured  properties will always be restored.

Likewise if you mistakenly reconnect the two cameras to the wrong/swapped USB port, it will no longer overwrite or reset the configured settings. Just connect to the right USB ports or select the right USB device from the drop-down and press **Apply**. The configured settings will be restored to the camera (an OpenPnP restart might be needed for a fresh USB device enumeration).

Finally, if your camera device driver or OS does not properly store settings between OpenPnP sessions or OS reboots, they are now restored as soon OpenPnP reopens the camera.

Notes: 
- If you first switch the  **Freeze Properties?** on, press **Apply** for the properties to be initially frozen. 
- Once you want to change the camera device for a different make or model, you will likely need to disable **Freeze Properties?** and press **Apply** to query reasonable settings from the new camera (availability and ranges of properties may change between makes and models). 

# Implementation Details
1. Tested under Linux with ELP and built-in web cam.
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. Successful `mvn test` before submitting the Pull Request. 
