### PR TITLE
Reapply frozen camera properties when the machine is homing.

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/camera/OpenPnpCaptureCamera.java
+++ b/src/main/java/org/openpnp/machine/reference/camera/OpenPnpCaptureCamera.java
@@ -587,4 +587,12 @@ public class OpenPnpCaptureCamera extends ReferenceCamera implements Runnable {
     public void reapplyProperties() {
         setPropertiesStream(stream);
     }
+
+    @Override
+    public void home() throws Exception {
+        super.home();
+        if (isFreezeProperties()) {
+            reapplyProperties();
+        }
+    }
 }


### PR DESCRIPTION
# Description
Based on #1510, reapply frozen camera properties when the machine is homing.

# Justification
User reports that immediate reapplication on camera open does not take.
https://groups.google.com/g/openpnp/c/SpkC2XxB_jk/m/v7DsejnEBQAJ

# Instructions for Use
See Wiki (additional instruction added):
https://github.com/openpnp/openpnp/wiki/OpenPnpCaptureCamera#freezing-camera-properties

# Implementation Details
1. Cannot test, reporting user must test.
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. Successful `mvn test` before submitting the Pull Request.
