### PR TITLE
Sort placements rewrite

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/ReferencePnpJobProcessor.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferencePnpJobProcessor.java
@@ -1299,17 +1299,19 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
             long t = System.currentTimeMillis();
             Location start; // start location of traveling salesman, current location of the head
         
-            // no optimization can take place if there are not enough placements
-            if (plannedPlacements.size() <= 1) {
-            }
-
             // if multi-nozzle optimization has been disabled, stop here
             if (!optimizeMultipleNozzles) {
                 return plannedPlacements;
             }
             
+            // no optimization can take place if there are not enough placements
+            if (plannedPlacements.size() <= 1) {
+                return plannedPlacements;
+            }
+
             // if any sort locations are now empty, skip the optimization
             if (plannedPlacements.stream().filter(p -> {return sortLocator.getLocation(p) == null;}).count() != 0) {
+                Logger.debug("Optimization skipped because not all placements provide locations");
                 return plannedPlacements;
             }
             

--- a/src/main/java/org/openpnp/machine/reference/ReferencePnpJobProcessor.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferencePnpJobProcessor.java
@@ -586,7 +586,7 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
         public Step step() throws JobProcessorException {
             
             // sort plannedPlacements for picking with alignment as next/end location using TSM
-            List<PlannedPlacement> optimizedPlannedPlacements = optimizePlacements(new pickLocator(), new alignLocator());
+            List<PlannedPlacement> optimizedPlannedPlacements = optimizePlacements(new PickLocator(), new AlignLocator());
             
             return new Pick(optimizedPlannedPlacements);
         }
@@ -805,7 +805,7 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
         public Step step() throws JobProcessorException {
 
             // sort plannedPlacements for alignment with place as next/end location using TSM
-            List<PlannedPlacement> optimizedPlannedPlacements = optimizePlacements(new alignLocator(), new placeLocator());
+            List<PlannedPlacement> optimizedPlannedPlacements = optimizePlacements(new AlignLocator(), new PlaceLocator());
             
             // continue with alignment
             return new Align(optimizedPlannedPlacements);
@@ -901,7 +901,7 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
         public Step step() throws JobProcessorException {
             
             // sort plannedPlacements for place using TSM
-            List<PlannedPlacement> optimizedPlannedPlacements = optimizePlacements(new placeLocator(), null);
+            List<PlannedPlacement> optimizedPlannedPlacements = optimizePlacements(new PlaceLocator(), null);
             
             return new Place(optimizedPlannedPlacements);
         }
@@ -1364,7 +1364,7 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
     }
     
     // FIXME: can "TravellingSalesman.Locator<PlannedPlacement>" be converted into a shorter name?
-    private class pickLocator implements TravellingSalesman.Locator<PlannedPlacement> {
+    private class PickLocator implements TravellingSalesman.Locator<PlannedPlacement> {
         public Location getLocation(PlannedPlacement p) {
             Location location;
             final Nozzle nozzle = p.nozzle;
@@ -1391,7 +1391,7 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
         }
     }
     
-    private class alignLocator implements TravellingSalesman.Locator<PlannedPlacement> {
+    private class AlignLocator implements TravellingSalesman.Locator<PlannedPlacement> {
         public Location getLocation(PlannedPlacement p) {
             Location location;
             final Camera camera;
@@ -1416,7 +1416,7 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
         }
     }
     
-    private class placeLocator implements TravellingSalesman.Locator<PlannedPlacement> {
+    private class PlaceLocator implements TravellingSalesman.Locator<PlannedPlacement> {
         public Location getLocation(PlannedPlacement p) {
             final Nozzle nozzle = p.nozzle;
             final JobPlacement jobPlacement = p.jobPlacement;

--- a/src/main/java/org/openpnp/machine/reference/ReferencePnpJobProcessor.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferencePnpJobProcessor.java
@@ -96,6 +96,10 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
 
     protected Head head;
 
+    protected Locator pickLocator;
+    protected Locator alignLocator;
+    protected Locator placeLocator;
+    
     protected List<JobPlacement> jobPlacements = new ArrayList<>();
 
     private Step currentStep = null;
@@ -173,6 +177,9 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
             catch (Exception e) {
                 throw new JobProcessorException(machine, e);
             }
+            pickLocator  = new PickLocator();
+            alignLocator = new AlignLocator();
+            placeLocator = new PlaceLocator();
             
             checkSetupErrors();
             
@@ -570,7 +577,7 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
         public Step step() throws JobProcessorException {
             
             // sort plannedPlacements for picking with alignment as next/end location using TSM
-            List<PlannedPlacement> optimizedPlannedPlacements = optimizePlacements(new PickLocator(), new AlignLocator());
+            List<PlannedPlacement> optimizedPlannedPlacements = optimizePlacements(pickLocator, alignLocator);
             
             return new Pick(optimizedPlannedPlacements);
         }
@@ -789,7 +796,7 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
         public Step step() throws JobProcessorException {
 
             // sort plannedPlacements for alignment with place as next/end location using TSM
-            List<PlannedPlacement> optimizedPlannedPlacements = optimizePlacements(new AlignLocator(), new PlaceLocator());
+            List<PlannedPlacement> optimizedPlannedPlacements = optimizePlacements(alignLocator, placeLocator);
             
             // continue with alignment
             return new Align(optimizedPlannedPlacements);
@@ -885,7 +892,8 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
         public Step step() throws JobProcessorException {
             
             // sort plannedPlacements for place using TSM
-            List<PlannedPlacement> optimizedPlannedPlacements = optimizePlacements(new PlaceLocator(), null);
+            // FIXME: if the planner would provide a look-ahead feature, we could use it for further optimization here
+            List<PlannedPlacement> optimizedPlannedPlacements = optimizePlacements(placeLocator, null);
             
             return new Place(optimizedPlannedPlacements);
         }

--- a/src/main/java/org/openpnp/machine/reference/ReferencePnpJobProcessor.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferencePnpJobProcessor.java
@@ -147,7 +147,7 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
     /**
      * Get the location of ref with respect to the head mountable hm
      */
-    protected Location getHeadLocation(HeadMountable hm, Location ref)
+    protected Location convertToHeadLocation(HeadMountable hm, Location ref)
     {
         Location location;
         
@@ -578,7 +578,7 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
     /**
      * Optimize nozzles for best pick performance
      */
-    protected class OptimizeNozzlesForPick extends OptimizationNozzlesStep {
+    protected class OptimizeNozzlesForPick extends AbstractOptimizationNozzlesStep {
         public OptimizeNozzlesForPick(List<PlannedPlacement> plannedPlacements) {
             super(plannedPlacements);
         }
@@ -797,7 +797,7 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
     /**
      * Optimize nozzles for best alignment performance
      */
-    protected class OptimizeNozzlesForAlign extends OptimizationNozzlesStep {
+    protected class OptimizeNozzlesForAlign extends AbstractOptimizationNozzlesStep {
         public OptimizeNozzlesForAlign(List<PlannedPlacement> plannedPlacements) {
             super(plannedPlacements);
         }
@@ -893,7 +893,7 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
     /**
      * Optimize nozzles for best place performance
      */
-    protected class OptimizeNozzlesForPlace extends OptimizationNozzlesStep {
+    protected class OptimizeNozzlesForPlace extends AbstractOptimizationNozzlesStep {
         public OptimizeNozzlesForPlace(List<PlannedPlacement> plannedPlacements) {
             super(plannedPlacements);
         }
@@ -1261,9 +1261,9 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
     /**
      * This class groups a step for step for multi-nozzle optimization
      */
-    protected abstract class OptimizationNozzlesStep implements Step {
+    protected abstract class AbstractOptimizationNozzlesStep implements Step {
         private final List<PlannedPlacement> plannedPlacements;
-        protected OptimizationNozzlesStep(List<PlannedPlacement> plannedPlacements) {
+        protected AbstractOptimizationNozzlesStep(List<PlannedPlacement> plannedPlacements) {
             this.plannedPlacements = plannedPlacements;
         }
 
@@ -1326,7 +1326,7 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
             // all nozzles are expected to be mounted on the same head so using
             // any nozzle as reference shall provide the same head location.
             Nozzle nozzle = plannedPlacements.get(0).nozzle;
-            start = getHeadLocation(nozzle, nozzle.getLocation());
+            start = convertToHeadLocation(nozzle, nozzle.getLocation());
             
             // b) calculate end location as center between all locations of the next step
             Location endLocation = calcCenterLocation(endLocator);
@@ -1376,7 +1376,7 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
             try {
                 final Feeder feeder = findFeeder(machine, part);
 
-                location = getHeadLocation(nozzle, feeder.getPickLocation());
+                location = convertToHeadLocation(nozzle, feeder.getPickLocation());
             } catch (Exception e) {
                 // ignore exceptions
                 location = null;
@@ -1401,7 +1401,7 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
             try {
                 camera = VisionUtils.getBottomVisionCamera();
                 
-                location = getHeadLocation(nozzle, camera.getLocation());
+                location = convertToHeadLocation(nozzle, camera.getLocation());
             } catch (Exception e) {
                 // ignore exceptions
                 location = null;
@@ -1427,7 +1427,7 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
                     placement.getLocation());
         
             // convert location to where the head will move to to place the part
-            return getHeadLocation(nozzle, location);
+            return convertToHeadLocation(nozzle, location);
         }
         
         @Override

--- a/src/main/java/org/openpnp/spi/PnpJobPlanner.java
+++ b/src/main/java/org/openpnp/spi/PnpJobPlanner.java
@@ -13,11 +13,6 @@ public interface PnpJobPlanner {
         public Feeder feeder;
         public PartAlignment.PartAlignmentOffset alignmentOffsets;
         
-        // the following locations are used for optimization purposes and may not be accurate or complete.
-        public Location pickLocation;   // (preliminary) location the pick will take place - as feed/pick might not work, this location is preliminary and optimization using it my fail.
-        public Location alignLocation;  // location the alignment will take place. - may be null if alignment for this part is disabled
-        public Location placeLocation;  // location the part will be place to
-
         public PlannedPlacement(Nozzle nozzle, NozzleTip nozzleTip, JobPlacement jobPlacement) {
             this.nozzle = nozzle;
             this.nozzleTip = nozzleTip;

--- a/src/main/java/org/openpnp/spi/PnpJobPlanner.java
+++ b/src/main/java/org/openpnp/spi/PnpJobPlanner.java
@@ -12,8 +12,61 @@ public interface PnpJobPlanner {
         public final NozzleTip nozzleTip;
         public Feeder feeder;
         public PartAlignment.PartAlignmentOffset alignmentOffsets;
-        public Location sortLocation;	// location used to sort placements as part of the job processing
+        private Location pickLocation;	// (preliminary) location the pick will take place - as feed/pick might not work, this location is preliminary and optimization using it my fail.
+        private Location alignLocation; // location the alignment will take place. - may be null if alignment for this part is disabled
+        private Location placeLocation; // location the part will be place to
 
+        public enum LocationType {
+            PICK, ALIGN, PLACE, NONE;   // location type, used to return one of [pick|align|place]Location
+        }
+        
+        // return the location of given type
+        public Location getLocation(LocationType type) {
+            Location l = null;
+            switch (type)
+            {
+                case PICK:
+                    l = pickLocation;
+                    break;
+                    
+                case ALIGN:
+                    l = alignLocation;
+                    break;
+                    
+                case PLACE:
+                    l = placeLocation;
+                    break;
+                    
+                case NONE:
+                    l = null;
+                    break;
+            }
+            
+            return l;
+        }
+
+        // set a specific location type
+        public void setLocation(Location l, LocationType type) {
+            switch (type)
+            {
+                case PICK:
+                    pickLocation = l;
+                    break;
+                    
+                case ALIGN:
+                    alignLocation = l;
+                    break;
+                    
+                case PLACE:
+                    placeLocation = l;
+                    break;
+                    
+                case NONE:
+                    l = null;
+                    break;
+            }
+        }
+        
         public PlannedPlacement(Nozzle nozzle, NozzleTip nozzleTip, JobPlacement jobPlacement) {
             this.nozzle = nozzle;
             this.nozzleTip = nozzleTip;

--- a/src/main/java/org/openpnp/spi/PnpJobPlanner.java
+++ b/src/main/java/org/openpnp/spi/PnpJobPlanner.java
@@ -12,6 +12,8 @@ public interface PnpJobPlanner {
         public final NozzleTip nozzleTip;
         public Feeder feeder;
         public PartAlignment.PartAlignmentOffset alignmentOffsets;
+        
+        // the following locations are used for optimization purposes and may not be accurate or complete.
         private Location pickLocation;	// (preliminary) location the pick will take place - as feed/pick might not work, this location is preliminary and optimization using it my fail.
         private Location alignLocation; // location the alignment will take place. - may be null if alignment for this part is disabled
         private Location placeLocation; // location the part will be place to

--- a/src/main/java/org/openpnp/spi/PnpJobPlanner.java
+++ b/src/main/java/org/openpnp/spi/PnpJobPlanner.java
@@ -14,64 +14,10 @@ public interface PnpJobPlanner {
         public PartAlignment.PartAlignmentOffset alignmentOffsets;
         
         // the following locations are used for optimization purposes and may not be accurate or complete.
-        private Location pickLocation;	// (preliminary) location the pick will take place - as feed/pick might not work, this location is preliminary and optimization using it my fail.
-        private Location alignLocation; // location the alignment will take place. - may be null if alignment for this part is disabled
-        private Location placeLocation; // location the part will be place to
+        public Location pickLocation;   // (preliminary) location the pick will take place - as feed/pick might not work, this location is preliminary and optimization using it my fail.
+        public Location alignLocation;  // location the alignment will take place. - may be null if alignment for this part is disabled
+        public Location placeLocation;  // location the part will be place to
 
-        public enum LocationType {
-            PICK("pick"), ALIGN("alignment"), PLACE("place");   // location type, used to return one of [pick|align|place]Location
-            
-            private final String name;
-            
-            LocationType(String name) {
-                this.name = name;
-            }
-            
-            @Override
-            public String toString() {
-                return name;
-            }
-        }
-        
-        // return the location of given type
-        public Location getLocation(LocationType type) {
-            Location l = null;
-            switch (type)
-            {
-                case PICK:
-                    l = pickLocation;
-                    break;
-                    
-                case ALIGN:
-                    l = alignLocation;
-                    break;
-                    
-                case PLACE:
-                    l = placeLocation;
-                    break;
-            }
-            
-            return l;
-        }
-
-        // set a specific location type
-        public void setLocation(Location l, LocationType type) {
-            switch (type)
-            {
-                case PICK:
-                    pickLocation = l;
-                    break;
-                    
-                case ALIGN:
-                    alignLocation = l;
-                    break;
-                    
-                case PLACE:
-                    placeLocation = l;
-                    break;
-            }
-        }
-        
         public PlannedPlacement(Nozzle nozzle, NozzleTip nozzleTip, JobPlacement jobPlacement) {
             this.nozzle = nozzle;
             this.nozzleTip = nozzleTip;

--- a/src/main/java/org/openpnp/spi/PnpJobPlanner.java
+++ b/src/main/java/org/openpnp/spi/PnpJobPlanner.java
@@ -19,7 +19,18 @@ public interface PnpJobPlanner {
         private Location placeLocation; // location the part will be place to
 
         public enum LocationType {
-            PICK, ALIGN, PLACE, NONE;   // location type, used to return one of [pick|align|place]Location
+            PICK("pick"), ALIGN("alignment"), PLACE("place");   // location type, used to return one of [pick|align|place]Location
+            
+            private final String name;
+            
+            LocationType(String name) {
+                this.name = name;
+            }
+            
+            @Override
+            public String toString() {
+                return name;
+            }
         }
         
         // return the location of given type
@@ -37,10 +48,6 @@ public interface PnpJobPlanner {
                     
                 case PLACE:
                     l = placeLocation;
-                    break;
-                    
-                case NONE:
-                    l = null;
                     break;
             }
             
@@ -61,10 +68,6 @@ public interface PnpJobPlanner {
                     
                 case PLACE:
                     placeLocation = l;
-                    break;
-                    
-                case NONE:
-                    l = null;
                     break;
             }
         }


### PR DESCRIPTION
# Description
This PR is a rewrite of PR #1574 by transforming the optimization into steps which are inserted into the workflow of the JobProcessor. sortLocation is removed from PnpJobPlanner and [pick|align|place]location added. This locations are precalculated in the plan() step and then used for the individual optimizations via a getter and an enum for selection.

# Justification
The old implementation was not clean and did not provide the option to extend the optimization by taking the next location into account.

# Instructions for Use
There is no change compared to PR #1574 exception that the optimization is a little better now because the next location is taken into account. Therefore jobs shall process a little faster now.

This is documentation for a user, not for a developer.

# Implementation Details
1. How did you test the change? Be descriptive. Untested code will not be accepted. **using a real job in a simulation machine**
2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)? **yes**
3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing. **yes: I removes PnpJobPlanner from PlannedPlacement and added other locations which are precalculated and then used for the optimization**
4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted. **yes**
