### PR TITLE
Fix getPickLocation of ReferenceTrayFeeder

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/feeder/ReferenceTrayFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/ReferenceTrayFeeder.java
@@ -84,11 +84,7 @@ public class ReferenceTrayFeeder extends ReferenceFeeder {
         // and then add them to the location to get the final pickLocation.
         pickLocation = location.add(offsets.multiply(partX, partY, 0.0, 0.0));
         
-        Logger.debug(String.format("Location of part # %d, x %d, y %d, xPos %f, yPos %f, rPos %f",
-                feedCount, partX, partY, pickLocation.getX(), pickLocation.getY(),
-                pickLocation.getRotation()));
-
-        Logger.debug("{}.getPickLocation => {}", getName(), pickLocation);
+        Logger.debug("{}.getPickLocation => {}, part # {}, x {}, y {}", getName(), pickLocation, feedCount, partX, partY);
         return pickLocation;
     }
 

--- a/src/main/java/org/openpnp/machine/reference/feeder/ReferenceTrayFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/ReferenceTrayFeeder.java
@@ -53,7 +53,6 @@ public class ReferenceTrayFeeder extends ReferenceFeeder {
 
     @Override
     public Location getPickLocation() {
-        Location pickLocation;
         int partX, partY;
         int feedCountBase0 = feedCount -1; // UI uses feedCount base 1, the following calculations are base 0
 
@@ -83,10 +82,7 @@ public class ReferenceTrayFeeder extends ReferenceFeeder {
         // Multiply the offsets by the X/Y part indexes to get the total offsets
         // and then add the pickLocation to offset the final value.
         // and then add them to the location to get the final pickLocation.
-        pickLocation = location.add(offsets.multiply(partX, partY, 0.0, 0.0));
-        
-        Logger.debug("{}.getPickLocation => {}, part # {}, x {}, y {}", getName(), pickLocation, feedCountBase0 + 1, partX, partY);
-        return pickLocation;
+        return location.add(offsets.multiply(partX, partY, 0.0, 0.0));
     }
 
     public void feed(Nozzle nozzle) throws Exception {
@@ -170,8 +166,7 @@ public class ReferenceTrayFeeder extends ReferenceFeeder {
         int oldValue = this.feedCount;
         this.feedCount = feedCount;
         firePropertyChange("feedCount", oldValue, feedCount);
-        // evaluate getPickLocation() to write the new pick location into the logs
-        getPickLocation();
+        Logger.debug("{}.setFeedCount(): feedCount {}, pickLocation {}", getName(), feedCount, getPickLocation());
     }
 
     @Override

--- a/src/main/java/org/openpnp/machine/reference/feeder/ReferenceTrayFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/ReferenceTrayFeeder.java
@@ -89,7 +89,7 @@ public class ReferenceTrayFeeder extends ReferenceFeeder {
         Logger.debug("{}.feed({})", getName(), nozzle);
 
         if (feedCount >= (trayCountX * trayCountY)) {
-            throw new Exception("Tray empty.");
+            throw new Exception("Feeder: " + getName() + " (" + getPart().getId() + ") - tray empty.");
         }
 
         setFeedCount(getFeedCount() + 1);
@@ -116,7 +116,7 @@ public class ReferenceTrayFeeder extends ReferenceFeeder {
             throw new UnsupportedOperationException("No part loaded that could be taken back.");
         }
         if (!nozzle.getPart().equals(getPart())) {
-            throw new UnsupportedOperationException("Feeder: " + getName() + " - Can not take back " + nozzle.getPart().getName() + " this feeder only supports " + getPart().getName());
+            throw new UnsupportedOperationException("Feeder: " + getName() + " - Can not take back " + nozzle.getPart().getId() + " this feeder only supports " + getPart().getId());
         }
         if (!canTakeBackPart()) {
             throw new UnsupportedOperationException("Feeder: " + getName() + " - Currently no free slot. Can not take back the part.");

--- a/src/main/java/org/openpnp/machine/reference/feeder/ReferenceTrayFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/ReferenceTrayFeeder.java
@@ -49,46 +49,51 @@ public class ReferenceTrayFeeder extends ReferenceFeeder {
     @Element
     private Location offsets = new Location(LengthUnit.Millimeters);
     @Attribute
-    private int feedCount = 0;
-
-    private Location pickLocation;
+    private int feedCount = 0;  // UI is base 1, 0 is ok because a pick operation always preceded by a feed, which increments feedCount to 1
 
     @Override
     public Location getPickLocation() throws Exception {
-        if (pickLocation == null) {
-            pickLocation = location;
-        }
-        Logger.debug("{}.getPickLocation => {}", getName(), pickLocation);
-        return pickLocation;
-    }
-
-    public void feed(Nozzle nozzle) throws Exception {
-        Logger.debug("{}.feed({})", getName(), nozzle);
+        Location pickLocation;
         int partX, partY;
+        int feedCountBase0 = feedCount -1; // UI uses feedCount base 1, the following calculations are base 0
 
-        if (feedCount >= (trayCountX * trayCountY)) {
+        // if feedCound is currently 0, assume its one
+        // this can happen if the pickLocation is requested before any feed operation
+        // return first location in that case
+        if (feedCount == 0) {
+            feedCountBase0 = 0;
+        }
+        
+        if (feedCount > (trayCountX * trayCountY)) {
             throw new Exception("Tray empty.");
         }
 
         if (trayCountX >= trayCountY) {
             // X major axis.
-            partX = feedCount / trayCountY;
-            partY = feedCount % trayCountY;
+            partX = feedCountBase0 / trayCountY;
+            partY = feedCountBase0 % trayCountY;
         }
         else {
             // Y major axis.
-            partX = feedCount % trayCountX;
-            partY = feedCount / trayCountX;
+            partX = feedCountBase0 % trayCountX;
+            partY = feedCountBase0 / trayCountX;
         }
 
         // Multiply the offsets by the X/Y part indexes to get the total offsets
         // and then add the pickLocation to offset the final value.
         // and then add them to the location to get the final pickLocation.
         pickLocation = location.add(offsets.multiply(partX, partY, 0.0, 0.0));
-
-        Logger.debug(String.format("Feeding part # %d, x %d, y %d, xPos %f, yPos %f, rPos %f",
+        
+        Logger.debug(String.format("Location of part # %d, x %d, y %d, xPos %f, yPos %f, rPos %f",
                 feedCount, partX, partY, pickLocation.getX(), pickLocation.getY(),
                 pickLocation.getRotation()));
+
+        Logger.debug("{}.getPickLocation => {}", getName(), pickLocation);
+        return pickLocation;
+    }
+
+    public void feed(Nozzle nozzle) throws Exception {
+        Logger.debug("{}.feed({})", getName(), nozzle);
 
         setFeedCount(getFeedCount() + 1);
     }
@@ -120,12 +125,6 @@ public class ReferenceTrayFeeder extends ReferenceFeeder {
             throw new UnsupportedOperationException("Feeder: " + getName() + " - Currently no free slot. Can not take back the part.");
         }
         
-        // can be null, if part had been picked from an other feeder
-        if (pickLocation == null) {
-            // repeat last feed operation, so that the pickLocation is the last free spot 
-            setFeedCount(getFeedCount() - 1); // is immediately increased during feed
-            feed(nozzle);
-        }
         // ok, now put the part back on the location of the last pick
         nozzle.moveToPickLocation(this);
         nozzle.place();


### PR DESCRIPTION
# Description
This PR fixes the getPickLocation method of the ReferenceTrayFeeder by always calculating it based on current UI values. In the previous implementation the location was static and only updated on feed operations. This is not ideal as there is no direct relation to the UI and its not obvious to the user.

# Justification
I tried to use a ReferenceTrayFeeder and failed because I was not able to verify its configuration prior use. Changing feedCount or offsets did not help to check the locations a part would be picked up from.

This is documentation for a user, not for a developer.

# Implementation Details
1. How did you test the change? Be descriptive. Untested code will not be accepted. **I used a simulation machine and verified that UI changes are immediately reflected as well as feed and pick operations work as before.**
2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)? **yes**
3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing. **no**
4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted. **yes**
