### PR TITLE
Fix / SimulationModeMachine simulated actuator delay

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/SimulationModeMachine.java
+++ b/src/main/java/org/openpnp/machine/reference/SimulationModeMachine.java
@@ -404,13 +404,13 @@ public class SimulationModeMachine extends ReferenceMachine {
                     }
                 }
             }
-        }
-        if (realtime) {
-            try {
-                Logger.trace("{} simulate actuation, sleep 5ms", actuator.getName());
-                Thread.sleep(5);
-            }
-            catch (InterruptedException e) {
+            if (realtime) {
+                try {
+                    Logger.trace("{} simulate actuation, sleep 5ms", actuator.getName());
+                    Thread.sleep(5);
+                }
+                catch (InterruptedException e) {
+                }
             }
         }
     }


### PR DESCRIPTION
# Description
The `SimulationModeMachine` simulates an actuation delay by sleeping for 50ms (now 5ms). Unfortunately, the sleep was not nested into the proper `if`-block that checks if the `SimulationModeMachine` is present and in simulation mode.

This is the culmination of #1593 and #1595.

# Justification
Obvious.

# Instructions for Use
No change in usage.

The actuation sleep is logged with TRACE messages of this kind:

`2023-11-02 13:16:25.007 SimulationModeMachine TRACE: BLOW-OFF simulate actuation, sleep 5ms`

# Implementation Details
1. Tested `mvn test`, and by user based on #1595.
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. Successful `mvn test` before submitting the Pull Request. 
