### PR TITLE
Return from estimateCaptureFps after timeout even if no frames are actually captured.

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/camera/OpenPnpCaptureCamera.java
+++ b/src/main/java/org/openpnp/machine/reference/camera/OpenPnpCaptureCamera.java
@@ -226,10 +226,16 @@ public class OpenPnpCaptureCamera extends ReferenceCamera implements Runnable {
         int capturedFrames = 0;
         for (int frames = 0; frames < 480; frames++) {
             stream.capture();
-            while (!stream.hasNewFrame()) {
+            while (true) {
+                t1 = System.currentTimeMillis();
+                if (stream.hasNewFrame()) {
+                    capturedFrames++;
+                    break;
+                }
+                if (t1 > timeout) {
+                    break;
+                }
             }
-            t1 = System.currentTimeMillis();
-            capturedFrames++;
             if (t1 > timeout) {
                 if (warmup) {
                     // Warmup complete. 


### PR DESCRIPTION
Fixes FPS Test button causing OpenPnP to hang
if camera is lost/unplugged or stops receiving frames.

# Description
estimateCameraFps function has a while loop which only exits when the camera indicates it has a new frame.

Assuming hasNewFrame returns false when the camera is unplugged then exiting the while loop when the timeout expires will prevent OpenPnP from hanging endlessly.

# Justification
Hopefully fixes bug reported [on the Google group](https://groups.google.com/g/openpnp/c/mtA_lAcj6GY).

# Instructions for Use
N/A. Problem was seen on loss of camera during an FPS test.

# Implementation Details
1. How did you test the change? Compile tested only - I don't use OpenPnPCaptureCamera and this FPS test is specific to that.
2. Coding style followed.
3. No spi or model changes.
4. Maven tests passed, but don't cover the changed code.
