### PR TITLE
Fix/Schultz Feeder Actions in Machine Tasks

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/feeder/wizards/SchultzFeederConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/wizards/SchultzFeederConfigurationWizard.java
@@ -28,6 +28,7 @@ import javax.swing.JButton;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JTextField;
+import javax.swing.SwingUtilities;
 import javax.swing.border.EtchedBorder;
 import javax.swing.border.TitledBorder;
 
@@ -286,7 +287,9 @@ public class SchultzFeederConfigurationWizard extends AbstractReferenceFeederCon
                             "Failed, unable to find an actuator named " + feeder.getIdActuatorName());
                 }
                 String s = actuator.read(feeder.getActuatorValue());
-                idText.setText(s == null ? "" : s);
+                SwingUtilities.invokeLater(() -> {
+                    idText.setText(s == null ? "" : s);
+                });
             });
         }
     };
@@ -348,7 +351,9 @@ public class SchultzFeederConfigurationWizard extends AbstractReferenceFeederCon
                             "Failed, unable to find an actuator named " + feeder.getFeedCountActuatorName());
                 }
                 String s = actuator.read(feeder.getActuatorValue());
-                feedCountValue.setText(s == null ? "" : s);
+                SwingUtilities.invokeLater(() -> {
+                    feedCountValue.setText(s == null ? "" : s);
+                });
             });
         }
     };
@@ -371,7 +376,9 @@ public class SchultzFeederConfigurationWizard extends AbstractReferenceFeederCon
 
                 AbstractActuator.suggestValueType(actuator, Actuator.ActuatorValueType.Double);
                 actuator.actuate(feeder.getActuatorValue());
-                feedCountValue.setText("");
+                SwingUtilities.invokeLater(() -> {
+                    feedCountValue.setText("");
+                });
             });
         }
     };
@@ -392,7 +399,9 @@ public class SchultzFeederConfigurationWizard extends AbstractReferenceFeederCon
                             "Failed, unable to find an actuator named " + feeder.getPitchActuatorName());
                 }
                 String s = actuator.read(feeder.getActuatorValue());
-                pitchValue.setText(s == null ? "" : s);
+                SwingUtilities.invokeLater(() -> {
+                    pitchValue.setText(s == null ? "" : s);
+                });
             });
         }
     };
@@ -435,7 +444,9 @@ public class SchultzFeederConfigurationWizard extends AbstractReferenceFeederCon
                             "Failed, unable to find an actuator named " + feeder.getStatusActuatorName());
                 }
                 String s = actuator.read(feeder.getActuatorValue());
-                statusText.setText(s == null ? "" : s);
+                SwingUtilities.invokeLater(() -> {
+                    statusText.setText(s == null ? "" : s);
+                });
             });
         }
     };

--- a/src/main/java/org/openpnp/machine/reference/feeder/wizards/SchultzFeederConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/wizards/SchultzFeederConfigurationWizard.java
@@ -274,9 +274,6 @@ public class SchultzFeederConfigurationWizard extends AbstractReferenceFeederCon
         @Override
         public void actionPerformed(ActionEvent arg0) {
             UiUtils.submitUiMachineTask(() -> {
-                if (!(Configuration.get().getMachine().isEnabled())) {
-                    throw new Exception ("Start machine first.");
-                }
                 if (feeder.getIdActuatorName() == null || feeder.getIdActuatorName().equals("")) {
                     Logger.warn("No getIdActuatorName specified for feeder {}.", feeder.getName());
                     return;
@@ -298,9 +295,6 @@ public class SchultzFeederConfigurationWizard extends AbstractReferenceFeederCon
         @Override
         public void actionPerformed(ActionEvent arg0) {
             UiUtils.submitUiMachineTask(() -> {
-                if (!(Configuration.get().getMachine().isEnabled())) {
-                    throw new Exception ("Start machine first.");
-                }
                 if (feeder.getActuatorName() == null || feeder.getActuatorName().equals("")) {
                     Logger.warn("No actuatorName specified for feeder {}.", feeder.getName());
                     return;
@@ -320,9 +314,6 @@ public class SchultzFeederConfigurationWizard extends AbstractReferenceFeederCon
         @Override
         public void actionPerformed(ActionEvent arg0) {
             UiUtils.submitUiMachineTask(() -> {
-                if (!(Configuration.get().getMachine().isEnabled())) {
-                    throw new Exception ("Start machine first.");
-                }
                 if (feeder.getPostPickActuatorName() == null || feeder.getPostPickActuatorName().equals("")) {
                     Logger.warn("No postPickActuatorName specified for feeder {}.", feeder.getName());
                     return;
@@ -345,9 +336,6 @@ public class SchultzFeederConfigurationWizard extends AbstractReferenceFeederCon
         @Override
         public void actionPerformed(ActionEvent arg0) {
             UiUtils.submitUiMachineTask(() -> {
-                if (!(Configuration.get().getMachine().isEnabled())) {
-                    throw new Exception ("Start machine first.");
-                }
                 if (feeder.getFeedCountActuatorName() == null || feeder.getFeedCountActuatorName().equals("")) {
                     Logger.warn("No feedCountActuatorName specified for feeder {}.", feeder.getName());
                     return;
@@ -369,9 +357,6 @@ public class SchultzFeederConfigurationWizard extends AbstractReferenceFeederCon
         @Override
         public void actionPerformed(ActionEvent arg0) {
             UiUtils.submitUiMachineTask(() -> {
-                if (!(Configuration.get().getMachine().isEnabled())) {
-                    throw new Exception ("Start machine first.");
-                }
                 if (feeder.getClearCountActuatorName() == null || feeder.getClearCountActuatorName().equals("")) {
                     Logger.warn("No clearCountActuatorName specified for feeder {}.", feeder.getName());
                     return;
@@ -395,9 +380,6 @@ public class SchultzFeederConfigurationWizard extends AbstractReferenceFeederCon
         @Override
         public void actionPerformed(ActionEvent arg0) {
             UiUtils.submitUiMachineTask(() -> {
-                if (!(Configuration.get().getMachine().isEnabled())) {
-                    throw new Exception ("Start machine first.");
-                }
                 if (feeder.getPitchActuatorName() == null || feeder.getPitchActuatorName().equals("")) {
                     Logger.warn("No pitchActuatorName specified for feeder {}.", feeder.getName());
                     return;
@@ -419,9 +401,6 @@ public class SchultzFeederConfigurationWizard extends AbstractReferenceFeederCon
         @Override
         public void actionPerformed(ActionEvent arg0) {
             UiUtils.submitUiMachineTask(() -> {
-                if (!(Configuration.get().getMachine().isEnabled())) {
-                    throw new Exception ("Start machine first.");
-                }
                 if (feeder.getTogglePitchActuatorName() == null || feeder.getTogglePitchActuatorName().equals("")) {
                     Logger.warn("No togglePitchActuatorName specified for feeder {}.", feeder.getName());
                     return;
@@ -444,9 +423,6 @@ public class SchultzFeederConfigurationWizard extends AbstractReferenceFeederCon
         @Override
         public void actionPerformed(ActionEvent arg0) {
             UiUtils.submitUiMachineTask(() -> {
-                if (!(Configuration.get().getMachine().isEnabled())) {
-                    throw new Exception ("Start machine first.");
-                }
                 if (feeder.getStatusActuatorName() == null || feeder.getStatusActuatorName().equals("")) {
                     Logger.warn("No statusActuatorName specified for feeder {}.", feeder.getName());
                     return;

--- a/src/main/java/org/openpnp/machine/reference/feeder/wizards/SlotSchultzFeederConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/wizards/SlotSchultzFeederConfigurationWizard.java
@@ -712,7 +712,9 @@ extends AbstractConfigurationWizard {
                             "Failed, unable to find an actuator named " + feeder.getIdActuatorName());
                 }
                 String s = actuator.read(feeder.getActuatorValue());
-                idText.setText(s == null ? "" : s);
+                SwingUtilities.invokeLater(() -> {
+                    idText.setText(s == null ? "" : s);
+                });
             });
         }
     };
@@ -773,7 +775,9 @@ extends AbstractConfigurationWizard {
                             "Failed, unable to find an actuator named " + feeder.getFeedCountActuatorName());
                 }
                 String s = actuator.read(feeder.getActuatorValue());
-                feedCountValue.setText(s == null ? "" : s);
+                SwingUtilities.invokeLater(() -> {
+                    feedCountValue.setText(s == null ? "" : s);
+                });
             });
         }
     };
@@ -795,7 +799,9 @@ extends AbstractConfigurationWizard {
                 }
                 AbstractActuator.suggestValueType(actuator, Actuator.ActuatorValueType.Double);
                 actuator.actuate(feeder.getActuatorValue());
-                feedCountValue.setText("");
+                SwingUtilities.invokeLater(() -> {
+                    feedCountValue.setText("");
+                });
             });
         }
     };
@@ -816,7 +822,9 @@ extends AbstractConfigurationWizard {
                             "Failed, unable to find an actuator named " + feeder.getPitchActuatorName());
                 }
                 String s = actuator.read(feeder.getActuatorValue());
-                pitchValue.setText(s == null ? "" : s);
+                SwingUtilities.invokeLater(() -> {
+                    pitchValue.setText(s == null ? "" : s);
+                });
             });
         }
     };
@@ -859,7 +867,9 @@ extends AbstractConfigurationWizard {
                             "Failed, unable to find an actuator named " + feeder.getStatusActuatorName());
                 }
                 String s = actuator.read(feeder.getActuatorValue());
-                statusText.setText(s == null ? "" : s);
+                SwingUtilities.invokeLater(() -> {
+                    statusText.setText(s == null ? "" : s);
+                });
             });
         }
     };
@@ -876,8 +886,10 @@ extends AbstractConfigurationWizard {
                 if (newLocation == null) {
                     throw new Exception("Unable to locate fiducial");
                 } else {
-                    xPickLocTf.setText(newLocation.getLengthX().toString());
-                    yPickLocTf.setText(newLocation.getLengthY().toString());
+                    SwingUtilities.invokeLater(() -> {
+                        xPickLocTf.setText(newLocation.getLengthX().toString());
+                        yPickLocTf.setText(newLocation.getLengthY().toString());
+                    });
                 }
             });
         }

--- a/src/main/java/org/openpnp/machine/reference/feeder/wizards/SlotSchultzFeederConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/wizards/SlotSchultzFeederConfigurationWizard.java
@@ -700,9 +700,6 @@ extends AbstractConfigurationWizard {
         @Override
         public void actionPerformed(ActionEvent arg0) {
             UiUtils.submitUiMachineTask(() -> {
-                if (!(Configuration.get().getMachine().isEnabled())) {
-                    throw new Exception ("Start machine first.");
-                }
                 if (feeder.getIdActuatorName() == null || feeder.getIdActuatorName().equals("")) {
                     Logger.warn("No getIdActuatorName specified for feeder {}.", feeder.getName());
                     return;
@@ -724,9 +721,6 @@ extends AbstractConfigurationWizard {
         @Override
         public void actionPerformed(ActionEvent arg0) {
             UiUtils.submitUiMachineTask(() -> {
-                if (!(Configuration.get().getMachine().isEnabled())) {
-                    throw new Exception ("Start machine first.");
-                }
                 if (feeder.getActuatorName() == null || feeder.getActuatorName().equals("")) {
                     Logger.warn("No actuatorName specified for feeder {}.", feeder.getName());
                     return;
@@ -746,9 +740,6 @@ extends AbstractConfigurationWizard {
         @Override
         public void actionPerformed(ActionEvent arg0) {
             UiUtils.submitUiMachineTask(() -> {
-                if (!(Configuration.get().getMachine().isEnabled())) {
-                    throw new Exception ("Start machine first.");
-                }
                 if (feeder.getPostPickActuatorName() == null || feeder.getPostPickActuatorName().equals("")) {
                     Logger.warn("No postPickActuatorName specified for feeder {}.", feeder.getName());
                     return;
@@ -770,9 +761,6 @@ extends AbstractConfigurationWizard {
         @Override
         public void actionPerformed(ActionEvent arg0) {
             UiUtils.submitUiMachineTask(() -> {
-                if (!(Configuration.get().getMachine().isEnabled())) {
-                    throw new Exception ("Start machine first.");
-                }
                 if (feeder.getFeedCountActuatorName() == null || feeder.getFeedCountActuatorName().equals("")) {
                     Logger.warn("No feedCountActuatorName specified for feeder {}.", feeder.getName());
                     return;
@@ -793,10 +781,7 @@ extends AbstractConfigurationWizard {
     private Action clearCountActuatorAction = new AbstractAction("Clear feed count") {
         @Override
         public void actionPerformed(ActionEvent arg0) {
-            UiUtils.messageBoxOnException(() -> {
-                if (!(Configuration.get().getMachine().isEnabled())) {
-                    throw new Exception ("Start machine first.");
-                }
+            UiUtils.submitUiMachineTask(() -> {
                 if (feeder.getClearCountActuatorName() == null || feeder.getClearCountActuatorName().equals("")) {
                     Logger.warn("No clearCountActuatorName specified for feeder {}.", feeder.getName());
                     return;
@@ -818,10 +803,7 @@ extends AbstractConfigurationWizard {
     private Action pitchActuatorAction = new AbstractAction("Get pitch") {
         @Override
         public void actionPerformed(ActionEvent arg0) {
-            UiUtils.messageBoxOnException(() -> {
-                if (!(Configuration.get().getMachine().isEnabled())) {
-                    throw new Exception ("Start machine first.");
-                }
+            UiUtils.submitUiMachineTask(() -> {
                 if (feeder.getPitchActuatorName() == null || feeder.getPitchActuatorName().equals("")) {
                     Logger.warn("No feedCountActuatorName specified for feeder {}.", feeder.getName());
                     return;
@@ -843,9 +825,6 @@ extends AbstractConfigurationWizard {
         @Override
         public void actionPerformed(ActionEvent arg0) {
             UiUtils.submitUiMachineTask(() -> {
-                if (!(Configuration.get().getMachine().isEnabled())) {
-                    throw new Exception ("Start machine first.");
-                }
                 if (feeder.getTogglePitchActuatorName() == null || feeder.getTogglePitchActuatorName().equals("")) {
                     Logger.warn("No togglePitchActuatorName specified for feeder {}.", feeder.getName());
                     return;
@@ -868,9 +847,6 @@ extends AbstractConfigurationWizard {
         @Override
         public void actionPerformed(ActionEvent arg0) {
             UiUtils.submitUiMachineTask(() -> {
-                if (!(Configuration.get().getMachine().isEnabled())) {
-                    throw new Exception ("Start machine first.");
-                }
                 if (feeder.getStatusActuatorName() == null || feeder.getStatusActuatorName().equals("")) {
                     Logger.warn("No statusActuatorName specified for feeder {}.", feeder.getName());
                     return;
@@ -892,19 +868,16 @@ extends AbstractConfigurationWizard {
         @Override
         public void actionPerformed(ActionEvent arg0) {
             UiUtils.submitUiMachineTask(() -> {
-                // make sure machine is powered on
-                if(Configuration.get().getMachine().isEnabled()) {
-                    if (feeder.getFiducialPart() == null) {
-                        Logger.warn("No fiducial defined for feeder {}.", feeder.getName());
-                        return;
-                    }
-                    Location newLocation = feeder.getFiducialLocation(feeder.getLocation(), feeder.getFiducialPart());
-                    if (newLocation == null) {
-                        throw new Exception("Unable to locate fiducial");
-                    } else {
-                        xPickLocTf.setText(newLocation.getLengthX().toString());
-                        yPickLocTf.setText(newLocation.getLengthY().toString());
-                    }
+                if (feeder.getFiducialPart() == null) {
+                    Logger.warn("No fiducial defined for feeder {}.", feeder.getName());
+                    return;
+                }
+                Location newLocation = feeder.getFiducialLocation(feeder.getLocation(), feeder.getFiducialPart());
+                if (newLocation == null) {
+                    throw new Exception("Unable to locate fiducial");
+                } else {
+                    xPickLocTf.setText(newLocation.getLengthX().toString());
+                    yPickLocTf.setText(newLocation.getLengthY().toString());
                 }
             });
         }


### PR DESCRIPTION
# Description
User reported malfunction of "SchultzGetPitch" actuator. It is likely the following fixes will resolve that:

1. Make sure all `SchultzFeederConfigurationWizard` and `SlotSchultzFeederConfigurationWizard` actuator actions are done in machine tasks.
2. Remove unnecessary `machine.isEnabled(()` tests inside these machine task.
3. Perform all UI changes from actuator reading in deferred way to prevent race conditions.

# Justification
See user report:
https://groups.google.com/g/openpnp/c/SFUnSoJpUig/m/FjN4IjZlCAAJ

Some actuators were still read in `UiUtils.messageBoxOnException()` handlers instead of `UiUtils.submitUiMachineTask()`.

# Instructions for Use
No change in usage.

# Implementation Details
1. User has to do the ultimate test with hardware.
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
4. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
5. Successful `mvn test`, but does not cover this.
