### PR TITLE
Fixed in GcodeDriver:

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/driver/GcodeAsyncDriver.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/GcodeAsyncDriver.java
@@ -278,7 +278,7 @@ public class GcodeAsyncDriver extends GcodeDriver {
                 catch (Exception e) {
                     // We probably got a timeout exception. We can't throw from the writer thread. Therefore, set 
                     // the exception as an error response, it will be reported when the driver wants to do the next step. 
-                    errorResponse = new Line(e.getMessage());
+                    errorResponse = new Line(e.getMessage(), true);
                     //Logger.error("[{}] {}", getCommunications().getConnectionName(), e);
                 }
             }


### PR DESCRIPTION
# Description
I've encounted a few bugs in GCodeDriver:
- when connection error appears (e.g. serial port was busy) it was unable to reconnect once again. In my case this was a terminal program that occupied the serial port. So when I closed it I was still unable to turn on the machine.
- when parse error raises because of no command was confirmed (i.e. Grbl answered with 'error:xxx') it was not handled correctly. This actually was a strange bug - when the controller cannot process a request for some reason OpenPNP treats it as a 'timeout' exception. To me, when the controller answered (no matter if it was an error message) then this should be considered as cofirmed request.

# Justification
These fixes really made my life easier (at least on machine setting up and debugging). As well, I believe, they can do for other users.

# Instructions for Use
Not a new feature, just a bug fix.

# Implementation Details
1. How did you test the change? Be descriptive. Untested code will not be accepted.

Automatic test passed. Manually tested in particular circumstances:

1st case:
1) turn on terminal program to keep the serial port busy, try to turn on machine. You'll get an error message.
2) close the terminal and try again. You'll get the same error. 
2.1) **When fixed** - it should connect successfully (unless something else is wrong).

2nd case:
1) define both _COMMAND_CONFIRM_REGEX_ and _COMMAND_ERROR_REGEX_
2) leliberately set _MOVE_TO_COMMAND_ ot faulty value (e.g. add some random characters at the end so that controller reacted with error code)
3) try to move an axis. You'll get a 'timeout' error. 
3.1) **When fixed** - this will be a normal error message.

3. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)?
Yes. I guess.

PS. Probably errorResponse is no longer needed, but I left it in place not to make this change too large.