### PR TITLE
Fix /  adjustHeadOffsetsDependencies() applied twice

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/solutions/VisionSolutions.java
+++ b/src/main/java/org/openpnp/machine/reference/solutions/VisionSolutions.java
@@ -960,7 +960,6 @@ public class VisionSolutions implements Solutions.Subject {
                                             else {
                                                 nozzle.setHeadOffsets(headOffsets);
                                                 Logger.info("Set nozzle "+nozzle.getName()+" head offsets to "+headOffsets+" (previously "+headOffsetsBefore+")");
-                                                nozzle.adjustHeadOffsetsDependencies(headOffsetsBefore, headOffsets);
                                             }
                                         }
                                         return true;


### PR DESCRIPTION

# Description

When `adjustHeadOffsetsDependencies()` was refactored to be used universally inside `setHeadOffsets()`, I forgot to remove it in `VisionSolutions`.

# Justification

User report:
https://groups.google.com/g/openpnp/c/FZiiQQ_NGXs/m/eTsJ1kMIAQAJ

# Instructions for Use
No change in usage.

# Implementation Details
1. Just used `mvn test`, hope the reporting user will test with the actual issue on his machine.
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. Successful `mvn test` before submitting the Pull Request.
