### PR TITLE
Fix/Revert-revert the Maven openpnp-capture-java dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -183,7 +183,7 @@
 		<dependency>
 			<groupId>org.openpnp</groupId>
 			<artifactId>openpnp-capture-java</artifactId>
-			<version>0.0.22</version>
+			<version>0.0.27-0</version>
 		</dependency>
 		<dependency>
 		    <groupId>javax.xml.bind</groupId>


### PR DESCRIPTION
# Description
Revert-revert the Maven `openpnp-capture-java` dependency back to 0.0.27.

This undoes #1558.

# Justification
The version of `openpnp-capture-java` turned out _not_ to be the culprit. Instead it the Install4j packaged Java 17 has a bug/incompatibility, caused in turn by Microsoft's inherently bad design of COM.

See
https://bugs.openjdk.org/browse/JDK-8270269

# Instructions for Use
To get it, upgrade to the latest `test` version of OpenPnP.

## Windows Workaround
For Windows users, to workaround the installer's Java 17 problem for now, proceed as follows:

Download Microsoft's Java 11 .msi

https://learn.microsoft.com/en-us/java/openjdk/download#openjdk-11

and install it

https://learn.microsoft.com/en-us/java/openjdk/install#install-via-msi

and then start openpnp using this command:

```sh
java --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.desktop/java.awt=ALL-UNNAMED --add-opens=java.desktop/java.awt.color=ALL-UNNAMED -jar "C:\Program Files\openpnp\openpnp-gui-0.0.1-alpha-SNAPSHOT.jar"
```

You can save it into an `openpnp.cmd` file for instance.

Creating a simple link did not work for me on Windows 11. Command-lines seem length limited, or something.

# Implementation Details
1. Tested the workaround. The actual deploy here must be tested life.
2. The [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style) does not apply.
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. Running `mvn -DskipTests clean package` before submitting the Pull Request. Confirmed `openpnp-capture-java-0.0.27-0.jar` is in `target/lib`.
