### PR TITLE
Fix bug introduced by PR1547

### DIFF
--- a/src/main/java/org/openpnp/gui/JobPanel.java
+++ b/src/main/java/org/openpnp/gui/JobPanel.java
@@ -1136,6 +1136,7 @@ public class JobPanel extends JPanel {
     protected void addBoard(File file) throws Exception {
         Board board = new Board(configuration.getBoard(file));
         BoardLocation boardLocation = new BoardLocation(board);
+        boardLocation.setLocation(Configuration.get().getMachine().getDefaultBoardLocation());
         
         Configuration.get().resolveBoard(job, boardLocation);
         
@@ -1220,6 +1221,7 @@ public class JobPanel extends JPanel {
     protected void addPanel(File file) throws Exception {
         Panel panel = new Panel(configuration.getPanel(file));
         PanelLocation panelLocation = new PanelLocation(panel);
+        panelLocation.setLocation(Configuration.get().getMachine().getDefaultBoardLocation());
         
         Configuration.get().resolvePanel(job, panelLocation);
         

--- a/src/main/java/org/openpnp/model/BoardLocation.java
+++ b/src/main/java/org/openpnp/model/BoardLocation.java
@@ -76,10 +76,7 @@ public class BoardLocation extends PlacementsHolderLocation<BoardLocation> {
      * Default constructor
      */
     public BoardLocation() {
-    	/**
-    	 * use the location defined as default board location for the reference machine
-    	 */
-        setLocation(Configuration.get().getMachine().getDefaultBoardLocation());
+        setLocation(new Location(LengthUnit.Millimeters));
     }
 
     /**


### PR DESCRIPTION
# Description
This change moves the initialization of board and panel locations from the BoardLocation default constructor to the addBoard and addPanel methods of JobPanel.

# Justification
Initialization of board locations in the BoardLocation default constructor can fail due to accessing of the machine configuration (to obtain the default board location) before the machine configuration is completely loaded. The consequence of this is that the Panels tab is always empty after a restart of OpenPnP and there will be erroneous errors reported in the log implying the *.panel.xml files are corrupted when in fact they are fine. This change moves the initialization to its proper place, namely where a new board or panel is being added to the job.

# Instructions for Use
No special instructions for operators.

# Implementation Details
1. How did you test the change? Be descriptive. Untested code will not be accepted. **Verified the Panels tab is now correctly populated on a restart and no errors are reported in the log. Also verified that boards and panels that are added to a job still have their location initialized to the Default Board Location as desired.**
2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)? **Yes**
3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing. **No changes were made to these packages.**
4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted. **Maven tests were run and all passed**
