### PR TITLE
Fix / Upgrade to openpnp-capture-java 0.0.28-0.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -183,7 +183,7 @@
 		<dependency>
 			<groupId>org.openpnp</groupId>
 			<artifactId>openpnp-capture-java</artifactId>
-			<version>0.0.27-0</version>
+			<version>0.0.28-0</version>
 		</dependency>
 		<dependency>
 		    <groupId>javax.xml.bind</groupId>


### PR DESCRIPTION
# Description
Upgrade to openpnp-capture-java 0.0.28-0.

# Justification
See 
- https://github.com/openpnp/openpnp-capture/pull/68
- https://github.com/openpnp/openpnp-capture-java/commit/52374b9730a8d3d78163bbad8c4b8761469743ab

# Instructions for Use
Upgrade `test` version.

# Implementation Details
1. Tested local develop on Windows, using Java 11. Real test will be after deploy, using the installer-packaged JVM. 
2. The [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style) does not apply.
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. Used `mvn -DskipTests clean package` to build and then test the faulty functions under Windows.
