### PR TITLE
Fix / Bump Nashorn Java Script Support for Java 17+

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -138,7 +138,7 @@
 		<dependency>
 			<groupId>org.openjdk.nashorn</groupId>
 			<artifactId>nashorn-core</artifactId>
-			<version>15.0</version>
+			<version>15.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.tinylog</groupId>


### PR DESCRIPTION
# Description
This bumps the `org.openjdk.nashorn` Java Script engine to 15.4 for support of Java 17 and later.

# Justification
Users reported that Java Script scripting was disabled:
https://github.com/openpnp/openpnp/pull/1562#issuecomment-1563996722

See also:
- https://github.com/openpnp/openpnp/pull/1475#issuecomment-1236712135
- https://github.com/szegedi/nashorn/wiki/Using-Nashorn-with-different-Java-versions#using-nashorn-on-java-11-to-14

# Instructions for Use
Upgrade to the newest `test` version.

# Implementation Details
1. After updating the POM I confirmed the java script engine works under Java 11. Support of Java 17 will only be confirmed once deployed.
2. The [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style) does not apply.
3. No changes  the `org.openpnp.spi` or `org.openpnp.model` packages.
4. Successful `mvn clean package` before submitting the Pull Request.
