### PR TITLE
Fix / private Visibility on adjustHeadOffsetsDependencies()

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/ReferenceNozzle.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceNozzle.java
@@ -230,7 +230,7 @@ public class ReferenceNozzle extends AbstractNozzle implements ReferenceHeadMoun
      * @param headOffsetsNew
      * @param offsetsDiff
      */
-    public void adjustHeadOffsetsDependencies(Location headOffsetsOld, Location headOffsetsNew) {
+    private void adjustHeadOffsetsDependencies(Location headOffsetsOld, Location headOffsetsNew) {
         Location offsetsDiff = headOffsetsNew.subtract(headOffsetsOld).convertToUnits(LengthUnit.Millimeters);
         if (offsetsDiff.getLinearDistanceTo(Location.origin) > 0.01) {
             // Changing a X, Y head offset invalidates the nozzle tip calibration. Just changing Z leaves it intact. 


### PR DESCRIPTION
# Description
Make  adjustHeadOffsetsDependencies() private, to prevent future bugs as in #1612 

# Justification
See discussion:
https://groups.google.com/g/openpnp/c/FZiiQQ_NGXs/m/-ISHrc6eAgAJ

# Instructions for Use
No change.

# Implementation Details
N/A
