### PR TITLE
Fix / jSerialComm temporary workaround

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
 		<dependency>
   			<groupId>com.fazecast</groupId>
   			<artifactId>jSerialComm</artifactId>
-  			<version>[2.0.0,3.0.0)</version>
+  			<version>2.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.swinglabs.swingx</groupId>

--- a/src/main/java/org/openpnp/machine/reference/driver/GcodeAsyncDriver.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/GcodeAsyncDriver.java
@@ -229,10 +229,12 @@ public class GcodeAsyncDriver extends GcodeDriver {
 
         @Override
         public void run() {
-            // Get the copy that is valid for this thread. 
+            // Get the copies that are valid for this thread.
             LinkedBlockingQueue<CommandLine> commandQueue = GcodeAsyncDriver.this.commandQueue;
-            CommandLine lastCommand = null;
+            ReferenceDriverCommunications comms = getCommunications();
+            String connectionName = comms.getConnectionName();
 
+            CommandLine lastCommand = null;
             while (!disconnectRequested) {
                 CommandLine command;
                 try {
@@ -260,8 +262,8 @@ public class GcodeAsyncDriver extends GcodeDriver {
                         // Set up the wanted confirmations for next time.
                         lastCommand = command;
                         receivedConfirmationsQueue.clear();
-                        getCommunications().writeLine(command.line);
-                        Logger.trace("[{}] >> {}", getCommunications().getConnectionName(), command);
+                        comms.writeLine(command.line);
+                        Logger.trace("[{}] >> {}", connectionName, command);
                     }
                     else {
                         confirmationComplete = true;
@@ -272,7 +274,7 @@ public class GcodeAsyncDriver extends GcodeDriver {
                     }
                 }
                 catch (IOException e) {
-                    Logger.error("Write error on {}: {}", getCommunications().getConnectionName(), e);
+                    Logger.error("Write error on {}: {}", connectionName, e);
                     return;
                 }
                 catch (Exception e) {
@@ -282,7 +284,7 @@ public class GcodeAsyncDriver extends GcodeDriver {
                     //Logger.error("[{}] {}", getCommunications().getConnectionName(), e);
                 }
             }
-            Logger.trace("[{}] disconnectRequested, bye-bye.", getCommunications().getConnectionName());
+            Logger.trace("[{}] disconnectRequested, bye-bye.", connectionName);
         }
     }
 


### PR DESCRIPTION
# Description
This provides a temporary workaround for the current issue with `jSerialComm`.

* Block jSerialComm at 2.9.3 until https://github.com/Fazecast/jSerialComm/issues/505 is resolved.
* Keep serial read timeout as introduced by https://github.com/openpnp/openpnp/pull/1569.
* Fix the bug in https://github.com/openpnp/openpnp/issues/1235, resume reading on timeout.
* Keep https://github.com/openpnp/openpnp/pull/1508 (which was found to cause problems too), it is equally solved by the read timeout.
* Add a debug log when a read timeout happens during a write, which would indicate that the writer was blocked until the reader timed out, which may or may not point to an internal read/write/full-duplex deadlock. Which might cause the problems through https://github.com/openpnp/openpnp/pull/1508.
* As an afterthought: In the reader/writer thread, keep copies of the comms and name, so changing them through the GUI while connected, is okay.

# Justification
See the follow up of:
https://github.com/openpnp/openpnp/pull/1569#issuecomment-1627268331

# Instructions for Use
No change in use.

# Implementation Details
1. Tested extensively with three test controllers Duet, Smoothie and TinyG in parallel.
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. Successful `mvn test` before submitting the Pull Request.
