### PR TITLE
Diptrace import rotation fix

### DIFF
--- a/src/main/java/org/openpnp/gui/importer/DipTraceImporter.java
+++ b/src/main/java/org/openpnp/gui/importer/DipTraceImporter.java
@@ -119,11 +119,20 @@ public class DipTraceImporter implements BoardImporter {
             double placementX = Double.parseDouble(tokens[2]);   		// X (mm) in Diptrace export
             double placementY = Double.parseDouble(tokens[3]);   		// Y (mm) in Diptrace export
             double placementRotation = Double.parseDouble(tokens[5]); 	// Rotate in Diptrace export
-            String placementLayer = tokens[4];    						// Side in Diptrace export
+            Side placementLayer = tokens[4].charAt(0) == 'T' ? Side.Top : Side.Bottom;    	// Side in Diptrace export
+
+            if(placementLayer == Side.Bottom){
+                // Bottom parts need to be mirrored
+                placementRotation = 180 - placementRotation;
+
+                // ensure rotation is positive for better UX
+                if(placementRotation < 0){
+                    placementRotation = placementRotation + 360;
+                }
+            }
 
             Placement placement = new Placement(placementId);
-            placement.setLocation(new Location(LengthUnit.Millimeters, placementX, placementY, 0,
-                    placementRotation));
+            placement.setLocation(new Location(LengthUnit.Millimeters, placementX, placementY, 0, placementRotation));
             Configuration cfg = Configuration.get();
             if (cfg != null && createMissingParts) {
                 String partId = pkgName + "-" + partValue;
@@ -143,7 +152,7 @@ public class DipTraceImporter implements BoardImporter {
 
             }
 
-            placement.setSide(placementLayer.charAt(0) == 'T' ? Side.Top : Side.Bottom);
+            placement.setSide(placementLayer);
             placements.add(placement);
         }
         reader.close();


### PR DESCRIPTION
DipTrace exports rotation of bottom parts 'mirrored'. This PR fixes this by mirroring parts rotation during import.

Tested on my machine. See below. All diodes should point to the center.

[rotation-30x30.csv](https://github.com/openpnp/openpnp/files/10327785/rotation-30x30.csv)

**Before the fix**

Top:
<img width="678" alt="Screenshot of Screen Sharing (31-12-2022, 12-59-21)" src="https://user-images.githubusercontent.com/1329094/210152058-4cdee66a-b13a-4b78-9f1d-8bc2a85e1451.png">

Bottom:

<img width="678" alt="Screenshot of Screen Sharing (31-12-2022, 12-59-51)" src="https://user-images.githubusercontent.com/1329094/210152068-09093cb4-6a84-48bc-9625-41697d6bf184.png">


**After the fix**

Top:

<img width="678" alt="Screenshot of Screen Sharing (31-12-2022, 12-59-21)" src="https://user-images.githubusercontent.com/1329094/210152078-f31b2aa6-87f0-4ae1-99db-9b9733d77aeb.png">

Bottom:

<img width="677" alt="Screenshot of Screen Sharing (31-12-2022, 12-58-55)" src="https://user-images.githubusercontent.com/1329094/210152083-add04266-1687-43ac-9ee3-aab2538be444.png">


