### PR TITLE
Fix/j serial upgrade

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,6 @@
 	<scm>
 		<connection>scm:git:https://github.com/openpnp/openpnp.git </connection>
 	</scm>
-
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.build.timestamp.format>yyyy-MM-dd_HH-mm-ss</maven.build.timestamp.format>
@@ -67,7 +66,7 @@
 		<dependency>
   			<groupId>com.fazecast</groupId>
   			<artifactId>jSerialComm</artifactId>
-  			<version>2.9.3</version>
+  			<version>2.10.2-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.swinglabs.swingx</groupId>
@@ -471,5 +470,9 @@
 			<id>openpnp</id>
 			<url>https://github.com/openpnp/openpnp-maven-repo/raw/develop</url>
 		</repository>
+        <repository>
+            <id>sonatype</id>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+        </repository>
 	</repositories>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
 		<dependency>
   			<groupId>com.fazecast</groupId>
   			<artifactId>jSerialComm</artifactId>
-  			<version>2.10.2-SNAPSHOT</version>
+  			<version>2.10.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.swinglabs.swingx</groupId>
@@ -470,9 +470,5 @@
 			<id>openpnp</id>
 			<url>https://github.com/openpnp/openpnp-maven-repo/raw/develop</url>
 		</repository>
-        <repository>
-            <id>sonatype</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-        </repository>
 	</repositories>
 </project>

--- a/src/main/java/org/openpnp/machine/neoden4/NeoDen4Driver.java
+++ b/src/main/java/org/openpnp/machine/neoden4/NeoDen4Driver.java
@@ -222,6 +222,7 @@ public class NeoDen4Driver extends AbstractReferenceDriver {
     public synchronized void connect() throws Exception {
         createMachineObjects();
 
+        getCommunications().setDriverName(getName());
         getCommunications().connect();
 
         connected = false;

--- a/src/main/java/org/openpnp/machine/reference/camera/SimulatedUpCamera.java
+++ b/src/main/java/org/openpnp/machine/reference/camera/SimulatedUpCamera.java
@@ -178,8 +178,6 @@ public class SimulatedUpCamera extends ReferenceCamera {
         LengthUnit units = LengthUnit.Millimeters;
         Location unitsPerPixel = getSimulatedUnitsPerPixel().convertToUnits(units);
 
-        boolean hasDrawn;
-
         // Draw the nozzle
         // Get nozzle offsets from camera
         Location offsets = l.subtractWithRotation(getSimulatedLocation());

--- a/src/main/java/org/openpnp/machine/reference/driver/GcodeAsyncDriver.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/GcodeAsyncDriver.java
@@ -274,7 +274,7 @@ public class GcodeAsyncDriver extends GcodeDriver {
                     }
                 }
                 catch (IOException e) {
-                    Logger.error("Write error on {}: {}", connectionName, e);
+                    Logger.error(e, "[{}] Write error", connectionName);
                     return;
                 }
                 catch (Exception e) {
@@ -312,7 +312,7 @@ public class GcodeAsyncDriver extends GcodeDriver {
             return;
         }
 
-        Logger.debug("{} commandQueue.offer({}, {})...", getCommunications().getConnectionName(), command, timeout);
+        Logger.debug("[{}] commandQueue offer >> {}", getCommunications().getConnectionName(), command);
         command = preProcessCommand(command);
         if (command.isEmpty()) {
             Logger.debug("{} empty command after pre process", getCommunications().getConnectionName());
@@ -343,13 +343,17 @@ public class GcodeAsyncDriver extends GcodeDriver {
      * @throws InterruptedException
      */
     protected void waitForEmptyCommandQueue() {
-        long t1 = System.currentTimeMillis() + getTimeoutAtMachineSpeed();
+        long t0 = System.currentTimeMillis();
+        long t1 = t0 + getTimeoutAtMachineSpeed();
         while (System.currentTimeMillis() < t1) {
             if (commandQueue.size() == 0) {
+                long dt = System.currentTimeMillis() - t0;
+                if (dt > 20) {
+                        Logger.trace("{} waited {}ms for empty command queue.", getName(), dt);
+                }
                 return; // --->
             }
             try {
-                Logger.trace("{} wait for empty command queue.", getName());
                 Thread.sleep(10);
             }
             catch (InterruptedException e) {

--- a/src/main/java/org/openpnp/machine/reference/driver/GcodeDriver.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/GcodeDriver.java
@@ -364,6 +364,7 @@ public class GcodeDriver extends AbstractReferenceDriver implements Named {
     public synchronized void connect() throws Exception {
         disconnectRequested = false;
         getCommunications().setDriverName(getName());
+        Logger.debug("[{}] Connect", getCommunications().getConnectionName());
         getCommunications().connect();
         connected = false;
 
@@ -382,7 +383,7 @@ public class GcodeDriver extends AbstractReferenceDriver implements Named {
 
         }
 
-        // Disable the machine
+        // Disable the driver
         setEnabled(false);
 
         // Send startup Gcode

--- a/src/main/java/org/openpnp/machine/reference/driver/GcodeDriver.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/GcodeDriver.java
@@ -363,6 +363,7 @@ public class GcodeDriver extends AbstractReferenceDriver implements Named {
 
     public synchronized void connect() throws Exception {
         disconnectRequested = false;
+        getCommunications().setDriverName(getName());
         getCommunications().connect();
         connected = false;
 
@@ -1344,7 +1345,7 @@ public class GcodeDriver extends AbstractReferenceDriver implements Named {
                     receivedLine = comms.readLine();
                     if (receivedLine == null) {
                         // Line read failed eg. due to socket closure
-                        Logger.error("Failed to read gcode response");
+                        Logger.error("[{}] Failed to read gcode response", connectionName);
                         return;
                     }
                     receivedLine = receivedLine.trim();
@@ -1354,11 +1355,11 @@ public class GcodeDriver extends AbstractReferenceDriver implements Named {
                 }
                 catch (IOException e) {
                     if (disconnectRequested) {
-                        Logger.trace("Read error while disconnecting (expected)");
+                        Logger.trace("[{}] Read error while disconnecting (expected)", connectionName);
                         return;
                     }
                     else {
-                        Logger.error(e, "Read error");
+                        Logger.error(e, "[{}] Read error", connectionName);
                         return;
                     }
                 }

--- a/src/main/java/org/openpnp/machine/reference/driver/SerialPortCommunications.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/SerialPortCommunications.java
@@ -94,9 +94,11 @@ public class SerialPortCommunications extends ReferenceDriverCommunications {
 
     private SerialPort serialPort;
 
+    @Override
     public synchronized void connect() throws Exception {
         disconnect();
         serialPort = SerialPort.getCommPort(portName);
+        serialPort.flushIOBuffers();
         serialPort.openPort(0);
         serialPort.setComPortParameters(baud, dataBits.mask, stopBits.mask, parity.mask);
         serialPort.setFlowControl(flowControl.mask);
@@ -107,9 +109,10 @@ public class SerialPortCommunications extends ReferenceDriverCommunications {
             serialPort.setRTS();
         }
         serialPort.setComPortTimeouts(
-                SerialPort.TIMEOUT_READ_SEMI_BLOCKING | SerialPort.TIMEOUT_WRITE_BLOCKING, 500, 0);
+                SerialPort.TIMEOUT_READ_SEMI_BLOCKING | SerialPort.TIMEOUT_WRITE_BLOCKING, 0, 0);
     }
 
+    @Override
     public synchronized void disconnect() throws Exception {
         if (serialPort != null && serialPort.isOpen()) {
             serialPort.closePort();
@@ -163,7 +166,7 @@ public class SerialPortCommunications extends ReferenceDriverCommunications {
 
     @Override
     public String getConnectionName() {
-        return "serial://" + portName;
+        return (driverName != null ? driverName +":" : "") + portName;
     }
 
     public String getPortName() {

--- a/src/main/java/org/openpnp/machine/reference/driver/SimulatedCommunications.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/SimulatedCommunications.java
@@ -62,7 +62,7 @@ public class SimulatedCommunications extends ReferenceDriverCommunications {
     @Override
     public String getConnectionName(){
         GcodeServer server = gcodeServer; // prevent race by taking a copy
-        return "simulated: "+(server == null ? "off" : "port "+server.getListenerPort());
+        return (driverName != null ? driverName +":" : "") + "simulated: "+(server == null ? "off" : "port "+server.getListenerPort());
     }
 
     @Override

--- a/src/main/java/org/openpnp/machine/reference/driver/TcpCommunications.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/TcpCommunications.java
@@ -64,7 +64,7 @@ public class TcpCommunications extends ReferenceDriverCommunications {
 
     @Override
     public String getConnectionName(){
-        return "tcp://" + ipAddress + ":" + port;
+        return (driverName != null ? driverName +":" : "") + ipAddress + ":" + port;
     }
 
     @Override

--- a/src/main/java/org/openpnp/machine/reference/solutions/VisionSolutions.java
+++ b/src/main/java/org/openpnp/machine/reference/solutions/VisionSolutions.java
@@ -1433,8 +1433,8 @@ public class VisionSolutions implements Solutions.Subject {
             int minDiameter = (int) (expectedOffsetAndDiameter != null ? 
                     expectedDiameter/fiducialMargin - 1
                     : 7);
-            int searchDiameter = (int) (Math.max(subjectAreaDiameter/2, maxDiameter*fiducialMargin)
-                    + Math.min(image.cols(), image.rows())*extraSearchRange);
+            int searchDiameter = (int) (Math.max(subjectAreaDiameter, maxDiameter*fiducialMargin*2)
+                    + Math.min(image.cols(), image.rows())*extraSearchRange*2);
             int expectedX = bufferedImage.getWidth()/2 + (int) (expectedOffsetAndDiameter != null ? expectedOffsetAndDiameter.getX() : 0);
             int expectedY = bufferedImage.getHeight()/2 + (int) (expectedOffsetAndDiameter != null ? expectedOffsetAndDiameter.getY() : 0);
 


### PR DESCRIPTION
# Description
Integrates the `jSerialComm` version 2.10.2, which was fixed very quickly :rocket:, after we reported https://github.com/Fazecast/jSerialComm/issues/505.

This PR contains the following:

- Set `jSerialComm` to 2.10.2.
- Remove serial read timeout again.
- Remove serial timeout during write "full duplex deadlocking diagnostics".
- Add `serialPort.flushIOBuffers()` before opening serial, as recommended.

While testing and debugging the various versions, there were some issues that I just solved on the go:

- Add the driver name to `ReferenceDriverCommunications`, so it is easier to diagnose from the logs with multiple drivers (you no longer need to remember which serial port/ip address is which driver).
- Unified the communications logging, and exception reporting.
- Quieter logging for $-command queue draining (TinyG).

-  **Issues & Solutions:** the search diameter in preliminary camera calibration was computed as if a radius (halved). With the excessive simulated nozzle run-out that I used in testing, it would therefore fail. This might in retrospect also explain some user reports.

# Justification
- Fixes any issues introduced by the version 2.10.1.
- Improves diagnosing communications, especially with multiple drivers.


# Instructions for Use
No change in use.

# Implementation Details
1. Tested with three controller rig (Duet, Smoothie, TinyG), but with simulated cameras and test hob.
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. Successful `mvn test` before submitting the Pull Request.
