### PR TITLE
Fix UI bug in Job Placements Table

### DIFF
--- a/src/main/java/org/openpnp/gui/JobPlacementsPanel.java
+++ b/src/main/java/org/openpnp/gui/JobPlacementsPanel.java
@@ -118,6 +118,7 @@ public class JobPlacementsPanel extends JPanel {
     private ActionGroup editFeederActionGroup;
     private Preferences prefs = Preferences.userNodeForPackage(JobPlacementsPanel.class);
     private Configuration configuration;
+    private boolean editDefinition;
 
 
     private static Color typeColorFiducial = new Color(157, 188, 255);
@@ -491,9 +492,9 @@ public class JobPlacementsPanel extends JPanel {
                     boardOrPanelLocation.getParent() == jobPanel.getJob().getRootPanelLocation();
             singleInstance = boardOrPanelLocation != null && 
                     1 == jobPanel.getJob().instanceCount(boardOrPanelLocation.getPlacementsHolder());
-            tableModel.setPlacementsHolderLocation(boardOrPanelLocation, topLevel && singleInstance && 
-                    (boardOrPanelLocation instanceof BoardLocation));
-            topLevelSingleInstanceActionGroup.setEnabled(topLevel && singleInstance && (boardOrPanelLocation instanceof BoardLocation));
+            editDefinition = topLevel && singleInstance && (boardOrPanelLocation instanceof BoardLocation);
+            tableModel.setPlacementsHolderLocation(boardOrPanelLocation, editDefinition);
+            topLevelSingleInstanceActionGroup.setEnabled(editDefinition);
 
             updateRowFilter();
         }
@@ -769,7 +770,12 @@ public class JobPlacementsPanel extends JPanel {
         @Override
         public void actionPerformed(ActionEvent arg0) {
             for (Placement placement : getSelections()) {
-                placement.setType(type);
+                if (editDefinition) {
+                    placement.getDefinition().setType(type);
+                }
+                else {
+                    placement.setType(type);
+                }
                 tableModel.fireTableDataChanged();
                 updateActivePlacements();
             }
@@ -806,7 +812,12 @@ public class JobPlacementsPanel extends JPanel {
         @Override
         public void actionPerformed(ActionEvent arg0) {
             for (Placement placement : getSelections()) {
-                placement.setSide(side);
+                if (editDefinition) {
+                    placement.getDefinition().setSide(side);
+                }
+                else {
+                    placement.setSide(side);
+                }
                 tableModel.fireTableCellUpdated(placement, 
                         Translations.getString("PlacementsTableModel.ColumnName.Side")); //$NON-NLS-1$
                 updateActivePlacements();
@@ -844,8 +855,12 @@ public class JobPlacementsPanel extends JPanel {
         @Override
         public void actionPerformed(ActionEvent arg0) {
             for (Placement placement : getSelections()) {
-                Object oldValue = placement.getErrorHandling();
-                placement.setErrorHandling(errorHandling);
+                if (editDefinition) {
+                    placement.getDefinition().setErrorHandling(errorHandling);
+                }
+                else {
+                    placement.setErrorHandling(errorHandling);
+                }
                 tableModel.fireTableCellUpdated(placement, 
                         Translations.getString("PlacementsTableModel.ColumnName.ErrorHandling")); //$NON-NLS-1$
                 updateActivePlacements();
@@ -915,8 +930,12 @@ public class JobPlacementsPanel extends JPanel {
         @Override
         public void actionPerformed(ActionEvent arg0) {
             for (Placement placement : getSelections()) {
-                Object oldValue = placement.isEnabled();
-                placement.setEnabled(enabled);
+                if (editDefinition) {
+                    placement.getDefinition().setEnabled(enabled);
+                }
+                else {
+                    placement.setEnabled(enabled);
+                }
                 tableModel.fireTableCellUpdated(placement,
                         Translations.getString("PlacementsTableModel.ColumnName.Enabled")); //$NON-NLS-1$
                 updateActivePlacements();


### PR DESCRIPTION
# Description
Fixes a user interface problem first described [here](https://groups.google.com/g/openpnp/c/N2sTPcGlPgI) in the user forum. Basically, the context menus for setting the Enabled, Side, Type, and Error Handling states of placements in the Job tab's Placements Table were not correctly handling the case where the board's definition should have been being updated versus just the board instance in the job.  This only occurs when a single instance of any particular board design is at the top level of the job, i.e., there are not multiple copies of the board in the job nor is it a member of a panel in the job.

# Justification
Fixes a user interface bug that impacts all users.

# Instructions for Use
No real instructions for use - the context menus now work as they should.

# Implementation Details
1. How did you test the change? **Was able to duplicate the problem and verified after the changes were made, the problem no longer occurred.**
2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)? **Yes**.
3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing. **No changes were made to those packages.**
4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted. **All Maven tests were run and passed.**
