### PR TITLE
Make sure the NashornScriptEngineFactory is always loaded with OpenPnP.

### DIFF
--- a/src/main/java/org/openpnp/scripting/Scripting.java
+++ b/src/main/java/org/openpnp/scripting/Scripting.java
@@ -19,6 +19,7 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.pool2.impl.DefaultPooledObjectInfo;
 import org.apache.commons.pool2.impl.GenericKeyedObjectPool;
+import org.openjdk.nashorn.api.scripting.NashornScriptEngineFactory;
 import org.openpnp.gui.MainFrame;
 import org.openpnp.model.Configuration;
 import org.pmw.tinylog.Logger;
@@ -70,13 +71,20 @@ public class Scripting {
         // Central yet: https://github.com/beanshell/beanshell/issues/603.
         ScriptEngineFactory bshFactory = new BshScriptEngineFactory();
         manager.registerEngineName(bshFactory.getNames()
-                                             .get(0),
+                .get(0),
                 bshFactory);
         extensionToEngineNameMap.put("bsh", bshFactory.getNames()
-                                                      .get(0));
+                .get(0));
         extensionToEngineNameMap.put("java", bshFactory.getNames()
-                                                       .get(0));
+                .get(0));
 
+        // Hack to make sure Nashorn is there.
+        ScriptEngineFactory jsFactory = new NashornScriptEngineFactory();
+        manager.registerEngineName(jsFactory.getNames()
+                .get(0),
+                jsFactory);
+        extensionToEngineNameMap.put("js", jsFactory.getNames()
+                .get(0));
 
         // Create the scripts directory if it doesn't exist.
         if (!scriptsDirectory.exists()) {


### PR DESCRIPTION
# Description
This makes sure the `NashornScriptEngineFactory` class is always loaded and registered in OpenPnP, even if the classpath is not given.

![Startup Java 17](https://github.com/openpnp/openpnp/assets/9963310/34371c3d-c9bb-4d92-ba6b-f3e7684201aa)

![OpenPnP with Java 17](https://github.com/openpnp/openpnp/assets/9963310/db8a4196-aa25-441f-b30b-6e62d47518d4)

# Justification
See #1563 and before that https://github.com/openpnp/openpnp/pull/1562#issuecomment-1563996722

# Instructions for Use
Upgrade to newest OpenPnP `test` version.

# Implementation Details
1. Tested by using Java 17 explicitly.
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. Successful `mvn package` before submitting the Pull Request.
