### PR TITLE
Feature / Better URI Browsing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -236,6 +236,12 @@
 			<artifactId>commons-pool2</artifactId>
 			<version>2.11.1</version>
 		</dependency>
+        <!-- https://mvnrepository.com/artifact/org.apache.commons/commons-lang3 -->
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.12.0</version>
+        </dependency>
 	</dependencies>
 	<build>
 		<plugins>

--- a/src/main/java/org/openpnp/Main.java
+++ b/src/main/java/org/openpnp/Main.java
@@ -61,7 +61,8 @@ public class Main {
     public static String getSourceUri() {
         String version = Main.class.getPackage().getImplementationVersion();
         if (version == null) {
-            version = "-"; // default branch is selected
+            // Select the test branch, as this is likely a developer running OpenPnP.
+            version = "test"; 
         }
         else {
             // Take the hash.

--- a/src/main/java/org/openpnp/gui/IssuesAndSolutionsPanel.java
+++ b/src/main/java/org/openpnp/gui/IssuesAndSolutionsPanel.java
@@ -23,7 +23,6 @@ package org.openpnp.gui;
 
 import java.awt.BorderLayout;
 import java.awt.Color;
-import java.awt.Desktop;
 import java.awt.Font;
 import java.awt.event.ActionEvent;
 import java.awt.event.ItemEvent;
@@ -31,7 +30,6 @@ import java.awt.event.ItemListener;
 import java.awt.event.MouseEvent;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
-import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.prefs.Preferences;
@@ -523,15 +521,12 @@ public class IssuesAndSolutionsPanel extends JPanel {
 
         @Override
         public void actionPerformed(ActionEvent e) {
-            UiUtils.messageBoxOnException(() -> { 
-                List<Solutions.Issue> issues = getSelections();
-                for (Solutions.Issue issue : issues) {
-                    if (issue.getUri() != null) {
-                        Desktop dt = Desktop.getDesktop();
-                        dt.browse(new URI(issue.getUri()));;
-                    }
+            List<Solutions.Issue> issues = getSelections();
+            for (Solutions.Issue issue : issues) {
+                if (issue.getUri() != null) {
+                    UiUtils.browseUri(issue.getUri());
                 }
-            });
+            }
         }
     };
 
@@ -544,10 +539,7 @@ public class IssuesAndSolutionsPanel extends JPanel {
 
         @Override
         public void actionPerformed(ActionEvent e) {
-            UiUtils.messageBoxOnException(() -> { 
-                Desktop dt = Desktop.getDesktop();
-                dt.browse(new URI("https://github.com/openpnp/openpnp/wiki/Issues-and-Solutions"));;
-            });
+            UiUtils.browseUri("https://github.com/openpnp/openpnp/wiki/Issues-and-Solutions"); 
         }
     };
 

--- a/src/main/java/org/openpnp/gui/MainFrame.java
+++ b/src/main/java/org/openpnp/gui/MainFrame.java
@@ -23,7 +23,6 @@ import java.awt.AWTEvent;
 import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Component;
-import java.awt.Desktop;
 import java.awt.Dimension;
 import java.awt.EventQueue;
 import java.awt.FlowLayout;
@@ -40,7 +39,6 @@ import java.awt.event.WindowEvent;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.lang.reflect.Method;
-import java.net.URI;
 import java.security.InvalidParameterException;
 import java.util.HashMap;
 import java.util.Locale;
@@ -95,6 +93,7 @@ import org.openpnp.model.Configuration;
 import org.openpnp.model.Configuration.TablesLinked;
 import org.openpnp.model.LengthUnit;
 import org.openpnp.scripting.ScriptFileWatcher;
+import org.openpnp.util.UiUtils;
 import org.pmw.tinylog.Logger;
 
 import com.jgoodies.forms.layout.ColumnSpec;
@@ -1274,72 +1273,28 @@ public class MainFrame extends JFrame {
     private Action quickStartLinkAction = new AbstractAction(Translations.getString("Menu.Help.QuickStart")) { //$NON-NLS-1$
         @Override
         public void actionPerformed(ActionEvent arg0) {
-            String uri = "https://github.com/openpnp/openpnp/wiki/Quick-Start"; //$NON-NLS-1$
-            try {
-                if (Desktop.isDesktopSupported()) {
-                    Desktop.getDesktop().browse(new URI(uri));
-                }
-                else {
-                    throw new Exception("Not supported."); //$NON-NLS-1$
-                }
-            }
-            catch (Exception e) {
-                MessageBoxes.errorBox(MainFrame.this, "Unable to launch default browser.", "Unable to launch default browser. Please visit " + uri); //$NON-NLS-1$ //$NON-NLS-2$
-            }
+            UiUtils.browseUri("https://github.com/openpnp/openpnp/wiki/Quick-Start"); //$NON-NLS-1$
         }
     };
     
     private Action setupAndCalibrationLinkAction = new AbstractAction(Translations.getString("Menu.Help.SetupAndCalibration")) { //$NON-NLS-1$
         @Override
         public void actionPerformed(ActionEvent arg0) {
-            String uri = "https://github.com/openpnp/openpnp/wiki/Setup-and-Calibration"; //$NON-NLS-1$
-            try {
-                if (Desktop.isDesktopSupported()) {
-                    Desktop.getDesktop().browse(new URI(uri));
-                }
-                else {
-                    throw new Exception("Not supported."); //$NON-NLS-1$
-                }
-            }
-            catch (Exception e) {
-                MessageBoxes.errorBox(MainFrame.this, "Unable to launch default browser.", "Unable to launch default browser. Please visit " + uri); //$NON-NLS-1$ //$NON-NLS-2$
-            }
+            UiUtils.browseUri("https://github.com/openpnp/openpnp/wiki/Setup-and-Calibration"); //$NON-NLS-1$
         }
     };
     
     private Action userManualLinkAction = new AbstractAction(Translations.getString("Menu.Help.UserManual")) { //$NON-NLS-1$
         @Override
         public void actionPerformed(ActionEvent arg0) {
-            String uri = "https://github.com/openpnp/openpnp/wiki/User-Manual"; //$NON-NLS-1$
-            try {
-                if (Desktop.isDesktopSupported()) {
-                    Desktop.getDesktop().browse(new URI(uri));
-                }
-                else {
-                    throw new Exception("Not supported."); //$NON-NLS-1$
-                }
-            }
-            catch (Exception e) {
-                MessageBoxes.errorBox(MainFrame.this, "Unable to launch default browser.", "Unable to launch default browser. Please visit " + uri); //$NON-NLS-1$ //$NON-NLS-2$
-            }
+            UiUtils.browseUri("https://github.com/openpnp/openpnp/wiki/User-Manual"); //$NON-NLS-1$
         }
     };
     
     private Action changeLogAction = new AbstractAction(Translations.getString("Menu.Help.ChangeLog")) { //$NON-NLS-1$
         @Override
         public void actionPerformed(ActionEvent arg0) {
-            String uri = "https://github.com/openpnp/openpnp/blob/develop/CHANGES.md"; //$NON-NLS-1$
-            try {
-                if (Desktop.isDesktopSupported()) {
-                    Desktop.getDesktop().browse(new URI(uri));
-                }
-                else {
-                    throw new Exception("Not supported."); //$NON-NLS-1$
-                }
-            }
-            catch (Exception e) {
-                MessageBoxes.errorBox(MainFrame.this, "Unable to launch default browser.", "Unable to launch default browser. Please visit " + uri); //$NON-NLS-1$ //$NON-NLS-2$
-            }
+            UiUtils.browseUri("https://github.com/openpnp/openpnp/blob/develop/CHANGES.md"); //$NON-NLS-1$
         }
     };
     

--- a/src/main/java/org/openpnp/gui/MainFrame.java
+++ b/src/main/java/org/openpnp/gui/MainFrame.java
@@ -76,6 +76,7 @@ import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 import javax.swing.undo.UndoManager;
 
+import org.openpnp.Main;
 import org.openpnp.Translations;
 import org.openpnp.gui.components.CameraPanel;
 import org.openpnp.gui.components.ThemeDialog;
@@ -1294,7 +1295,7 @@ public class MainFrame extends JFrame {
     private Action changeLogAction = new AbstractAction(Translations.getString("Menu.Help.ChangeLog")) { //$NON-NLS-1$
         @Override
         public void actionPerformed(ActionEvent arg0) {
-            UiUtils.browseUri("https://github.com/openpnp/openpnp/blob/develop/CHANGES.md"); //$NON-NLS-1$
+            UiUtils.browseUri(Main.getSourceUri()+"CHANGES.md"); //$NON-NLS-1$
         }
     };
     

--- a/src/main/java/org/openpnp/gui/SubmitDiagnosticsDialog.java
+++ b/src/main/java/org/openpnp/gui/SubmitDiagnosticsDialog.java
@@ -2,7 +2,6 @@ package org.openpnp.gui;
 
 import java.awt.BorderLayout;
 import java.awt.Color;
-import java.awt.Desktop;
 import java.awt.FlowLayout;
 import java.awt.Font;
 import java.awt.Robot;
@@ -10,7 +9,6 @@ import java.awt.event.ActionEvent;
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.FilenameFilter;
-import java.net.URI;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
@@ -29,10 +27,11 @@ import javax.swing.JProgressBar;
 import javax.swing.JTextArea;
 import javax.swing.JTextPane;
 import javax.swing.UIManager;
+import javax.swing.border.BevelBorder;
 import javax.swing.border.EmptyBorder;
+import javax.swing.border.SoftBevelBorder;
 
 import org.apache.commons.io.FileUtils;
-import org.onvif.ver10.device.wsdl.GetSystemSupportInformation;
 import org.openpnp.Main;
 import org.openpnp.gui.support.MessageBoxes;
 import org.openpnp.imgur.Imgur;
@@ -42,6 +41,7 @@ import org.openpnp.model.Board;
 import org.openpnp.model.BoardLocation;
 import org.openpnp.model.Configuration;
 import org.openpnp.model.Job;
+import org.openpnp.util.UiUtils;
 import org.pmw.tinylog.Logger;
 
 import com.github.kennedyoliveira.pastebin4j.AccountCredentials;
@@ -53,8 +53,6 @@ import com.jgoodies.forms.layout.ColumnSpec;
 import com.jgoodies.forms.layout.FormLayout;
 import com.jgoodies.forms.layout.FormSpecs;
 import com.jgoodies.forms.layout.RowSpec;
-import javax.swing.border.SoftBevelBorder;
-import javax.swing.border.BevelBorder;
 
 public class SubmitDiagnosticsDialog extends JDialog {
 
@@ -351,9 +349,7 @@ public class SubmitDiagnosticsDialog extends JDialog {
                         return;
                     }
                     Logger.info("Created diagnostics package at: " + url);
-                    if (Desktop.isDesktopSupported()) {
-                        Desktop.getDesktop().browse(new URI(url));
-                    }
+                    UiUtils.browseUri(url);
                     setVisible(false);
                 }
                 catch (Exception e1) {

--- a/src/main/java/org/openpnp/gui/components/MarkupTextPane.java
+++ b/src/main/java/org/openpnp/gui/components/MarkupTextPane.java
@@ -21,7 +21,6 @@
 
 package org.openpnp.gui.components;
 
-import java.awt.Desktop;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.net.URI;
@@ -30,6 +29,7 @@ import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 
+import org.openpnp.util.UiUtils;
 import org.openpnp.util.XmlSerialize;
 
 import com.jgoodies.forms.layout.ColumnSpec;
@@ -55,14 +55,9 @@ public class MarkupTextPane extends JScrollPane {
             @Override
             public void mouseClicked(MouseEvent e) {
                 if (uri != null) {
-                    Desktop desk = Desktop.getDesktop();
-                    try {
-                        // HACK: can't truly pinpoint hyperlinks in the text, so this is usually
-                        // just a link to the original online version, where links can be followed up.
-                        desk.browse(uri);
-                    }
-                    catch (Exception e1) {
-                    }
+                    // HACK: can't truly pinpoint hyperlinks in the text, so this is usually
+                    // just a link to the original online version, where links can be followed up.
+                    UiUtils.browseUri(uri.toString());
                 }
             }
         });

--- a/src/main/java/org/openpnp/machine/reference/wizards/ReferenceNozzleCameraOffsetWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/wizards/ReferenceNozzleCameraOffsetWizard.java
@@ -1,10 +1,25 @@
 package org.openpnp.machine.reference.wizards;
 
-import com.jgoodies.forms.layout.ColumnSpec;
-import com.jgoodies.forms.layout.FormLayout;
-import com.jgoodies.forms.layout.FormSpecs;
-import com.jgoodies.forms.layout.RowSpec;
+import java.awt.Cursor;
+import java.awt.event.ActionEvent;
+import java.util.List;
+
+import javax.swing.AbstractAction;
+import javax.swing.Action;
+import javax.swing.BorderFactory;
+import javax.swing.JButton;
+import javax.swing.JCheckBox;
+import javax.swing.JComboBox;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JTextField;
+import javax.swing.SwingConstants;
+import javax.swing.border.TitledBorder;
+
 import org.jdesktop.beansbinding.AutoBinding;
+import org.jdesktop.beansbinding.AutoBinding.UpdateStrategy;
+import org.jdesktop.beansbinding.BeanProperty;
+import org.jdesktop.beansbinding.Bindings;
 import org.openpnp.Translations;
 import org.openpnp.gui.components.ComponentDecorators;
 import org.openpnp.gui.support.AbstractConfigurationWizard;
@@ -14,21 +29,13 @@ import org.openpnp.gui.support.MutableLocationProxy;
 import org.openpnp.machine.reference.ReferenceNozzle;
 import org.openpnp.model.Location;
 import org.openpnp.spi.Camera;
+import org.openpnp.util.UiUtils;
 import org.pmw.tinylog.Logger;
 
-import javax.swing.*;
-import javax.swing.border.TitledBorder;
-
-import java.awt.Cursor;
-import java.awt.Desktop;
-import java.awt.event.ActionEvent;
-import java.io.IOException;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.util.List;
-import org.jdesktop.beansbinding.BeanProperty;
-import org.jdesktop.beansbinding.Bindings;
-import org.jdesktop.beansbinding.AutoBinding.UpdateStrategy;
+import com.jgoodies.forms.layout.ColumnSpec;
+import com.jgoodies.forms.layout.FormLayout;
+import com.jgoodies.forms.layout.FormSpecs;
+import com.jgoodies.forms.layout.RowSpec;
 
 public class ReferenceNozzleCameraOffsetWizard extends AbstractConfigurationWizard {
 
@@ -289,13 +296,7 @@ public class ReferenceNozzleCameraOffsetWizard extends AbstractConfigurationWiza
     private Action openAdviceUrl = new AbstractAction("Open Advice Url") {
         @Override
         public void actionPerformed(ActionEvent e) {
-        	try {
-				Desktop.getDesktop().browse(new URI("https://github.com/openpnp/openpnp/wiki/Setup-and-Calibration:-Nozzle-Setup#head-offsets"));
-			} catch (IOException | URISyntaxException e1) {
-				// TODO Auto-generated catch block
-				e1.printStackTrace();
-			}
-            
+            UiUtils.browseUri("https://github.com/openpnp/openpnp/wiki/Setup-and-Calibration_Nozzle-Setup#head-offsets");
         }
     };
 

--- a/src/main/java/org/openpnp/model/Solutions.java
+++ b/src/main/java/org/openpnp/model/Solutions.java
@@ -22,10 +22,8 @@
 package org.openpnp.model;
 
 import java.awt.Color;
-import java.awt.Desktop;
 import java.beans.PropertyChangeListener;
 import java.beans.PropertyChangeSupport;
-import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -52,6 +50,7 @@ import org.openpnp.spi.Camera;
 import org.openpnp.spi.ControllerAxis;
 import org.openpnp.spi.Machine;
 import org.openpnp.spi.PropertySheetHolder;
+import org.openpnp.util.UiUtils;
 import org.openpnp.util.VisionUtils;
 import org.openpnp.util.XmlSerialize;
 import org.pmw.tinylog.Logger;
@@ -512,8 +511,7 @@ public class Solutions extends AbstractTableModel {
         @Override
         public void setState(State state) throws Exception {
             if (state == State.Solved) {
-                Desktop dt = Desktop.getDesktop();
-                dt.browse(new URI(uri));
+                UiUtils.browseUri(uri);
             }
             super.setState(state);
         }

--- a/src/main/java/org/openpnp/util/UiUtils.java
+++ b/src/main/java/org/openpnp/util/UiUtils.java
@@ -12,6 +12,7 @@ import java.util.function.Consumer;
 import javax.swing.JOptionPane;
 import javax.swing.SwingUtilities;
 
+import org.apache.commons.lang3.SystemUtils;
 import org.openpnp.gui.MainFrame;
 import org.openpnp.gui.support.MessageBoxes;
 import org.openpnp.model.Configuration;
@@ -265,16 +266,15 @@ public class UiUtils {
                     // No luck, try a more direct & hacky method. 
                     // Adapted from Teocci's https://stackoverflow.com/a/51758886 CC BY-SA 4.0
                     Runtime rt = Runtime.getRuntime();
-                    String os = System.getProperty("os.name").toLowerCase();
-                    if (os.contains("win")) {
+                    if (SystemUtils.IS_OS_WINDOWS) {
                         rt.exec("rundll32 url.dll,FileProtocolHandler " + uri).waitFor();
                     } 
-                    else if (os.contains("mac")) {
+                    else if (SystemUtils.IS_OS_MAC) {
                         String[] cmd = {"open", uri};
                         rt.exec(cmd).waitFor();
                     } 
                     else {
-                        // Default to unix flavor.
+                        // Default to Unix flavor.
                         // See https://portland.freedesktop.org/doc/xdg-open.html
                         String[] cmd = {"xdg-open", uri};
                         rt.exec(cmd).waitFor();


### PR DESCRIPTION
# Description

OpenPnP **Issues & Solutions** has introduced routine linking to the OpenPnP Wiki. The documentation is often very important to understand the issues and solutions at hand. Sometimes it is the only thing available, i.e., users are asked to follow the instruction in the Wiki in order to resolve the issue, no automatic action is available.

Unfortunately, on some systems the Java Desktop support for browsing is _very strangely_ not implemented. On my Kubuntu for instance, pressing any of the info buttons only shows this: 

![Screenshot_20230501_085829](https://user-images.githubusercontent.com/9963310/235430919-df43231c-df89-4e0d-88bc-30e8af8e1926.png)

The PR  now unifies the URI browsing through `UiUtils.browseUri()`. This could also prove useful to automatically map to a different base-URL and/or documentation system in the future. See also #1543.

The new  `UiUtils.browseUri()` first tries the `Desktop.getDesktop().browse()` method, but then also falls back to use simple OS specific command-line alternatives, adapted from this Stack Overflow [answer](https://stackoverflow.com/a/51758886) by  [Teocci](https://stackoverflow.com/users/5372008/teocci). 

If this fails too, it copies the URI to the clipboard, and tells the user:

![Screenshot_20230501_100901](https://user-images.githubusercontent.com/9963310/235431291-d29704e0-c623-47df-9fd8-c748c6ad6b33.png)

The URI is now also logged, so if the clipboard were to fail too, there would still be yet another manual fallback for the user.

URIs pointing to GitHub versioned files (`CHANGES.md` etc.) were fixed to support a developer testing locally. In the absence of a version's git commit hash, hey are now pointed at the `test` branch.

# Justification
See above.

# Instructions for Use
There is no change in usage, but the browsing should now work on platforms that do not support the  `Desktop.getDesktop().browse()` method. 

# Implementation Details
1. Tested on Kubuntu 22.04/KDE Plasma Version 5.24.7. The browsing now works using the [xdg-open](https://portland.freedesktop.org/doc/xdg-open.html) command-line fallback. Other OS alternatives for Windows and Mac are untested, but I believe they are hardly ever going to be used, as proper `Desktop` support is available on these platforms.
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. Successful `mvn test` before submitting the Pull Request. 
