### PR TITLE
Feature / ReferencePushPullFeeder: Diagnostics for Sprocket Hole Detection

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/feeder/ReferencePushPullFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/ReferencePushPullFeeder.java
@@ -1500,6 +1500,10 @@ public class ReferencePushPullFeeder extends ReferenceFeeder {
                             if (Math.abs(circle.diameter*mmScale.getX() - sprocketHoleDiameterMm) < sprocketHoleToleranceMm) {
                                 results.add(circle);
                             }
+                            else {
+                                Logger.debug("Dismissed Circle with non-compliant diameter "+(circle.diameter*mmScale.getX())+"mm, "
+                                        + "allowed tolerance is ±"+sprocketHoleToleranceMm+"mm");
+                            }
                         }
                         else if ((result) instanceof RotatedRect) {
                             RotatedRect rect = ((RotatedRect) result);
@@ -1507,6 +1511,11 @@ public class ReferencePushPullFeeder extends ReferenceFeeder {
                             if (Math.abs(rect.size.width*mmScale.getX() - sprocketHoleDiameterMm) < sprocketHoleToleranceMm
                                     && Math.abs(rect.size.height*mmScale.getX() - sprocketHoleDiameterMm) < sprocketHoleToleranceMm) {
                                 results.add(new Result.Circle(rect.center.x, rect.center.y, diameter));
+                            }
+                            else {
+                                Logger.debug("Dismissed RotatedRect with non-compliant width or height "
+                                        +(rect.size.width*mmScale.getX())+"mm x "+rect.size.height*mmScale.getX()+"mm, "
+                                                + "allowed tolerance is ±"+sprocketHoleToleranceMm+"mm");
                             }
                         }
                         else if ((result) instanceof KeyPoint) {
@@ -1522,6 +1531,10 @@ public class ReferencePushPullFeeder extends ReferenceFeeder {
                     }
                     List<Ransac.Line> ransacLines = Ransac.ransac(points, 100, sprocketHoleTolerancePx, 
                             sprocketHolePitchPx, sprocketHoleTolerancePx, false);
+                    if (ransacLines.isEmpty()) {
+                        Logger.debug("Ransac algorithm has not found any lines of sprocket holes with "+sprocketHolePitchMm+"mm pitch, "
+                                + "allowed pitch and line tolerance is ±"+sprocketHoleToleranceMm+"mm");
+                    }
                     // Get the best line within the calibration tolerance
                     Ransac.Line bestLine = null;
                     Location bestUnitVector = null;
@@ -1561,6 +1574,7 @@ public class ReferencePushPullFeeder extends ReferenceFeeder {
                         }
                         else if (autoSetupMode == null) {
                             lines.add(line);
+                            Logger.debug("Dismissed line by distance, "+(distanceMm)+"mm, not within "+minDistanceMm+"mm .. "+maxDistanceMm+"mm");
                         }
                     }
 


### PR DESCRIPTION
# Description

After computer vision has detected sprocket holes purely by vision criteria, the `ReferencePushPullFeeder` applies various criteria to further filter sprockets holes for setup and calibration. This PR adds logging diagnostics when sprocket holes (or sprocket hole lines) are dismissed due to geometric constraints. Constraints are derived from EIA-481 standards.

The vision-detected holes are filtered after the pipeline:

1. The exact size of the detected hole must match the EIA standard (1.5mm), within a certain tolerance.
2. The holes must appear in a straight line.
3. The holes in the line must appear with a pitch of 4mm (at least two of them, can be multiple of 4mm).
4. The line must have a certain distance, not too close to the pick location (avoid mixing up part pockets with sprocket holes), and not too far away either. 

# Justification
User report.
https://groups.google.com/g/openpnp/c/Xb2ldDyj2Mc/m/qs6Bt3cnAgAJ

# Instructions for Use
When having problems with ReferencePushPullFeeder sprocket hole detection, please have a look at the log. All the above-mentioned criteria should be reported (criteria 2 and 3 cannot be discriminated).

# Implementation Details
1. Apart from `mvn test`, no specific testing was done. Instead, I hope the user will report back findings with the present issues.
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. Successful `mvn test`.
