### PR TITLE
Feature/Script to sort Translation Properties

### DIFF
--- a/src/main/resources/org/openpnp/sort-properties.sh
+++ b/src/main/resources/org/openpnp/sort-properties.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+cp translations.properties translations.properties.bak \
+&& LC_ALL=C sort -t$'=' -k1,1 translations.properties > translations.properties.new \
+&& mv translations.properties.new translations.properties


### PR DESCRIPTION
# Description
WindowBuilder seems to shuffle the `./src/main/resources/org/openpnp/translations.properties` file whenever the slightest text change is made in the interactive editor. Despite intensive search I have not found a way to stop that.

This PR adds a simple bash script to sort the `translations.properties` file (more or less) the same way the normal externalization seems to do. By using a canonical sort order, the changes to the file become minimal in terms of versioning.

# Justification
The diff in the  `translations.properties` file should be kept minimal.

# Instructions for Use
After each change that affects the  `translations.properties` file, execute the `./src/main/resources/org/openpnp/sort-properties.sh` script in a bash class shell. The script creates backups for safety.

# Implementation Details
1. Tested in several past PRs. Now published.
2. The [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style) does not apply.
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. `mvn test` does not apply.
