### PR TITLE
Fixed propagation of Set Enabled and Set Error Handling context menus

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,29 @@
 This file lists major or notable changes to OpenPnP in chronological order. This is not
 a complete change list, only those that may directly interest or affect users.
 
+# 2023-02-14
+
+## Panelization and other UI changes/improvements
+
+Panels are now stand-alone entities much like boards. They are now stored in *.panel.xml files
+rather than being "built-into" the job file. Panels can now have arbitrary layouts and can consist
+of any number of different boards and/or subpanels. Many of the issues issues that have been
+reported with the legacy panelization method have been fixed.
+
+Two new tabs have been added to the UI. The Panels tab is the primary area for creating and editing
+panels. The Boards tab is now the primary areas for creating and editing boards. The Job tab is now
+primarily for selecting boards and/or panels (defined on the aforementioned tabs) to be assembled, 
+setting their location and orientation on the machine and, of course, executing the job.
+
+There is now a button on the Job tab (the Panels and Boards tabs have one as well) that opens a 
+graphical viewer that displays the physical layout of the job (or Panel or Board).
+
+The column widths on the Job, Panels, and Boards tabs are now remembered between OpenPnP sessions.
+Numeric columns on those tabs are also now aligned on their decimal points. 
+
+See also:
+https://github.com/openpnp/openpnp/pull/1507
+
 # 2022-12-02
 
 ## UI translation improvements

--- a/src/main/java/org/openpnp/gui/BoardPlacementsPanel.java
+++ b/src/main/java/org/openpnp/gui/BoardPlacementsPanel.java
@@ -774,6 +774,14 @@ public class BoardPlacementsPanel extends JPanel {
         @Override
         public void actionPerformed(ActionEvent arg0) {
             for (Placement placement : getSelections()) {
+                //First set it to the "wrong" state so that when we set it to the correct state,
+                //the change is sure to propagate to all instances defined by the Placement
+                if (errorHandling == Placement.ErrorHandling.Alert) {
+                    placement.setErrorHandling(Placement.ErrorHandling.Defer);
+                }
+                else {
+                    placement.setErrorHandling(Placement.ErrorHandling.Alert);
+                }
                 placement.setErrorHandling(errorHandling);
                 tableModel.fireTableCellUpdated(placement, 
                         Translations.getString("PlacementsHolderPlacementsTableModel.ColumnName.ErrorHandling")); //$NON-NLS-1$
@@ -808,6 +816,9 @@ public class BoardPlacementsPanel extends JPanel {
         @Override
         public void actionPerformed(ActionEvent arg0) {
             for (Placement placement : getSelections()) {
+                //First set it to the "wrong" state so that when we set it to the correct state,
+                //the change is sure to propagate to all instances defined by the Placement
+                placement.setEnabled(!enabled);
                 placement.setEnabled(enabled);
                 tableModel.fireTableCellUpdated(placement, 
                         Translations.getString("PlacementsHolderPlacementsTableModel.ColumnName.Enabled")); //$NON-NLS-1$


### PR DESCRIPTION
# Description
Fixes context menu selections for Set Enabled and Set Error Handling on the Boards tab so that they properly propagate to all instances of the Placement.

# Justification
Bug fix for all users.

# Instructions for Use
No special instructions - this just makes it work as expected.

# Implementation Details
1. How did you test the change? **Setup a job with multiple instances of a board, changed the Enabled status and the Error Handling for some placements on one of the boards, and then used the context menu on the Boards tab to set them to their default state. Verified that all instances of the placements in the job were now back at their default settings.**
2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)? **Yes.**
3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing. **No changes to any of these packages.**
4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted. **Maven tests were run and all passed.**