### PR TITLE
add an option to automatically load the most recent job

### DIFF
--- a/src/main/java/org/openpnp/gui/JobPanel.java
+++ b/src/main/java/org/openpnp/gui/JobPanel.java
@@ -461,6 +461,14 @@ public class JobPanel extends JPanel {
 
                 machine.getPnpJobProcessor().addTextStatusListener(textStatusListener);
 
+                if (machine.isAutoLoadMostRecentJob()) {
+                    // try to load the most recent job
+                    if (recentJobs.size() > 0) {
+                        File file = recentJobs.get(0);
+                        loadJobExec(file);
+                    }
+                }
+
                 // Create an empty Job if one is not loaded
                 if (getJob() == null) {
                     setJob(new Job());
@@ -837,10 +845,7 @@ public class JobPanel extends JPanel {
                     return;
                 }
                 File file = new File(new File(fileDialog.getDirectory()), fileDialog.getFile());
-                Job job = configuration.loadJob(file);
-                setJob(job);
-                addRecentJob(file);
-                mainFrame.getFeedersTab().updateView();
+                loadJobExec(file);
             }
             catch (Exception e) {
                 e.printStackTrace();
@@ -1641,10 +1646,7 @@ public class JobPanel extends JPanel {
                 return;
             }
             try {
-                Job job = configuration.loadJob(file);
-                setJob(job);
-                addRecentJob(file);
-                mainFrame.getFeedersTab().updateView();
+                loadJobExec(file);
             }
             catch (Exception e) {
                 e.printStackTrace();
@@ -1652,6 +1654,19 @@ public class JobPanel extends JPanel {
                         Translations.getString("JobPanel.Action.Job.RecentJobs.ErrorBox.Title"), e.getMessage()); //$NON-NLS-1$
             }
         }
+    }
+
+    /**
+     * Perform all action required to load a job from a given file
+     * 
+     * @param file job to load
+     * @throws Exception
+     */
+    private void loadJobExec(File file) throws Exception {
+        Job job = configuration.loadJob(file);
+        setJob(job);
+        addRecentJob(file);
+        mainFrame.getFeedersTab().updateView();
     }
 
     private final MachineListener machineListener = new MachineListener.Adapter() {

--- a/src/main/java/org/openpnp/gui/JobPanel.java
+++ b/src/main/java/org/openpnp/gui/JobPanel.java
@@ -461,17 +461,26 @@ public class JobPanel extends JPanel {
 
                 machine.getPnpJobProcessor().addTextStatusListener(textStatusListener);
 
-                if (machine.isAutoLoadMostRecentJob()) {
-                    // try to load the most recent job
-                    if (recentJobs.size() > 0) {
-                        File file = recentJobs.get(0);
-                        loadJobExec(file);
-                    }
-                }
-
                 // Create an empty Job if one is not loaded
                 if (getJob() == null) {
                     setJob(new Job());
+                }
+
+                if (machine.isAutoLoadMostRecentJob()) {
+                    // try to load the most recent job
+                    if (recentJobs.size() > 0) {
+                        // execute the auto-load from within the UI thread
+                        SwingUtilities.invokeLater(() -> {
+                            File file = recentJobs.get(0);
+                            try {
+                                loadJobExec(file);
+                            } catch (Exception e) {
+                                // in case of error, log it and set an empty job
+                                Logger.warn("Loading recent job {} failed: {}", file.getName(), e.getMessage());
+                                setJob(new Job());
+                            }
+                        });
+                    }
                 }
             }
         });

--- a/src/main/java/org/openpnp/gui/JobPanel.java
+++ b/src/main/java/org/openpnp/gui/JobPanel.java
@@ -454,6 +454,7 @@ public class JobPanel extends JPanel {
         loadRecentJobs();
 
         Configuration.get().addListener(new ConfigurationListener.Adapter() {
+            // FYI: this listener is executed asynchronously
             public void configurationComplete(Configuration configuration) throws Exception {
                 Machine machine = configuration.getMachine();
 

--- a/src/main/java/org/openpnp/gui/JobPanel.java
+++ b/src/main/java/org/openpnp/gui/JobPanel.java
@@ -461,26 +461,17 @@ public class JobPanel extends JPanel {
 
                 machine.getPnpJobProcessor().addTextStatusListener(textStatusListener);
 
-                // Create an empty Job if one is not loaded
-                if (getJob() == null) {
-                    setJob(new Job());
-                }
-
                 if (machine.isAutoLoadMostRecentJob()) {
                     // try to load the most recent job
                     if (recentJobs.size() > 0) {
-                        // execute the auto-load from within the UI thread
-                        SwingUtilities.invokeLater(() -> {
-                            File file = recentJobs.get(0);
-                            try {
-                                loadJobExec(file);
-                            } catch (Exception e) {
-                                // in case of error, log it and set an empty job
-                                Logger.warn("Loading recent job {} failed: {}", file.getName(), e.getMessage());
-                                setJob(new Job());
-                            }
-                        });
+                        File file = recentJobs.get(0);
+                        loadJobExec(file);
                     }
+                }
+
+                // Create an empty Job if one is not loaded
+                if (getJob() == null) {
+                    setJob(new Job());
                 }
             }
         });

--- a/src/main/java/org/openpnp/machine/reference/ReferenceMachine.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceMachine.java
@@ -155,6 +155,9 @@ public class ReferenceMachine extends AbstractMachine {
     private boolean poolScriptingEngines = false;
 
     @Element(required = false)
+    private boolean autoLoadMostRecentJob = false;
+
+    @Element(required = false)
     private Solutions solutions = new Solutions();
 
     @Deprecated // now in the Solutions object.
@@ -343,7 +346,14 @@ public class ReferenceMachine extends AbstractMachine {
         this.poolScriptingEngines = poolScriptingEngines;
     }
 
+    public boolean isAutoLoadMostRecentJob() {
+        return autoLoadMostRecentJob;
+    }
 
+    public void setAutoLoadMostRecentJob(boolean autoLoadMostRecentJob) {
+        this.autoLoadMostRecentJob = autoLoadMostRecentJob;
+    }
+    
     @Override
     public Wizard getConfigurationWizard() {
         return new ReferenceMachineConfigurationWizard(this);

--- a/src/main/java/org/openpnp/machine/reference/wizards/ReferenceMachineConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/wizards/ReferenceMachineConfigurationWizard.java
@@ -28,6 +28,8 @@ import com.jgoodies.forms.layout.RowSpec;
 
 public class ReferenceMachineConfigurationWizard extends AbstractConfigurationWizard {
 
+    private static final long serialVersionUID = 1L;
+    
     private final ReferenceMachine machine;
     private JCheckBox checkBoxHomeAfterEnabled;
     private String motionPlannerClassName;
@@ -46,6 +48,7 @@ public class ReferenceMachineConfigurationWizard extends AbstractConfigurationWi
     private JTextField unsafeZRoamingDistance;
     private JCheckBox parkAfterHomed;
     private JCheckBox poolScriptingEngines;
+    private JCheckBox autoLoadMostRecentJob;
 
     public ReferenceMachineConfigurationWizard(ReferenceMachine machine) {
         this.machine = machine;
@@ -63,6 +66,8 @@ public class ReferenceMachineConfigurationWizard extends AbstractConfigurationWi
                 FormSpecs.RELATED_GAP_COLSPEC,
                 ColumnSpec.decode("default:grow"),},
             new RowSpec[] {
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
                 FormSpecs.RELATED_GAP_ROWSPEC,
                 FormSpecs.DEFAULT_ROWSPEC,
                 FormSpecs.RELATED_GAP_ROWSPEC,
@@ -133,7 +138,13 @@ public class ReferenceMachineConfigurationWizard extends AbstractConfigurationWi
         poolScriptingEngines = new JCheckBox("");
         panelGeneral.add(poolScriptingEngines, "4, 14");
 
-                JPanel panelLocations = new JPanel();
+        JLabel lblAutoLoadMostRecentJob = new JLabel("Auto-load most recent job?");
+        panelGeneral.add(lblAutoLoadMostRecentJob, "2, 16, right, default");
+
+        autoLoadMostRecentJob = new JCheckBox("");
+        panelGeneral.add(autoLoadMostRecentJob, "4, 16");
+
+        JPanel panelLocations = new JPanel();
         panelLocations.setBorder(new TitledBorder(null, Translations.getString(
                 "ReferenceMachineConfigurationWizard.PanelLocations.Border.title"), //$NON-NLS-1$
                 TitledBorder.LEADING, TitledBorder.TOP, null, null));
@@ -241,6 +252,7 @@ public class ReferenceMachineConfigurationWizard extends AbstractConfigurationWi
         addWrappedBinding(this, "motionPlannerClassName", motionPlannerClass, "selectedItem");
 
         addWrappedBinding(machine, "poolScriptingEngines", poolScriptingEngines, "selected");
+        addWrappedBinding(machine, "autoLoadMostRecentJob", autoLoadMostRecentJob, "selected");
 
         MutableLocationProxy discardLocation = new MutableLocationProxy();
         bind(UpdateStrategy.READ_WRITE, machine, "discardLocation", discardLocation, "location");

--- a/src/main/java/org/openpnp/spi/Machine.java
+++ b/src/main/java/org/openpnp/spi/Machine.java
@@ -397,4 +397,9 @@ public interface Machine extends WizardConfigurable, PropertySheetHolder, Closea
      * @return True if scripting engines should be pooled for faster reuse.
      */
     public boolean isPoolScriptingEngines();
+
+    /**
+     * @return True if automatic loading of most recent job at start has been enabled.
+     */
+    public boolean isAutoLoadMostRecentJob();
 }


### PR DESCRIPTION
# Description
This PR provides auto-loading of the most recent job on startup on request.

If the new configuration option "Auto-load most recent job?" on the Configuration tab of the machine is enabled and there are known recent jobs, the most recent one will be loaded automatically. Per default this option is disabled.

# Justification
At least with debugging is tedious to always load the same job to test with. And if OpenPnP starts with the "Untitled.job.xml" anyhow, why not load the most recent one, which is known to have some meaning for the user anyhow.

This is documentation for a user, not for a developer.

# Implementation Details
1. How did you test the change? Be descriptive. Untested code will not be accepted. **I used it while developing other code**
2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)? **yes**
3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing. **yes: isAutoLoadMostRecenetJob() was added to Machine.java to read the state of the configuration option from within JobPanel.java**
4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted. **yes**
