### PR TITLE
Fix / Issues & Solutions: missing accleration suppresses whole G-code line

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/solutions/GcodeDriverSolutions.java
+++ b/src/main/java/org/openpnp/machine/reference/solutions/GcodeDriverSolutions.java
@@ -884,7 +884,7 @@ public class GcodeDriverSolutions implements Solutions.Subject {
                     }
                     else {
                         // Reset the acceleration (it is not automatically reset on some controllers). 
-                        commandBuilt = "{Acceleration:M204 S%.2f} ; Initialize acceleration\n";
+                        commandBuilt = "{Acceleration:M204 S%.2f ; Initialize acceleration}\n";
                         // Home all axes.
                         commandBuilt += "G28 ; Home all axes";
                     }
@@ -916,7 +916,7 @@ public class GcodeDriverSolutions implements Solutions.Subject {
                         else {
                             // Apply acceleration limit.
                             int digits = digitsToExpress(aMin);
-                            commandBuilt = "{Acceleration:M204 S%."+digits+"f} ";
+                            commandBuilt = "{Acceleration:M204 S%."+digits+"f }";
                             if (dialect == FirmwareType.Marlin) {
                                 // Non-conformant G-code parser, needs newline.
                                 commandBuilt += "\n";


### PR DESCRIPTION
# Description

In Issues & Solutions, change the suggested `Acceleration` setting G-code so that a missing `Acceleration` variable would suppress the whole line.

Affects `HOMING_COMMAND` and `MOVE_TO_COMMAND`.

# Justification
Marlin does not "ok" lines that do not contain any G-code (comments-only). This in turn disrupts confirmation flow control.

See the user reports:
https://groups.google.com/g/openpnp/c/ZKTx8tGYr4E/m/fWnjPyYFBgAJ

# Instructions for Use
Just use Issues & Solutions to suggest a `HOMING_COMMAND` or `MOVE_TO_COMMAND`.

# Implementation Details
1. Tested in simulation using GcodeServer. Confirmed acceleration setting commands are suppressed. Marlin users must ultimately test it.
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. Successful `mvn test` before submitting the Pull Request.
