### PR TITLE
Fix / Revert openpnp-capture-java to 0.0.22

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -183,7 +183,7 @@
 		<dependency>
 			<groupId>org.openpnp</groupId>
 			<artifactId>openpnp-capture-java</artifactId>
-			<version>0.0.27-0</version>
+			<version>0.0.24</version>
 		</dependency>
 		<dependency>
 		    <groupId>javax.xml.bind</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -183,7 +183,7 @@
 		<dependency>
 			<groupId>org.openpnp</groupId>
 			<artifactId>openpnp-capture-java</artifactId>
-			<version>0.0.24</version>
+			<version>0.0.22</version>
 		</dependency>
 		<dependency>
 		    <groupId>javax.xml.bind</groupId>


### PR DESCRIPTION
# Description
Reverts `openpnp-capture-java` dependecy to version 0.0.22 due to persistent Windows COM problems. This corresponds to the version prior to 2023-03-20 22:24:13.

See: 6f9b8030a9fbdcf79e1cc3368309a28f444826bb

Note: all other changes in the `pom.xml` were preserved.

# Justification
Windows users currently can't work reliably:

https://groups.google.com/g/openpnp/c/0WTDo56vwow/m/xs6F6kqQBAAJ
https://groups.google.com/g/openpnp/c/SFUnSoJpUig/m/ZtXvnAAHCAAJ

# Instructions for Use
Upgrade the testing version.

# Implementation Details
1. Basic tests performed under Linux. Test by users needed to confirm it helps (it worked for me on Windows).
2. No [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style) applies.
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. `mvn test` does not apply, but `mvn package` tested, confirmed that target contains 0.0.22 version.
