### PR TITLE
Feature/Better Test Alignment, Centering

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/SimulationModeMachine.java
+++ b/src/main/java/org/openpnp/machine/reference/SimulationModeMachine.java
@@ -55,7 +55,6 @@ import org.openpnp.spi.HeadMountable;
 import org.openpnp.spi.Locatable.LocationOption;
 import org.openpnp.spi.Machine;
 import org.openpnp.spi.Nozzle;
-import org.openpnp.spi.base.AbstractNozzle;
 import org.openpnp.util.Collect;
 import org.openpnp.util.GcodeServer;
 import org.openpnp.util.NanosecondTime;
@@ -386,10 +385,8 @@ public class SimulationModeMachine extends ReferenceMachine {
                                                         +" pick location not recognized.");
                                             }
                                         }
-                                        if (nozzle instanceof AbstractNozzle) {
-                                            Double rotationModeOffset = ((AbstractNozzle) nozzle).getRotationModeOffset();
-                                            rotationModeOffsetAtPick.put(nozzle, rotationModeOffset == null ? 0.0 : rotationModeOffset);
-                                        }
+                                        Double rotationModeOffset = nozzle.getRotationModeOffset();
+                                        rotationModeOffsetAtPick.put(nozzle, rotationModeOffset == null ? 0.0 : rotationModeOffset);
                                     }
                                     else {
                                         // Place
@@ -537,13 +534,13 @@ public class SimulationModeMachine extends ReferenceMachine {
                         LocationOption.SuppressStaticCompensation,
                         LocationOption.SuppressDynamicCompensation);
                 // If the part rotation is wanted, we need to adjust the 
-                if (partRotation && hm instanceof AbstractNozzle) {
+                if (partRotation && hm instanceof Nozzle) {
                     Double rotationOffset = rotationModeOffsetAtPick.get(hm);
                     if (rotationOffset != null) {
                         location = location.derive(null, null, null, location.getRotation() + rotationOffset);
                     }
                     else {
-                        rotationOffset = ((AbstractNozzle)hm).getRotationModeOffset();
+                        rotationOffset = ((Nozzle)hm).getRotationModeOffset();
                         if (rotationOffset != null) {
                             location = location.derive(null, null, null, location.getRotation() + rotationOffset);
                         }

--- a/src/main/java/org/openpnp/machine/reference/vision/ReferenceBottomVision.java
+++ b/src/main/java/org/openpnp/machine/reference/vision/ReferenceBottomVision.java
@@ -39,7 +39,6 @@ import org.openpnp.spi.Nozzle;
 import org.openpnp.spi.NozzleTip;
 import org.openpnp.spi.PartAlignment;
 import org.openpnp.spi.PropertySheetHolder;
-import org.openpnp.spi.base.AbstractNozzle;
 import org.openpnp.util.MovableUtils;
 import org.openpnp.util.OpenCvUtils;
 import org.openpnp.util.UiUtils;
@@ -129,13 +128,12 @@ public class ReferenceBottomVision extends AbstractPartAlignment {
         else {
             offsets = findOffsetsPostRotate(part, boardLocation, placement, nozzle, camera, bottomVisionSettings);
         }
-        if (nozzle.isAligningRotationMode() && nozzle instanceof AbstractNozzle) {
+        if (nozzle.isAligningRotationMode()) {
             // Add the rotation offset to the rotation mode rather than adjusting for it in placement. This has the advantage of
             // showing the rotation aligned with the part rotation in the DRO, cross-hairs etc.
-            AbstractNozzle abstractNozzle = (AbstractNozzle) nozzle;
-            double rotOff = abstractNozzle.getRotationModeOffset() != null ? abstractNozzle.getRotationModeOffset() : 0;
-            abstractNozzle.setRotationModeOffset(rotOff + offsets.getLocation().getRotation());
-            Location newOffsets = offsets.getLocation()/*.rotateXy(offsets.getLocation().getRotation())*/.derive(null, null, null, 0.);
+            double rotOff = nozzle.getRotationModeOffset() != null ? nozzle.getRotationModeOffset() : 0;
+            nozzle.setRotationModeOffset(rotOff + offsets.getLocation().getRotation());
+            Location newOffsets = offsets.getLocation().derive(null, null, null, 0.);
             offsets = new PartAlignmentOffset(newOffsets, offsets.getPreRotated()); 
         }
         return offsets;

--- a/src/main/java/org/openpnp/machine/reference/vision/ReferenceBottomVision.java
+++ b/src/main/java/org/openpnp/machine/reference/vision/ReferenceBottomVision.java
@@ -1,5 +1,6 @@
 package org.openpnp.machine.reference.vision;
 
+import java.awt.image.BufferedImage;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -277,7 +278,7 @@ public class ReferenceBottomVision extends AbstractPartAlignment {
             // subtract visionCenterOffset
             offsets = offsets.subtract(bottomVisionSettings.getVisionOffset().rotateXy(wantedAngle));
 
-            displayResult(pipeline, part, offsets, camera, nozzle);
+            displayResult(OpenCvUtils.toBufferedImage(pipeline.getWorkingImage()), part, offsets, camera, nozzle);
             offsetsCheck(part, nozzle, offsets);
 
             return new PartAlignment.PartAlignmentOffset(offsets, true);
@@ -320,7 +321,7 @@ public class ReferenceBottomVision extends AbstractPartAlignment {
             // subtract visionCenterOffset
             offsets = offsets.subtract(bottomVisionSettings.getVisionOffset().rotateXy(offsets.getRotation()));
 
-            displayResult(pipeline, part, offsets, camera, nozzle);
+            displayResult(OpenCvUtils.toBufferedImage(pipeline.getWorkingImage()), part, offsets, camera, nozzle);
             offsetsCheck(part, nozzle, offsets);
 
             return new PartAlignmentOffset(offsets, false);
@@ -412,7 +413,8 @@ public class ReferenceBottomVision extends AbstractPartAlignment {
         return true;
     }
 
-    private static void displayResult(CvPipeline pipeline, Part part, Location offsets, Camera camera, Nozzle nozzle) {
+    @Override
+    public void displayResult(BufferedImage image, Part part, Location offsets, Camera camera, Nozzle nozzle) {
         String s = part.getId();
         if (offsets != null) {
             LengthConverter lengthConverter = new LengthConverter();
@@ -429,7 +431,7 @@ public class ReferenceBottomVision extends AbstractPartAlignment {
                 mainFrame
                 .getCameraViews()
                 .getCameraView(camera)
-                .showFilteredImage(OpenCvUtils.toBufferedImage(pipeline.getWorkingImage()), s,
+                .showFilteredImage(image, s,
                         2000);
                 // Also make sure the right nozzle is selected for correct cross-hair rotation.
                 MovableUtils.fireTargetedUserAction(nozzle);
@@ -589,7 +591,7 @@ public class ReferenceBottomVision extends AbstractPartAlignment {
             }
             pipelineShot.processResult(result);
             // Display the shot result.   
-            displayResult(pipeline, part, null, camera, nozzle);
+            displayResult(OpenCvUtils.toBufferedImage(pipeline.getWorkingImage()), part, null, camera, nozzle);
         }
         return (RotatedRect) pipeline.getCurrentPipelineShot().processCompositeResult().getModel();
     }

--- a/src/main/java/org/openpnp/machine/reference/vision/wizards/BottomVisionSettingsConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/vision/wizards/BottomVisionSettingsConfigurationWizard.java
@@ -575,9 +575,11 @@ public class BottomVisionSettingsConfigurationWizard extends AbstractConfigurati
         Camera camera = VisionUtils.getBottomVisionCamera();
         Placement dummy = new Placement("Dummy");
         dummy.setLocation(new Location(LengthUnit.Millimeters, 0, 0, 0, angle));
+        Double rotationBefore = nozzle.getRotationModeOffset();
         PartAlignment.PartAlignmentOffset alignmentOffset = VisionUtils.findPartAlignmentOffsets(bottomVision, nozzle.getPart(),
                 null, dummy, nozzle);
         Location offsets = alignmentOffset.getLocation();
+        Double rotationAfter = nozzle.getRotationModeOffset();
 
         if (!centerAfterTest) {
             return;
@@ -617,8 +619,13 @@ public class BottomVisionSettingsConfigurationWizard extends AbstractConfigurati
         nozzle.moveTo(centeredLocation);
         // Take a fresh camera shot.
         BufferedImage image = camera.lightSettleAndCapture();
-        // Display with the the final offsets.
-        bottomVision.displayResult(image, nozzle.getPart(), offsets, camera, nozzle);
+        // Display with the the final offsets, but also include the rotation mode offset adjustment.
+        double rotationOffset = 0;
+        if (rotationBefore != null && rotationAfter != null) {
+            rotationOffset = rotationAfter - rotationBefore;
+        }
+        Location offsetsDisplayed = offsets.deriveLengths(null, null, null, offsets.getRotation() + rotationOffset);
+        bottomVision.displayResult(image, nozzle.getPart(), offsetsDisplayed, camera, nozzle);
     }
 
     private void determineVisionOffset() throws Exception {

--- a/src/main/java/org/openpnp/machine/reference/vision/wizards/BottomVisionSettingsConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/vision/wizards/BottomVisionSettingsConfigurationWizard.java
@@ -615,15 +615,14 @@ public class BottomVisionSettingsConfigurationWizard extends AbstractConfigurati
             // instead of the nozzle.
             centeredLocation = centeredLocation.subtract(offsets);
         }
-        // Center, rotate and align the part like that.
+        // Center, rotate and align the part.
         nozzle.moveTo(centeredLocation);
         // Take a fresh camera shot.
         BufferedImage image = camera.lightSettleAndCapture();
+        // Wait a moment to let the last alignment pass result display sink in.
+        Thread.sleep(500);
         // Display with the the final offsets, but also include the rotation mode offset adjustment.
-        double rotationOffset = 0;
-        if (rotationBefore != null && rotationAfter != null) {
-            rotationOffset = rotationAfter - rotationBefore;
-        }
+        double rotationOffset = (rotationAfter != null ? rotationAfter : 0) - (rotationBefore != null ? rotationBefore : 0);
         Location offsetsDisplayed = offsets.deriveLengths(null, null, null, offsets.getRotation() + rotationOffset);
         bottomVision.displayResult(image, nozzle.getPart(), offsetsDisplayed, camera, nozzle);
     }

--- a/src/main/java/org/openpnp/machine/reference/vision/wizards/BottomVisionSettingsConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/vision/wizards/BottomVisionSettingsConfigurationWizard.java
@@ -1,6 +1,7 @@
 package org.openpnp.machine.reference.vision.wizards;
 
 import java.awt.Component;
+import java.awt.image.BufferedImage;
 import java.util.List;
 import java.util.Map;
 
@@ -571,6 +572,7 @@ public class BottomVisionSettingsConfigurationWizard extends AbstractConfigurati
     public void alignAndCenter(ReferenceBottomVision bottomVision, Nozzle nozzle, double angle, boolean centerAfterTest)
             throws Exception {
         // perform the alignment
+        Camera camera = VisionUtils.getBottomVisionCamera();
         Placement dummy = new Placement("Dummy");
         dummy.setLocation(new Location(LengthUnit.Millimeters, 0, 0, 0, angle));
         PartAlignment.PartAlignmentOffset alignmentOffset = VisionUtils.findPartAlignmentOffsets(bottomVision, nozzle.getPart(),
@@ -582,36 +584,41 @@ public class BottomVisionSettingsConfigurationWizard extends AbstractConfigurati
         }
 
         // Nominal position of the part over camera center
-        Location cameraLocation = bottomVision.getCameraLocationAtPartHeight(nozzle.getPart(), VisionUtils.getBottomVisionCamera(),
+        Location cameraLocation = bottomVision.getCameraLocationAtPartHeight(nozzle.getPart(), camera,
                 nozzle, angle);
 
+        // Calculate the centered, rotated and aligned location.
+        Location centeredLocation; 
         if (alignmentOffset.getPreRotated()) {
-            Location centeredLocation = cameraLocation.subtractWithRotation(alignmentOffset.getLocation());
-            nozzle.moveTo(centeredLocation);
-            return;
+            // Pre-rotated is straight-forward.
+            centeredLocation = cameraLocation.subtractWithRotation(alignmentOffset.getLocation());
         }
+        else {
+            // Post-rotate is more complicated. 
+            // Rotate the point 0,0 using the bottom offsets as a center point by the angle
+            // that is the difference between the bottom vision angle and the calculated global
+            // placement angle.
+            centeredLocation = new Location(LengthUnit.Millimeters).rotateXyCenterPoint(offsets,
+                    cameraLocation.getRotation() - offsets.getRotation());
 
-        // Rotate the point 0,0 using the bottom offsets as a center point by the angle
-        // that is
-        // the difference between the bottom vision angle and the calculated global
-        // placement angle.
-        Location location = new Location(LengthUnit.Millimeters).rotateXyCenterPoint(offsets,
-                cameraLocation.getRotation() - offsets.getRotation());
+            // Set the angle to the difference mentioned above, aligning the part to the
+            // same angle as the placement.
+            centeredLocation = centeredLocation.derive(null, null, null, cameraLocation.getRotation() - offsets.getRotation());
 
-        // Set the angle to the difference mentioned above, aligning the part to the
-        // same angle as
-        // the placement.
-        location = location.derive(null, null, null, cameraLocation.getRotation() - offsets.getRotation());
+            // Add the placement final location to move our local coordinate into global
+            // space
+            centeredLocation = centeredLocation.add(cameraLocation);
 
-        // Add the placement final location to move our local coordinate into global
-        // space
-        location = location.add(cameraLocation);
-
-        // Subtract the bottom vision offsets to move the part to the final location,
-        // instead of the nozzle.
-        location = location.subtract(offsets);
-
-        nozzle.moveTo(location);
+            // Subtract the bottom vision offsets to move the part to the final location,
+            // instead of the nozzle.
+            centeredLocation = centeredLocation.subtract(offsets);
+        }
+        // Center, rotate and align the part like that.
+        nozzle.moveTo(centeredLocation);
+        // Take a fresh camera shot.
+        BufferedImage image = camera.lightSettleAndCapture();
+        // Display with the the final offsets.
+        bottomVision.displayResult(image, nozzle.getPart(), offsets, camera, nozzle);
     }
 
     private void determineVisionOffset() throws Exception {

--- a/src/main/java/org/openpnp/spi/Nozzle.java
+++ b/src/main/java/org/openpnp/spi/Nozzle.java
@@ -51,6 +51,18 @@ public interface Nozzle
     public RotationMode getRotationMode();
 
     /**
+     * @return the rotation mode offset currently set.
+     */
+    public Double getRotationModeOffset();
+
+    /**
+     * Set the rotation mode offset to be applied.
+     * 
+     * @param rotationModeOffset
+     */
+    void setRotationModeOffset(Double rotationModeOffset);
+
+    /**
      * @return Whether the bottom vision aligment of parts adjust the Rotation Mode of the nozzle to include the 
      * alignment rotation offset.
      */
@@ -224,4 +236,5 @@ public interface Nozzle
      * If part is null, a zero Length is returned.  
      */
     Length getSafePartHeight(Part part);
+
 }

--- a/src/main/java/org/openpnp/spi/PartAlignment.java
+++ b/src/main/java/org/openpnp/spi/PartAlignment.java
@@ -1,5 +1,7 @@
 package org.openpnp.spi;
 
+import java.awt.image.BufferedImage;
+
 import org.openpnp.gui.support.Wizard;
 import org.openpnp.model.BoardLocation;
 import org.openpnp.model.Location;
@@ -66,5 +68,17 @@ public interface PartAlignment extends PartSettingsHolder, Named, Solutions.Subj
     public boolean canHandle(PartSettingsHolder partSettingsHolder, boolean allowDisabled);
 
     boolean isEnabled();
+
+    /**
+     * Display the result of an Alignment on the camera view. 
+     * 
+     * @param image
+     * @param part
+     * @param offsets
+     * @param camera
+     * @param nozzle
+     */
+    void displayResult(BufferedImage image, Part part, Location offsets, Camera camera,
+            Nozzle nozzle);
 
 }

--- a/src/main/java/org/openpnp/spi/base/AbstractNozzle.java
+++ b/src/main/java/org/openpnp/spi/base/AbstractNozzle.java
@@ -224,10 +224,12 @@ public abstract class AbstractNozzle extends AbstractHeadMountable implements No
         setRotationModeOffset(newRotationModeOffset);
     }
 
+    @Override
     public Double getRotationModeOffset() {
         return rotationModeOffset;
     }
 
+    @Override
     public void setRotationModeOffset(Double rotationModeOffset) {
         Object oldValue = this.rotationModeOffset;
         this.rotationModeOffset = rotationModeOffset;


### PR DESCRIPTION
# Description
In **Test Alignment** we have the option **Center after the test**, which centers the part in the camera view in its final aligned position.

![Test Alignment](https://github.com/openpnp/openpnp/assets/9963310/e8c660f8-0f29-4728-aeae-9fc7c48d077e)

This PR improves this a bit by taking another picture after the part has been centered, making sure the lights are switched on and the camera image settled. Plus it also displays the final (overall) offsets result (including any adjusted rotation mode offset). This image is then frozen for two seconds, immediately overriding the one displayed from the last alignment pass, which was still not centered: 

![Centered view](https://github.com/openpnp/openpnp/assets/9963310/f86d16b0-34c8-4a48-990e-fc6e4af7fe3c)

This now also works, if the camera has FPS 0, i.e., where it would not have worked before. 

# Justification
This popped up in the course of supporting a user problem. 

https://groups.google.com/g/openpnp/c/ln98xGXjzsY/m/gVm0FTTRBAAJ

IMPORTANT NOTE: although this addition will likely remove the symptom of the user problem _as a side effect_, it will not fix the underlying issue (which is still unsolved at the time of writing this).

# Instructions for Use
No change in usage.

# Implementation Details
1. Tested in simulation.
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. Adds new method in the `org.openpnp.spi` packages, pushing up the `org.openpnp.spi.PartAlignment.displayResult()` `org.openpnp.spi.Nozzle.getRotationModeOffset()` and  `org.openpnp.spi.Nozzle.setRotationModeOffset()`, which were formerly in derived classes, and are now required to implement this.
4. Successful `mvn test` before submitting the Pull Request.
