### PR TITLE
Job Placements UI enhancement

### DIFF
--- a/src/main/java/org/openpnp/gui/JobPlacementsPanel.java
+++ b/src/main/java/org/openpnp/gui/JobPlacementsPanel.java
@@ -265,11 +265,18 @@ public class JobPlacementsPanel extends JPanel {
         });
         table.addMouseListener(new MouseAdapter() {
             public void mouseClicked(MouseEvent mouseEvent) {
+                int row = table.rowAtPoint(new Point(mouseEvent.getX(), mouseEvent.getY()));
+                int col = table.columnAtPoint(new Point(mouseEvent.getX(), mouseEvent.getY()));
+
+                // if enabled column is clicked, refresh the row to update status immediately
+                if (col == 0) {
+                    refreshSelectedRow();
+                    updateActivePlacements();
+                }
+
                 if (mouseEvent.getClickCount() != 2) {
                     return;
                 }
-                int row = table.rowAtPoint(new Point(mouseEvent.getX(), mouseEvent.getY()));
-                int col = table.columnAtPoint(new Point(mouseEvent.getX(), mouseEvent.getY()));
                 if (tableModel.getColumnClass(col) == Status.class) {
                     Status status = (Status) tableModel.getValueAt(row, col);
                     // TODO: This is some sample code for handling the user


### PR DESCRIPTION
# Description
This PR enhances the Job Placements table by immediately updating the Status if a placement is enabled or disabled using the mouse.

# Justification
It's inconvenient to change the row after a placement has been enabled or disabled until the status is updated. By studding the code I learned, that the space bar could be used for that purpose as well and that there the Status is immediately updated.

# Implementation Details
1. How did you test the change? Be descriptive. Untested code will not be accepted. **using the debugger and test job**
2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)? **yes**
3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing. **no**
4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted. **yes**
