### PR TITLE
Fix erroneous reset of placement transform when cells are selected for editing but are not changed

### DIFF
--- a/src/main/java/org/openpnp/gui/support/LengthCellValue.java
+++ b/src/main/java/org/openpnp/gui/support/LengthCellValue.java
@@ -71,6 +71,14 @@ public class LengthCellValue implements Comparable<LengthCellValue> {
         this.length = length;
     }
 
+    /**
+     * Gets the length rounded to the precision displayed in the cell
+     * @return the length
+     */
+    public Length getDisplayedLength() {
+        return Length.parse(toString());
+    }
+    
     public boolean isDisplayNativeUnits() {
         return displayNativeUnits;
     }

--- a/src/main/java/org/openpnp/gui/support/MonospacedFontWithAffineStatusTableCellRenderer.java
+++ b/src/main/java/org/openpnp/gui/support/MonospacedFontWithAffineStatusTableCellRenderer.java
@@ -51,28 +51,32 @@ public class MonospacedFontWithAffineStatusTableCellRenderer extends DefaultTabl
             alternateGlobalColor = globalColor;
             alternateLocalColor = localColor;
         }
+        Color foreground = table.getForeground();
+        Color background = row%2==0 ? rowColor : alternateRowColor;
         if (isSelected) {
-            setForeground(table.getSelectionForeground());
-            super.setBackground(table.getSelectionBackground());
+            foreground = table.getSelectionForeground();
+            background = table.getSelectionBackground();
         }
-        else {
-            Color foreground = table.getForeground();
-            Color background = row%2==0 ? rowColor : alternateRowColor;
-            try {
-                PlacementsTransformStatus transformStatus = ((PlacementsHolderLocationsTableModel) table.getModel()).getPlacementsHolderLocation(table.convertRowIndexToModel(row)).getPlacementsTransformStatus();
-                if (transformStatus == PlacementsTransformStatus.GloballySet) {
-                    background = row%2==0 ? globalColor : alternateGlobalColor;
-                }
-                else if (transformStatus == PlacementsTransformStatus.LocallySet) {
-                    background = row%2==0 ? localColor : alternateLocalColor;
+        try {
+            PlacementsTransformStatus transformStatus = ((PlacementsHolderLocationsTableModel) table.getModel()).getPlacementsHolderLocation(table.convertRowIndexToModel(row)).getPlacementsTransformStatus();
+            if (transformStatus == PlacementsTransformStatus.GloballySet) {
+                background = row%2==0 ? globalColor : alternateGlobalColor;
+                if (isSelected) {
+                    background = background.darker();
                 }
             }
-            catch (Exception ex) {
-                //do nothing
+            else if (transformStatus == PlacementsTransformStatus.LocallySet) {
+                background = row%2==0 ? localColor : alternateLocalColor;
+                if (isSelected) {
+                    background = background.darker();
+                }
             }
-            setForeground(foreground);
-            setBackground(background);
         }
+        catch (Exception ex) {
+            //do nothing
+        }
+        setForeground(foreground);
+        setBackground(background);
         setFont(new Font( "Monospaced", Font.BOLD, super.getFont().getSize()));
         return this;
     }

--- a/src/main/java/org/openpnp/gui/support/RotationCellValue.java
+++ b/src/main/java/org/openpnp/gui/support/RotationCellValue.java
@@ -67,6 +67,14 @@ public class RotationCellValue implements Comparable<RotationCellValue> {
         this.rotation = rotation;
     }
 
+    /**
+     * Gets the rotation rounded to the precision displayed in the cell
+     * @return the rotation
+     */
+    public double getDisplayedRotation() {
+        return Double.parseDouble(toString());
+    }
+    
     public boolean isDisplayNativeUnits() {
         return displayNativeUnits;
     }

--- a/src/main/java/org/openpnp/gui/tablemodel/PlacementsHolderLocationsTableModel.java
+++ b/src/main/java/org/openpnp/gui/tablemodel/PlacementsHolderLocationsTableModel.java
@@ -254,34 +254,57 @@ public class PlacementsHolderLocationsTableModel extends AbstractObjectTableMode
             else if (columnIndex == 5) {
                 LengthCellValue value = (LengthCellValue) aValue;
                 Length length = value.getLength();
+                Length displayedLength = value.getDisplayedLength();
                 Location oldValue = placementsHolderLocation.getGlobalLocation();
-                Location location = Length.setLocationField(configuration, oldValue, length, Length.Field.X);
-                placementsHolderLocation.setGlobalLocation(location);
-                fireTableCellDecendantsUpdated(rowIndex, TableModelEvent.ALL_COLUMNS);
+                Length oldLength = oldValue.getLengthX();
+                Length displayedOldLength = new LengthCellValue(oldLength).getDisplayedLength();
+                //Check to see if the operator actually changed anything in the cell. The first check
+                //catches changes made to the digits to the right of what would ordinarily be displayed
+                //and the second check catches changes to the displayed digits 
+                if (length.compareTo(displayedLength) != 0 || length.compareTo(displayedOldLength) != 0) {
+                    Location location = Length.setLocationField(configuration, oldValue, length, Length.Field.X);
+                    placementsHolderLocation.setGlobalLocation(location);
+                    fireTableCellDecendantsUpdated(rowIndex, TableModelEvent.ALL_COLUMNS);
+                }
             }
             else if (columnIndex == 6) {
                 LengthCellValue value = (LengthCellValue) aValue;
                 Length length = value.getLength();
+                Length displayedLength = value.getDisplayedLength();
                 Location oldValue = placementsHolderLocation.getGlobalLocation();
-                Location location = Length.setLocationField(configuration, oldValue, length, Length.Field.Y);
-                placementsHolderLocation.setGlobalLocation(location);
-                fireTableCellDecendantsUpdated(rowIndex, TableModelEvent.ALL_COLUMNS);
+                Length oldLength = oldValue.getLengthY();
+                Length displayedOldLength = new LengthCellValue(oldLength).getDisplayedLength();
+                if (length.compareTo(displayedLength) != 0 || length.compareTo(displayedOldLength) != 0) {
+                    Location location = Length.setLocationField(configuration, oldValue, length, Length.Field.Y);
+                    placementsHolderLocation.setGlobalLocation(location);
+                    fireTableCellDecendantsUpdated(rowIndex, TableModelEvent.ALL_COLUMNS);
+                }
             }
             else if (columnIndex == 7) {
                 LengthCellValue value = (LengthCellValue) aValue;
                 Length length = value.getLength();
+                Length displayedLength = value.getDisplayedLength();
                 Location oldValue = placementsHolderLocation.getGlobalLocation();
-                Location location = Length.setLocationField(configuration, oldValue, length, Length.Field.Z);
-                placementsHolderLocation.setGlobalLocation(location);
-                fireTableCellDecendantsUpdated(rowIndex, columnIndex);
+                Length oldLength = oldValue.getLengthZ();
+                Length displayedOldLength = new LengthCellValue(oldLength).getDisplayedLength();
+                if (length.compareTo(displayedLength) != 0 || length.compareTo(displayedOldLength) != 0) {
+                    Location location = Length.setLocationField(configuration, oldValue, length, Length.Field.Z);
+                    placementsHolderLocation.setGlobalLocation(location);
+                    fireTableCellDecendantsUpdated(rowIndex, TableModelEvent.ALL_COLUMNS);
+                }
             }
             else if (columnIndex == 8) {
                 RotationCellValue value = (RotationCellValue) aValue;
                 double rotation = value.getRotation();
+                double displayedRotation = value.getDisplayedRotation();
                 Location oldValue = placementsHolderLocation.getGlobalLocation();
-                Location location = oldValue.derive(null, null, null, rotation);
-                placementsHolderLocation.setLocation(location);
-                fireTableCellDecendantsUpdated(rowIndex, TableModelEvent.ALL_COLUMNS);
+                double oldRotation = oldValue.getRotation();
+                double displayedOldRotation = new RotationCellValue(oldRotation).getDisplayedRotation();
+                if (rotation != displayedRotation || rotation != displayedOldRotation) {
+                    Location location = oldValue.derive(null, null, null, rotation);
+                    placementsHolderLocation.setGlobalLocation(location);
+                    fireTableCellDecendantsUpdated(rowIndex, TableModelEvent.ALL_COLUMNS);
+                }
             }
             else if (columnIndex == 9) {
                 if ((placementsHolderLocation.getParent() == null) ||


### PR DESCRIPTION
# Description
This change fixes a bug where the placement affine transform was erroneously being cleared when the operator selected cells in the Job table for editing but did not actually change anything. It also makes the shading of the location cells visible (which indicates the status of the affine transform) even when the row in the Job table is selected.

# Justification
Fixes a bug and makes the affine transform status visible even when the row is selected.

# Instructions for Use
No special instructions for the operator.

# Implementation Details
1. How did you test the change? **Duplicated the issue and after the code changes observed that the affine transform no longer gets reset when one of the location cells is selected for editing, but nothing is changed. Also checked that the affine status shading is now visible even when the row is selected.**
2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)? **Yes.**
3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing. **No changes were made to those packages.**
4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted. **All Maven tests were run and passed.**
