### PR TITLE
Linux support for Neoden 4 cameras

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -244,7 +244,7 @@
 	</dependencies>
 	<build>
 		<plugins>
-			<!-- Used to specify that the Maven Eclipse task should download sources 
+			<!-- Used to specify that the Maven Eclipse task should download sources
 				and JavaDocs and attach them to the Eclipse project. -->
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
@@ -256,7 +256,7 @@
 				</configuration>
 			</plugin>
 
-			<!-- Creates a build number property that is then embedded into the manifest 
+			<!-- Creates a build number property that is then embedded into the manifest
 				by the maven-jar-plugin. -->
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
@@ -277,7 +277,7 @@
 				</configuration>
 			</plugin>
 
-			<!-- Specifies the source and class versions that should be used when 
+			<!-- Specifies the source and class versions that should be used when
 				compiling and sets the main class to the OpenPnP startup class. -->
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
@@ -293,10 +293,10 @@
 				</configuration>
 			</plugin>
 
-			<!-- * Enables creation of INDEX.LIST to improve classloader performance. 
-				* Specifies the main class to make jar runnable. * Adds Implementation-Version 
-				info to jar manifest. * Creates a classpath entry in jar so that dependencies 
-				can be loaded directly. * Specifies a classpath prefix so that dependencies 
+			<!-- * Enables creation of INDEX.LIST to improve classloader performance.
+				* Specifies the main class to make jar runnable. * Adds Implementation-Version
+				info to jar manifest. * Creates a classpath entry in jar so that dependencies
+				can be loaded directly. * Specifies a classpath prefix so that dependencies
 				can be bundled in. -->
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
@@ -350,7 +350,7 @@
 				</configuration>
 			</plugin>
 
-			<!-- Checks source code for common format violations and stops the build 
+			<!-- Checks source code for common format violations and stops the build
 				if any are found. -->
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
@@ -403,7 +403,7 @@
 					<includeTestSourceDirectory>true</includeTestSourceDirectory>
 					<!-- Exclude Eagle importer code, which is auto generated -->
 					<!-- Exclude Neoden dll function names we can't modify -->
-					<excludes>org/openpnp/model/eagle/xml/*,org/openpnp/machine/neoden4/Neoden4CamDll*</excludes>
+					<excludes>org/openpnp/model/eagle/xml/*,org/openpnp/machine/neoden4/Neoden4CameraDriver*</excludes>
 					<!-- Add any resource files to exclude here -->
 					<resourceExcludes></resourceExcludes>
 				</configuration>

--- a/src/main/java/org/openpnp/machine/neoden4/Neoden4CameraDriver.java
+++ b/src/main/java/org/openpnp/machine/neoden4/Neoden4CameraDriver.java
@@ -1,12 +1,8 @@
 package org.openpnp.machine.neoden4;
 
 import com.sun.jna.Library;
-import com.sun.jna.Native;
 
-public interface Neoden4CamDll extends Library {
-	
-	public static Neoden4CamDll INSTANCE = 
-			(Neoden4CamDll) Native.synchronizedLibrary(Native.load("NeodenCamera.dll", Neoden4CamDll.class));
+public interface Neoden4CameraDriver extends Library {
 
 	public boolean img_capture(int which_camera);
 
@@ -14,7 +10,7 @@ public interface Neoden4CamDll extends Library {
 
 	public boolean img_led(int camera, short mode);
 
-	public int img_read(int which_camera,  byte[] pFrameBuffer, int BytesToRead, int timeoutMs);
+	public int img_read(int which_camera, byte[] pFrameBuffer, int BytesToRead, int timeoutMs);
 
 	public int img_readAsy(int which_camera, byte[] pFrameBuffer, int BytesToRead, int timeoutMs);
 

--- a/src/main/java/org/openpnp/machine/neoden4/Neoden4CameraHandler.java
+++ b/src/main/java/org/openpnp/machine/neoden4/Neoden4CameraHandler.java
@@ -2,9 +2,21 @@ package org.openpnp.machine.neoden4;
 
 import org.pmw.tinylog.Logger;
 
-public final class Neoden4CameraHandler implements Neoden4CamDll {
+import com.jgoodies.common.base.SystemUtils;
+import com.sun.jna.Native;
+
+public final class Neoden4CameraHandler implements Neoden4CameraDriver {
+
+	private static Neoden4CameraDriver driver;
 
 	public Neoden4CameraHandler() {
+		String sharedLib = "libneodencam";
+		if (SystemUtils.IS_OS_WINDOWS) {
+			sharedLib = "NeodenCamera.dll";
+		}
+
+		driver = (Neoden4CameraDriver) Native
+				.synchronizedLibrary(Native.load(sharedLib, Neoden4CameraDriver.class));
 	}
 
 	private static Neoden4CameraHandler instance;
@@ -47,52 +59,52 @@ public final class Neoden4CameraHandler implements Neoden4CamDll {
 
 	@Override
 	public boolean img_capture(int which_camera) {
-		return INSTANCE.img_capture(which_camera);
+		return driver.img_capture(which_camera);
 	}
 
 	@Override
 	public int img_init() {
-		return INSTANCE.img_init();
+		return driver.img_init();
 	}
 
 	@Override
 	public boolean img_led(int camera, short mode) {
-		return INSTANCE.img_led(camera, mode);
+		return driver.img_led(camera, mode);
 	}
 
 	@Override
 	public int img_read(int which_camera, byte[] pFrameBuffer, int BytesToRead, int timeoutMs) {
-		return INSTANCE.img_read(which_camera, pFrameBuffer, BytesToRead, timeoutMs);
+		return driver.img_read(which_camera, pFrameBuffer, BytesToRead, timeoutMs);
 	}
 
 	@Override
 	public int img_readAsy(int which_camera, byte[] pFrameBuffer, int BytesToRead, int timeoutMs) {
-		return INSTANCE.img_readAsy(which_camera, pFrameBuffer, BytesToRead, timeoutMs);
+		return driver.img_readAsy(which_camera, pFrameBuffer, BytesToRead, timeoutMs);
 	}
 
 	@Override
 	public int img_reset(int which_camera) {
-		return INSTANCE.img_reset(which_camera);
+		return driver.img_reset(which_camera);
 	}
 
 	@Override
 	public boolean img_set_exp(int which_camera, short exposure) {
-		return INSTANCE.img_set_exp(which_camera, exposure);
+		return driver.img_set_exp(which_camera, exposure);
 	}
 
 	@Override
 	public boolean img_set_gain(int which_camera, short gain) {
-		return INSTANCE.img_set_gain(which_camera, gain);
+		return driver.img_set_gain(which_camera, gain);
 	}
 
 	@Override
 	public boolean img_set_lt(int which_camera, short a2, short a3) {
-		return INSTANCE.img_set_lt(which_camera, a2, a3);
+		return driver.img_set_lt(which_camera, a2, a3);
 	}
 
 	@Override
 	public boolean img_set_wh(int which_camera, short w, short h) {
-		return INSTANCE.img_set_wh(which_camera, w, h);
+		return driver.img_set_wh(which_camera, w, h);
 	}
 
 }


### PR DESCRIPTION
# Description
This PR adds Linux support for the Neoden 4 cameras using [libneodencam](https://github.com/jsphpl/libneodencam).

# Justification
Always good to support Linux, right?

# Instructions for Use
In order to use OpenPNP with the Neoden 4 camera driver on Linux, you need to build and install [libneodencam](https://github.com/jsphpl/libneodencam) as described in the linked repository. Everything else works the same as on Windows. I will update the Wiki with Linux instructions for Neoden 4 when this PR is merged. Until then, instructions can be found in the libneodencam repo.

# Implementation Details
The Neoden4CamDll interface is renamed to Neoden4CameraDriver because libneodencam.so exposes the same interface as the Windows dll.

Neoden4CameraHandler now has a `driver` property that is populated with the respective native library on initialization. If the OS is identified as Windows, `NeodenCamera.dll` is loaded. Otherwise we load `libneodencam.1.so`.
