### PR TITLE
fix(sec): upgrade org.apache.xmlgraphics:batik-transcoder to 1.13

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
 		<dependency>
 			<groupId>org.apache.xmlgraphics</groupId>
 			<artifactId>batik-transcoder</artifactId>
-			<version>1.7</version>
+			<version>1.17</version>
 		</dependency>
 		<dependency>
 			<groupId>com.google.zxing</groupId>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.apache.xmlgraphics:batik-transcoder 1.7
- [CVE-2019-17566](https://www.oscs1024.com/hd/CVE-2019-17566)


### What did I do？
Upgrade org.apache.xmlgraphics:batik-transcoder from 1.7 to 1.13 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How can we automate the detection of these types of issues?
By using the [GitHub Actions](https://github.com/murphysecurity/actions) configurations provided by murphysec, we can conduct automatic code security checks in our CI pipeline.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS