### PR TITLE
Feature: Import pads from KiCad footprint file

### DIFF
--- a/src/main/java/org/openpnp/gui/PackageVisionPanel.java
+++ b/src/main/java/org/openpnp/gui/PackageVisionPanel.java
@@ -140,6 +140,9 @@ public class PackageVisionPanel extends JPanel {
         JButton generateBga = new JButton(generateBgaAction);
         panelGenerate.add(generateBga);
 
+        JButton generateKiCad = new JButton(generateFromKiCad);
+        panelGenerate.add(generateKiCad);
+
         JLabel lblBodyWidth = new JLabel(Translations.getString("PackageVisionPanel.SettingsPanel.BodyWidthLabel.text")); //$NON-NLS-1$
         propertiesPanel.add(lblBodyWidth, "2, 4, right, default");
 
@@ -356,6 +359,17 @@ public class PackageVisionPanel extends JPanel {
         @Override
         public void actionPerformed(ActionEvent arg0) {
             generatePads(Generator.Bga);
+        }
+    };
+
+    public final Action generateFromKiCad = new AbstractAction() {
+        {
+            putValue(SMALL_ICON, Icons.kicad);
+            putValue(SHORT_DESCRIPTION, "Import a footprint from KiCad module.");
+        }
+        @Override
+        public void actionPerformed(ActionEvent arg0) {
+            generatePads(Generator.KiCad);
         }
     };
 

--- a/src/main/java/org/openpnp/gui/PackageVisionPanel.java
+++ b/src/main/java/org/openpnp/gui/PackageVisionPanel.java
@@ -140,8 +140,8 @@ public class PackageVisionPanel extends JPanel {
         JButton generateBga = new JButton(generateBgaAction);
         panelGenerate.add(generateBga);
 
-        JButton generateKiCad = new JButton(generateFromKiCad);
-        panelGenerate.add(generateKiCad);
+        JButton generateKicad = new JButton(generateFromKicad);
+        panelGenerate.add(generateKicad);
 
         JLabel lblBodyWidth = new JLabel(Translations.getString("PackageVisionPanel.SettingsPanel.BodyWidthLabel.text")); //$NON-NLS-1$
         propertiesPanel.add(lblBodyWidth, "2, 4, right, default");
@@ -362,14 +362,14 @@ public class PackageVisionPanel extends JPanel {
         }
     };
 
-    public final Action generateFromKiCad = new AbstractAction() {
+    public final Action generateFromKicad = new AbstractAction() {
         {
             putValue(SMALL_ICON, Icons.kicad);
             putValue(SHORT_DESCRIPTION, "Import a footprint from KiCad module.");
         }
         @Override
         public void actionPerformed(ActionEvent arg0) {
-            generatePads(Generator.KiCad);
+            generatePads(Generator.Kicad);
         }
     };
 

--- a/src/main/java/org/openpnp/gui/importer/KicadModImporter.java
+++ b/src/main/java/org/openpnp/gui/importer/KicadModImporter.java
@@ -17,7 +17,7 @@
  * For more information about OpenPnP visit http://openpnp.org
  */
 
-package org.openpnp.gui.support;
+package org.openpnp.gui.importer;
 
 import java.awt.FileDialog;
 import java.io.BufferedReader;
@@ -40,18 +40,20 @@ import org.openpnp.model.Footprint.Pad;
  * Rectangular, rounded rectangular, circular and oval pad shapes are supported. Trapezoid and custom 
  * pad shapes are ignored. A FileDialog is openened to select a file once this class is instantiated. 
  * Imported pads are available as List<Pad>.
+ * 
+ * This module may become part of an all-in-one KiCad board import one day.
  */
 
  
-public class KiCadImporter {
+public class KicadModImporter {
 
     Footprint footprint = new Footprint();
 
-    public class KiCadPad {
+    public class KicadPad {
     
         String padDefinition;
 
-        public KiCadPad(String definition) {
+        public KicadPad(String definition) {
             padDefinition = definition;
         }
 
@@ -148,7 +150,7 @@ public class KiCadImporter {
         }
     }
 
-    public KiCadImporter() {
+    public KicadModImporter() {
         try {
             FileDialog fileDialog = new FileDialog(MainFrame.get());
             fileDialog.setFilenameFilter(new FilenameFilter() {
@@ -168,7 +170,7 @@ public class KiCadImporter {
             String line = reader.readLine();
             while (line != null) {
                 if (line.trim().startsWith("(pad ")) {
-                    KiCadPad kipad = new KiCadPad(line.trim());
+                    KicadPad kipad = new KicadPad(line.trim());
                     if (kipad.getType().equals("smd") && kipad.isTopCu()) {
                         Pad pad = new Pad();
                         pad.setName(kipad.getName());
@@ -202,7 +204,7 @@ public class KiCadImporter {
             reader.close();
         }
         catch (Exception e) {
-            MessageBoxes.errorBox(MainFrame.get(), "KiCad Footprint Load Error", e.getMessage());
+            MessageBoxes.errorBox(MainFrame.get(), "Kicad Footprint Load Error", e.getMessage());
         }
     }
 

--- a/src/main/java/org/openpnp/gui/support/Icons.java
+++ b/src/main/java/org/openpnp/gui/support/Icons.java
@@ -123,6 +123,7 @@ public class Icons {
     public static Icon footprintQuad = getIcon("/icons/footprint-quad.svg");
     public static Icon footprintDual = getIcon("/icons/footprint-dual.svg");
     public static Icon footprintBga = getIcon("/icons/footprint-bga.svg");
+    public static Icon kicad = getIcon("/icons/kicad-logo.svg");
 
     public static Icon getIcon(String resourceName, int width, int height) {
         if (resourceName.endsWith(".svg")) {

--- a/src/main/java/org/openpnp/gui/support/KiCadImporter.java
+++ b/src/main/java/org/openpnp/gui/support/KiCadImporter.java
@@ -1,0 +1,212 @@
+/*
+ * Copyright (C) 2023 Jason von Nieda <jason@vonnieda.org>
+ * 
+ * This file is part of OpenPnP.
+ * 
+ * OpenPnP is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * OpenPnP is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License along with OpenPnP. If not, see
+ * <http://www.gnu.org/licenses/>.
+ * 
+ * For more information about OpenPnP visit http://openpnp.org
+ */
+
+package org.openpnp.gui.support;
+
+import java.awt.FileDialog;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FilenameFilter;
+import java.io.FileReader;
+import java.util.List;
+import java.util.regex.Pattern;
+import java.util.regex.Matcher;
+
+import org.openpnp.gui.MainFrame;
+import org.openpnp.gui.support.MessageBoxes;
+import org.openpnp.model.Footprint;
+import org.openpnp.model.Footprint.Pad;
+
+/**
+ * @author Jonas Lehmke <jonas@lehmke.xyz>
+ * 
+ * This module reads a KiCad footprint from file (*.kicad_mod) and parses it to a Footprint instance.
+ * Rectangular, rounded rectangular, circular and oval pad shapes are supported. Trapezoid and custom 
+ * pad shapes are ignored. A FileDialog is openened to select a file once this class is instantiated. 
+ * Imported pads are available as List<Pad>.
+ */
+
+ 
+public class KiCadImporter {
+
+    Footprint footprint = new Footprint();
+
+    public class KiCadPad {
+    
+        String padDefinition;
+
+        public KiCadPad(String definition) {
+            padDefinition = definition;
+        }
+
+        String getName() {
+            Pattern p = Pattern.compile("^\\(pad\\s\"(\\w*)\"\\s(\\w*)\\s(\\w*)");
+            Matcher m = p.matcher(padDefinition);
+            if(m.find()) {
+                return m.group(1);
+            }
+            return "";
+        }
+
+        String getType() {
+            Pattern p = Pattern.compile("^\\(pad\\s\"(\\w*)\"\\s(\\w*)\\s(\\w*)");
+            Matcher m = p.matcher(padDefinition);
+            if(m.find()) {
+                return m.group(2);
+            }
+            return "";
+        }
+
+        String getShape() {
+            Pattern p = Pattern.compile("^\\(pad\\s\"(\\w*)\"\\s(\\w*)\\s(\\w*)");
+            Matcher m = p.matcher(padDefinition);
+            if(m.find()) {
+                return m.group(3);
+            }
+            return "";
+        }
+
+        double getWidth() {
+            Pattern p = Pattern.compile("\\(size ([\\-0-9.]*) ([\\-0-9\\.]*)\\)");
+            Matcher m = p.matcher(padDefinition);
+            if(m.find()) {
+                return Double.parseDouble(m.group(1));
+            }
+            return 0.;
+        }
+
+        double getHeight() {
+            Pattern p = Pattern.compile("\\(size ([\\-0-9\\.]*) ([\\-0-9\\.]*)\\)");
+            Matcher m = p.matcher(padDefinition);
+            if(m.find()) {
+                return Double.parseDouble(m.group(2));
+            }
+            return 0.;
+        }
+
+        double getX() {
+            Pattern p = Pattern.compile("\\(at ([\\-0-9.]*) ([\\-0-9.]*)\\s?([^\\)]*)\\)");
+            Matcher m = p.matcher(padDefinition);
+            if(m.find()) {
+                return Double.parseDouble(m.group(1));
+            }
+            return 0.;
+        }
+
+        double getY() {
+            Pattern p = Pattern.compile("\\(at ([\\-0-9.]*) ([\\-0-9.]*)\\s?([^\\)]*)\\)");
+            Matcher m = p.matcher(padDefinition);
+            if(m.find()) {
+                return Double.parseDouble(m.group(2)) * (-1); // Negative because of different conventions
+            }
+            return 0.;
+        }
+
+        double getRotation() {
+            Pattern p = Pattern.compile("\\(at ([\\-0-9.]*) ([\\-0-9.]*)\\s?([^\\)]*)\\)");
+            Matcher m = p.matcher(padDefinition);
+            if(m.find()) {
+                if (m.group(3).length() > 0) {
+                    return Double.parseDouble(m.group(3));
+                }
+            }
+            return 0.;
+        }
+
+        double getRoundness() {
+            Pattern p = Pattern.compile("\\(roundrect_rratio ([\\-0-9.]*)\\)");
+            Matcher m = p.matcher(padDefinition);
+            if(m.find()) {
+                return Double.parseDouble(m.group(1)) * 100;
+            }
+            return 0.;
+        }
+
+        boolean isTopCu() {
+            Pattern p = Pattern.compile("\\(layers ([^\\)]*)\\)");
+            Matcher m = p.matcher(padDefinition);
+            if(m.find()) {
+                return m.group(1).contains("F.Cu") || m.group(1).contains("*.Cu");
+            }
+            return false;
+        }
+    }
+
+    public KiCadImporter() {
+        try {
+            FileDialog fileDialog = new FileDialog(MainFrame.get());
+            fileDialog.setFilenameFilter(new FilenameFilter() {
+                @Override
+                public boolean accept(File dir, String name) {
+                    return name.toLowerCase().endsWith(".kicad_mod");
+                }
+            });
+            fileDialog.setVisible(true);
+            if (fileDialog.getFile() == null) {
+                return;
+            }
+
+            File file = new File(new File(fileDialog.getDirectory()), fileDialog.getFile());
+            BufferedReader reader = new BufferedReader(new FileReader(file));
+            
+            String line = reader.readLine();
+            while (line != null) {
+                if (line.trim().startsWith("(pad ")) {
+                    KiCadPad kipad = new KiCadPad(line.trim());
+                    if (kipad.getType().equals("smd") && kipad.isTopCu()) {
+                        Pad pad = new Pad();
+                        pad.setName(kipad.getName());
+                        pad.setWidth(kipad.getWidth());
+                        pad.setHeight(kipad.getHeight());
+                        pad.setX(kipad.getX());
+                        pad.setY(kipad.getY());
+                        pad.setRotation(kipad.getRotation());
+
+                        if (kipad.getShape().equals("rect")) {
+                            pad.setRoundness(0);
+                        } else if (kipad.getShape().equals("circle")) {
+                            pad.setRoundness(100);
+                        } else if (kipad.getShape().equals("oval")) {
+                            pad.setRoundness(100);
+                        } else if (kipad.getShape().equals("roundrect")) {
+                            pad.setRoundness(kipad.getRoundness());
+                        } else {
+                            System.out.println("Warning: Unsupported pad type: " + kipad.getShape());
+                            line = reader.readLine();
+                            continue;
+                        }
+
+                        footprint.addPad(pad);
+                    }
+                }
+
+                line = reader.readLine();
+            }
+
+            reader.close();
+        }
+        catch (Exception e) {
+            MessageBoxes.errorBox(MainFrame.get(), "KiCad Footprint Load Error", e.getMessage());
+        }
+    }
+
+    public List<Pad> getPads() {
+        return footprint.getPads();
+    }
+}

--- a/src/main/java/org/openpnp/model/Footprint.java
+++ b/src/main/java/org/openpnp/model/Footprint.java
@@ -27,6 +27,8 @@ import java.awt.geom.RoundRectangle2D;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.openpnp.gui.support.KiCadImporter;
+
 import org.simpleframework.xml.Attribute;
 import org.simpleframework.xml.ElementList;
 
@@ -68,7 +70,8 @@ public class Footprint extends AbstractModelObject{
     public enum Generator {
         Dual,
         Quad,
-        Bga;
+        Bga,
+        KiCad;
     }
 
     public Shape getShape() {
@@ -493,6 +496,14 @@ public class Footprint extends AbstractModelObject{
                 if (bodyWidth == 0 && bodyHeight == 0) {
                     setBodyWidth(outerDimension+padPitch);
                     setBodyHeight(outerDimension+padPitch);
+                }
+                break;
+            }
+            case KiCad:
+            {
+                KiCadImporter importer = new KiCadImporter();
+                for (Pad pad : importer.getPads()) {
+                    addPad(pad);
                 }
                 break;
             }

--- a/src/main/java/org/openpnp/model/Footprint.java
+++ b/src/main/java/org/openpnp/model/Footprint.java
@@ -27,7 +27,7 @@ import java.awt.geom.RoundRectangle2D;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.openpnp.gui.support.KiCadImporter;
+import org.openpnp.gui.importer.KicadModImporter;
 
 import org.simpleframework.xml.Attribute;
 import org.simpleframework.xml.ElementList;
@@ -71,7 +71,7 @@ public class Footprint extends AbstractModelObject{
         Dual,
         Quad,
         Bga,
-        KiCad;
+        Kicad;
     }
 
     public Shape getShape() {
@@ -499,9 +499,9 @@ public class Footprint extends AbstractModelObject{
                 }
                 break;
             }
-            case KiCad:
+            case Kicad:
             {
-                KiCadImporter importer = new KiCadImporter();
+                KicadModImporter importer = new KicadModImporter();
                 for (Pad pad : importer.getPads()) {
                     addPad(pad);
                 }

--- a/src/main/resources/icons/kicad-logo.svg
+++ b/src/main/resources/icons/kicad-logo.svg
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="24"
+   height="24"
+   viewBox="0 0 0.25 0.25"
+   version="1.1"
+   id="svg586"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   sodipodi:docname="kicad-logo.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview588"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:document-units="mm"
+     showgrid="false"
+     inkscape:zoom="29.02709"
+     inkscape:cx="10.800256"
+     inkscape:cy="11.816548"
+     inkscape:window-width="1613"
+     inkscape:window-height="1024"
+     inkscape:window-x="45"
+     inkscape:window-y="29"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="layer1" />
+  <defs
+     id="defs583" />
+  <g
+     inkscape:label="Ebene 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <g
+       id="g1295"
+       transform="matrix(0.98323641,0,0,0.98323641,0.00686603,0.0066756)">
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:#314cb0;fill-opacity:1;fill-rule:nonzero;stroke:#1d2d68;stroke-width:0.008689;stroke-miterlimit:4;stroke-opacity:1"
+         d="m 0.01905029,0.02756601 h 0.20491754 c 9.185e-4,0 0.001659,7.7352e-4 0.001659,0.0017347 v 0.19668365 c 0,9.6096e-4 -7.3948e-4,0.001735 -0.001659,0.001735 H 0.01905029 c -9.185e-4,0 -0.0016587,-7.7354e-4 -0.0016587,-0.001735 V 0.02930075 c 0,-9.6079e-4 7.3948e-4,-0.0017347 0.0016587,-0.0017347 z"
+         id="rect3438-4-1-6-9-8-4" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path3008"
+         style="font-style:normal;font-weight:normal;font-size:120.794px;line-height:122%;font-family:Sans;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.00179136"
+         d="M 0.07026684,0.11047778 0.10059025,0.07212434 c 0.006199,-0.0078182 0.009298,-0.01366404 0.009298,-0.01753908 -9e-8,-0.0014086 -1.7626e-4,-0.0025364 -5.2829e-4,-0.0033808 h 0.052934 c -0.004014,0.0022544 -0.009051,0.0070087 -0.0151089,0.01426289 -0.001621,0.0019027 -0.004472,0.005388 -0.008558,0.01046072 l -0.039727,0.04944737 0.0474398,0.0652959 c 0.002888,0.003945 0.006551,0.008382 0.0109883,0.0133123 0.001197,0.001268 0.002923,0.002782 0.005177,0.004544 h -0.0543077 c 4.2253e-4,-0.001621 6.3384e-4,-0.003064 6.3397e-4,-0.004331 -1.1e-7,-0.003873 -0.002677,-0.009474 -0.00803,-0.0167994 L 0.07026636,0.14576793 v 0.042157 c -5e-8,0.009791 0.0019724,0.0166586 0.0059171,0.0206032 H 0.02652478 c 0.0027471,-0.002747 0.0045087,-0.005882 0.0052834,-0.009404 4.2253e-4,-0.001972 6.3389e-4,-0.00567 6.3389e-4,-0.0110944 v -0.116328 c -2e-8,-0.0054228 -2.1136e-4,-0.009122 -6.3389e-4,-0.01109441 -7.749e-4,-0.0035218 -0.0025364,-0.006657 -0.0052834,-0.009404 h 0.04965871 c -0.0039447,0.0039448 -0.0059171,0.01077756 -0.0059171,0.02049749 v 0.03877611" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path3010"
+         style="font-style:normal;font-weight:normal;font-size:120.794px;line-height:122%;font-family:Sans;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.00179136"
+         d="m 0.21216384,0.09293875 v 0.09699286 c -5e-8,0.005071 1.4081e-4,0.008382 4.2271e-4,0.009932 5.6337e-4,0.00317 0.002042,0.006058 0.004437,0.008664 h -0.046489 c 0.002395,-0.002606 0.003873,-0.005494 0.004437,-0.008664 2.8168e-4,-0.00155 4.2253e-4,-0.00486 4.227e-4,-0.009932 v -0.0786086 c -10e-9,-0.005071 -1.4098e-4,-0.008347 -4.227e-4,-0.009825 -5.6355e-4,-0.003099 -0.002007,-0.005952 -0.004331,-0.008558 h 0.041523 M 0.19377991,0.03768103 c 0.005846,1.6e-7 0.0108124,0.0020785 0.0148982,0.006234 0.004155,0.0040857 0.006234,0.0090507 0.006234,0.01489816 -5e-8,0.0059868 -0.002042,0.01102312 -0.006128,0.01510887 -0.004014,0.0040145 -0.009016,0.0060233 -0.0150027,0.0060217 -0.005846,1.1e-7 -0.0108473,-0.0020421 -0.0150027,-0.0061278 -0.004086,-0.0041555 -0.006128,-0.0091569 -0.006128,-0.01500273 -2e-8,-0.0059868 0.002007,-0.01098827 0.006022,-0.01500272 0.004086,-0.0040857 0.009122,-0.0061278 0.0151089,-0.0061278" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:#314cb0;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.00179136"
+         d="m 0.16882865,0.03594179 h 0.0507227 v 0.04842205 h -0.0507227 z"
+         id="rect4352-5-1" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:#ff7700;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.00179136"
+         d="m 0.21518601,0.02761783 c 0,0.01182792 -0.009616,0.02141524 -0.0214788,0.02141524 -0.0118628,0 -0.0214788,-0.0095878 -0.0214788,-0.02141524 0,-0.01182791 0.009616,-0.0214154 0.0214788,-0.0214154 0.0118628,0 0.0214788,0.0095878 0.0214788,0.0214154 z"
+         id="path3552-6-3-7" />
+    </g>
+  </g>
+</svg>


### PR DESCRIPTION
# Description
This commit implements a simple parser for KiCad footprint files (*.kicad_mod). Rectangular, rounded rectangular, circular and oval pad shapes are supported. Trapezoid and custom pad shapes are ignored. A FileDialog is openened to select a file. Imported pads are stored in a list inside the KiCadImporter class and transfered to the Footprint instance once parsing is completed.

# Justification
This feature is useful to ease importing of footprints, as manual generation isn't handy and the generator templates don't fit to complex footprints. Even people not using KiCad at all can benefit from just using the very extensive KiCad footprint library, which is just a directory structure with footprints. KiCad is a very mature open-source electronics design suite and in my opinion open-source projects should work towards supporting each other to improve their usability, spread and reputation.

# Instructions for Use

- Click on the KiCad logo button in the generators section at Packages > Selected package > Footprint.
- Choose the *.kicad_mod file you wish to import.

![](https://user-images.githubusercontent.com/71590538/225002893-f5c0a6d6-23bf-49e0-9896-99c1fced5b12.png)

# Implementation Details
This is a simple feature, not altering anything critical. It was tested by importing simple and complex footprints from the KiCad library and comparing them to the illustration in the KiCad footprint editor.

**Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)?**
Yes, but not enforced by the IDE and I am not a frequent Java developer. So deviations may have happened.

**If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing.**
A very simple and short extension of the Footprint.java class to support the new KiCad generator. Only existing code sections were extended in a similar fashion, so risk of the change should be low. 

**Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted.**
 `mvn test` without errors.

**Rectangular/Circular pads supported, axes not mirrored.**
![](https://user-images.githubusercontent.com/71590538/225003129-d9d4d7f1-7282-4f05-909e-8939d3b7f8ef.png) 
![](https://user-images.githubusercontent.com/71590538/225003146-929347e3-1bea-49f7-ae6f-d4238322aae2.png)
**Rounded rectangular pads supported, dimensions fit.**
![](https://user-images.githubusercontent.com/71590538/225003157-f8c4251e-69b7-4b0e-9549-67d2786ab678.png)
**Custom pads not supported, ignored (center pad).**
![](https://user-images.githubusercontent.com/71590538/225003160-d3f0e920-3dbe-497a-98e4-7defbae595dc.png)
![](https://user-images.githubusercontent.com/71590538/225003172-e1259871-e2f2-414e-86ab-5098a8701d3a.png)
**Oval pads supported.**
![](https://user-images.githubusercontent.com/71590538/225003179-0cbc4969-070c-4e18-955d-66ec0cfcad88.png)
![](https://user-images.githubusercontent.com/71590538/225003192-a813c4e9-d4bb-4a70-aae0-ece2ac3b7479.png)

# Notes
This is my first contribution to OpenPnP and I want to thank all of its developers for this amazing piece of software! I am not entirely sure if org.openpnp.gui.support is the right spot for the KiCadImporter class and if the logo usage (GPLv3) is acceptable. I am fully open to changes on that!