### PR TITLE
Feature/Ensure Machine Homing Before Motion

### DIFF
--- a/src/main/java/org/openpnp/gui/components/CameraView.java
+++ b/src/main/java/org/openpnp/gui/components/CameraView.java
@@ -74,6 +74,7 @@ import org.openpnp.model.Configuration;
 import org.openpnp.model.Length;
 import org.openpnp.model.LengthUnit;
 import org.openpnp.model.Location;
+import org.openpnp.model.Motion;
 import org.openpnp.spi.Actuator;
 import org.openpnp.spi.Camera;
 import org.openpnp.spi.HeadMountable;
@@ -1548,7 +1549,7 @@ public class CameraView extends JComponent implements CameraListener {
                 if (currentLocation.getLinearLengthTo(camera.getLocation()).compareTo(camera.getRoamingRadius()) < 0
                         && location.getLinearLengthTo(camera.getLocation()).compareTo(camera.getRoamingRadius()) < 0) {
                     // Within the roaming area, no need to go to Safe Z.
-                    nozzle.moveTo(location);
+                    nozzle.moveTo(location, Motion.MotionOption.JogMotion);
                 }
                 else {
                     // Current or new location outside roaming area. Move to safe Z.

--- a/src/main/java/org/openpnp/machine/reference/ReferenceMachine.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceMachine.java
@@ -254,6 +254,7 @@ public class ReferenceMachine extends AbstractMachine {
         }
         else {
             // remove homed-flag if machine is disabled
+            getMotionPlanner().unhome();
             this.setHomed(false);
             fireMachineAboutToBeDisabled("User requested stop.");
             // In a multi-driver machine, we must try to disable all drivers even if one throws.
@@ -512,6 +513,7 @@ public class ReferenceMachine extends AbstractMachine {
 
         if (isHomed()) {
             // if one rehomes, the isHomed flag has to be removed
+            getMotionPlanner().unhome();
             this.setHomed(false);
         }
 

--- a/src/main/java/org/openpnp/machine/reference/driver/AbstractMotionPlanner.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/AbstractMotionPlanner.java
@@ -88,7 +88,9 @@ public abstract class AbstractMotionPlanner extends AbstractModelObject implemen
     protected TreeMap<Double, Motion> motionPlan = new TreeMap<Double, Motion>();
 
     private AxesLocation lastDirectionalBacklashOffset = new AxesLocation();
-    private List<Driver> lastPlannedDrivers = new ArrayList<Driver>(); 
+    private List<Driver> lastPlannedDrivers = new ArrayList<Driver>();
+
+    private boolean homed = false; 
 
     @Override
     public synchronized void home() throws Exception {
@@ -111,6 +113,12 @@ public abstract class AbstractMotionPlanner extends AbstractModelObject implemen
         }
         // Make sure we're on the same page with the controller and wait for still-stand.
         waitForCompletion(null, CompletionType.WaitForStillstandIndefinitely);
+        homed = true;
+    }
+
+    @Override
+    public void unhome() {
+        homed  = false;
     }
 
     @Override
@@ -150,7 +158,7 @@ public abstract class AbstractMotionPlanner extends AbstractModelObject implemen
                 currentLocation
                 .put(axesLocation);
 
-        if (!getMachine().isHomed()) {
+        if (!homed) {
             // Machine is unhomed, check if move is legal.
             int optionFlags = Motion.optionFlags(options);
             AxesLocation segment = currentLocation.motionSegmentTo(newLocation);

--- a/src/main/java/org/openpnp/machine/reference/driver/AbstractMotionPlanner.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/AbstractMotionPlanner.java
@@ -122,6 +122,11 @@ public abstract class AbstractMotionPlanner extends AbstractModelObject implemen
     }
 
     @Override
+    public boolean isHomed() {
+        return homed;
+    }
+
+    @Override
     public synchronized void setGlobalOffsets(AxesLocation axesLocation) throws Exception {
         // Make sure we're on the same page with the controller, but there is no need to  wait for it to physically complete.
         executeMotionPlan(CompletionType.CommandStillstand);

--- a/src/main/java/org/openpnp/machine/reference/driver/AbstractReferenceDriver.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/AbstractReferenceDriver.java
@@ -44,6 +44,9 @@ public abstract class AbstractReferenceDriver extends AbstractDriver {
     @Attribute(required = false)
     protected boolean syncInitialLocation = false;
 
+    @Attribute(required = false)
+    protected boolean allowUnhomedMotion = false;
+
     /**
      * TODO The following properties are for backwards compatibility and can be removed after 2019-07-15. 
      */
@@ -172,7 +175,20 @@ public abstract class AbstractReferenceDriver extends AbstractDriver {
     }
 
     public void setSyncInitialLocation(boolean syncInitialLocation) {
+        Object oldValue = this.syncInitialLocation;
         this.syncInitialLocation = syncInitialLocation;
+        firePropertyChange("syncInitialLocation", oldValue, syncInitialLocation);
+    }
+
+    @Override
+    public boolean isAllowUnhomedMotion() {
+        return allowUnhomedMotion;
+    }
+
+    public void setAllowUnhomedMotion(boolean allowUnhomedMotion) {
+        Object oldValue = this.allowUnhomedMotion;
+        this.allowUnhomedMotion = allowUnhomedMotion;
+        firePropertyChange("allowUnhomedMotion", oldValue, allowUnhomedMotion);
     }
 
     public boolean isInSimulationMode() {

--- a/src/main/java/org/openpnp/spi/Driver.java
+++ b/src/main/java/org/openpnp/spi/Driver.java
@@ -98,6 +98,13 @@ import org.openpnp.spi.MotionPlanner.CompletionType;
     boolean isSyncInitialLocation();
 
     /**
+     * @return true if the driver allows motion on an unhomed machine.
+     */
+    default boolean isAllowUnhomedMotion() {
+        return false;
+    }
+
+    /**
      * @return true if a motion is still assumed to be pending, i.e. waitForCompletion() has not yet been called.  
      * 
      */

--- a/src/main/java/org/openpnp/spi/MotionPlanner.java
+++ b/src/main/java/org/openpnp/spi/MotionPlanner.java
@@ -89,6 +89,11 @@ public interface MotionPlanner extends PropertySheetHolder, Solutions.Subject {
     public void home() throws Exception;
 
     /**
+     * Mark the motion planner as unhomed.
+     */
+    public void unhome();
+
+    /**
      * Set the current physical or virtual axis positions to be reinterpreted as the specified coordinates. 
      * Used after visual homing and to reset a rotation angle after it has wrapped around. 
      * 

--- a/src/main/java/org/openpnp/spi/MotionPlanner.java
+++ b/src/main/java/org/openpnp/spi/MotionPlanner.java
@@ -89,9 +89,14 @@ public interface MotionPlanner extends PropertySheetHolder, Solutions.Subject {
     public void home() throws Exception;
 
     /**
-     * Mark the motion planner as unhomed.
+     * Mark the motion planner and underlying drivers as unhomed.
      */
     public void unhome();
+
+    /**
+     * @return true when the motion planner has homed all drivers.
+     */
+    boolean isHomed();
 
     /**
      * Set the current physical or virtual axis positions to be reinterpreted as the specified coordinates. 

--- a/src/main/resources/org/openpnp/translations.properties
+++ b/src/main/resources/org/openpnp/translations.properties
@@ -1,5 +1,5 @@
 #Eclipse messages class
-#Wed Feb 08 11:26:39 CET 2023
+#Mon Apr 03 10:44:19 CEST 2023
 AbstractActuatorConfigurationWizard.CoordinateSystemPanel.AxisInterlockLabel.text=Axis Interlock?
 AbstractActuatorConfigurationWizard.CoordinateSystemPanel.AxisInterlockLabel.toolTipText=Enable to get an extra Wizard tab to configure an Axis Interlocking Actuator
 AbstractActuatorConfigurationWizard.CoordinateSystemPanel.AxisLabel.text=Axis
@@ -59,11 +59,13 @@ AbstractReferenceDriverConfigurationWizard.CommunicationMethodPanel.StopBitsLabe
 AbstractReferenceDriverConfigurationWizard.ControllerPanel.Border.title=Properties
 AbstractReferenceDriverConfigurationWizard.ControllerPanel.NameLabel.text=Name
 AbstractReferenceDriverConfigurationWizard.ControllerPanel.SyncInitialLocationLabel.text=Sync Initial Location
-AbstractReferenceDriverConfigurationWizard.ControllerPanel.SyncInitialLocationLabel.toolTipText=<html>\nAfter enabling the driver, get the initial location from the controller.<br/>\nIt allows you to safely jog an unhomed machine.\n</html>
+AbstractReferenceDriverConfigurationWizard.ControllerPanel.SyncInitialLocationLabel.toolTipText=<html>\nAfter enabling the driver, synchronize the initial location from the controller.<br/>\nAllows you to safely jog an unhomed machine.<br/>\nNote, when this option is enabled, the location will also be synchronized<br/>\nwhenever you press <strong>Apply</strong> while the machine is enabled, making sure<br/>\nthe option is immediately effective.\n</html>
 AbstractReferenceDriverConfigurationWizard.TCPPanel.Border.title=TCP
 AbstractReferenceDriverConfigurationWizard.TCPPanel.IPAddressLabel.text=IP Address
 AbstractReferenceDriverConfigurationWizard.TCPPanel.IPAddressLabel.toolTipText=IP address or host-name. Set to "GcodeServer" for an internally simulated Controller.
 AbstractReferenceDriverConfigurationWizard.TCPPanel.PortLabel.text=Port
+AbstractReferenceDriverConfigurationWizard.lblAllowUnhomedMotion.text=Allow Unhomed Motion
+AbstractReferenceDriverConfigurationWizard.lblAllowUnhomedMotion.toolTipText=<html>\n<p>Allow the driver axes to move in the unhomed machine state.<br/>\nThis likely only makes sense for machines with absolute linear encoders.</p>\n<p>Note, the option is only available when the <strong>Sync Initial Location</strong><br/>\nis first enabled, making sure OpenPnP always knows the current location.</p>\n</html>
 AbstractReferenceDriverConfigurationWizard.lblMinSupportedSpeed.text=Minimum Speed
 AbstractReferenceDriverConfigurationWizard.lblMinSupportedSpeed.toolTipText=<html>\r\n<p>\r\nMinimum Speed % fully supported by the driver.\r\n</p><p>\r\nExcessively low minimum speeds lead to excessive required precision for<br/>\r\nfeed-rates, acceleration (and jerk) rates. By keeping the minmum speed % at<br/>\r\nreasonable levels (e.g. 5%), the computation and can be optimized. <br/>\r\nFewer decimal digits are required (GcodeDriver) which lowers required<br/>\r\nserial bandwidth.\r\n</p><p>\r\nLower speeds are still possible, but they will slightly change characteristics,<br/>\r\ne.g. accelerate faster, cruise longer.\r\n</p>\r\n</html>\r\n
 AbstractSignaler.Action.Delete.Description=Delete the currently selected signaler.

--- a/src/test/java/BasicJobTest.java
+++ b/src/test/java/BasicJobTest.java
@@ -9,9 +9,9 @@ import org.openpnp.machine.reference.ReferencePnpJobProcessor;
 import org.openpnp.machine.reference.driver.test.TestDriver;
 import org.openpnp.machine.reference.driver.test.TestDriver.TestDriverDelegate;
 import org.openpnp.machine.reference.feeder.ReferenceTubeFeeder;
+import org.openpnp.model.Abstract2DLocatable.Side;
 import org.openpnp.model.AxesLocation;
 import org.openpnp.model.Board;
-import org.openpnp.model.Abstract2DLocatable.Side;
 import org.openpnp.model.BoardLocation;
 import org.openpnp.model.Configuration;
 import org.openpnp.model.Job;
@@ -119,6 +119,7 @@ public class BasicJobTest {
 
         ReferencePnpJobProcessor jobProcessor = (ReferencePnpJobProcessor) machine.getPnpJobProcessor();
         machine.setEnabled(true);
+        machine.home();
         machine.execute(() -> { 
             jobProcessor.addTextStatusListener(text -> {
                 System.out.println(text);

--- a/src/test/java/HttpActuatorTest.java
+++ b/src/test/java/HttpActuatorTest.java
@@ -1,3 +1,5 @@
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -7,13 +9,12 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openpnp.machine.reference.HttpActuator;
 import org.openpnp.model.Configuration;
+import org.openpnp.spi.Machine;
 
 import com.google.common.io.Files;
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
 import com.sun.net.httpserver.HttpServer;
-
-import static org.junit.jupiter.api.Assertions.*;
 
 
 public class HttpActuatorTest {
@@ -43,8 +44,10 @@ public class HttpActuatorTest {
         
         String stringResult="";
         try {
-            Configuration.get().getMachine().setEnabled(true);
-            stringResult= Configuration.get().getMachine().execute(() -> {
+            Machine machine = Configuration.get().getMachine();
+            machine.setEnabled(true);
+            machine.home();
+            stringResult= machine.execute(() -> {
                  return  actuator.read();
             }, false, 0);
       

--- a/src/test/java/ReferenceBottomVisionOffsetTest.java
+++ b/src/test/java/ReferenceBottomVisionOffsetTest.java
@@ -10,8 +10,8 @@ import org.junit.jupiter.api.Test;
 import org.openpnp.machine.reference.ReferenceNozzleTip;
 import org.openpnp.machine.reference.camera.SimulatedUpCamera;
 import org.openpnp.machine.reference.vision.ReferenceBottomVision;
-import org.openpnp.model.Board;
 import org.openpnp.model.Abstract2DLocatable.Side;
+import org.openpnp.model.Board;
 import org.openpnp.model.BoardLocation;
 import org.openpnp.model.BottomVisionSettings;
 import org.openpnp.model.Configuration;
@@ -95,6 +95,7 @@ public class ReferenceBottomVisionOffsetTest {
         };
         
         machine.setEnabled(true);
+        machine.home();
         Location maxError = new Location(LengthUnit.Millimeters, 0.1, 0.1, 0, 0.07);
         for (Location[] testPair: testData) {
             machine.execute(() -> {
@@ -140,6 +141,7 @@ public class ReferenceBottomVisionOffsetTest {
         };
         
         machine.setEnabled(true);
+        machine.home();
         Location maxError = new Location(LengthUnit.Millimeters, 0.1, 0.1, 0, 0.07);
         for (Location[] testPair: testData) {
             machine.execute(() -> {
@@ -186,6 +188,7 @@ public class ReferenceBottomVisionOffsetTest {
         };
         
         machine.setEnabled(true);
+        machine.home();
         Location maxError = new Location(LengthUnit.Millimeters, 0.1, 0.1, 0, 0.07);
         for (Location[] testPair: testData) {
             machine.execute(() -> {
@@ -234,6 +237,7 @@ public class ReferenceBottomVisionOffsetTest {
         };
         
         machine.setEnabled(true);
+        machine.home();
         Location maxError = new Location(LengthUnit.Millimeters, 0.1, 0.1, 0, 0.07);
         for (Location[] testPair: testData) {
             machine.execute(() -> {
@@ -281,6 +285,7 @@ public class ReferenceBottomVisionOffsetTest {
         };
         
         machine.setEnabled(true);
+        machine.home();
         Location maxError = new Location(LengthUnit.Millimeters, 0.1, 0.1, 0, 0.07);
         for (Location[] testPair: testData) {
             machine.execute(() -> {
@@ -327,6 +332,7 @@ public class ReferenceBottomVisionOffsetTest {
         };
         
         machine.setEnabled(true);
+        machine.home();
         Location maxError = new Location(LengthUnit.Millimeters, 0.1, 0.1, 0, 0.07);
         for (Location[] testPair: testData) {
             machine.execute(() -> {
@@ -373,6 +379,7 @@ public class ReferenceBottomVisionOffsetTest {
         };
         
         machine.setEnabled(true);
+        machine.home();
         Location maxError = new Location(LengthUnit.Millimeters, 0.1, 0.1, 0, 0.07);
         for (Location[] testPair: testData) {
             machine.execute(() -> {
@@ -423,6 +430,7 @@ public class ReferenceBottomVisionOffsetTest {
         camera.setErrorOffsets(error);
         
         machine.setEnabled(true);
+        machine.home();
         Location maxError = new Location(LengthUnit.Millimeters, 0.1, 0.1, 0, 0.07);
         for (Location[] testPair: testData) {
             machine.execute(() -> {
@@ -476,6 +484,7 @@ public class ReferenceBottomVisionOffsetTest {
         camera.setErrorOffsets(error);
 
         machine.setEnabled(true);
+        machine.home();
         Location maxError = new Location(LengthUnit.Millimeters, 0.1, 0.1, 0, 0.07);
         for (Location[] testPair: testData) {
             machine.execute(() -> {

--- a/src/test/java/ReferenceBottomVisionTest.java
+++ b/src/test/java/ReferenceBottomVisionTest.java
@@ -64,6 +64,7 @@ public class ReferenceBottomVisionTest {
 
         camera.setErrorOffsets(error);
         machine.setEnabled(true);
+        machine.home();
         machine.execute(() -> {
             nozzle.pick(part);
             PartAlignmentOffset offset = bottomVision.findOffsets(part, null, null, nozzle);

--- a/src/test/java/SampleJobTest.java
+++ b/src/test/java/SampleJobTest.java
@@ -121,6 +121,7 @@ public class SampleJobTest {
         Job job = Configuration.get().loadJob(jobFile);
 
         machine.setEnabled(true);
+        machine.home();
         machine.execute(() -> {
             machine.home();
             jobProcessor.initialize(job);

--- a/src/test/java/SamplePanelizedJobTest.java
+++ b/src/test/java/SamplePanelizedJobTest.java
@@ -121,6 +121,7 @@ public class SamplePanelizedJobTest {
         Job job = Configuration.get().loadJob(jobFile);
 
         machine.setEnabled(true);
+        machine.home();
         machine.execute(() -> {
             machine.home();
             jobProcessor.initialize(job);

--- a/src/test/java/VisionCompositingTest.java
+++ b/src/test/java/VisionCompositingTest.java
@@ -91,6 +91,7 @@ public class VisionCompositingTest {
         bottomVision.setMaxLinearOffset(new Length(0.1, LengthUnit.Millimeters));
 
         machine.setEnabled(true);
+        machine.home();
         machine.execute(() -> {
             for (Part part: Configuration.get().getParts()) {
                 if (!part.getId().startsWith("FID")) {


### PR DESCRIPTION
# Description

On unhomed machines the current position is not known by the controller, they often power-up/reset to zero coordinates at the position the machine randomly happens to be. Positioning the machine to a prerecorded location can therefore lead to a crash. Only few actions in OpenPnP check if the machine is homed and prevent that. Most notably the generic **Position to Location** buttons do not.

This PR makes this safer. In doing so, it distinguishes two types of motion:
 
- Jog motion is allowed, when the current controller machine position is positively known to OpenPnP. It is assumed that the user observes the true machine position and will avoid jogging into obstacles. 
- Non-jog motion is generally disallowed on unhomed machines. 

The machine homing safety checks are centrally administered inside the motion planner, so motion generated from all sources is covered. 

The behavior can be overridden on the driver, in case it proves too restrictive, e.g. for controllers where absolute linear encoders are available and homing is simply not required, or where homing is inherently and safely done when powering up. This option can be controlled per driver, i.e. it can be treated differently if multiple drivers/controllers with different capabilities are involved. The drivers assigned to axes determine which drivers are relevant for a certain motion.

## Features

- Only allow unhomed jog moves if **Sync Initial Location** is enabled on relevant drivers, making sure OpenPnP knows the current coordinates of the controller. Note, OpenPnP uses absolute, not relative G-code to jog, so it needs to know the prior position.
- Only allow unhomed non-jog moves if **Allow Unhomed Motion** is enabled on relevant drivers. The option is only available and effective if the **Sync Initial Location** is enabled first. 
- Motion that is not admissible is caught with error message (see screenshot in **Instructions for Use**).
- Adds `Driver.isAllowUnhomedMotion()` method and implementation in `AbstractReferenceDriver` and its UI.
- Adds `MotionPlanner.isHomed()` and `MotionPlanner.unhome()` to keep track of the homing status of the motion planner itself. This is needed, as some motion (e.g. visual homing) is performed as part of the homing cycle, _before_ the machine (as a whole) is marked as homed.
- When the wizard **Apply** is pressed while the machine is enabled, it now synchronizes the location, so
a newly enabled **Sync Initial Location** option is immediately effective, and any permissible motion therefore safe.
- Drag moves inside the **Roaming Radius** of the bottom camera are now considered jog moves.
- Revised tooltips on **Sync Initial Location** driver option.

# Justification
See user report:
https://groups.google.com/g/openpnp/c/c6yPl2uTDUw/m/zE85_5vRAwAJ

# Instructions for Use

Use the (already existing) **Sync Initial Location** to make sure OpenPnP knows the current controller coordinates after connecting, i.e., after enabling the machine.

Use the new **Allow Unhomed Motion** if you want to allow non-jog motion even when the machine is unhomed. This likely only makes sense if your machine has absolute linear encoders or other means of inherent and safe homing on power-up/reset.
  
![Screenshot_20230403_101639](https://user-images.githubusercontent.com/9963310/229500739-5c1f7c1d-f6dc-4b3e-9a54-f28476c46828.png)

# Implementation Details
1. Tested in simulation using GcodeServer.
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. Changes in the `org.openpnp.spi`: added the `Driver.isAllowUnhomedMotion()`, `MotionPlanner.isHomed()` and `MotionPlanner.unhome()` methods.
4. Successful `mvn test` before submitting the Pull Request.
