### PR TITLE
Skip interrupting to unload a nozzle tip while loading a new tip

### DIFF
--- a/src/main/java/org/openpnp/gui/JobPanel.java
+++ b/src/main/java/org/openpnp/gui/JobPanel.java
@@ -995,14 +995,16 @@ public class JobPanel extends JPanel {
                 }
             }
             
-            MessageBoxes.errorBox(getTopLevelAncestor(), 
-                    Translations.getString("JobPanel.JobRun.Error.ErrorBox.Title"), t.getMessage()); //$NON-NLS-1$
+            // update the state before showing the error to allow exceptions with continuations to change it
             if (state == State.Running || state == State.Pausing) {
                 setState(State.Paused);
             }
             else if (state == State.Stopping) {
                 setState(State.Stopped);
             }
+            
+            // call showError() to support exceptions with continuation
+            UiUtils.showError(getTopLevelAncestor(), Translations.getString("JobPanel.JobRun.Error.ErrorBox.Title"), t); //$NON-NLS-1$
         });
     }
 

--- a/src/main/java/org/openpnp/gui/support/MessageBoxes.java
+++ b/src/main/java/org/openpnp/gui/support/MessageBoxes.java
@@ -50,8 +50,9 @@ public class MessageBoxes {
         Logger.debug("{}: {}", title, cause);
         message = message.replaceAll("\n", "<br/>");
         message = message.replaceAll("\r", "");
-        message = message.replaceAll("<", "&lt;");
-        message = message.replaceAll(">", "&gt;");
+        // FIXME: why are this replacements here? They make html in message void and even the <br> above.
+        //message = message.replaceAll("<", "&lt;");
+        //message = message.replaceAll(">", "&gt;");
         message = "<html><body width=\"400\">" + message + "</body></html>";
 
         // if this errorBox shall ask for Continuation, show a ConfirmDialog and return if the user selected YES

--- a/src/main/java/org/openpnp/gui/support/MessageBoxes.java
+++ b/src/main/java/org/openpnp/gui/support/MessageBoxes.java
@@ -31,8 +31,9 @@ import org.pmw.tinylog.Logger;
 public class MessageBoxes {
 
 
-    public static void errorBox(Component parent, String title, Throwable cause) {
+    public static boolean errorBox(Component parent, String title, Throwable cause, boolean withContinuation) {
         String message = null;
+        boolean ret = false;
         if (cause != null) {
             message = cause.getMessage();
             if (message == null || message.trim().isEmpty()) {
@@ -52,7 +53,19 @@ public class MessageBoxes {
         message = message.replaceAll("<", "&lt;");
         message = message.replaceAll(">", "&gt;");
         message = "<html><body width=\"400\">" + message + "</body></html>";
-        JOptionPane.showMessageDialog(parent, message, title, JOptionPane.ERROR_MESSAGE);
+
+        // if this errorBox shall ask for Continuation, show a ConfirmDialog and return if the user selected YES
+        if (withContinuation) {
+            ret = JOptionPane.showConfirmDialog(parent, message, title, JOptionPane.OK_CANCEL_OPTION, JOptionPane.ERROR_MESSAGE) == JOptionPane.OK_OPTION;
+        } else {
+            JOptionPane.showMessageDialog(parent, message, title, JOptionPane.ERROR_MESSAGE);
+        }
+        
+        return ret;
+    }
+
+    public static void errorBox(Component parent, String title, Throwable cause) {
+        errorBox(parent, title, cause, false);
     }
 
     public static void errorBox(Component parent, String title, String message) {

--- a/src/main/java/org/openpnp/gui/support/MessageBoxes.java
+++ b/src/main/java/org/openpnp/gui/support/MessageBoxes.java
@@ -30,6 +30,16 @@ import org.pmw.tinylog.Logger;
 
 public class MessageBoxes {
 
+    // prepare message for use in a message box
+    static String prepareMessage(String message) {
+        if (message == null) {
+            message = "";
+        }
+        message = message.replaceAll("\n", "<br/>");
+        message = message.replaceAll("\r", "");
+        message = "<html><body width=\"400\">" + message + "</body></html>";
+        return message;
+    }    
 
     public static boolean errorBox(Component parent, String title, Throwable cause, boolean withContinuation) {
         String message = null;
@@ -50,9 +60,7 @@ public class MessageBoxes {
         Logger.debug("{}: {}", title, cause);
         message = message.replaceAll("<", "&lt;");
         message = message.replaceAll(">", "&gt;");
-        message = message.replaceAll("\n", "<br/>");
-        message = message.replaceAll("\r", "");
-        message = "<html><body width=\"400\">" + message + "</body></html>";
+        message = prepareMessage(message);
 
         // if this errorBox shall ask for Continuation, show a ConfirmDialog and return if the user selected YES
         if (withContinuation) {
@@ -73,9 +81,7 @@ public class MessageBoxes {
             message = "";
         }
         Logger.debug("{}: {}", title, message);
-        message = message.replaceAll("\n", "<br/>");
-        message = message.replaceAll("\r", "");
-        message = "<html><body width=\"400\">" + message + "</body></html>";
+        message = prepareMessage(message);
         JOptionPane.showMessageDialog(parent, message, title, JOptionPane.ERROR_MESSAGE);
     }
 
@@ -84,9 +90,7 @@ public class MessageBoxes {
             message = "";
         }
         Logger.debug("{}: {}", title, message);
-        message = message.replaceAll("\n", "<br/>");
-        message = message.replaceAll("\r", "");
-        message = "<html><body width=\"400\">" + message + "</body></html>";
+        message = prepareMessage(message);
         return JOptionPane.showConfirmDialog(parent, message, title, JOptionPane.YES_NO_OPTION) == JOptionPane.YES_OPTION;
     }
 
@@ -94,9 +98,7 @@ public class MessageBoxes {
         if (message == null) {
             message = "";
         }
-        message = message.replaceAll("\n", "<br/>");
-        message = message.replaceAll("\r", "");
-        message = "<html><body width=\"400\">" + message + "</body></html>";
+        message = prepareMessage(message);
         JOptionPane.showMessageDialog(MainFrame.get(), message, title, JOptionPane.INFORMATION_MESSAGE);
     }
 

--- a/src/main/java/org/openpnp/gui/support/MessageBoxes.java
+++ b/src/main/java/org/openpnp/gui/support/MessageBoxes.java
@@ -48,11 +48,10 @@ public class MessageBoxes {
             message = "No message supplied.";
         }
         Logger.debug("{}: {}", title, cause);
+        message = message.replaceAll("<", "&lt;");
+        message = message.replaceAll(">", "&gt;");
         message = message.replaceAll("\n", "<br/>");
         message = message.replaceAll("\r", "");
-        // FIXME: why are this replacements here? They make html in message void and even the <br> above.
-        //message = message.replaceAll("<", "&lt;");
-        //message = message.replaceAll(">", "&gt;");
         message = "<html><body width=\"400\">" + message + "</body></html>";
 
         // if this errorBox shall ask for Continuation, show a ConfirmDialog and return if the user selected YES

--- a/src/main/java/org/openpnp/machine/reference/ReferenceNozzle.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceNozzle.java
@@ -610,7 +610,7 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
             nt.getNozzleWhereLoaded().unloadNozzleTip();
         }
 
-        unloadNozzleTip();
+        unloadNozzleTip(true);  // signal that a loadNozzleTip will immediately follow not interrupting if manual nozzle tip change is configured
 
         double speed = getHead().getMachine().getSpeed();
         if (!nt.isUnloadedNozzleTipStandin()) {
@@ -704,7 +704,7 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
     }
 
     @Override
-    public void unloadNozzleTip() throws Exception {
+    public void unloadNozzleTip(boolean loadNozzleTipFollows) throws Exception {
         if (getPart() != null) {
             throw new Exception("Nozzle "+getName()+" still has a part loaded. Please discard first.");
         }
@@ -779,7 +779,8 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
 
         setNozzleTip(null);
 
-        if (!changerEnabled) {
+        // if a loadNozzleTip() is already known to follow, do not interrupt for unload
+        if (!changerEnabled && !loadNozzleTipFollows) {
             waitForCompletion(CompletionType.WaitForStillstand);
             throw new JobProcessorException(this, 
                     "Task interrupted: Please perform a manual nozzle tip "+nt.getName()+" unload from nozzle "+getName()+" now. "
@@ -797,6 +798,11 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
         }
     }
 
+    @Override
+    public void unloadNozzleTip() throws Exception {
+        unloadNozzleTip(false);
+    }
+    
     protected void assertManualChangeLocation() throws Exception {
         if (isManualNozzleTipChangeLocationUndefined()) {
             throw new Exception("Nozzle "+getName()+" Manual Change Location is not configured!");

--- a/src/main/java/org/openpnp/machine/reference/ReferenceNozzle.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceNozzle.java
@@ -657,33 +657,44 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
 
                     ensureZCalibrated(true);
 
+                    Location startLocation = nt.getChangerStartLocationCalibrated(true);
+                    if (startLocation.isInitialized()) {
+                        Logger.debug("{}.loadNozzleTip({}): moveTo Start Location", getName(), nozzleTip.getName());
+                        MovableUtils.moveToLocationAtSafeZ(this, startLocation, speed);
+                    }
+
                     Actuator tcPostOneActuator = getMachine().getActuatorByName(nt.getChangerActuatorPostStepOne());
-                    Actuator tcPostTwoActuator = getMachine().getActuatorByName(nt.getChangerActuatorPostStepTwo());
-                    Actuator tcPostThreeActuator = getMachine().getActuatorByName(nt.getChangerActuatorPostStepThree());
-
-                    Logger.debug("{}.loadNozzleTip({}): moveTo Start Location", getName(), nozzleTip.getName());
-                    MovableUtils.moveToLocationAtSafeZ(this, nt.getChangerStartLocationCalibrated(true), speed);
-
                     if (tcPostOneActuator != null) {
                         tcPostOneActuator.actuate(true);
                     }
 
-                    Logger.debug("{}.loadNozzleTip({}): moveTo Mid Location", getName(), nozzleTip.getName());
-                    moveTo(nt.getChangerMidLocationCalibrated(false), nt.getChangerStartToMidSpeed() * speed);
+                    Location midLocation = nt.getChangerMidLocationCalibrated(false);
+                    if (midLocation.isInitialized()) {
+                        Logger.debug("{}.loadNozzleTip({}): moveTo Mid Location", getName(), nozzleTip.getName());
+                        moveTo(midLocation, nt.getChangerStartToMidSpeed() * speed);
+                    }
 
+                    Actuator tcPostTwoActuator = getMachine().getActuatorByName(nt.getChangerActuatorPostStepTwo());
                     if (tcPostTwoActuator !=null) {
                         tcPostTwoActuator.actuate(true);
                     }
 
-                    Logger.debug("{}.loadNozzleTip({}): moveTo Mid Location 2", getName(), nozzleTip.getName());
-                    moveTo(nt.getChangerMidLocation2Calibrated(false), nt.getChangerMidToMid2Speed() * speed);
+                    Location midLocation2 = nt.getChangerMidLocation2Calibrated(false);
+                    if (midLocation2.isInitialized()) {
+                        Logger.debug("{}.loadNozzleTip({}): moveTo Mid Location 2", getName(), nozzleTip.getName());
+                        moveTo(midLocation2, nt.getChangerMidToMid2Speed() * speed);
+                    }
 
+                    Actuator tcPostThreeActuator = getMachine().getActuatorByName(nt.getChangerActuatorPostStepThree());
                     if (tcPostThreeActuator !=null) {
                         tcPostThreeActuator.actuate(true);
                     }
 
-                    Logger.debug("{}.loadNozzleTip({}): moveTo End Location", getName(), nozzleTip.getName());
-                    moveTo(nt.getChangerEndLocationCalibrated(false), nt.getChangerMid2ToEndSpeed() * speed);
+                    Location endLocation = nt.getChangerEndLocationCalibrated(false);
+                    if (endLocation.isInitialized()) {
+                        Logger.debug("{}.loadNozzleTip({}): moveTo End Location", getName(), nozzleTip.getName());
+                        moveTo(endLocation, nt.getChangerMid2ToEndSpeed() * speed);
+                    }
                     moveToSafeZ(getHead().getMachine().getSpeed());
 
                     Logger.debug("{}.loadNozzleTip({}): Finished", getName(), nozzleTip.getName());
@@ -756,33 +767,45 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
 
                     ensureZCalibrated(false);
 
-                    Actuator tcPostOneActuator = getMachine().getActuatorByName(nt.getChangerActuatorPostStepOne());
-                    Actuator tcPostTwoActuator = getMachine().getActuatorByName(nt.getChangerActuatorPostStepTwo());
+
+                    Location endLocation = nt.getChangerEndLocationCalibrated(true);
+                    if (endLocation.isInitialized()) {
+                        Logger.debug("{}.unloadNozzleTip(): moveTo End Location", getName());
+                        MovableUtils.moveToLocationAtSafeZ(this, endLocation, speed);
+                    }
+
                     Actuator tcPostThreeActuator = getMachine().getActuatorByName(nt.getChangerActuatorPostStepThree());
-
-                    Logger.debug("{}.unloadNozzleTip(): moveTo End Location", getName());
-                    MovableUtils.moveToLocationAtSafeZ(this, nt.getChangerEndLocationCalibrated(true), speed);
-
                     if (tcPostThreeActuator !=null) {
                         tcPostThreeActuator.actuate(true);
                     }
 
-                    Logger.debug("{}.unloadNozzleTip(): moveTo Mid Location 2", getName());
-                    moveTo(nt.getChangerMidLocation2Calibrated(false), nt.getChangerMid2ToEndSpeed() * speed);
+                    Location midLocation2 = nt.getChangerMidLocation2Calibrated(false);
+                    if (midLocation2.isInitialized()) {
+                        Logger.debug("{}.unloadNozzleTip(): moveTo Mid Location 2", getName());
+                        moveTo(midLocation2, nt.getChangerMid2ToEndSpeed() * speed);
+                    }
 
+                    Actuator tcPostTwoActuator = getMachine().getActuatorByName(nt.getChangerActuatorPostStepTwo());
                     if (tcPostTwoActuator !=null) {
                         tcPostTwoActuator.actuate(true);
                     }
 
-                    Logger.debug("{}.unloadNozzleTip(): moveTo Mid Location", getName());
-                    moveTo(nt.getChangerMidLocationCalibrated(false), nt.getChangerMidToMid2Speed() * speed);
+                    Location midLocation = nt.getChangerMidLocationCalibrated(false);
+                    if (midLocation.isInitialized()) {
+                        Logger.debug("{}.unloadNozzleTip(): moveTo Mid Location", getName());
+                        moveTo(midLocation, nt.getChangerMidToMid2Speed() * speed);
+                    }
 
+                    Actuator tcPostOneActuator = getMachine().getActuatorByName(nt.getChangerActuatorPostStepOne());
                     if (tcPostOneActuator != null) {
                         tcPostOneActuator.actuate(true);
                     }
 
-                    Logger.debug("{}.unloadNozzleTip(): moveTo Start Location", getName());
-                    moveTo(nt.getChangerStartLocationCalibrated(false), nt.getChangerStartToMidSpeed() * speed);
+                    Location startLocation = nt.getChangerStartLocationCalibrated(false);
+                    if (startLocation.isInitialized()) {
+                        Logger.debug("{}.unloadNozzleTip(): moveTo Start Location", getName());
+                        moveTo(startLocation, nt.getChangerStartToMidSpeed() * speed);
+                    }
                     moveToSafeZ(getHead().getMachine().getSpeed());
 
                     Logger.debug("{}.unloadNozzleTip(): Finished", getName());

--- a/src/main/java/org/openpnp/machine/reference/ReferenceNozzle.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceNozzle.java
@@ -629,7 +629,7 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
                 // combine this unload exception with following unload/load exceptions into one
                 // There is code behind the exception that may calibrate the bare nozzle, which is
                 // not executed due to the exception.
-                manualChangeInstructions += " a manual nozzle tip " + nt.getName() + " unload from nozzle " + n.getName() + " and";
+                manualChangeInstructions += "\na manual nozzle tip " + nt.getName() + " unload from nozzle " + n.getName() + " and";
             }
         }
 
@@ -640,7 +640,7 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
             // combine this unload exception with following unload/load exceptions into one
             // There is code behind the exception that may calibrate the bare nozzle, which is
             // not executed due to the exception.
-            manualChangeInstructions += " a manual nozzle tip " + nt2.getName() + " unload from nozzle " + getName() + " and";
+            manualChangeInstructions += "\na manual nozzle tip " + nt2.getName() + " unload from nozzle " + getName() + " and";
         }
 
         Actuator tcPostOneActuator = getMachine().getActuatorByName(nt.getChangerActuatorPostStepOne());
@@ -720,8 +720,8 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
                     this.nozzleTip.getCalibration().reset(this);
                 }
                 waitForCompletion(CompletionType.WaitForStillstand);
-                manualChangeInstructions += " a manual nozzle tip " + nt.getName()+" load on nozzle "+getName()+" now.";
-                manualChangeInstructions += " When you press OK, the nozzle tip will be calibrated (if enabled).";
+                manualChangeInstructions += "\na manual nozzle tip " + nt.getName()+" load on nozzle "+getName()+" now.";
+                manualChangeInstructions += "\nWhen you press OK, the nozzle tip will be calibrated (if enabled).";
                 throw new ManualLoadException(this, 
                         new UiUtils.ExceptionWithContinuation(manualChangeInstructions,  () -> { loadNozzleTipFinish(nozzleTip); }));
             }

--- a/src/main/java/org/openpnp/machine/reference/ReferenceNozzle.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceNozzle.java
@@ -600,139 +600,137 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
 
     @Override
     public void loadNozzleTip(NozzleTip nozzleTip) throws Exception {
-        if (this.nozzleTip == nozzleTip) {
-            return;
-        }
+        // if the requested nozzle-tip is already loaded, skip the load step, but continue as calibration might be required.
+        if (this.nozzleTip != nozzleTip) {
+            if (getPart() != null) {
+                throw new Exception("Nozzle "+getName()+" still has a part loaded. Please discard first.");
+            }
 
-        if (getPart() != null) {
-            throw new Exception("Nozzle "+getName()+" still has a part loaded. Please discard first.");
-        }
+            // Make sure there is no rotation offset still applied.
+            setRotationModeOffset(null);
 
-        // Make sure there is no rotation offset still applied.
-        setRotationModeOffset(null);
+            ReferenceNozzleTip nt = (ReferenceNozzleTip) nozzleTip;
 
-        ReferenceNozzleTip nt = (ReferenceNozzleTip) nozzleTip;
+            if (!getCompatibleNozzleTips().contains(nt)) {
+                throw new Exception("Can't load incompatible nozzle tip.");
+            }
 
-        if (!getCompatibleNozzleTips().contains(nt)) {
-            throw new Exception("Can't load incompatible nozzle tip.");
-        }
+            // compose instructions for manual nozzle tip changing on the fly while catching unload exceptions
+            String manualChangeInstructions = "Task interrupted: Please perform";
 
-        // compose instructions for manual nozzle tip changing on the fly while catching unload exceptions
-        String manualChangeInstructions = "Task interrupted: Please perform";
+            ReferenceNozzle n = nt.getNozzleWhereLoaded();  // remember the nozzle to generate change instructions, if needed
+            if (nt.getNozzleWhereLoaded() != null) {
+                // Nozzle tip is on different nozzle - unload it from there first.
+                try {
+                    nt.getNozzleWhereLoaded().unloadNozzleTip();
+                } catch (ManualUnloadException e) {
+                    // combine this unload exception with following unload/load exceptions into one
+                    // There is code behind the exception that may calibrate the bare nozzle, which is
+                    // not executed due to the exception.
+                    manualChangeInstructions += "\na manual nozzle tip " + nt.getName() + " unload from nozzle " + n.getName() + " and";
+                }
+            }
 
-        ReferenceNozzle n = nt.getNozzleWhereLoaded();  // remember the nozzle to generate change instructions, if needed
-        if (nt.getNozzleWhereLoaded() != null) {
-            // Nozzle tip is on different nozzle - unload it from there first.
+            ReferenceNozzleTip nt2 = getNozzleTip();  // remember the nozzle tip currently loaded to generate change instructions, if needed
             try {
-                nt.getNozzleWhereLoaded().unloadNozzleTip();
+                unloadNozzleTip();
             } catch (ManualUnloadException e) {
                 // combine this unload exception with following unload/load exceptions into one
                 // There is code behind the exception that may calibrate the bare nozzle, which is
                 // not executed due to the exception.
-                manualChangeInstructions += "\na manual nozzle tip " + nt.getName() + " unload from nozzle " + n.getName() + " and";
+                manualChangeInstructions += "\na manual nozzle tip " + nt2.getName() + " unload from nozzle " + getName() + " and";
+            }
+
+            Actuator tcPostOneActuator = getMachine().getActuatorByName(nt.getChangerActuatorPostStepOne());
+            Actuator tcPostTwoActuator = getMachine().getActuatorByName(nt.getChangerActuatorPostStepTwo());
+            Actuator tcPostThreeActuator = getMachine().getActuatorByName(nt.getChangerActuatorPostStepThree());
+
+            double speed = getHead().getMachine().getSpeed();
+            if (!nt.isUnloadedNozzleTipStandin()) {
+                if (changerEnabled) {
+                    Logger.debug("{}.loadNozzleTip({}): Start", getName(), nozzleTip.getName());
+
+                    Map<String, Object> globals = new HashMap<>();
+                    globals.put("head", getHead());
+                    globals.put("nozzle", this);
+                    globals.put("nozzleTip", nt);
+
+                    Configuration.get()
+                    .getScripting()
+                    .on("NozzleTip.BeforeLoad", globals);
+
+                    ensureZCalibrated(true);
+
+                    Logger.debug("{}.loadNozzleTip({}): moveTo Start Location",
+                            new Object[] {getName(), nozzleTip.getName()});
+                    MovableUtils.moveToLocationAtSafeZ(this, nt.getChangerStartLocationCalibrated(true), speed);
+
+                    if (tcPostOneActuator != null) {
+                        tcPostOneActuator.actuate(true);
+                    }
+
+                    Logger.debug("{}.loadNozzleTip({}): moveTo Mid Location",
+                            new Object[] {getName(), nozzleTip.getName()});
+                    moveTo(nt.getChangerMidLocationCalibrated(false), nt.getChangerStartToMidSpeed() * speed);
+
+                    if (tcPostTwoActuator !=null) {
+                        tcPostTwoActuator.actuate(true);
+                    }
+
+                    Logger.debug("{}.loadNozzleTip({}): moveTo Mid Location 2",
+                            new Object[] {getName(), nozzleTip.getName()});
+                    moveTo(nt.getChangerMidLocation2Calibrated(false), nt.getChangerMidToMid2Speed() * speed);
+
+                    if (tcPostThreeActuator !=null) {
+                        tcPostThreeActuator.actuate(true);
+                    }
+
+                    Logger.debug("{}.loadNozzleTip({}): moveTo End Location",
+                            new Object[] {getName(), nozzleTip.getName()});
+                    moveTo(nt.getChangerEndLocationCalibrated(false), nt.getChangerMid2ToEndSpeed() * speed);
+                    moveToSafeZ(getHead().getMachine().getSpeed());
+
+                    Logger.debug("{}.loadNozzleTip({}): Finished",
+                            new Object[] {getName(), nozzleTip.getName()});
+
+                    Configuration.get()
+                    .getScripting()
+                    .on("NozzleTip.Loaded", globals);
+                }
+                else {
+                    Logger.debug("{}.loadNozzleTip({}): moveTo manual Location",
+                            new Object[] {getName(), nozzleTip.getName()});
+                    assertManualChangeLocation();
+                    MovableUtils.moveToLocationAtSafeZ(this, getManualNozzleTipChangeLocation());
+                }
+            }
+
+            setNozzleTip(nt);
+
+            // force the nozzle tip now installed to be uncalibrated
+            this.nozzleTip.getCalibration().reset(this);
+
+            // FIXME: shall this be here or further below or in both places?
+            ensureZCalibrated(true);
+
+            if (!nt.isUnloadedNozzleTipStandin()) {
+                if (!changerEnabled) {
+                    if (this.nozzleTip.getCalibration().isRecalibrateOnNozzleTipChangeNeeded(this) 
+                            || this.nozzleTip.getCalibration().isRecalibrateOnNozzleTipChangeInJobNeeded(this)) {
+                        Logger.debug("{}.loadNozzleTip() nozzle tip {} calibration reset", getName(), this.nozzleTip.getName());
+                        // can't automatically recalibrate with manual change - reset() for now
+                        this.nozzleTip.getCalibration().reset(this);
+                    }
+                    waitForCompletion(CompletionType.WaitForStillstand);
+                    manualChangeInstructions += "\na manual nozzle tip " + nt.getName()+" load on nozzle "+getName()+" now.";
+                    manualChangeInstructions += "\nWhen you press OK, the nozzle tip will be calibrated (if enabled).";
+                    throw new ManualLoadException(this, 
+                            new UiUtils.ExceptionWithContinuation(manualChangeInstructions,  () -> { loadNozzleTip(nozzleTip); }));
+                }
             }
         }
 
-        ReferenceNozzleTip nt2 = getNozzleTip();  // remember the nozzle tip currently loaded to generate change instructions, if needed
-        try {
-            unloadNozzleTip();
-        } catch (ManualUnloadException e) {
-            // combine this unload exception with following unload/load exceptions into one
-            // There is code behind the exception that may calibrate the bare nozzle, which is
-            // not executed due to the exception.
-            manualChangeInstructions += "\na manual nozzle tip " + nt2.getName() + " unload from nozzle " + getName() + " and";
-        }
-
-        Actuator tcPostOneActuator = getMachine().getActuatorByName(nt.getChangerActuatorPostStepOne());
-        Actuator tcPostTwoActuator = getMachine().getActuatorByName(nt.getChangerActuatorPostStepTwo());
-        Actuator tcPostThreeActuator = getMachine().getActuatorByName(nt.getChangerActuatorPostStepThree());
-
-        double speed = getHead().getMachine().getSpeed();
-        if (!nt.isUnloadedNozzleTipStandin()) {
-            if (changerEnabled) {
-                Logger.debug("{}.loadNozzleTip({}): Start", getName(), nozzleTip.getName());
-
-                Map<String, Object> globals = new HashMap<>();
-                globals.put("head", getHead());
-                globals.put("nozzle", this);
-                globals.put("nozzleTip", nt);
-
-                Configuration.get()
-                .getScripting()
-                .on("NozzleTip.BeforeLoad", globals);
-
-                ensureZCalibrated(true);
-
-                Logger.debug("{}.loadNozzleTip({}): moveTo Start Location",
-                        new Object[] {getName(), nozzleTip.getName()});
-                MovableUtils.moveToLocationAtSafeZ(this, nt.getChangerStartLocationCalibrated(true), speed);
-
-                if (tcPostOneActuator != null) {
-                    tcPostOneActuator.actuate(true);
-                }
-
-                Logger.debug("{}.loadNozzleTip({}): moveTo Mid Location",
-                        new Object[] {getName(), nozzleTip.getName()});
-                moveTo(nt.getChangerMidLocationCalibrated(false), nt.getChangerStartToMidSpeed() * speed);
-
-                if (tcPostTwoActuator !=null) {
-                    tcPostTwoActuator.actuate(true);
-                }
-
-                Logger.debug("{}.loadNozzleTip({}): moveTo Mid Location 2",
-                        new Object[] {getName(), nozzleTip.getName()});
-                moveTo(nt.getChangerMidLocation2Calibrated(false), nt.getChangerMidToMid2Speed() * speed);
-
-                if (tcPostThreeActuator !=null) {
-                    tcPostThreeActuator.actuate(true);
-                }
-
-                Logger.debug("{}.loadNozzleTip({}): moveTo End Location",
-                        new Object[] {getName(), nozzleTip.getName()});
-                moveTo(nt.getChangerEndLocationCalibrated(false), nt.getChangerMid2ToEndSpeed() * speed);
-                moveToSafeZ(getHead().getMachine().getSpeed());
-
-                Logger.debug("{}.loadNozzleTip({}): Finished",
-                        new Object[] {getName(), nozzleTip.getName()});
-
-                Configuration.get()
-                .getScripting()
-                .on("NozzleTip.Loaded", globals);
-            }
-            else {
-                Logger.debug("{}.loadNozzleTip({}): moveTo manual Location",
-                        new Object[] {getName(), nozzleTip.getName()});
-                assertManualChangeLocation();
-                MovableUtils.moveToLocationAtSafeZ(this, getManualNozzleTipChangeLocation());
-            }
-        }
-
-        setNozzleTip(nt);
-
-        ensureZCalibrated(true);
-
-        if (!nt.isUnloadedNozzleTipStandin()) {
-            if (!changerEnabled) {
-                if (this.nozzleTip.getCalibration().isRecalibrateOnNozzleTipChangeNeeded(this) 
-                        || this.nozzleTip.getCalibration().isRecalibrateOnNozzleTipChangeInJobNeeded(this)) {
-                    Logger.debug("{}.loadNozzleTip() nozzle tip {} calibration reset", getName(), this.nozzleTip.getName());
-                    // can't automatically recalibrate with manual change - reset() for now
-                    this.nozzleTip.getCalibration().reset(this);
-                }
-                waitForCompletion(CompletionType.WaitForStillstand);
-                manualChangeInstructions += "\na manual nozzle tip " + nt.getName()+" load on nozzle "+getName()+" now.";
-                manualChangeInstructions += "\nWhen you press OK, the nozzle tip will be calibrated (if enabled).";
-                throw new ManualLoadException(this, 
-                        new UiUtils.ExceptionWithContinuation(manualChangeInstructions,  () -> { loadNozzleTipFinish(nozzleTip); }));
-            }
-        }
-
-        loadNozzleTipFinish(nozzleTip);
-    }
-
-    // this is the final part of the nozzle tip load procedure and a separate method 
-    // to be called either directly or as continuation of a manual nozzle tip change
-    private void loadNozzleTipFinish(NozzleTip nozzleTip) throws Exception {
+        // FIXME: shall this be here or further up or in both places?
         ensureZCalibrated(true);
 
         if (this.nozzleTip.getCalibration().isRecalibrateOnNozzleTipChangeNeeded(this)) {
@@ -755,82 +753,82 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
         // Make sure there is no rotation offset still applied.
         setRotationModeOffset(null);
 
-        if (nozzleTip == null) {
-            return;
-        }
+        // if this nozzle is already empty, skip the unload procedure, but continue to eventually calibration the bare nozzle
+        if (nozzleTip != null) {
+            ReferenceNozzleTip nt = (ReferenceNozzleTip) nozzleTip;
 
-        ReferenceNozzleTip nt = (ReferenceNozzleTip) nozzleTip;
+            Actuator tcPostOneActuator = getMachine().getActuatorByName(nt.getChangerActuatorPostStepOne());
+            Actuator tcPostTwoActuator = getMachine().getActuatorByName(nt.getChangerActuatorPostStepTwo());
+            Actuator tcPostThreeActuator = getMachine().getActuatorByName(nt.getChangerActuatorPostStepThree());
 
-        Actuator tcPostOneActuator = getMachine().getActuatorByName(nt.getChangerActuatorPostStepOne());
-        Actuator tcPostTwoActuator = getMachine().getActuatorByName(nt.getChangerActuatorPostStepTwo());
-        Actuator tcPostThreeActuator = getMachine().getActuatorByName(nt.getChangerActuatorPostStepThree());
+            if (!nt.isUnloadedNozzleTipStandin()) {
+                Logger.debug("{}.unloadNozzleTip(): Start", getName());
 
-        if (!nt.isUnloadedNozzleTipStandin()) {
-            Logger.debug("{}.unloadNozzleTip(): Start", getName());
+                double speed = getHead().getMachine().getSpeed();
 
-            double speed = getHead().getMachine().getSpeed();
+                if (changerEnabled) {
+                    Map<String, Object> globals = new HashMap<>();
+                    globals.put("head", getHead());
+                    globals.put("nozzle", this);
+                    globals.put("nozzleTip", nt);
+                    Configuration.get()
+                    .getScripting()
+                    .on("NozzleTip.BeforeUnload", globals);
 
-            if (changerEnabled) {
-                Map<String, Object> globals = new HashMap<>();
-                globals.put("head", getHead());
-                globals.put("nozzle", this);
-                globals.put("nozzleTip", nt);
-                Configuration.get()
-                .getScripting()
-                .on("NozzleTip.BeforeUnload", globals);
+                    ensureZCalibrated(false);
 
-                ensureZCalibrated(false);
+                    Logger.debug("{}.unloadNozzleTip(): moveTo End Location", getName());
+                    MovableUtils.moveToLocationAtSafeZ(this, nt.getChangerEndLocationCalibrated(true), speed);
 
-                Logger.debug("{}.unloadNozzleTip(): moveTo End Location", getName());
-                MovableUtils.moveToLocationAtSafeZ(this, nt.getChangerEndLocationCalibrated(true), speed);
+                    if (tcPostThreeActuator !=null) {
+                        tcPostThreeActuator.actuate(true);
+                    }
 
-                if (tcPostThreeActuator !=null) {
-                    tcPostThreeActuator.actuate(true);
+                    Logger.debug("{}.unloadNozzleTip(): moveTo Mid Location 2", getName());
+                    moveTo(nt.getChangerMidLocation2Calibrated(false), nt.getChangerMid2ToEndSpeed() * speed);
+
+                    if (tcPostTwoActuator !=null) {
+                        tcPostTwoActuator.actuate(true);
+                    }
+
+                    Logger.debug("{}.unloadNozzleTip(): moveTo Mid Location", getName());
+                    moveTo(nt.getChangerMidLocationCalibrated(false), nt.getChangerMidToMid2Speed() * speed);
+
+                    if (tcPostOneActuator != null) {
+                        tcPostOneActuator.actuate(true);
+                    }
+
+                    Logger.debug("{}.unloadNozzleTip(): moveTo Start Location", getName());
+                    moveTo(nt.getChangerStartLocationCalibrated(false), nt.getChangerStartToMidSpeed() * speed);
+                    moveToSafeZ(getHead().getMachine().getSpeed());
+
+                    Logger.debug("{}.unloadNozzleTip(): Finished", getName());
+
+                    Configuration.get()
+                    .getScripting()
+                    .on("NozzleTip.Unloaded", globals);
                 }
-
-                Logger.debug("{}.unloadNozzleTip(): moveTo Mid Location 2", getName());
-                moveTo(nt.getChangerMidLocation2Calibrated(false), nt.getChangerMid2ToEndSpeed() * speed);
-
-                if (tcPostTwoActuator !=null) {
-                    tcPostTwoActuator.actuate(true);
+                else {
+                    Logger.debug("{}.unloadNozzleTip({}): moveTo manual Location",
+                            new Object[] {getName(), nozzleTip.getName()});
+                    assertManualChangeLocation();
+                    MovableUtils.moveToLocationAtSafeZ(this, getManualNozzleTipChangeLocation());
                 }
+            }
 
-                Logger.debug("{}.unloadNozzleTip(): moveTo Mid Location", getName());
-                moveTo(nt.getChangerMidLocationCalibrated(false), nt.getChangerMidToMid2Speed() * speed);
+            setNozzleTip(null);
 
-                if (tcPostOneActuator != null) {
-                    tcPostOneActuator.actuate(true);
+            // FIXME: once combined continuation is implemented, continue unloading with itself to eventually calibrate the bare nozzle
+            if (!changerEnabled) {
+                // generate a warning that calibrating the unloaded nozzle is not supported
+                ReferenceNozzleTip calibrationNozzleTip = this.getCalibrationNozzleTip();
+                if (calibrationNozzleTip != null && calibrationNozzleTip.getCalibration().isRecalibrateOnNozzleTipChangeNeeded(this)) {
+                    Logger.warn("{}.unloadNozzleTip() nozzle tip {} calibration configured but not supported in combination with manual nozzle tip changing");
                 }
-
-                Logger.debug("{}.unloadNozzleTip(): moveTo Start Location", getName());
-                moveTo(nt.getChangerStartLocationCalibrated(false), nt.getChangerStartToMidSpeed() * speed);
-                moveToSafeZ(getHead().getMachine().getSpeed());
-
-                Logger.debug("{}.unloadNozzleTip(): Finished", getName());
-
-                Configuration.get()
-                .getScripting()
-                .on("NozzleTip.Unloaded", globals);
+                waitForCompletion(CompletionType.WaitForStillstand);
+                throw new ManualUnloadException(this, "Task interrupted: Please perform a manual nozzle tip "+nt.getName()+" unload from nozzle "+getName()+" now. "
+                                + "You can then resume/restart the interrupted task.");
             }
-            else {
-                Logger.debug("{}.unloadNozzleTip({}): moveTo manual Location",
-                        new Object[] {getName(), nozzleTip.getName()});
-                assertManualChangeLocation();
-                MovableUtils.moveToLocationAtSafeZ(this, getManualNozzleTipChangeLocation());
-            }
-        }
-
-        setNozzleTip(null);
-
-        if (!changerEnabled) {
-            // generate a warning that calibrating the unloaded nozzle is not supported
-            ReferenceNozzleTip calibrationNozzleTip = this.getCalibrationNozzleTip();
-            if (calibrationNozzleTip != null && calibrationNozzleTip.getCalibration().isRecalibrateOnNozzleTipChangeNeeded(this)) {
-                Logger.warn("{}.unloadNozzleTip() nozzle tip {} calibration configured but not supported in combination with manual nozzle tip changing");
-            }
-            waitForCompletion(CompletionType.WaitForStillstand);
-            throw new ManualUnloadException(this, "Task interrupted: Please perform a manual nozzle tip "+nt.getName()+" unload from nozzle "+getName()+" now. "
-                            + "You can then resume/restart the interrupted task.");
         }
 
         // For manual nozzle tip changing, the code will never get here because of the exception.

--- a/src/main/java/org/openpnp/machine/reference/ReferencePnpJobProcessor.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferencePnpJobProcessor.java
@@ -515,7 +515,6 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
                     nozzle.getName(), 
                     nozzleTip.getName());
             try {
-                nozzle.unloadNozzleTip(true);       // signal that a load will immediately follow, skipping the interruption if manual nozzle tip change is configured
                 nozzle.loadNozzleTip(nozzleTip);
             }
             catch (Exception e) {

--- a/src/main/java/org/openpnp/machine/reference/ReferencePnpJobProcessor.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferencePnpJobProcessor.java
@@ -515,7 +515,7 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
                     nozzle.getName(), 
                     nozzleTip.getName());
             try {
-                nozzle.unloadNozzleTip();
+                nozzle.unloadNozzleTip(true);       // signal that a load will immediately follow, skipping the interruption if manual nozzle tip change is configured
                 nozzle.loadNozzleTip(nozzleTip);
             }
             catch (Exception e) {

--- a/src/main/java/org/openpnp/spi/JobProcessor.java
+++ b/src/main/java/org/openpnp/spi/JobProcessor.java
@@ -4,7 +4,6 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 
 import org.openpnp.model.Job;
-import org.openpnp.util.UiUtils.Thrunnable;
 
 public interface JobProcessor extends PropertySheetHolder, WizardConfigurable {
     public interface TextStatusListener {
@@ -54,8 +53,8 @@ public interface JobProcessor extends PropertySheetHolder, WizardConfigurable {
             this.source = source;
         }
 
-        public JobProcessorException(Object source, String message, boolean interrupting) {
-            super(message);
+        public JobProcessorException(Object source, Throwable throwable, boolean interrupting) {
+            super(getThrowableMessage(throwable), throwable);
             this.source = source;
             this.interrupting = interrupting;
         }
@@ -68,34 +67,20 @@ public interface JobProcessor extends PropertySheetHolder, WizardConfigurable {
             return interrupting;
         }
     }
-    
-    // this extended exception class allows to specify a task to be executed once the user has agreed
-    public class JobProcessorExceptionWithContinuation extends JobProcessorException {
-        private static final long serialVersionUID = 1L;
 
-        final Thrunnable thrunnable;
-        
-        public JobProcessorExceptionWithContinuation(JobProcessorException e, Thrunnable thrunnable) {
-            super(e.getSource(), e);
-            this.thrunnable = thrunnable;
-        }
-        
-        public JobProcessorExceptionWithContinuation(Object source, String message, boolean interrupting, Thrunnable thrunnable) {
-            super(source, message, interrupting);
-            this.thrunnable = thrunnable;
-        }
-
-        public Thrunnable getThrunnable() {
-            return thrunnable;
-        }
-    }
-    
     public class ManualUnloadException extends JobProcessorException {
         private static final long serialVersionUID = 1L;
 
-        public ManualUnloadException(Object source, String message, boolean interrupting) {
-            super(source, message, interrupting);
+        public ManualUnloadException(Object source, Throwable throwable, boolean interrupting) {
+            super(source, throwable, interrupting);
         }
     }
 
+    public class ManualLoadException extends JobProcessorException {
+        private static final long serialVersionUID = 1L;
+
+        public ManualLoadException(Object source, Throwable throwable, boolean interrupting) {
+            super(source, throwable, interrupting);
+        }
+    }
 }

--- a/src/main/java/org/openpnp/spi/JobProcessor.java
+++ b/src/main/java/org/openpnp/spi/JobProcessor.java
@@ -53,6 +53,12 @@ public interface JobProcessor extends PropertySheetHolder, WizardConfigurable {
             this.source = source;
         }
 
+        public JobProcessorException(Object source, String message, boolean interrupting) {
+            super(message);
+            this.source = source;
+            this.interrupting = interrupting;
+        }
+
         public JobProcessorException(Object source, Throwable throwable, boolean interrupting) {
             super(getThrowableMessage(throwable), throwable);
             this.source = source;

--- a/src/main/java/org/openpnp/spi/JobProcessor.java
+++ b/src/main/java/org/openpnp/spi/JobProcessor.java
@@ -67,20 +67,4 @@ public interface JobProcessor extends PropertySheetHolder, WizardConfigurable {
             return interrupting;
         }
     }
-
-    public class ManualUnloadException extends JobProcessorException {
-        private static final long serialVersionUID = 1L;
-
-        public ManualUnloadException(Object source, Throwable throwable, boolean interrupting) {
-            super(source, throwable, interrupting);
-        }
-    }
-
-    public class ManualLoadException extends JobProcessorException {
-        private static final long serialVersionUID = 1L;
-
-        public ManualLoadException(Object source, Throwable throwable, boolean interrupting) {
-            super(source, throwable, interrupting);
-        }
-    }
 }

--- a/src/main/java/org/openpnp/spi/JobProcessor.java
+++ b/src/main/java/org/openpnp/spi/JobProcessor.java
@@ -4,6 +4,7 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 
 import org.openpnp.model.Job;
+import org.openpnp.util.UiUtils.Thrunnable;
 
 public interface JobProcessor extends PropertySheetHolder, WizardConfigurable {
     public interface TextStatusListener {
@@ -67,4 +68,34 @@ public interface JobProcessor extends PropertySheetHolder, WizardConfigurable {
             return interrupting;
         }
     }
+    
+    // this extended exception class allows to specify a task to be executed once the user has agreed
+    public class JobProcessorExceptionWithContinuation extends JobProcessorException {
+        private static final long serialVersionUID = 1L;
+
+        final Thrunnable thrunnable;
+        
+        public JobProcessorExceptionWithContinuation(JobProcessorException e, Thrunnable thrunnable) {
+            super(e.getSource(), e);
+            this.thrunnable = thrunnable;
+        }
+        
+        public JobProcessorExceptionWithContinuation(Object source, String message, boolean interrupting, Thrunnable thrunnable) {
+            super(source, message, interrupting);
+            this.thrunnable = thrunnable;
+        }
+
+        public Thrunnable getThrunnable() {
+            return thrunnable;
+        }
+    }
+    
+    public class ManualUnloadException extends JobProcessorException {
+        private static final long serialVersionUID = 1L;
+
+        public ManualUnloadException(Object source, String message, boolean interrupting) {
+            super(source, message, interrupting);
+        }
+    }
+
 }

--- a/src/main/java/org/openpnp/spi/Nozzle.java
+++ b/src/main/java/org/openpnp/spi/Nozzle.java
@@ -147,6 +147,21 @@ public interface Nozzle
     public void unloadNozzleTip() throws Exception;
     
     /**
+     * Changer interface:
+     * 
+     * Unload the current NozzleTip from the Nozzle, leaving it empty.
+     * 
+     * After this call getNozzleTip() should return null.
+     * 
+     * This is a special version of the unloadNozzleTip() method that does not interrupt on manual nozzle tip
+     * changes if a loadNozzleTip() is known to follow.
+     * 
+     * @param loadNozzleTipFollows If true, a loadNozzleTip() call will follow and no interrutp for unload will be generated.
+     * @throws Exception
+     */
+    public void unloadNozzleTip(boolean loadNozzleTipFollows) throws Exception;
+
+    /**
      * Get the part that is currently picked on the Nozzle, or null if none is picked.
      * Should typically be non-null after a pick operation and before a place operation and null
      * after a pick operation. Of note, it should be non-null after a failed pick operation

--- a/src/main/java/org/openpnp/spi/Nozzle.java
+++ b/src/main/java/org/openpnp/spi/Nozzle.java
@@ -147,21 +147,6 @@ public interface Nozzle
     public void unloadNozzleTip() throws Exception;
     
     /**
-     * Changer interface:
-     * 
-     * Unload the current NozzleTip from the Nozzle, leaving it empty.
-     * 
-     * After this call getNozzleTip() should return null.
-     * 
-     * This is a special version of the unloadNozzleTip() method that does not interrupt on manual nozzle tip
-     * changes if a loadNozzleTip() is known to follow.
-     * 
-     * @param loadNozzleTipFollows If true, a loadNozzleTip() call will follow and no interrutp for unload will be generated.
-     * @throws Exception
-     */
-    public void unloadNozzleTip(boolean loadNozzleTipFollows) throws Exception;
-
-    /**
      * Get the part that is currently picked on the Nozzle, or null if none is picked.
      * Should typically be non-null after a pick operation and before a place operation and null
      * after a pick operation. Of note, it should be non-null after a failed pick operation

--- a/src/main/java/org/openpnp/util/UiUtils.java
+++ b/src/main/java/org/openpnp/util/UiUtils.java
@@ -100,6 +100,7 @@ public class UiUtils {
                     if (combinedContinuation == null) {
                         combinedContinuation = continuation; // just take the first one
                     } else {
+                        // FIXME: implement continuation chaining
                         Logger.warn("Combined continuation not supported yet.");
                     }
                 }

--- a/src/main/java/org/openpnp/util/UiUtils.java
+++ b/src/main/java/org/openpnp/util/UiUtils.java
@@ -18,6 +18,7 @@ import org.openpnp.gui.support.MessageBoxes;
 import org.openpnp.model.Configuration;
 import org.openpnp.model.Location;
 import org.openpnp.spi.HeadMountable;
+import org.openpnp.spi.JobProcessor.JobProcessorExceptionWithContinuation;
 import org.openpnp.spi.MotionPlanner.CompletionType;
 import org.pmw.tinylog.Logger;
 
@@ -72,6 +73,14 @@ public class UiUtils {
         }
         else {
             Logger.error(t);
+        }
+
+        // FIXME: add Cancel button and  only execute on OK
+        if (t instanceof JobProcessorExceptionWithContinuation) {
+            Thrunnable thrunnable = ((JobProcessorExceptionWithContinuation)t).getThrunnable();
+            if (thrunnable != null) {
+                submitUiMachineTask(thrunnable);
+            }
         }
     }
 

--- a/src/main/java/org/openpnp/util/UiUtils.java
+++ b/src/main/java/org/openpnp/util/UiUtils.java
@@ -87,9 +87,11 @@ public class UiUtils {
 
     /**
      * Show an error using a message box, if the GUI is present, otherwise just log the error.
+     * @param parent
+     * @param title
      * @param t
      */
-    public static void showError(Throwable t) {
+    public static void showError(Component parent, String title, Throwable t) {
         
         // Go through all causes, creating a combined continuation
         Thrunnable combinedContinuation = null;
@@ -107,8 +109,8 @@ public class UiUtils {
             }
         }
             
-        if (MainFrame.get() != null) {
-            boolean execContinuation = MessageBoxes.errorBox(MainFrame.get(), "Error", t, combinedContinuation != null);
+        if (parent != null) {
+            boolean execContinuation = MessageBoxes.errorBox(parent, title, t, combinedContinuation != null);
 
             // execution continuation, if user agrees
             if (combinedContinuation != null && execContinuation) {
@@ -120,7 +122,14 @@ public class UiUtils {
         }
     }
 
-
+    /**
+     * Show an error using a message box. This version provides the simplified interface where the
+     * title is fixed to "Error" and the parent is the main frame.
+     */
+    public static void showError(Throwable t) {
+        showError(MainFrame.get(), "Error", t);
+    }
+    
     /**
      * Functional version of Machine.submit which guarantees that the the onSuccess and onFailure
      * handlers will be run on the Swing event thread.


### PR DESCRIPTION
# Description
This PR enhances the usability for machines with manual nozzle tip changing enabled by skipping the interruption to load the nozzle tip if a load will immediately follow.

# Justification
At present the job processor generates two interrupts to change one nozzle tip, one for the unload and a second for the load. The unload is useless and a waste of time if a load is known to immediately follow.

This is documentation for a user, not for a developer.

# Implementation Details
1. How did you test the change? Be descriptive. Untested code will not be accepted. **using a simulation machine**
2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)? **yes**
3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing. **yes: I added a new version of unloadNozzleTip() which can taken an argument to signal that a load will follow.**
4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted. **yes**
