### PR TITLE
Default board location

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/wizards/ReferenceMachineConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/wizards/ReferenceMachineConfigurationWizard.java
@@ -35,6 +35,10 @@ public class ReferenceMachineConfigurationWizard extends AbstractConfigurationWi
     private JTextField discardYTf;
     private JTextField discardZTf;
     private JTextField discardCTf;
+    private JTextField defaultBoardXTf;
+    private JTextField defaultBoardYTf;
+    private JTextField defaultBoardZTf;
+    private JTextField defaultBoardCTf;
     private JComboBox motionPlannerClass;
     private boolean reloadWizard;
     private JCheckBox autoToolSelect;
@@ -151,6 +155,8 @@ public class ReferenceMachineConfigurationWizard extends AbstractConfigurationWi
                 FormSpecs.RELATED_GAP_ROWSPEC,
                 FormSpecs.DEFAULT_ROWSPEC,
                 FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
                 FormSpecs.DEFAULT_ROWSPEC,}));
         
                 JLabel lblX = new JLabel("X");
@@ -190,9 +196,33 @@ public class ReferenceMachineConfigurationWizard extends AbstractConfigurationWi
         panelLocations.add(discardCTf, "10, 4");
         discardCTf.setColumns(5);
         
-                LocationButtonsPanel locationButtonsPanel =
+                LocationButtonsPanel discardLocationButtonsPanel =
                         new LocationButtonsPanel(discardXTf, discardYTf, discardZTf, discardCTf);
-        panelLocations.add(locationButtonsPanel, "12, 4");
+        panelLocations.add(discardLocationButtonsPanel, "12, 4");
+
+		        JLabel lblDefaultBoardPoint = new JLabel(Translations.getString(
+		                "ReferenceMachineConfigurationWizard.PanelLocations.DefaultBoardLocationLabel.text")); //$NON-NLS-1$
+		panelLocations.add(lblDefaultBoardPoint, "2, 6");
+		
+		        defaultBoardXTf = new JTextField();
+		panelLocations.add(defaultBoardXTf, "4, 6");
+		defaultBoardXTf.setColumns(5);
+		
+		        defaultBoardYTf = new JTextField();
+		panelLocations.add(defaultBoardYTf, "6, 6");
+		defaultBoardYTf.setColumns(5);
+		
+		        defaultBoardZTf = new JTextField();
+		panelLocations.add(defaultBoardZTf, "8, 6");
+		defaultBoardZTf.setColumns(5);
+		
+		        defaultBoardCTf = new JTextField();
+		panelLocations.add(defaultBoardCTf, "10, 6");
+		defaultBoardCTf.setColumns(5);
+		
+		        LocationButtonsPanel defaultBoardLocationButtonsPanel =
+		                new LocationButtonsPanel(defaultBoardXTf, defaultBoardYTf, defaultBoardZTf, defaultBoardCTf);
+		panelLocations.add(defaultBoardLocationButtonsPanel, "12, 6");
     }
 
     @Override
@@ -224,6 +254,19 @@ public class ReferenceMachineConfigurationWizard extends AbstractConfigurationWi
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(discardYTf);
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(discardZTf);
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(discardCTf);
+
+        MutableLocationProxy defaultBoardLocation = new MutableLocationProxy();
+        bind(UpdateStrategy.READ_WRITE, machine, "defaultBoardLocation", defaultBoardLocation, "location");
+        addWrappedBinding(defaultBoardLocation, "lengthX", defaultBoardXTf, "text", lengthConverter);
+        addWrappedBinding(defaultBoardLocation, "lengthY", defaultBoardYTf, "text", lengthConverter);
+        addWrappedBinding(defaultBoardLocation, "lengthZ", defaultBoardZTf, "text", lengthConverter);
+        addWrappedBinding(defaultBoardLocation, "rotation", defaultBoardCTf, "text", doubleConverter);
+
+        ComponentDecorators.decorateWithAutoSelectAndLengthConversion(unsafeZRoamingDistance);
+        ComponentDecorators.decorateWithAutoSelectAndLengthConversion(defaultBoardXTf);
+        ComponentDecorators.decorateWithAutoSelectAndLengthConversion(defaultBoardYTf);
+        ComponentDecorators.decorateWithAutoSelectAndLengthConversion(defaultBoardZTf);
+        ComponentDecorators.decorateWithAutoSelectAndLengthConversion(defaultBoardCTf);
     }
 
     public String getMotionPlannerClassName() {

--- a/src/main/java/org/openpnp/model/BoardLocation.java
+++ b/src/main/java/org/openpnp/model/BoardLocation.java
@@ -76,7 +76,10 @@ public class BoardLocation extends PlacementsHolderLocation<BoardLocation> {
      * Default constructor
      */
     public BoardLocation() {
-        setLocation(new Location(LengthUnit.Millimeters));
+    	/**
+    	 * use the location defined as default board location for the reference machine
+    	 */
+        setLocation(Configuration.get().getMachine().getDefaultBoardLocation());
     }
 
     /**

--- a/src/main/java/org/openpnp/spi/Machine.java
+++ b/src/main/java/org/openpnp/spi/Machine.java
@@ -340,6 +340,8 @@ public interface Machine extends WizardConfigurable, PropertySheetHolder, Closea
 
     public Location getDiscardLocation();
 
+    public Location getDefaultBoardLocation();
+
     public void setSpeed(double speed);
 
     public double getSpeed();

--- a/src/main/java/org/openpnp/spi/base/AbstractMachine.java
+++ b/src/main/java/org/openpnp/spi/base/AbstractMachine.java
@@ -91,6 +91,9 @@ public abstract class AbstractMachine extends AbstractModelObject implements Mac
     @Element(required = false)
     protected Location discardLocation = new Location(LengthUnit.Millimeters);
 
+    @Element(required = false)
+    protected Location defaultBoardLocation = new Location(LengthUnit.Millimeters);
+
     @Attribute(required = false)
     protected double speed = 1.0D;
     
@@ -736,6 +739,14 @@ public abstract class AbstractMachine extends AbstractModelObject implements Mac
 
     public void setDiscardLocation(Location discardLocation) {
         this.discardLocation = discardLocation;
+    }
+
+    public Location getDefaultBoardLocation() {
+        return defaultBoardLocation;
+    }
+
+    public void setDefaultBoardLocation(Location defaultBoardLocation) {
+        this.defaultBoardLocation = defaultBoardLocation;
     }
 
     @Override

--- a/src/main/resources/org/openpnp/translations.properties
+++ b/src/main/resources/org/openpnp/translations.properties
@@ -1355,6 +1355,7 @@ ReferenceMachineConfigurationWizard.PanelGeneral.ParkAllAtSafeZLabel.text=Park a
 ReferenceMachineConfigurationWizard.PanelGeneral.ParkAllAtSafeZLabel.toolTipText=When the Z Park button is pressed, move all tools mounted on the same head to safe Z.
 ReferenceMachineConfigurationWizard.PanelGeneral.UnsafeZRoamingLabel.text=Unsafe Z Roaming
 ReferenceMachineConfigurationWizard.PanelLocations.Border.title=Locations
+ReferenceMachineConfigurationWizard.PanelLocations.DefaultBoardLocationLabel.text=Default Board Location
 ReferenceMachineConfigurationWizard.PanelLocations.DiscardLocationLabel.text=Discard Location
 ReferenceMachineConfigurationWizard.PanelLocations.RotationLabel.text=Rotation
 ReferenceMachineConfigurationWizard.lblAutoToolSelect.toolTipText=Whenever an explicit user action is performed on a tool, automatically select it in Machine Controls.


### PR DESCRIPTION
# Description
This PR add a default board location property to the ReferenceMachine Locations section. This location will be used as default when a board is added to a job. 

# Justification
On machines with a dedicated board registration system like CHM-T36 or 48, the location of boards on the machine is always the same. With this preconfigured location there is almost no board position setup required for new boards anymore.

# Instructions for Use
The default default board location is the same as the hardware coded location currently in place. So without specifying a default board location nothing will change. Once the default board location is specified boards added to jobs will automatically have this location as reference. 

# Implementation Details
1. How did you test the change? Be descriptive. Untested code will not be accepted. _I've set the default board location and added new and existing boards to jobs and verified, that the default location is set as expected. I also verified, that the default board location is stored in machine.xml._
2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)? _I copied some code and kept the format as it was._
3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing. _I modified spi by coping DiscardLocation related code to get the default board location in the config file and to provide getter and setter methods._
4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted. _I executed "Run As -> Marvin test" from within Eclipse without errors._
