### PR TITLE
Fix / Serial read hang

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/driver/GcodeDriver.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/GcodeDriver.java
@@ -1350,7 +1350,7 @@ public class GcodeDriver extends AbstractReferenceDriver implements Named {
                 }
                 catch (IOException e) {
                     if (disconnectRequested) {
-                        Logger.trace("Read error while disconnecting (normal)");
+                        Logger.trace("Read error while disconnecting (expected)");
                         return;
                     }
                     else {
@@ -1420,10 +1420,10 @@ public class GcodeDriver extends AbstractReferenceDriver implements Named {
             }
             catch (IllegalArgumentException e) {
                 // Axis is not present in pattern. That's a warning, but might not be supported by controller, so we let it go. 
-                Logger.warn("Axis {} letter {} missing in POSITION_REPORT_REGEX groups.", axis.getName(), axis.getLetter());
+                Logger.warn("{}: Axis {} letter {} missing in POSITION_REPORT_REGEX groups.", getName(), axis.getName(), axis.getLetter());
             }
             catch (Exception e) {
-                Logger.warn("Error processing position report for axis {}: {}", axis.getName(), e);
+                Logger.warn("{}: Error processing position report for axis {}: {}", getName(), axis.getName(), e);
             }
         }
         // Store the latest momentary position.
@@ -1681,15 +1681,15 @@ public class GcodeDriver extends AbstractReferenceDriver implements Named {
                 detectFirmwareSequence();
                 return null;
             }, 
-                    false, 100, 1000);
+                    false, 2000, 2000);
         }
         else {
             // If the machine is not enabled, use an ad hoc connection.
             boolean wasConnected = connected;
-            if (!wasConnected) {
-                connect();
-            }
             try {
+                if (!wasConnected) {
+                    connect();
+                }
                 detectFirmwareSequence();
             }
             finally {

--- a/src/main/java/org/openpnp/machine/reference/driver/SerialPortCommunications.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/SerialPortCommunications.java
@@ -107,7 +107,7 @@ public class SerialPortCommunications extends ReferenceDriverCommunications {
             serialPort.setRTS();
         }
         serialPort.setComPortTimeouts(
-                SerialPort.TIMEOUT_READ_SEMI_BLOCKING | SerialPort.TIMEOUT_WRITE_BLOCKING, 0, 0);
+                SerialPort.TIMEOUT_READ_SEMI_BLOCKING | SerialPort.TIMEOUT_WRITE_BLOCKING, 500, 0);
     }
 
     public synchronized void disconnect() throws Exception {


### PR DESCRIPTION
# Description

Users suddenly reported UI hangs with TinyG. After extensive debugging, revisions retracing and half a day of hair pulling, it turned out that reinstating a serial port read timeout solved the issue. Strangely the that abolished the timeout is over a year old. I can only speculate that the recent change from Java 8 to Java 11/17/19 somehow exposed the issue.

See PR #1378 and specifically, [this line-change](https://github.com/openpnp/openpnp/pull/1378/files#diff-dec1db26d6c2776bbec8768f001ed16c73d22f02ef6a455149992cdb83d227edL113), where the timeout of 500ms was removed:

```java
SerialPort.TIMEOUT_READ_SEMI_BLOCKING | SerialPort.TIMEOUT_WRITE_BLOCKING, 500, 0);
```

## Debugging

When the hang happens, I see no obvious OpenPnP threads being blocked in deadlock or similar. Strangely the AWT thread is blocked drawing a simple `FillRect` of the last button being pressed:

![image](https://github.com/openpnp/openpnp/assets/9963310/c5e2a211-728b-47bf-a2a1-70bf48a718f9)

The only other OpenPnP thread being actively blocked was a `SerialPort` read, which brought me to inspect it closer:

![image](https://github.com/openpnp/openpnp/assets/9963310/1b9c5cd3-48db-4c24-9ea1-0bc3d9fae51a)

The serial reader thread being blocked is actually supposed to be okay (that's what the thread is for). Still, I remembered #1378 and just out of sheer desperation tried to reinstate the timeout, and yes, it helped. 

## Fixes

- Reinstate the serial port read blocking timeout.

During debugging some other minor issues were fixed: 

- Better diagnostics for missing axis letter, name driver.
- Make timeouts more generous in multi-driver firmware detection (the next driver needs to wait for the previous to complete).
- Make sure to disconnect after a firmware detection ad-hoc connection fails late (connection may already be established).

# Justification
See
https://groups.google.com/g/openpnp/c/TW_xEbuD01Y/m/of_qtzcPAgAJ

# Instructions for Use
No change in use.

# Implementation Details
1. Tested with three controllers Smoothieware, Duet, TinyG under Windows.
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. Successful `mvn test` before submitting the Pull Request. 
