### PR TITLE
Fix pseudo-placement rotations and display correct footprint during multi-placement alignment process

### DIFF
--- a/src/main/java/org/openpnp/gui/panelization/ChildFiducialSelectorDialog.java
+++ b/src/main/java/org/openpnp/gui/panelization/ChildFiducialSelectorDialog.java
@@ -72,6 +72,7 @@ import org.openpnp.model.Part;
 import org.openpnp.model.Placement;
 import org.openpnp.model.PlacementsHolderLocation;
 import org.openpnp.model.Point;
+import org.openpnp.model.PseudoPlacement;
 import org.openpnp.util.Collect;
 import org.openpnp.util.QuickHull;
 import org.openpnp.util.Utils2D;
@@ -400,15 +401,21 @@ public class ChildFiducialSelectorDialog extends JDialog {
                 pseudoPlacement.removePropertyChangeListener(pseudoPlacement);
                 pseudoPlacement.setDefinition(pseudoPlacement);
                 pseudoPlacement.setEnabled(true);
-                pseudoPlacement.setLocation(Utils2D.calculateBoardPlacementLocation(child, 
-                        placement).derive(null, null, 0.0, null));
-                pseudoPlacement.setId(id);
-                pseudoPlacement.setSide(placement.getSide().
-                        flip(child.getGlobalSide() == Side.Bottom));
-                pseudoPlacement.setComments(
-                        Translations.getString("ChildFiducialSelectorDialog.PseudoPlacement.Comment")); //$NON-NLS-1$
-                pseudoPlacement.addPropertyChangeListener(pseudoPlacement);
-                allPseudoPlacements.add(pseudoPlacement);
+                try {
+                    Location location = PseudoPlacement.computeLocation(this.panelLocation.getPanel(), id);
+                    pseudoPlacement.setLocation(location);
+                    pseudoPlacement.setId(id);
+                    pseudoPlacement.setSide(placement.getSide().
+                            flip(child.getGlobalSide() == Side.Bottom));
+                    pseudoPlacement.setComments(
+                            Translations.getString("ChildFiducialSelectorDialog.PseudoPlacement.Comment")); //$NON-NLS-1$
+                    pseudoPlacement.addPropertyChangeListener(pseudoPlacement);
+                    allPseudoPlacements.add(pseudoPlacement);
+                }
+                catch (Exception e) {
+                    // TODO Auto-generated catch block
+                    e.printStackTrace();
+                }
             }
             if (child instanceof PanelLocation) {
                 generateAllPseudoPlacementsList((PanelLocation) child);

--- a/src/main/java/org/openpnp/gui/panelization/ChildFiducialSelectorDialog.java
+++ b/src/main/java/org/openpnp/gui/panelization/ChildFiducialSelectorDialog.java
@@ -76,6 +76,7 @@ import org.openpnp.model.PseudoPlacement;
 import org.openpnp.util.Collect;
 import org.openpnp.util.QuickHull;
 import org.openpnp.util.Utils2D;
+import org.pmw.tinylog.Logger;
 
 @SuppressWarnings("serial")
 public class ChildFiducialSelectorDialog extends JDialog {
@@ -370,6 +371,10 @@ public class ChildFiducialSelectorDialog extends JDialog {
             }
             catch (Exception e) {
                 // TODO Auto-generated catch block
+                Logger.error("Unable to create pseudo-placement {}, please send this log file to " //$NON-NLS-1$
+                        + "the developers as this should never occur:", fiducial.getId()); //$NON-NLS-1$
+                Logger.info(panelLocation);
+                Logger.info(panelLocation.getPanel());
                 e.printStackTrace();
             }
         }
@@ -414,6 +419,9 @@ public class ChildFiducialSelectorDialog extends JDialog {
                 }
                 catch (Exception e) {
                     // TODO Auto-generated catch block
+                    Logger.error("Unable to compute location of pseudo-placement {}, please send " //$NON-NLS-1$
+                            + "this log file to the developers as this should never occur:", id); //$NON-NLS-1$
+                    Logger.info(this.panelLocation);
                     e.printStackTrace();
                 }
             }

--- a/src/main/java/org/openpnp/gui/processes/MultiPlacementBoardLocationProcess.java
+++ b/src/main/java/org/openpnp/gui/processes/MultiPlacementBoardLocationProcess.java
@@ -184,6 +184,8 @@ public class MultiPlacementBoardLocationProcess {
         //Get ready for the first placement
         idxPlacement = 0;
         placementId = placements.get(0).getId();
+        jobPanel.getJobPlacementsPanel().selectPlacement(
+                placements.get(0).getDefinition());
         expectedLocations.add(placements.get(0).getLocation()
                 .invert(boardSide==Side.Bottom, false, false, false));
         
@@ -228,6 +230,8 @@ public class MultiPlacementBoardLocationProcess {
             }
 
             //Get ready for the next placement
+            jobPanel.getJobPlacementsPanel().selectPlacement(
+                    placements.get(idxPlacement).getDefinition());
             placementId = placements.get(idxPlacement).getId();
             expectedLocations.add(placements.get(idxPlacement).getLocation()
                     .invert(boardSide==Side.Bottom, false, false, false));

--- a/src/main/java/org/openpnp/gui/support/Helpers.java
+++ b/src/main/java/org/openpnp/gui/support/Helpers.java
@@ -72,6 +72,8 @@ public class Helpers {
             int index = table.getModel().getRowCount() - 1;
             index = table.convertRowIndexToView(index);
             table.setRowSelectionInterval(index, index);
+            Rectangle cellRect = table.getCellRect(index, index, true);
+            table.scrollRectToVisible(cellRect);
         });
     }
 
@@ -114,18 +116,20 @@ public class Helpers {
     }
 
     public static void selectNextTableRow(JTable table){
-    	 int index = table.getSelectedRow();
+    	int index = table.getSelectedRow();
     	 
-    	 if (index == -1){
-    		 index = 0;
-    	 }
+    	if (index == -1){
+    	     index = 0;
+    	}
     	 
-         table.clearSelection();
-         if (++index > table.getRowCount() - 1){
+        table.clearSelection();
+        if (++index > table.getRowCount() - 1){
          	index = 0;
-         }
+        }
          
-         table.addRowSelectionInterval(index, index);   
+        table.addRowSelectionInterval(index, index);   
+        Rectangle cellRect = table.getCellRect(index, index, true);
+        table.scrollRectToVisible(cellRect);
     }
     
     public static void selectFirstTableRow(JTable table) {
@@ -133,6 +137,8 @@ public class Helpers {
         int index = 0;
         index = table.convertRowIndexToView(index);
         table.addRowSelectionInterval(index, index);
+        Rectangle cellRect = table.getCellRect(index, index, true);
+        table.scrollRectToVisible(cellRect);
     }
 
     /**

--- a/src/main/java/org/openpnp/gui/support/TableUtils.java
+++ b/src/main/java/org/openpnp/gui/support/TableUtils.java
@@ -34,6 +34,8 @@ import org.openpnp.gui.tablemodel.ColumnAlignable;
 
 public class TableUtils {
 
+    public static final int MIN_COLUMN_WIDTH = 10;
+    
     /**
      * Sets the horizontal alignment of each of the columns of the specified table..
      * @param tableModel - the table model for the table. Must implement ColumnAlignable.
@@ -109,8 +111,9 @@ public class TableUtils {
         for (int iCol=0; iCol<nCols; iCol++) {
             int iModelCol = table.getColumnModel().getColumn(iCol).getModelIndex();
             prefWidths[iCol] = prefs.getInt(prefKey + iModelCol, -1);
-            if (prefWidths[iCol] < 0) {
-                prefWidths[iCol] = table.getColumnModel().getColumn(iCol).getWidth();
+            if (prefWidths[iCol] < MIN_COLUMN_WIDTH) {
+                prefWidths[iCol] = Math.max(MIN_COLUMN_WIDTH,
+                        table.getColumnModel().getColumn(iCol).getWidth());
                 prefs.putInt(prefKey + iModelCol, prefWidths[iCol]);
             }
             if (widthTypes[iModelCol] == ColumnWidthSaveable.FIXED) {

--- a/src/main/java/org/openpnp/gui/viewers/PlacementsHolderLocationViewer.java
+++ b/src/main/java/org/openpnp/gui/viewers/PlacementsHolderLocationViewer.java
@@ -593,6 +593,9 @@ public class PlacementsHolderLocationViewer extends JPanel implements PropertyCh
     }
     
     public void regenerate() {
+        if (isJob) {
+            placementsHolderLocation = MainFrame.get().getJobTab().getJob().getRootPanelLocation();
+        }
         Rectangle2D oldBounds = graphicsBounds;
         generateGraphicalObjects(placementsHolderLocation);
         if (!graphicsBounds.equals(oldBounds)) {
@@ -812,6 +815,7 @@ public class PlacementsHolderLocationViewer extends JPanel implements PropertyCh
         GeometricPath2D profile = placementsHolderLocation.getPlacementsHolder().getProfile().convertToUnits(units);
         profile.transform(at);
         boolean atRoot = placementsHolderLocation == this.placementsHolderLocation;
+        boolean jobTopChild = isJob && placementsHolderLocation.getParent() == this.placementsHolderLocation;
         if (atRoot) {
             profileMap = new HashMap<>();
             placementMap = new HashMap<>();
@@ -832,7 +836,7 @@ public class PlacementsHolderLocationViewer extends JPanel implements PropertyCh
                 graphicsBounds.add(profile.getBounds2D());
             }
             List<Placement> placements = new ArrayList<>(placementsHolderLocation.getPlacementsHolder().getPlacements());
-            if (placementsHolderLocation instanceof PanelLocation) {
+            if ((atRoot || jobTopChild) && placementsHolderLocation instanceof PanelLocation) {
                 placements.addAll(((PanelLocation) placementsHolderLocation).getPanel().getPseudoPlacements()); 
             }
             for (Placement placement : placements) {
@@ -842,7 +846,12 @@ public class PlacementsHolderLocationViewer extends JPanel implements PropertyCh
                 
                 AffineTransform at2 = new AffineTransform();
                 at2.translate(loc.getX(), loc.getY());
-                at2.rotate(Math.toRadians(loc.getRotation()));
+                if (atRoot && placementsHolderLocation.getGlobalSide() != placement.getSide()) {
+                    at2.rotate(-Math.toRadians(loc.getRotation()));
+                }
+                else {
+                    at2.rotate(Math.toRadians(loc.getRotation()));
+                }
                 double d = (new Length(1, LengthUnit.Millimeters)).convertToUnits(units).getValue() * 0.5;
                 //In the future, we probably should use the actual shape of the footprint here - will
                 //probably wait until we can import Gerber files and get the true footprint from there
@@ -900,7 +909,10 @@ public class PlacementsHolderLocationViewer extends JPanel implements PropertyCh
                         offScr.setStroke(new BasicStroke(2, BasicStroke.CAP_SQUARE, BasicStroke.JOIN_ROUND));
                         PlacementsHolder<?> ph = phl.getPlacementsHolder();
                         List<Placement> placements = new ArrayList<>(ph.getPlacements());
-                        if (phl instanceof PanelLocation) {
+                        boolean atRoot = phl == this.placementsHolderLocation;
+                        boolean jobTopChild = isJob && phl.getParent() == this.placementsHolderLocation;
+
+                        if ((atRoot || jobTopChild) && phl instanceof PanelLocation) {
                             placements.addAll(((PanelLocation) phl).getPanel().getPseudoPlacements()); 
                         }
                         for (Placement placement : placements) {
@@ -1058,7 +1070,9 @@ public class PlacementsHolderLocationViewer extends JPanel implements PropertyCh
         for (Area profileArea : profileMap.keySet()) {
             PlacementsHolderLocation<?> placementsHolderLocation = profileMap.get(profileArea);
             List<Placement> placements = new ArrayList<>(placementsHolderLocation.getPlacementsHolder().getPlacements());
-            if (placementsHolderLocation instanceof PanelLocation) {
+            boolean atRoot = placementsHolderLocation == this.placementsHolderLocation;
+            boolean jobTopChild = isJob && placementsHolderLocation.getParent() == this.placementsHolderLocation;
+            if ((atRoot || jobTopChild) && placementsHolderLocation instanceof PanelLocation) {
                 placements.addAll(((PanelLocation) placementsHolderLocation).getPanel().getPseudoPlacements()); 
             }
             for (Placement placement : placements) {
@@ -1078,7 +1092,9 @@ public class PlacementsHolderLocationViewer extends JPanel implements PropertyCh
         for (Area profileArea : profileMap.keySet()) {
             PlacementsHolderLocation<?> placementsHolderLocation = profileMap.get(profileArea);
             List<Placement> placements = new ArrayList<>(placementsHolderLocation.getPlacementsHolder().getPlacements());
-            if (placementsHolderLocation instanceof PanelLocation) {
+            boolean atRoot = placementsHolderLocation == this.placementsHolderLocation;
+            boolean jobTopChild = isJob && placementsHolderLocation.getParent() == this.placementsHolderLocation;
+            if ((atRoot || jobTopChild) && placementsHolderLocation instanceof PanelLocation) {
                 placements.addAll(((PanelLocation) placementsHolderLocation).getPanel().getPseudoPlacements()); 
             }
             for (Placement placement : placements) {

--- a/src/main/java/org/openpnp/model/Panel.java
+++ b/src/main/java/org/openpnp/model/Panel.java
@@ -521,7 +521,7 @@ public class Panel extends PlacementsHolder<Panel> implements PropertyChangeList
      * alignment. This method should only be called on panel definitions.
      * @param pseudoPlacementId - the id of the pseudo-placement to create
      * @return - the pseudo-placement
-     * @throws Exception 
+     * @throws Exception if pseudoPlacementId is invalid
      * @throws UnsupportedOperationException if called on a non-panel definition
      */
     public Placement createPseudoPlacement(String pseudoPlacementId) throws Exception {

--- a/src/main/java/org/openpnp/model/Panel.java
+++ b/src/main/java/org/openpnp/model/Panel.java
@@ -513,7 +513,6 @@ public class Panel extends PlacementsHolder<Panel> implements PropertyChangeList
         pseudoPlacements.remove(pseudoPlacement);
         fireIndexedPropertyChange("pseudoPlacement", index, pseudoPlacement, null);
         pseudoPlacement.removePropertyChangeListener(this);
-        pseudoPlacement.dispose();
     }
     
     /**


### PR DESCRIPTION
# Description
Fixes the rotation angles for pseudo-placements and pseudo-fiducials on the bottom of panels. Also changes the Multi-Placement Alignment Process to individually select each placement in the Job Placements table as it runs so that the correct footprint will be overlayed on the top camera view.

# Justification
Will help anyone who uses the Multi-Placement Alignment Process to align their boards and panels. Note, the incorrect pseudo-placement and pseudo-fiducial rotation angles only affected how the footprints were overlayed on the top camera view - they had no affect on the actual alignment results since their rotations are not used in computing the placement affine transforms.

# Instructions for Use
No changes to usage instructions.

# Implementation Details
1. How did you test the change? Be descriptive. Untested code will not be accepted. **Added all the real placements and fiducials from all the boards on the test panel as pseudo-placements/fiducials and verified that they all now all have the same rotation as the real placements/fiducials (including those on the bottom of the panel).**
2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)? **Yes**
3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing. **No changes were made to these packages.**
4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted. **Maven tests were run and all passed.**
