### PR TITLE
- Fixed line lenght check if a comment column is present

### DIFF
--- a/src/main/java/org/openpnp/gui/importer/CsvImporter.java
+++ b/src/main/java/org/openpnp/gui/importer/CsvImporter.java
@@ -61,6 +61,7 @@ import org.openpnp.model.Location;
 import org.openpnp.model.Package;
 import org.openpnp.model.Part;
 import org.openpnp.model.Placement;
+import org.openpnp.util.Utils2D;
 import org.pmw.tinylog.Logger;
 
 import com.Ostermiller.util.CSVParser;
@@ -340,14 +341,7 @@ public abstract class CsvImporter {
 
                 double placementRotation = convert(as[rotationIndex]);
                 // convert rotation to [-180 .. 180]
-                // FIXME: this range is invalid as -180° == 180°. Whats the OpenPnP convention?
-                // FIXME: does OpenPnP provide a unified method to limit angles?
-                while (placementRotation > 180.0) {
-                    placementRotation -= 360.0;
-                }
-                while (placementRotation < -180.0) {
-                    placementRotation += 360.0;
-                }
+                placementRotation = Utils2D.angleNorm(placementRotation, 180);
                 
                 String partId = as[packageIndex] + "-" + as[valueIndex]; //$NON-NLS-1$
                 Part part = cfg.getPart(partId);


### PR DESCRIPTION
# Description
This PR fixes the import of comment columns if they are the last column in the file. It also fixes the behavior of an unchecked _Create Missing Parts_ checkbox. Previously no part was assigned to any placement in that case. Now an existing part is assigned and the placement is skipped if the part does not exists. A warning is logged in the later case.

In addition this PR changes placements whose ID starts with "FID" or "REF" followed by a digit to type fiducial.

# Justification
Both problems where reported at https://groups.google.com/g/openpnp/c/JjAjSdWhUkA/m/BLhpk9dyAwAJ.

# Instructions for Use
There is no change in usage.

# Implementation Details
1. How did you test the change? Be descriptive. Untested code will not be accepted. **The code was tested using the supplied .csv file.**
2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)? **yes**
3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing. **no**
4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted. **yes**
