### PR TITLE
Fix getPickLocation of ReferenceRotatedTrayFeeder

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/feeder/wizards/ReferenceRotatedTrayFeederConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/wizards/ReferenceRotatedTrayFeederConfigurationWizard.java
@@ -448,7 +448,7 @@ public class ReferenceRotatedTrayFeederConfigurationWizard extends AbstractConfi
         addWrappedBinding(feeder, "trayCountCols", textFieldTrayCountCols, "text", intConverter); //$NON-NLS-1$ //$NON-NLS-2$
         addWrappedBinding(feeder, "trayCountRows", textFieldTrayCountRows, "text", intConverter); //$NON-NLS-1$ //$NON-NLS-2$
 
-        bind(UpdateStrategy.READ_WRITE, feeder, "feedCount", textFieldFeedCount, "text", intConverter); //$NON-NLS-1$ //$NON-NLS-2$
+        addWrappedBinding(feeder, "feedCount", textFieldFeedCount, "text", intConverter); //$NON-NLS-1$ //$NON-NLS-2$
 
         bind(UpdateStrategy.READ, feeder, "remainingCount", lblComponentCount, "text",  //$NON-NLS-1$ //$NON-NLS-2$
                 new Converter<Integer, String>() {

--- a/src/main/java/org/openpnp/machine/reference/feeder/wizards/ReferenceRotatedTrayFeederConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/wizards/ReferenceRotatedTrayFeederConfigurationWizard.java
@@ -108,7 +108,7 @@ public class ReferenceRotatedTrayFeederConfigurationWizard extends AbstractConfi
     private MutableLocationProxy offsetsAndRotation = new MutableLocationProxy();
     private int nRows;
     private int nCols;
-
+    private int wizardFeedCount;
 
     /**
      * @wbp.parser.constructor
@@ -394,6 +394,8 @@ public class ReferenceRotatedTrayFeederConfigurationWizard extends AbstractConfi
         bind(UpdateStrategy.READ_WRITE, this, "nRows", textFieldTrayCountRows, "text", intConverter); //$NON-NLS-1$ //$NON-NLS-2$
         bind(UpdateStrategy.READ_WRITE, this, "nCols", textFieldTrayCountCols, "text", intConverter); //$NON-NLS-1$ //$NON-NLS-2$
 
+        bind(UpdateStrategy.READ_WRITE, this, "wizardFeedCount", textFieldFeedCount, "text", intConverter); //$NON-NLS-1$ //$NON-NLS-2$
+
         bind(UpdateStrategy.READ_WRITE, offsetsAndRotation, "lengthX", textFieldOffsetsX, "text", lengthConverter); //$NON-NLS-1$ //$NON-NLS-2$
         bind(UpdateStrategy.READ_WRITE, offsetsAndRotation, "lengthY", textFieldOffsetsY, "text", lengthConverter); //$NON-NLS-1$ //$NON-NLS-2$
         bind(UpdateStrategy.READ_WRITE, offsetsAndRotation, "rotation", textFieldTrayRotation, "text", doubleConverter); //$NON-NLS-1$ //$NON-NLS-2$
@@ -490,6 +492,16 @@ public class ReferenceRotatedTrayFeederConfigurationWizard extends AbstractConfi
         this.nCols = nCols;
     }
 
+    public int getwizardFeedCount() {
+        return wizardFeedCount;
+    }
+
+    public void setwizardFeedCount(int wizardFeedCount) {
+        int oldValue = this.wizardFeedCount;
+        this.wizardFeedCount = wizardFeedCount;
+        firePropertyChange("wizardFeedCount", oldValue, wizardFeedCount);
+    }
+
     /**
      * Calculates the tray's x (column) and y (row) offsets as well as the tray rotation.
      * @return the offsets and rotation
@@ -569,8 +581,11 @@ public class ReferenceRotatedTrayFeederConfigurationWizard extends AbstractConfi
     @Override
     public void validateInput() throws Exception {
         //Make sure the feed count isn't pointing beyond the end of the feeder
-        if (feeder.getFeedCount() > nCols*nRows) {
-            feeder.setFeedCount(nCols*nRows);
+        if (wizardFeedCount < 0) {
+            setwizardFeedCount(0);
+        }
+        if (wizardFeedCount > nCols*nRows) {
+            setwizardFeedCount(nCols*nRows);
         }
 
         //Compute offsets and rotation from points A, B, C, number of rows and number of columns


### PR DESCRIPTION
# Description
This PR fixes the getPickLocation method of the ReferenceRotatedTrayFeeder by always calculating it based on current UI values. In the previous implementation the location was static and only updated on feed operations. This is not ideal as there is no direct relation to the UI and its not obvious to the user.

# Justification
I tried to use a ReferenceRotatedTrayFeeder and failed because I was not able to verify its configuration prior use. Changing feedCount or offsets did not help to check the locations a part would be picked up from.

This is documentation for a user, not for a developer.

# Implementation Details
1. How did you test the change? Be descriptive. Untested code will not be accepted. **I've used a simulation machine and tried manual validation and feed/pick operations to work. Unfortunately the value entered in the Feed Count field never reaches the code and hence no update on that is visible. feed operations correctly increment it**
2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)? **yes**
3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing. **no**
4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted. **yes**
