### PR TITLE
Fix pad name rule - KicadModImporter

### DIFF
--- a/src/main/java/org/openpnp/gui/importer/KicadModImporter.java
+++ b/src/main/java/org/openpnp/gui/importer/KicadModImporter.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.regex.Pattern;
 import java.util.regex.Matcher;
 
+import org.openpnp.Translations;
 import org.openpnp.gui.MainFrame;
 import org.openpnp.gui.support.MessageBoxes;
 import org.openpnp.model.Footprint;
@@ -58,7 +59,7 @@ public class KicadModImporter {
         }
 
         String getName() {
-            Pattern p = Pattern.compile("^\\(pad\\s\"(\\w*)\"\\s(\\w*)\\s(\\w*)");
+            Pattern p = Pattern.compile("^\\(pad\\s\"?(\\w*)\"?\\s(\\w*)\\s(\\w*)");
             Matcher m = p.matcher(padDefinition);
             if(m.find()) {
                 return m.group(1);
@@ -67,7 +68,7 @@ public class KicadModImporter {
         }
 
         String getType() {
-            Pattern p = Pattern.compile("^\\(pad\\s\"(\\w*)\"\\s(\\w*)\\s(\\w*)");
+            Pattern p = Pattern.compile("^\\(pad\\s\"?(\\w*)\"?\\s(\\w*)\\s(\\w*)");
             Matcher m = p.matcher(padDefinition);
             if(m.find()) {
                 return m.group(2);
@@ -76,7 +77,7 @@ public class KicadModImporter {
         }
 
         String getShape() {
-            Pattern p = Pattern.compile("^\\(pad\\s\"(\\w*)\"\\s(\\w*)\\s(\\w*)");
+            Pattern p = Pattern.compile("^\\(pad\\s\"?(\\w*)\"?\\s(\\w*)\\s(\\w*)");
             Matcher m = p.matcher(padDefinition);
             if(m.find()) {
                 return m.group(3);
@@ -156,7 +157,7 @@ public class KicadModImporter {
             fileDialog.setFilenameFilter(new FilenameFilter() {
                 @Override
                 public boolean accept(File dir, String name) {
-                    return name.toLowerCase().endsWith(".kicad_mod");
+                    return name.toLowerCase().endsWith(".kicad_mod"); //$NON-NLS-1$
                 }
             });
             fileDialog.setVisible(true);
@@ -204,7 +205,7 @@ public class KicadModImporter {
             reader.close();
         }
         catch (Exception e) {
-            MessageBoxes.errorBox(MainFrame.get(), "Kicad Footprint Load Error", e.getMessage());
+            MessageBoxes.errorBox(MainFrame.get(), Translations.getString("KicadModImporter.LoadFile.Fail"), e.getMessage()); //$NON-NLS-1$
         }
     }
 

--- a/src/main/resources/org/openpnp/translations.properties
+++ b/src/main/resources/org/openpnp/translations.properties
@@ -691,6 +691,7 @@ JogControlsPanel.Tab.Special=Special
 JogControlsPanel.btnRecycle.text=Recycle
 JogControlsPanel.btnRecycle.toolTipText=Put the part on the current nozzle back in a feeder.
 JogControlsPanel.homeButton.toolTipText=<html>\nDisabled\: Machine Not Enabled.\n<br>Yellow\: Machine Not Homed\n<br>Black\: Machine Homed; Click to Rehome.\n</html>
+KicadModImporter.LoadFile.Fail=Kicad Footprint Load Error
 KicadPosImporter.Importer.Description=Import KiCAD .pos Files.
 KicadPosImporterDialog.Browse1Action.Name=Browse
 KicadPosImporterDialog.Browse1Action.ShortDescription=Browse


### PR DESCRIPTION
# Description
Marked the quotation mark character as optional in pad name rule. Updating static texts with the translation mechanism.

# Justification
According with many footprint downloaded throught [LibraryLoader ](https://www.samacsys.com/library-loader/) for Kicad edit regex for mark as optional quotation mark char in pad name rule.

# Instructions for Use
Same as original PR #1533 

# Implementation Details
1. Tested in real environment
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. Successfull  `mvn test` before submitting the Pull Request.
