### PR TITLE
Manual Change Location Enhancement

### DIFF
--- a/src/main/java/org/openpnp/gui/components/LocationButtonsPanel.java
+++ b/src/main/java/org/openpnp/gui/components/LocationButtonsPanel.java
@@ -60,6 +60,7 @@ import org.openpnp.util.UiUtils;
 public class LocationButtonsPanel extends JPanel {
     private JTextField textFieldX, textFieldY, textFieldZ, textFieldC;
     private String actuatorName;
+    private HeadMountable tool;     // this variable holds a spcific tool, if the tool-buttons shall react on that tool only, default is the selected nozzle
 
     private JButton buttonCenterTool;
     private JButton buttonCaptureCamera;
@@ -209,7 +210,18 @@ public class LocationButtonsPanel extends JPanel {
         return actuatorName;
     }
 
+    // set/specify a tool the tool/nozzle buttons shall react on. Default is the selected nozzle
+    public void setTool(HeadMountable tool) {
+        this.tool = tool;
+    }
+    
     public HeadMountable getTool() throws Exception {
+        // return the specified tool, if any
+        if (tool != null) {
+            return tool;
+        }
+
+        // else return the selected nozzle
         return MainFrame.get().getMachineControls().getSelectedNozzle();
     }
 

--- a/src/main/java/org/openpnp/machine/reference/wizards/ReferenceNozzleToolChangerWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/wizards/ReferenceNozzleToolChangerWizard.java
@@ -147,6 +147,7 @@ public class ReferenceNozzleToolChangerWizard extends AbstractConfigurationWizar
         
         changerStartLocationButtonsPanel = new LocationButtonsPanel(manualNozzleTipChangeX,
                 manualNozzleTipChangeY, manualNozzleTipChangeZ, (JTextField) null);
+        changerStartLocationButtonsPanel.setTool(nozzle);   // make the tool buttons react on the current nozzle only
         panelChanger.add(changerStartLocationButtonsPanel, "10, 8, fill, default");
     }
 


### PR DESCRIPTION
# Description
This PR slightly enhances the UI for Manual Change Location on the Tool Changer page of the nozzle by forcing the relevant nozzle as the tool when capturing locations.

# Justification
The Manual Change Location is only of relevant for the nozzle that is to be currently configured. Therefore it makes no sense to capture the location of any other nozzle.

This is documentation for a user, not for a developer.

# Implementation Details
1. How did you test the change? Be descriptive. Untested code will not be accepted. **using the debugger**
2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)? **yes**
3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing. **no**
4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted. **yes**
