### PR TITLE
JobProcessor: include nozzle name in text status messages

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/ReferencePnpJobProcessor.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferencePnpJobProcessor.java
@@ -533,23 +533,25 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
         
         @Override
         public Step stepImpl(PlannedPlacement plannedPlacement) throws JobProcessorException {
+            final Nozzle nozzle = plannedPlacement.nozzle;
+            
             if (plannedPlacement == null) {
                 return new Pick(plannedPlacements);
             }
             
-            final NozzleTip nozzleTip = plannedPlacement.nozzle.getNozzleTip();
+            final NozzleTip nozzleTip = nozzle.getNozzleTip();
             
             if (nozzleTip == null) {
                 return this;
             }
             
-            if (plannedPlacement.nozzle.isCalibrated()) {
+            if (nozzle.isCalibrated()) {
                 return this;
             }
             
-            fireTextStatus("Calibrate nozzle tip %s", nozzleTip);
+            fireTextStatus("Calibrate nozzle tip %s on nozzle %s", nozzleTip, nozzle.getName());
             try {
-                plannedPlacement.nozzle.calibrate();
+                nozzle.calibrate();
             }
             catch (Exception e) {
                 throw new JobProcessorException(nozzleTip, e);
@@ -735,8 +737,8 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
         
         private void pick(Nozzle nozzle, Feeder feeder, JobPlacement jobPlacement, Part part) throws JobProcessorException {
             try {
-                fireTextStatus("Pick %s from %s for %s.", part.getId(), feeder.getName(),
-                        jobPlacement.getPlacement().getId());
+                fireTextStatus("Pick %s from %s for %s using nozzle %s.", part.getId(), feeder.getName(),
+                        jobPlacement.getPlacement().getId(), nozzle.getName());
 
                 // Prepare the Nozzle for pick-to-place articulation.
                 Location placementLocation = Utils2D.calculateBoardPlacementLocation(jobPlacement.getBoardLocation(), jobPlacement.getPlacement().getLocation());
@@ -846,7 +848,7 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
 
             Exception lastException = null;
             for (int i = 0; i < ReferencePnpJobProcessor.this.getMaxVisionRetries(); i++) {
-                fireTextStatus("Aligning %s for %s.", part.getId(), placement.getId());
+                fireTextStatus("Aligning %s for %s using nozzle %s.", part.getId(), placement.getId(), nozzle.getName());
                 try {
                     plannedPlacement.alignmentOffsets = VisionUtils.findPartAlignmentOffsets(
                             partAlignment,
@@ -941,7 +943,7 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
         }
         
         private void place(Nozzle nozzle, Part part, Placement placement, Location placementLocation) throws JobProcessorException {
-            fireTextStatus("Placing %s for %s.", part.getId(), placement.getId());
+            fireTextStatus("Placing %s for %s using nozzle %s.", part.getId(), placement.getId(), nozzle.getName());
             
             try {
                 // Move to the placement location

--- a/src/main/java/org/openpnp/machine/reference/ReferencePnpJobProcessor.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferencePnpJobProcessor.java
@@ -533,12 +533,11 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
         
         @Override
         public Step stepImpl(PlannedPlacement plannedPlacement) throws JobProcessorException {
-            final Nozzle nozzle = plannedPlacement.nozzle;
-            
             if (plannedPlacement == null) {
                 return new Pick(plannedPlacements);
             }
             
+            final Nozzle nozzle = plannedPlacement.nozzle;
             final NozzleTip nozzleTip = nozzle.getNozzleTip();
             
             if (nozzleTip == null) {


### PR DESCRIPTION
# Description
This PR extends the text status messages the Job Processor generates by the effected nozzles name.

# Justification
On multi-nozzle machines and placement optimization enabled, the nozzle name is valuable information that better indicates the current state of the machine, especially while stepping.

This is documentation for a user, not for a developer.

# Implementation Details
1. How did you test the change? Be descriptive. Untested code will not be accepted. **operation is not effected, so there is nothing to test**
2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)? **yes**
3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing. **no**
4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted. **yes**
