### PR TITLE
Actuator signaler remove duplicate calls

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
 This file lists major or notable changes to OpenPnP in chronological order. This is not
 a complete change list, only those that may directly interest or affect users.
 
+# 2023-05-03
+
+Behaviour of ActuatorSignaler changed to only call the actuator if the job state has changed.
+
 # 2023-05-02
 
 Named CSV importer renamed to Reference CSV importer

--- a/src/main/java/org/openpnp/machine/reference/signaler/ActuatorSignaler.java
+++ b/src/main/java/org/openpnp/machine/reference/signaler/ActuatorSignaler.java
@@ -19,6 +19,7 @@ public class ActuatorSignaler extends AbstractSignaler {
 
     protected Machine machine;
     protected Actuator actuator;
+    protected AbstractJobProcessor.State lastJobState;	// last job state, used to only call the actuator if the job state has changed
 
     @Attribute(required = false)
     protected String actuatorId;
@@ -64,15 +65,23 @@ public class ActuatorSignaler extends AbstractSignaler {
     @Override
     public void signalJobProcessorState(AbstractJobProcessor.State state) {
         if(actuator != null && jobState != null) {
-            try {
-                if(state == jobState) {
-                    this.actuator.actuate(true);
-                } else {
-                    this.actuator.actuate(false);
-                }
-            } catch (Exception e) {
-                e.printStackTrace();
-            }
+        	// only call the underlying actuator if the state has changed
+        	// lastJobState is null on start so the first state change is always send to the actuator
+        	if (lastJobState != state) {
+        		// remember this state as last
+        		lastJobState = state;
+        		
+        		// call the actuator
+	            try {
+	                if(state == jobState) {
+	                    this.actuator.actuate(true);
+	                } else {
+	                    this.actuator.actuate(false);
+	                }
+	            } catch (Exception e) {
+	                e.printStackTrace();
+	            }
+        	}
         }
     }
     

--- a/src/main/java/org/openpnp/machine/reference/signaler/ActuatorSignaler.java
+++ b/src/main/java/org/openpnp/machine/reference/signaler/ActuatorSignaler.java
@@ -49,28 +49,28 @@ public class ActuatorSignaler extends AbstractSignaler {
     // update given actuator to newState
     // only execute an update if the state changes
     private void updateActuatorState(boolean newState) {
-    	if (actuator != null									// make sure an actuator is defined
-    			&& (   actuator.isActuated() == null			// some actuator don't provide isActuated()
-    				|| actuator.isActuated() != newState)) {	// if they do, check if the new state is different
-	        try {
-	        	actuator.actuate(newState);						// then set new state
-	        } catch (Exception e) {
-	            e.printStackTrace();
-	        }
+        if (actuator != null                                 // make sure an actuator is defined
+                && (   actuator.isActuated() == null         // some actuator don't provide isActuated()
+                    || actuator.isActuated() != newState)) { // if they do, check if the new state is different
+            try {
+            	actuator.actuate(newState);                  // then set new state
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
     	}
     }
     
     @Override
     public void signalMachineState(AbstractMachine.State state) {
         if(actuator != null && machineState != null) {
-        	updateActuatorState(state == machineState);
+            updateActuatorState(state == machineState);
         }
     }
 
     @Override
     public void signalJobProcessorState(AbstractJobProcessor.State state) {
         if(actuator != null && jobState != null) {
-        	updateActuatorState(state == jobState);
+            updateActuatorState(state == jobState);
         }
     }
     


### PR DESCRIPTION
# Description
This PR changes the way ActuatorSignaler works be filtering out duplicated calls to the actuator if the job state did not change.

# Justification
When using an ActuatorSignaler to signal a finished job, the actuator is called for each step of the job. This slows the job down dramatically even if no GCode is omitted. (Unfortunately with the NullDriver and the pnp-test.job I was not able to measure a difference in CPH.) One can see this behavior by filtering the log (at Trace level) for "Signaler". Without this PR there a many calls to the actuator with state false. With this PR applied, there are two calls with state false and one with state true.
In addition, this PR allows to use machine coordination with the actuator without a significant performance penalty. 

# Instructions for Use
There is no change in usage. Its just that the actuator and its driver is not called that frequent anymore.

# Implementation Details
1. How did you test the change? _I've used the pnp-test.job and filtered the log for "signaler". This shows the expected reduction in calls to the actuator._
2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)? _Yes_
3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing. _No_
4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted. _Yes_
