### PR TITLE
Save raw cropped image size and use it for diagnostics display instead of checking the image size

### DIFF
--- a/src/main/java/org/openpnp/gui/processes/CalibrateCameraProcess.java
+++ b/src/main/java/org/openpnp/gui/processes/CalibrateCameraProcess.java
@@ -182,6 +182,9 @@ public abstract class CalibrateCameraProcess {
 
         advCal = ((ReferenceCamera)camera).getAdvancedCalibration();
         
+        advCal.setRawCroppedImageWidth(pixelsX);
+        advCal.setRawCroppedImageHeight(pixelsY);
+        
         testPattern3dPointsList = new ArrayList<>();
         testPatternImagePointsList = new ArrayList<>();
         

--- a/src/main/java/org/openpnp/machine/reference/camera/ReferenceCamera.java
+++ b/src/main/java/org/openpnp/machine/reference/camera/ReferenceCamera.java
@@ -661,8 +661,7 @@ public abstract class ReferenceCamera extends AbstractBroadcastingCamera impleme
             if (undistortionMap2 == null) {
                 undistortionMap2 = new Mat();
             }
-            advancedCalibration.initUndistortRectifyMap(mat.size(), 
-                    undistortionMap1, undistortionMap2);
+            advancedCalibration.initUndistortRectifyMap(undistortionMap1, undistortionMap2);
         }
         Imgproc.remap(mat, dst, undistortionMap1, undistortionMap2, Imgproc.INTER_LINEAR);
         mat.release();

--- a/src/main/java/org/openpnp/machine/reference/solutions/CalibrationSolutions.java
+++ b/src/main/java/org/openpnp/machine/reference/solutions/CalibrationSolutions.java
@@ -1268,6 +1268,11 @@ public class CalibrationSolutions implements Solutions.Subject {
                                 testPatternImagePointsList, size, mirrored,
                                 apparentMotionDirection);
 
+                        if (advCal.getPrimaryLocation() != null) {
+                            //Do this here rather than in advCal.applyCalibrationToMachine so that
+                            //when calibrating manually, a different defaultZ can be used if desired
+                            camera.setDefaultZ(advCal.getPrimaryLocation().getLengthZ());
+                        }
                         advCal.applyCalibrationToMachine(head, camera);
 
                         // Tidy up.

--- a/src/main/java/org/openpnp/machine/reference/wizards/ReferenceCameraCalibrationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/wizards/ReferenceCameraCalibrationWizard.java
@@ -1059,7 +1059,7 @@ public class ReferenceCameraCalibrationWizard extends AbstractConfigurationWizar
                 else {
                     try {
                         referenceCamera.getAdvancedCalibration().processRawCalibrationData(
-                                new Size(referenceCamera.getWidth(), referenceCamera.getHeight()));
+                                new Size(advCal.getRawCroppedImageWidth(), advCal.getRawCroppedImageHeight()));
                     
                         postCalibrationProcessing();
                     }
@@ -1239,18 +1239,17 @@ public class ReferenceCameraCalibrationWizard extends AbstractConfigurationWizar
                 
                 int width = referenceCamera.getCropWidth();
                 int height = referenceCamera.getCropHeight();
-                BufferedImage rawImage = referenceCamera.captureRaw();
                 if (width > 0) {
-                    width = Math.min(width, rawImage.getWidth());
+                    width = Math.min(width, advCal.getRawCroppedImageWidth());
                 }
                 else {
-                    width = rawImage.getWidth();
+                    width = advCal.getRawCroppedImageWidth();
                 }
                 if (height > 0) {
-                    height = Math.min(height, rawImage.getHeight());
+                    height = Math.min(height, advCal.getRawCroppedImageHeight());
                 }
                 else {
-                    height = rawImage.getHeight();
+                    height = advCal.getRawCroppedImageHeight();
                 }
                 
                 if (chckbxShowOutliers.isSelected()) {

--- a/src/main/java/org/openpnp/spi/base/AbstractCamera.java
+++ b/src/main/java/org/openpnp/spi/base/AbstractCamera.java
@@ -133,7 +133,9 @@ public abstract class AbstractCamera extends AbstractHeadMountable implements Ca
     }
 
     public void setId(String id) {
+        Object oldValue = this.id;
         this.id = id;
+        firePropertyChange("id", oldValue, id);
     }
 
     @Override
@@ -143,8 +145,9 @@ public abstract class AbstractCamera extends AbstractHeadMountable implements Ca
 
     @Override
     public void setName(String name) {
+        Object oldValue = this.name;
         this.name = name;
-        firePropertyChange("name", null, name);
+        firePropertyChange("name", oldValue, name);
     }
 
     @Override
@@ -157,8 +160,10 @@ public abstract class AbstractCamera extends AbstractHeadMountable implements Ca
         if (this.head != head && this.headSet) {
             throw new Error("Can't change head on camera " + this);
         }
+        Object oldValue = this.head;
         this.head = head;
         this.headSet = true;
+        firePropertyChange("head", oldValue, head);
     }
 
     @Override
@@ -230,7 +235,9 @@ public abstract class AbstractCamera extends AbstractHeadMountable implements Ca
     }
 
     public void setEnableUnitsPerPixel3D(boolean enableUnitsPerPixel3D) {
+        Object oldValue = this.enableUnitsPerPixel3D;
         this.enableUnitsPerPixel3D = enableUnitsPerPixel3D;
+        firePropertyChange("enableUnitsPerPixel3D", oldValue, enableUnitsPerPixel3D);
     }
 
     @Override
@@ -292,7 +299,9 @@ public abstract class AbstractCamera extends AbstractHeadMountable implements Ca
 
     @Override
     public void setUnitsPerPixel(Location unitsPerPixel) {
+        Object oldValue = this.unitsPerPixel;
         this.unitsPerPixel = unitsPerPixel;
+        firePropertyChange("unitsPerPixel", oldValue, unitsPerPixel);
     }
 
     /**
@@ -313,7 +322,9 @@ public abstract class AbstractCamera extends AbstractHeadMountable implements Ca
      * were made.
      */
     public void setUnitsPerPixelPrimary(Location unitsPerPixelPrimary) {
+        Object oldValue = this.unitsPerPixel;
         this.unitsPerPixel = unitsPerPixelPrimary;
+        firePropertyChange("unitsPerPixelPrimary", oldValue, unitsPerPixelPrimary);
     }
 
     /**
@@ -334,7 +345,9 @@ public abstract class AbstractCamera extends AbstractHeadMountable implements Ca
      * measurements were made.
      */
     public void setUnitsPerPixelSecondary(Location unitsPerPixelSecondary) {
+        Object oldValue = this.unitsPerPixelSecondary;
         this.unitsPerPixelSecondary = unitsPerPixelSecondary;
+        firePropertyChange("unitsPerPixelSecondary", oldValue, unitsPerPixelSecondary);
     }
 
     @Override
@@ -343,7 +356,9 @@ public abstract class AbstractCamera extends AbstractHeadMountable implements Ca
     }
 
     public void setDefaultZ(Length defaultZ) {
+        Object oldValue = this.defaultZ;
         this.defaultZ = defaultZ;
+        firePropertyChange("defaultZ", oldValue, defaultZ);
     }
 
     /**
@@ -354,7 +369,9 @@ public abstract class AbstractCamera extends AbstractHeadMountable implements Ca
     }
 
     public void setCameraPrimaryZ(Length cameraPrimaryZ) {
+        Object oldValue = this.cameraPrimaryZ;
         this.cameraPrimaryZ = cameraPrimaryZ;
+        firePropertyChange("cameraPrimaryZ", oldValue, cameraPrimaryZ);
     }
 
     /**
@@ -365,7 +382,9 @@ public abstract class AbstractCamera extends AbstractHeadMountable implements Ca
     }
 
     public void setCameraSecondaryZ(Length cameraSecondaryZ) {
+        Object oldValue = this.cameraSecondaryZ;
         this.cameraSecondaryZ = cameraSecondaryZ;
+        firePropertyChange("cameraSecondaryZ", oldValue, cameraSecondaryZ);
     }
 
     @Override
@@ -374,7 +393,9 @@ public abstract class AbstractCamera extends AbstractHeadMountable implements Ca
     }
 
     public void setRoamingRadius(Length roamingRadius) {
+        Object oldValue = this.roamingRadius;
         this.roamingRadius = roamingRadius;
+        firePropertyChange("roamingRadius", oldValue, roamingRadius);
     }
 
     /**
@@ -432,8 +453,9 @@ public abstract class AbstractCamera extends AbstractHeadMountable implements Ca
 
     @Override
     public void setLooking(Looking looking) {
+        Object oldValue = this.looking;
         this.looking = looking;
-        firePropertyChange("looking", null, looking);
+        firePropertyChange("looking", oldValue, looking);
     }
 
     @Override
@@ -457,7 +479,9 @@ public abstract class AbstractCamera extends AbstractHeadMountable implements Ca
     }
 
     public void setBeforeCaptureLightOn(boolean beforeCaptureLightOn) {
+        Object oldValue = this.beforeCaptureLightOn;
         this.beforeCaptureLightOn = beforeCaptureLightOn;
+        firePropertyChange("beforeCaptureLightOn", oldValue, beforeCaptureLightOn);
     }
 
     public boolean isUserActionLightOn() {
@@ -465,7 +489,9 @@ public abstract class AbstractCamera extends AbstractHeadMountable implements Ca
     }
 
     public void setUserActionLightOn(boolean userActionLightOn) {
+        Object oldValue = this.userActionLightOn;
         this.userActionLightOn = userActionLightOn;
+        firePropertyChange("userActionLightOn", oldValue, userActionLightOn);
     }
 
     public boolean isAfterCaptureLightOff() {
@@ -473,7 +499,9 @@ public abstract class AbstractCamera extends AbstractHeadMountable implements Ca
     }
 
     public void setAfterCaptureLightOff(boolean afterCaptureLightOff) {
+        Object oldValue = this.afterCaptureLightOff;
         this.afterCaptureLightOff = afterCaptureLightOff;
+        firePropertyChange("afterCaptureLightOff", oldValue, afterCaptureLightOff);
     }
 
     public boolean isAntiGlareLightOff() {
@@ -481,7 +509,9 @@ public abstract class AbstractCamera extends AbstractHeadMountable implements Ca
     }
 
     public void setAntiGlareLightOff(boolean antiGlareLightOff) {
+        Object oldValue = this.antiGlareLightOff;
         this.antiGlareLightOff = antiGlareLightOff;
+        firePropertyChange("antiGlareLightOff", oldValue, antiGlareLightOff);
     }
 
     @Override
@@ -496,8 +526,10 @@ public abstract class AbstractCamera extends AbstractHeadMountable implements Ca
 
     @Override
     public void setVisionProvider(VisionProvider visionProvider) {
+        Object oldValue = this.visionProvider;
         this.visionProvider = visionProvider;
         visionProvider.setCamera(this);
+        firePropertyChange("visionProvider", oldValue, visionProvider);
     }
 
     @Override


### PR DESCRIPTION
# Description
This change adds two new attributes to AdvancedCameraCalibration to save the image width and height that were in effect when calibration was run. This allows the Calibration Results/Diagnostics to display correctly even if the camera is no longer connected to OpenPnP.

Also moved setting of the camera's defaultZ out of applyCalibrationToMachine to CalibrationSolutions just ahead of the call to applyCalibrationToMachine. This still sets defaultZ automatically when calibration is run via Issues&Solutions but allows it to be changed by the operator when running calibration manually.

Additionally, added calls to firePropertyChange in all AbstractCamera setters so that any GUI fields bound to those will properly update.

# Justification
Aids in off-line debugging.

# Instructions for Use
No special instructions for the operator.

# Implementation Details
1. How did you test the change? Be descriptive. Untested code will not be accepted. **Verified that the camera Calibration Results/Diagnostics display correctly regardless of the state of the camera connection.**
2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)? **Yes.**
3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing. **AbstractCamera was touched but only to add calls to firePropertyChange in all existing setters.**
4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted. **All Maven tests were run and passed.**
