### PR TITLE
Fix / ReferenceStripFeeder: Ensure the EIA-481 flag before persisting

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/feeder/ReferenceStripFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/ReferenceStripFeeder.java
@@ -46,6 +46,7 @@ import org.openpnp.vision.pipeline.CvStage;
 import org.simpleframework.xml.Attribute;
 import org.simpleframework.xml.Element;
 import org.simpleframework.xml.core.Commit;
+import org.simpleframework.xml.core.Persist;
 
 
 /**
@@ -493,6 +494,12 @@ public class ReferenceStripFeeder extends ReferenceFeeder {
                     Utils2D.angleNorm(getLocation().getRotation() - 90, 180)));
             standardEia481 = true;
         }
+    }
+
+    @Persist
+    private void persist() {
+        // Make sure the EIA-481 flag is initialized before persisting.
+        isStandardEia481(); // using side effect
     }
 
     public boolean isStandardEia481() {


### PR DESCRIPTION
# Description

Based on #1429 this fixes a case where a user sets up a `ReferenceStripFeeder` manually, i.e. not using the **Auto-Setup**, and also never positions to the pick location. or otherwise tests or uses it before saving Configuration. 

Upon reloading, the feeder will then receive a faulty -90° **Rotation in Tape** adjustment, per #1429.

# Justification
See the case:
https://groups.google.com/g/openpnp/c/y06sdptgGjc/m/5PL9ji-vAgAJ

# Instructions for Use
No change.

# Implementation Details
1. To be tested by reporting user.
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. Successful `mvn test` before submitting the Pull Request. 
