### PR TITLE
Feature / SimulationModeMachine: add option to (not) replace drivers with GcodeServer

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/SimulationModeMachine.java
+++ b/src/main/java/org/openpnp/machine/reference/SimulationModeMachine.java
@@ -114,6 +114,9 @@ public class SimulationModeMachine extends ReferenceMachine {
     @Attribute(required = false)
     private SimulationMode simulationMode = SimulationMode.Off;
 
+    @Attribute(required = false)
+    private boolean replacingDrivers = true;
+
     /**
      * The simulated non-squareness is applied to what the simulated cameras see.
      * Works on the ImageCamera.
@@ -199,6 +202,14 @@ public class SimulationModeMachine extends ReferenceMachine {
             }
         }
         this.simulationMode = simulationMode;
+    }
+
+    public boolean isReplacingDrivers() {
+        return replacingDrivers;
+    }
+
+    public void setReplacingDrivers(boolean replacingDrivers) {
+        this.replacingDrivers = replacingDrivers;
     }
 
     public double getSimulatedNonSquarenessFactor() {

--- a/src/main/java/org/openpnp/machine/reference/driver/AbstractReferenceDriver.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/AbstractReferenceDriver.java
@@ -193,7 +193,7 @@ public abstract class AbstractReferenceDriver extends AbstractDriver {
 
     public boolean isInSimulationMode() {
         SimulationModeMachine machine = SimulationModeMachine.getSimulationModeMachine();
-        return (machine != null && machine.getSimulationMode() != SimulationMode.Off);
+        return (machine != null && machine.getSimulationMode() != SimulationMode.Off && machine.isReplacingDrivers());
     }
 
     public ReferenceDriverCommunications getCommunications() {

--- a/src/main/java/org/openpnp/machine/reference/wizards/SimulationModeMachineConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/wizards/SimulationModeMachineConfigurationWizard.java
@@ -65,6 +65,7 @@ public class SimulationModeMachineConfigurationWizard extends AbstractConfigurat
     private JTextField simulatedCameraLag;
     private JTextField machineTableZ;
     private JTextField simulatedVibrationDuration;
+    private JCheckBox replacingDrivers;
 
     public SimulationModeMachineConfigurationWizard(SimulationModeMachine machine) {
         this.machine = machine;
@@ -80,6 +81,8 @@ public class SimulationModeMachineConfigurationWizard extends AbstractConfigurat
                 ColumnSpec.decode("max(50dlu;default)"),},
             new RowSpec[] {
                 FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
                 FormSpecs.DEFAULT_ROWSPEC,}));
 
         JLabel lblSimulationMode = new JLabel("Simulation Mode");
@@ -87,6 +90,13 @@ public class SimulationModeMachineConfigurationWizard extends AbstractConfigurat
 
         simulationMode = new JComboBox(SimulationMode.values());
         panelGeneral.add(simulationMode, "4, 2, fill, default");
+        
+        JLabel lblReplaceDrivers = new JLabel("Replace Drivers?");
+        lblReplaceDrivers.setToolTipText("<html>\nReplace driver connections with a built-in GcodeServer, simulating the real driver.<br/>\nWill only become effective when you disable/enable the machine.\n</html>");
+        panelGeneral.add(lblReplaceDrivers, "2, 4, right, default");
+        
+        replacingDrivers = new JCheckBox("");
+        panelGeneral.add(replacingDrivers, "4, 4");
 
         JPanel panelLocations = new JPanel();
         panelLocations.setBorder(new TitledBorder(null, "Simulated Imperfections", TitledBorder.LEADING,
@@ -263,6 +273,7 @@ public class SimulationModeMachineConfigurationWizard extends AbstractConfigurat
         LengthConverter lengthConverter = new LengthConverter();
 
         addWrappedBinding(machine, "simulationMode", simulationMode, "selectedItem");
+        addWrappedBinding(machine, "replacingDrivers", replacingDrivers, "selected");
 
         addWrappedBinding(machine, "simulatedNonSquarenessFactor", simulatedNonSquarenessFactor, "text", doubleConverter);
 


### PR DESCRIPTION
# Description
Make it optional to replace drivers with GcodeServer in simulation mode. The new option defaults to true, i.e., it behaves as before.

# Justification
It can make sense to drive external controllers using the simulation machine, performing a simulated job. 

See actual example here:
https://groups.google.com/g/openpnp/c/IshRY1IM80w/m/cmKHbbO6BQAJ

# Instructions for Use
The new option is on the **Simulation Mode** tab of the machine:

![Simulation Mode](https://github.com/openpnp/openpnp/assets/9963310/73392702-5f74-4cda-9db8-bf79b0963d8d)

After changing the option, press Apply and disable and re-enable the machine for the new option state to become effective.

# Implementation Details
1. Tested in simulation, the optional driver replacing works.
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. Successful `mvn test` before submitting the Pull Request. 
