### PR TITLE
Fix / Issues & Solutions: Logging, Timeout

### DIFF
--- a/src/main/java/org/openpnp/gui/IssuesAndSolutionsPanel.java
+++ b/src/main/java/org/openpnp/gui/IssuesAndSolutionsPanel.java
@@ -460,13 +460,13 @@ public class IssuesAndSolutionsPanel extends JPanel {
                 for (Solutions.Issue issue : issues) {
                     if (issue.canBeAccepted() ) {
                         if (issue.getState() != Solutions.State.Solved) {
-                            issue.setState(Solutions.State.Solved);
+                            issue.setStateCall(Solutions.State.Solved);
                         }
                     }
                     else {
                         // Be tolerant, we handle a PlainIssue with no auto-solution as dismissal.
                         if (issue.getState() != Solutions.State.Dismissed) {
-                            issue.setState(Solutions.State.Dismissed);
+                            issue.setStateCall(Solutions.State.Dismissed);
                         }
                     }
                 }
@@ -487,7 +487,7 @@ public class IssuesAndSolutionsPanel extends JPanel {
                 List<Solutions.Issue> issues = getSelections();
                 for (Solutions.Issue issue : issues) {
                     if (issue.getState() != Solutions.State.Dismissed) {
-                        issue.setState(Solutions.State.Dismissed);
+                        issue.setStateCall(Solutions.State.Dismissed);
                     }
                 }
             });
@@ -507,7 +507,7 @@ public class IssuesAndSolutionsPanel extends JPanel {
                 List<Solutions.Issue> issues = getSelections();
                 for (Solutions.Issue issue : issues) {
                     if (issue.getState() != Solutions.State.Open) {
-                        issue.setState(Solutions.State.Open);
+                        issue.setStateCall(Solutions.State.Open);
                     }
                 }
             });

--- a/src/main/java/org/openpnp/machine/reference/driver/GcodeDriver.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/GcodeDriver.java
@@ -1681,7 +1681,7 @@ public class GcodeDriver extends AbstractReferenceDriver implements Named {
                 detectFirmwareSequence();
                 return null;
             }, 
-                    false, 100, timeoutMilliseconds);
+                    false, 100, 1000);
         }
         else {
             // If the machine is not enabled, use an ad hoc connection.

--- a/src/main/java/org/openpnp/machine/reference/solutions/VisionSolutions.java
+++ b/src/main/java/org/openpnp/machine/reference/solutions/VisionSolutions.java
@@ -324,6 +324,7 @@ public class VisionSolutions implements Solutions.Subject {
                         @Override
                         public void set(int value) {
                             featureDiameter = value;
+                            Logger.debug("Manual feature diameter set to "+featureDiameter+"px");
                             try {
                                 UiUtils.submitUiMachineTask(() -> {
                                     try {
@@ -393,6 +394,7 @@ public class VisionSolutions implements Solutions.Subject {
                                                     Circle result = getSubjectPixelLocation(camera, null, new Circle(0, 0, (int)featureDiameter), 0.05, null, null, false);
                                                     featureDiameter = (int) Math.round(result.diameter);
                                                     getSubjectPixelLocation(camera, null, new Circle(0, 0, (int)featureDiameter), 0.05, "Best Diameter "+(int)featureDiameter+" px", null, false);
+                                                    Logger.debug("Next best feature diameter auto-detected at "+featureDiameter+"px");
                                                 }
                                                 catch (Exception e1) {
                                                 }

--- a/src/main/java/org/openpnp/model/Solutions.java
+++ b/src/main/java/org/openpnp/model/Solutions.java
@@ -54,6 +54,7 @@ import org.openpnp.spi.Machine;
 import org.openpnp.spi.PropertySheetHolder;
 import org.openpnp.util.VisionUtils;
 import org.openpnp.util.XmlSerialize;
+import org.pmw.tinylog.Logger;
 import org.simpleframework.xml.Attribute;
 import org.simpleframework.xml.ElementList;
 
@@ -321,6 +322,11 @@ public class Solutions extends AbstractTableModel {
 
         public State getState() {
             return state;
+        }
+
+        public void setStateCall(State state) throws Exception {
+            Logger.debug("About to set state "+state+" (from "+getState()+") on "+getSubject().getSubjectText()+": "+getIssue());
+            setState(state);
         }
 
         public void setState(State state) throws Exception {


### PR DESCRIPTION
# Description
- Logging when changing state of solutions.
- Logging when adjusting or auto-detecting a feature diameter.
- Use a much smaller timeout on `M115` firmware detection.

# Justification
Makes it easier to diagnose user support cases. 

# Instructions for Use
No changes in usage.

# Implementation Details
1. Tested in simulation.
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. No changes in the `org.openpnp.spi` and a single logging addition in the `org.openpnp.model` package.
4. Successful `mvn test` before submitting the Pull Request. 
