### PR TITLE
Fix / Board Protection

### DIFF
--- a/src/main/java/org/openpnp/gui/JogControlsPanel.java
+++ b/src/main/java/org/openpnp/gui/JogControlsPanel.java
@@ -29,7 +29,6 @@ import java.awt.event.ActionEvent;
 import java.beans.PropertyChangeListener;
 import java.util.HashMap;
 import java.util.Hashtable;
-import java.util.List;
 import java.util.Map;
 
 import javax.swing.AbstractAction;
@@ -49,7 +48,6 @@ import org.openpnp.ConfigurationListener;
 import org.openpnp.Translations;
 import org.openpnp.gui.support.Icons;
 import org.openpnp.gui.support.WrapLayout;
-import org.openpnp.model.BoardLocation;
 import org.openpnp.model.Configuration;
 import org.openpnp.model.Length;
 import org.openpnp.model.LengthUnit;
@@ -85,7 +83,7 @@ public class JogControlsPanel extends JPanel {
     private final Configuration configuration;
     private JPanel panelActuators;
     private JSlider sliderIncrements;
-    private JCheckBox boardProtectionOverrideCheck;
+    private JCheckBox boardProtectionCheck;
 
     /**
      * Create the panel.
@@ -159,8 +157,8 @@ public class JogControlsPanel extends JPanel {
         }
     }
 
-    public boolean getBoardProtectionOverrideEnabled() {
-        return boardProtectionOverrideCheck.isSelected();
+    public boolean isBoardProtectionEnabled() {
+        return boardProtectionCheck.isSelected();
     }
 
     private void jog(final int x, final int y, final int z, final int c) {
@@ -212,59 +210,12 @@ public class JogControlsPanel extends JPanel {
         }
 
         Location targetLocation = new Location(l.getUnits(), xPos, yPos, zPos, cPos);
-        if (!this.getBoardProtectionOverrideEnabled()) {
-            /* check board location before movement */
-            List<BoardLocation> boardLocations = machineControlsPanel.getJobPanel()
-                    .getJob()
-                    .getBoardLocations();
-            for (BoardLocation boardLocation : boardLocations) {
-                if (!boardLocation.isEnabled()) {
-                    continue;
-                }
-                boolean safe = nozzleLocationIsSafe(boardLocation.getGlobalLocation(),
-                        boardLocation.getBoard()
-                        .getDimensions(),
-                        targetLocation, new Length(1.0, l.getUnits()));
-                if (!safe) {
-                    throw new Exception(
-                            "Nozzle would crash into board: " + boardLocation.toString() + "\n" + //$NON-NLS-1$ //$NON-NLS-2$
-                            "To disable the board protection go to the \"Safety\" tab in the \"Machine Controls\" panel."); //$NON-NLS-1$
-                }
-            }
-        }
+
+        machineControlsPanel.checkJogMotionSafety(tool, targetLocation);
 
         tool.moveTo(targetLocation, MotionOption.JogMotion); 
 
         MovableUtils.fireTargetedUserAction(tool, true);
-    }
-
-    private boolean nozzleLocationIsSafe(Location origin, Location dimension, Location nozzle,
-            Length safeDistance) {
-        double distance = safeDistance.convertToUnits(nozzle.getUnits())
-                .getValue();
-        Location originConverted = origin.convertToUnits(nozzle.getUnits());
-        Location dimensionConverted = dimension.convertToUnits(dimension.getUnits());
-        double boardUpperZ = originConverted.getZ();
-        boolean containsXY = pointWithinRectangle(originConverted, dimensionConverted, nozzle);
-        boolean containsZ = nozzle.getZ() <= (boardUpperZ + distance);
-        return !(containsXY && containsZ);
-    }
-
-    private boolean pointWithinRectangle(Location origin, Location dimension, Location point) {
-        double rotation = Math.toRadians(origin.getRotation());
-        double ay = origin.getY() + Math.sin(rotation) * dimension.getX();
-        double ax = origin.getX() + Math.cos(rotation) * dimension.getX();
-        Location a = new Location(dimension.getUnits(), ax, ay, 0.0, 0.0);
-
-        double cx = origin.getX() - Math.cos(Math.PI / 2 - rotation) * dimension.getY();
-        double cy = origin.getY() + Math.sin(Math.PI / 2 - rotation) * dimension.getY();
-        Location c = new Location(dimension.getUnits(), cx, cy, 0.0, 0.0);
-
-        double bx = ax + cx - origin.getX();
-        double by = ay + cy - origin.getY();
-        Location b = new Location(dimension.getUnits(), bx, by, 0.0, 0.0);
-
-        return pointWithinTriangle(origin, b, a, point) || pointWithinTriangle(origin, c, b, point);
     }
 
     private boolean pointWithinTriangle(Location p1, Location p2, Location p3, Location p) {
@@ -474,11 +425,12 @@ public class JogControlsPanel extends JPanel {
                 null, panelSafety, null);
         panelSafety.setLayout(new FlowLayout(FlowLayout.LEFT, 5, 5));
 
-        boardProtectionOverrideCheck = new JCheckBox(
-                Translations.getString("JogControlsPanel.Label.OverrideBoardProtection")); //$NON-NLS-1$
-        boardProtectionOverrideCheck.setToolTipText(
-                Translations.getString("JogControlsPanel.Label.OverrideBoardProtection.Description")); //$NON-NLS-1$
-        panelSafety.add(boardProtectionOverrideCheck, "1, 1"); //$NON-NLS-1$
+        boardProtectionCheck = new JCheckBox(
+                Translations.getString("JogControlsPanel.Label.BoardProtection")); //$NON-NLS-1$
+        boardProtectionCheck.setSelected(true);
+        boardProtectionCheck.setToolTipText(
+                Translations.getString("JogControlsPanel.Label.BoardProtection.Description")); //$NON-NLS-1$
+        panelSafety.add(boardProtectionCheck, "1, 1"); //$NON-NLS-1$
     }
 
     private FocusTraversalPolicy focusPolicy = new FocusTraversalPolicy() {

--- a/src/main/resources/org/openpnp/translations.properties
+++ b/src/main/resources/org/openpnp/translations.properties
@@ -1,5 +1,5 @@
 #Eclipse messages class
-#Sat Jun 03 18:42:58 CEST 2023
+#Sun Jun 25 19:36:06 CEST 2023
 AbstractActuatorConfigurationWizard.CoordinateSystemPanel.AxisInterlockLabel.text=Axis Interlock?
 AbstractActuatorConfigurationWizard.CoordinateSystemPanel.AxisInterlockLabel.toolTipText=Enable to get an extra Wizard tab to configure an Axis Interlocking Actuator
 AbstractActuatorConfigurationWizard.CoordinateSystemPanel.AxisLabel.text=Axis
@@ -704,8 +704,8 @@ JogControlsPanel.Action.ThirdJogIncrement=Third Jog Increment
 JogControlsPanel.Action.positionCamera=Move camera to position of selected tool
 JogControlsPanel.Action.positionSelectedNozzle=Move last selected tool to camera position
 JogControlsPanel.Label.Distance=Distance
-JogControlsPanel.Label.OverrideBoardProtection=Override Board Protection
-JogControlsPanel.Label.OverrideBoardProtection.Description=Disable protection of the nozzle jogging closer than 1mm to any loaded board.
+JogControlsPanel.Label.BoardProtection=Board Protection
+JogControlsPanel.Label.BoardProtection.Description=Enable protection of the nozzle jogging closer than 1mm to any loaded board.
 JogControlsPanel.Label.Speed=Speed
 JogControlsPanel.Tab.Actuators=Actuators
 JogControlsPanel.Tab.Jog=Jog


### PR DESCRIPTION
# Description
This PR fixes and enhances the Board Protection, where Jogging motion is safety-checked against collisions with boards.

- The Machine Controls Safety Tab switch is now just named **Board Protection** and default-enabled, i.e. straight positive logic (formerly "Override" = inverted logic).
  
    ![Board Protection](https://github.com/openpnp/openpnp/assets/9963310/208951a0-b19d-4a9f-aa42-0c343011308d)

- Renamed the translation property key so translations will be lost, but not falsely left in inverted logic.
- Refactored `MachineControlsPanel.checkJogMotionSafety()` for central unified checking.
- In addition to "arrow" jogging, also check "Move tool to camera location" and (less likely relevant) "Move camera to tool location" for safety against boards.
- When the selected tool is jogged, _all_ the HeadMountables attached to the same Head will now be checked for safe motion.
- A dual nozzle machine will now check what the other/inverted nozzle does.
- A moved camera will also check any of the nozzles etc. perhaps still at low Z and moved with the head.
- Simplified the complicated former "two triangles" board collision detection into a simple transformation to local board coordinates and subsequent box test.
- If a part is on the nozzle, the part height is now taken into consideration for Z collision.
- If a part is on the nozzle, half the **Max. Part Diameter**, as set on the nozzle tip, is added to the safe distance.
- If a nozzle tip is loaded, half the **Outside Diameter** is added to the safe distance (whichever of the two is greater).
- The error message is now naming the head mountable that would be colliding, including loaded nozzle tip and part, if present.
   
   ![Board collision error](https://github.com/openpnp/openpnp/assets/9963310/89984b76-fa36-4408-8ca0-54b6d492bc3c)

- The error message's broken naming of the colliding board is fixed.
- Tools at their safe Z are always assumed to clear a board. In this case the board Z is assumed to not be set yet (usually left at zero after import). Note, with the new default board Z recently introduced, users can make sure the Z is always set and therefore safety-checked.

# Justification
- Various reports in the discussion group, when the board protection would jump at them because board Z was not set.
- User reporting bug:
  https://groups.google.com/g/openpnp/c/MMbZ2bBWhsM/m/_-usV-LFAAAJ

# Instructions for Use
Use as before.

Consider revisiting the  **Max. Part Diameter** and **Outside Diameter**  on the nozzle tips for their relevance as described above.

![Nozzle tip properties](https://github.com/openpnp/openpnp/assets/9963310/975e689c-9d04-4844-9f1d-834f235bee09)

# Implementation Details
1. Tested in the simulation with the test-job of various rotated and flipped boards. 
2. Did follow (and restore) the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. Successful run `mvn test` before submitting the Pull Request. 
