### PR TITLE
Fix / Add logging to all regular Thread.sleep() calls

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/ReferenceNozzle.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceNozzle.java
@@ -1095,6 +1095,7 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
         }
         else {
             // simple method, just dwell
+            Logger.trace(getName()+" dwell for pick vacuum "+milliseconds+"ms");
             Thread.sleep(milliseconds);
         }
     }
@@ -1129,6 +1130,7 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
         }
         else {
             // simple method, just dwell
+            Logger.trace(getName()+" dwell for place vacuum dissipation "+milliseconds+"ms");
             Thread.sleep(milliseconds);
         }
     }
@@ -1187,6 +1189,7 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
             }
             else {
                 // simple method, just dwell 
+                Logger.trace(getName()+" dwell for part off probing, open valve "+probingMilliseconds+"ms");
                 Thread.sleep(probingMilliseconds);
                 if (dwellMilliseconds <= 0) {
                     returnedVacuumLevel = readVacuumLevel();
@@ -1225,6 +1228,7 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
         else {
             // simple method, just dwell and then read the level
             if (dwellMilliseconds > 0) {
+                Logger.trace(getName()+" dwell for part off probing, closed valve "+dwellMilliseconds+"ms");
                 Thread.sleep(dwellMilliseconds);
                 returnedVacuumLevel = readVacuumLevel();
             }

--- a/src/main/java/org/openpnp/machine/reference/SimulationModeMachine.java
+++ b/src/main/java/org/openpnp/machine/reference/SimulationModeMachine.java
@@ -407,7 +407,8 @@ public class SimulationModeMachine extends ReferenceMachine {
         }
         if (realtime) {
             try {
-                Thread.sleep(50);
+                Logger.trace("{} simulate actuation, sleep 5ms", actuator.getName());
+                Thread.sleep(5);
             }
             catch (InterruptedException e) {
             }

--- a/src/main/java/org/openpnp/machine/reference/camera/AbstractSettlingCamera.java
+++ b/src/main/java/org/openpnp/machine/reference/camera/AbstractSettlingCamera.java
@@ -662,6 +662,7 @@ public abstract class AbstractSettlingCamera extends AbstractCamera {
             }
             if (settleMethod == SettleMethod.FixedTime) {
                 try {
+                    Logger.trace(getName()+" settling fixed time "+getSettleTimeMs()+"ms");
                     Thread.sleep(getSettleTimeMs());
                 }
                 catch (Exception e) {

--- a/src/main/java/org/openpnp/machine/reference/camera/SwitcherCamera.java
+++ b/src/main/java/org/openpnp/machine/reference/camera/SwitcherCamera.java
@@ -24,7 +24,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
 import org.openpnp.gui.support.Wizard;
@@ -125,6 +124,7 @@ public class SwitcherCamera extends ReferenceCamera {
                         if (this != switchedCamera) {
                             return null;
                         }
+                        Logger.trace(getName()+" switcher actuator delay "+actuatorDelayMillis+"ms");
                         Thread.sleep(actuatorDelayMillis);
                         // Succeeded, set the new state.
                         switchers.put(switcher, this);

--- a/src/main/java/org/openpnp/machine/reference/driver/GcodeDriver.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/GcodeDriver.java
@@ -371,6 +371,7 @@ public class GcodeDriver extends AbstractReferenceDriver implements Named {
         connectThreads();
 
         // Wait a bit while the controller starts up
+        Logger.trace(getName()+" waiting for connection "+connectWaitTimeMilliseconds+"ms");
         Thread.sleep(connectWaitTimeMilliseconds);
 
         // Consume any startup messages

--- a/src/main/java/org/openpnp/spi/base/AbstractHead.java
+++ b/src/main/java/org/openpnp/spi/base/AbstractHead.java
@@ -430,6 +430,7 @@ public abstract class AbstractHead extends AbstractModelObject implements Head {
                     if (!isCarryingPartOtherThanOn(nozzle)) {
                         pump.actuate(on);
                         if (on) {
+                            Logger.trace(getName()+" dwell for pump on "+getPumpOnWaitMilliseconds()+"ms");
                             Thread.sleep(getPumpOnWaitMilliseconds());
                         }
                     }
@@ -440,6 +441,7 @@ public abstract class AbstractHead extends AbstractModelObject implements Head {
                     if (on) {
                         if (pump.isActuated() == null || !pump.isActuated()) {
                             pump.actuate(on);
+                            Logger.trace(getName()+" dwell for pump on, keep running "+getPumpOnWaitMilliseconds()+"ms");
                             Thread.sleep(getPumpOnWaitMilliseconds());
                         }
                     }


### PR DESCRIPTION
# Description
In an effort to optimize OpenPnP for speed, there are some inexplicable pauses observed in the user's log. This PR adds some additional logging wherever `Thread.sleep()` is called in the regular code, so deliberate dwelling can be eliminated.

The `Neoden4` and `Photon` classes were not changed, these seem to do `Thread.sleep()` as part of their "protocol timing".

This PR also declares the command queue draining inter-thread signalling `boolean` `confirmationComplete` as `volatile`, and logs if it took longer than 1ms. However, the user in question does not actually use confirmation flow control, so this is merely for other users.

# Justification
See the discussion:
https://groups.google.com/g/openpnp/c/JUCRTa6pKbQ/m/q0zz8RFbAwAJ

# Instructions for Use
To get timing related logging, set the logging level to TRACE.

# Implementation Details
1. Tested using SampleTest, with changed logging.
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. Logging added in the `org.openpnp.spi` package.
4. Successful `mvn test` before submitting the Pull Request.
