### PR TITLE
fix(sec): upgrade org.python:jython-standalone to 2.7.1b3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -123,7 +123,7 @@
 		<dependency>
 			<groupId>org.python</groupId>
 			<artifactId>jython-standalone</artifactId>
-			<version>2.7.1</version>
+			<version>2.7.2b3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.beanshell</groupId>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.python:jython-standalone 2.7.1
- [CVE-2016-4000](https://www.oscs1024.com/hd/CVE-2016-4000)


### What did I do？
Upgrade org.python:jython-standalone from 2.7.1 to 2.7.1b3 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How can we automate the detection of these types of issues?
By using the [GitHub Actions](https://github.com/murphysecurity/actions) configurations provided by murphysec, we can conduct automatic code security checks in our CI pipeline.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS