### PR TITLE
Feature/BambooFeederAutoVision

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ hs_err*
 
 .vscode/
 /src/main/resources/org/openpnp/translations.properties.bak
+.DS_Store

--- a/src/main/java/org/openpnp/machine/pandaplacer/AbstractPandaplacerVisionFeeder.java
+++ b/src/main/java/org/openpnp/machine/pandaplacer/AbstractPandaplacerVisionFeeder.java
@@ -1,0 +1,797 @@
+/*
+ * Copyright (C) 2024 <pandaplacer.ca@gmail.com>
+ * based on the ReferencePushPullFeeder
+ * Copyright (C) 2020 <mark@makr.zone>
+ * based on the ReferenceLeverFeeder
+ * Copyright (C) 2011 Jason von Nieda <jason@vonnieda.org>
+ *
+ * This file is part of OpenPnP.
+ *
+ * OpenPnP is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * OpenPnP is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with OpenPnP. If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * For more information about OpenPnP visit http://openpnp.org
+ */
+
+package org.openpnp.machine.pandaplacer;
+
+import org.openpnp.ConfigurationListener;
+import org.openpnp.machine.reference.ReferenceFeeder;
+import org.openpnp.model.Configuration;
+import org.openpnp.model.Length;
+import org.openpnp.model.LengthUnit;
+import org.openpnp.model.Location;
+import org.openpnp.spi.Camera;
+import org.openpnp.spi.Head;
+import org.openpnp.spi.Machine;
+import org.openpnp.spi.MachineListener;
+import org.openpnp.util.FeederVisionHelper;
+import org.openpnp.util.MovableUtils;
+import org.openpnp.util.FeederVisionHelper;
+import org.openpnp.util.FeederVisionHelper.FindFeaturesMode;
+import org.openpnp.vision.pipeline.CvPipeline;
+import org.pmw.tinylog.Logger;
+import org.simpleframework.xml.Attribute;
+import org.simpleframework.xml.Element;
+
+public abstract class AbstractPandaplacerVisionFeeder extends ReferenceFeeder {
+
+    // Rotation of the part within the feeder (i.e. within the tape)
+    // This is compatible with tonyluken's PR #943 or a similar solution.
+    // Conversely, feeder.location.rotation contains the orientation of the feeder itself
+    // and it defines the local feeder coordinate system. The rotationInFeeder here can be removed
+    // once it is inherited.
+    @Attribute(required=false)
+    protected Double rotationInFeeder = 0.0;
+
+    @Attribute(required = false)
+    protected boolean normalizePickLocation = true;
+
+    @Attribute(required = false)
+    protected boolean snapToAxis = false;
+
+    @Element(required = false)
+    protected Location hole1Location = new Location(LengthUnit.Millimeters);
+    @Element(required = false)
+    protected Location hole2Location = new Location(LengthUnit.Millimeters);
+
+    @Element(required = false)
+    private Length partPitch = new Length(4, LengthUnit.Millimeters);
+    @Element(required = false)
+    private Length feedPitch = new Length(4, LengthUnit.Millimeters);
+
+
+    @Attribute(required = false)
+    private long feedCount = 0;
+
+    public enum PipelineType {
+        ColorKeyed("Default"),
+        CircularSymmetry("CircularSymmetry");
+
+        public String tag;
+
+        PipelineType(String tag) {
+            this.tag = tag;
+        }
+    }
+
+    @Element(required = false)
+    private CvPipeline pipeline = createDefaultPipeline(PipelineType.ColorKeyed);
+    @Attribute(required = false)
+    protected PipelineType pipelineType = PipelineType.ColorKeyed;
+
+    @Element(required = false)
+    private Length precisionWanted = new Length(0.1, LengthUnit.Millimeters);
+
+    @Attribute(required = false)
+    private int calibrationCount = 0;
+    @Element(required = false)
+    private Length sumOfErrors = new Length(0, LengthUnit.Millimeters);
+    @Element(required = false)
+    private Length sumOfErrorSquares = new Length(0, LengthUnit.Millimeters);
+
+
+    // These are not on the GUI but can be tweaked in the machine.xml /////////////////
+
+    // initial calibration tolerance, i.e. how much the feeder can be shifted physically
+    @Attribute(required = false)
+    protected double calibrationToleranceMm = 1.95;
+    // vision and comparison sprocket hole tolerance (in size, position)
+    @Attribute(required = false)
+    protected double sprocketHoleToleranceMm = 0.6;
+
+    @Attribute(required = false)
+    protected int calibrateMaxPasses = 3;
+    // how close the camera has to be to prevent one more pass
+    @Attribute(required = false)
+    protected double calibrateToleranceMm = 0.3;
+    @Attribute(required = false)
+    protected int calibrateMinStatistic = 2;
+
+    // Some EIA 481 standard constants.
+    static final double sprocketHoleDiameterMm = 1.5;
+    static final double sprocketHolePitchMm = 4;
+
+    /*
+     * visionOffset contains the difference between where the part was expected to be and where it
+     * is. Subtracting these offsets from the pickLocation produces the correct pick location.
+     */
+    protected Location visionOffset;
+
+    public enum CalibrationTrigger {
+        None,
+        OnFirstUse,
+        UntilConfident,
+        OnEachTapeFeed
+    }
+
+    @Attribute(required = false)
+    protected CalibrationTrigger calibrationTrigger = CalibrationTrigger.UntilConfident;
+
+    public static final Location nullLocation = new Location(LengthUnit.Millimeters);
+
+    static final private String xmlDefaultPipeline = "<cv-pipeline>\n"
+        + "   <stages>\n"
+        + "      <cv-stage class=\"org.openpnp.vision.pipeline.stages.ImageRead\" name=\"00\" enabled=\"false\" file=\"test.png\"/>\n"
+        + "      <cv-stage class=\"org.openpnp.vision.pipeline.stages.ImageCapture\" name=\"0\" enabled=\"true\" settle-first=\"true\" count=\"1\"/>\n"
+        + "      <cv-stage class=\"org.openpnp.vision.pipeline.stages.BlurGaussian\" name=\"1\" enabled=\"true\" kernel-size=\"5\"/>\n"
+        + "      <cv-stage class=\"org.openpnp.vision.pipeline.stages.AffineWarp\" name=\"11\" enabled=\"true\" length-unit=\"Millimeters\" x-0=\"0.0\" y-0=\"0.0\" x-1=\"0.0\" y-1=\"0.0\" x-2=\"0.0\" y-2=\"0.0\" scale=\"1.0\" rectify=\"true\" region-of-interest-property=\"regionOfInterest\"/>\n"
+        + "      <cv-stage class=\"org.openpnp.vision.pipeline.stages.ConvertColor\" name=\"12\" enabled=\"true\" conversion=\"Bgr2Gray\"/>\n"
+        + "      <cv-stage class=\"org.openpnp.vision.pipeline.stages.HistogramEqualizeAdaptive\" name=\"13\" enabled=\"false\" channels-to-equalize=\"First\" clip-limit=\"2.0\" number-of-tile-rows=\"1\" number-of-tile-cols=\"1\"/>\n"
+        + "      <cv-stage class=\"org.openpnp.vision.pipeline.stages.ImageRecall\" name=\"20\" enabled=\"true\" image-stage-name=\"1\"/>\n"
+        + "      <cv-stage class=\"org.openpnp.vision.pipeline.stages.MaskCircle\" name=\"21\" enabled=\"true\" diameter=\"600\"/>\n"
+        + "      <cv-stage class=\"org.openpnp.vision.pipeline.stages.ConvertColor\" name=\"22\" enabled=\"true\" conversion=\"Bgr2HsvFull\"/>\n"
+        + "      <cv-stage class=\"org.openpnp.vision.pipeline.stages.Normalize\" name=\"23\" enabled=\"false\"/>\n"
+        + "      <cv-stage class=\"org.openpnp.vision.pipeline.stages.MaskHsv\" name=\"24\" enabled=\"true\" auto=\"false\" fraction-to-mask=\"0.0\" hue-min=\"240\" hue-max=\"130\" saturation-min=\"110\" saturation-max=\"255\" value-min=\"10\" value-max=\"255\" invert=\"false\" binary-mask=\"true\"/>\n"
+        + "      <cv-stage class=\"org.openpnp.vision.pipeline.stages.BlurMedian\" name=\"25\" enabled=\"true\" kernel-size=\"13\"/>\n"
+        + "      <cv-stage class=\"org.openpnp.vision.pipeline.stages.FindContours\" name=\"27\" enabled=\"true\" retrieval-mode=\"List\" approximation-method=\"Simple\"/>\n"
+        + "      <cv-stage class=\"org.openpnp.vision.pipeline.stages.FilterContours\" name=\"28\" enabled=\"true\" contours-stage-name=\"27\" min-area=\"1000.0\" max-area=\"100000.0\"/>\n"
+        + "      <cv-stage class=\"org.openpnp.vision.pipeline.stages.FitEllipseContours\" name=\"results\" enabled=\"true\" contours-stage-name=\"28\"/>\n"
+        + "      <cv-stage class=\"org.openpnp.vision.pipeline.stages.ImageRecall\" name=\"30\" enabled=\"true\" image-stage-name=\"0\"/>\n"
+        + "      <cv-stage class=\"org.openpnp.vision.pipeline.stages.DrawEllipses\" name=\"31\" enabled=\"false\" ellipses-stage-name=\"results\" thickness=\"2\"/>\n"
+        + "   </stages>\n"
+        + "</cv-pipeline>";
+    static final private String xmlCircularSymmetryPipeline = "<cv-pipeline>\n"
+        + "   <stages>\n"
+        + "      <cv-stage class=\"org.openpnp.vision.pipeline.stages.ImageCapture\" name=\"0\" enabled=\"true\" default-light=\"true\" settle-first=\"true\" count=\"1\"/>\n"
+        + "      <cv-stage class=\"org.openpnp.vision.pipeline.stages.ImageWriteDebug\" name=\"deb0\" enabled=\"false\" prefix=\"push_pull_\" suffix=\".png\"/>\n"
+        + "      <cv-stage class=\"org.openpnp.vision.pipeline.stages.BlurGaussian\" name=\"1\" enabled=\"true\" kernel-size=\"5\"/>\n"
+        + "      <cv-stage class=\"org.openpnp.vision.pipeline.stages.AffineWarp\" name=\"2\" enabled=\"true\" length-unit=\"Millimeters\" x-0=\"0.0\" y-0=\"0.0\" x-1=\"0.0\" y-1=\"0.0\" x-2=\"0.0\" y-2=\"0.0\" scale=\"1.0\" rectify=\"true\" region-of-interest-property=\"regionOfInterest\"/>\n"
+        + "      <cv-stage class=\"org.openpnp.vision.pipeline.stages.ConvertColor\" name=\"3\" enabled=\"true\" conversion=\"Bgr2Gray\"/>\n"
+        + "      <cv-stage class=\"org.openpnp.vision.pipeline.stages.ImageRecall\" name=\"5\" enabled=\"true\" image-stage-name=\"0\"/>\n"
+        + "      <cv-stage class=\"org.openpnp.vision.pipeline.stages.DetectCircularSymmetry\" name=\"results\" enabled=\"true\" min-diameter=\"10\" max-diameter=\"100\" max-distance=\"100\" max-target-count=\"10\" min-symmetry=\"1.2\" corr-symmetry=\"0.2\" property-name=\"sprocketHole\" outer-margin=\"0.3\" inner-margin=\"0.1\" sub-sampling=\"8\" super-sampling=\"1\" symmetry-score=\"RingMedianVarianceVsRingVarianceSum\" diagnostics=\"false\"/>\n"
+        + "      <cv-stage class=\"org.openpnp.vision.pipeline.stages.ImageRecall\" name=\"7\" enabled=\"false\" image-stage-name=\"0\"/>\n"
+        + "      <cv-stage class=\"org.openpnp.vision.pipeline.stages.DrawCircles\" name=\"8\" enabled=\"false\" circles-stage-name=\"results\" thickness=\"1\">\n"
+        + "         <color r=\"255\" g=\"0\" b=\"0\" a=\"255\"/>\n"
+        + "      </cv-stage>\n"
+        + "      <cv-stage class=\"org.openpnp.vision.pipeline.stages.ImageWriteDebug\" name=\"deb1\" enabled=\"false\" prefix=\"push_pull_result_\" suffix=\".png\"/>\n"
+        + "   </stages>\n"
+        + "</cv-pipeline>";
+
+
+    public void checkHomedState(Machine machine) {
+        if (!machine.isHomed()) {
+            this.resetCalibration();
+        }
+    }
+
+    public AbstractPandaplacerVisionFeeder() {
+        Configuration.get().addListener(new ConfigurationListener.Adapter() {
+            @Override
+            public void configurationComplete(Configuration configuration) throws Exception {
+                // Listen to the machine become unhomed to invalidate feeder calibration.
+                // Note that home()  first switches the machine isHomed() state off, then on again,
+                // so we also catch re-homing.
+                Configuration.get().getMachine().addListener(new MachineListener.Adapter() {
+
+                    @Override
+                    public void machineHeadActivity(Machine machine, Head head) {
+                        checkHomedState(machine);
+                    }
+
+                    @Override
+                    public void machineEnabled(Machine machine) {
+                        checkHomedState(machine);
+                    }
+                });
+            }
+        });
+    }
+
+    public Camera getCamera() throws Exception {
+        return  Configuration.get()
+                .getMachine()
+                .getDefaultHead()
+                .getDefaultCamera();
+    }
+
+    public void assertCalibrated(boolean tapeFeed) throws Exception {
+        if (getHole1Location().convertToUnits(LengthUnit.Millimeters).getLinearDistanceTo(getHole2Location()) < 3) {
+            throw new Exception("Feeder "+getName()+" sprocket hole locations undefined/too close together.");
+        }
+        if ((visionOffset == null && calibrationTrigger != CalibrationTrigger.None)
+                || (tapeFeed && calibrationTrigger == CalibrationTrigger.UntilConfident && !isPrecisionSufficient())
+                || (tapeFeed && calibrationTrigger == CalibrationTrigger.OnEachTapeFeed)) {
+            // not yet calibrated (enough)
+            obtainCalibratedVisionOffset();
+            if (visionOffset == null) {
+                // no lock obtained
+                throw new Exception(String.format("Vision failed on feeder %s.", getName()));
+            }
+        }
+    }
+
+    public boolean isPrecisionSufficient() {
+        if (calibrationCount < calibrateMinStatistic) {
+            return false;
+        }
+        else if (getPrecisionConfidenceLimit().divide(getPrecisionWanted()) > 1.0) {
+            return false;
+        }
+        return true;
+    }
+
+    public boolean isVisionEnabled() {
+        return calibrationTrigger != CalibrationTrigger.None;
+    }
+
+    @Override
+    public Location getPickLocation() throws Exception {
+        // Numbers are 1-based (a feed is needed before the very first part can be picked),
+        // therefore the modulo calculation is a bit gnarly.
+        // The 1-based approach has the benefit, that at feed count 0 (reset) the part closest to the reel
+        // is the pick location which is the last part in a multi-part feed cycle, which is the one we want for setup.
+        long partInCycle = ((getFeedCount()+getPartsPerFeedCycle()-1) % getPartsPerFeedCycle())+1;
+        return getPickLocation(partInCycle, visionOffset);
+    }
+
+//    // Inherited from ReferenceFeeder. Actual feeders will implement this
+//    @Override
+//    public void feed(Nozzle nozzle) throws Exception {
+//    }
+
+    public void ensureCameraZ(Camera camera, boolean setZ) throws Exception {
+        if (camera.isUnitsPerPixelAtZCalibrated()
+                && !getLocation().getLengthZ().isInitialized()) {
+            throw new Exception("Feeder "+getName()+": Please set the Pick Location Z coordinate first, "
+                    + "it is required to determine the true scale of the camera view for accurate computer vision.");
+        }
+        if (setZ && getLocation().getLengthZ().isInitialized()) {
+            // If we already have the Feeder Z, move the camera there to get the right units per pixel.
+            camera.moveTo(camera.getLocation().deriveLengths(null, null, getLocation().getLengthZ(), null));
+        }
+    }
+
+
+    protected void obtainCalibratedVisionOffset() throws Exception {
+        Camera camera = getCamera();
+        try (CvPipeline pipeline = getCvPipeline(camera, true, false)) {
+            performVisionOperations(camera, pipeline, false, false, true);
+        }
+    }
+
+    @Override
+    public String toString() {
+        return String.format("%s id %s", getClass().getName(), id);
+    }
+
+    @Override
+    public void setLocation(Location location) {
+        super.setLocation(location);
+        resetCalibration();
+    }
+
+    public Double getRotationInFeeder() {
+        if (rotationInFeeder == null) {
+            rotationInFeeder = 0.0;
+        }
+        return rotationInFeeder;
+    }
+
+    public void setRotationInFeeder(Double rotationInFeeder) {
+        Object oldValue = this.rotationInFeeder;
+        this.rotationInFeeder = rotationInFeeder;
+        firePropertyChange("rotationInFeeder", oldValue, rotationInFeeder);
+    }
+
+    public boolean isNormalizePickLocation() {
+        return normalizePickLocation;
+    }
+
+    public void setNormalizePickLocation(boolean normalizePickLocation) {
+        Object oldValue = this.normalizePickLocation;
+        this.normalizePickLocation = normalizePickLocation;
+        firePropertyChange("normalizePickLocation", oldValue, normalizePickLocation);
+    }
+
+    public boolean isSnapToAxis() {
+        return snapToAxis;
+    }
+
+    public void setSnapToAxis(boolean snapToAxis) {
+        Object oldValue = this.snapToAxis;
+        this.snapToAxis = snapToAxis;
+        firePropertyChange("snapToAxis", oldValue, snapToAxis);
+    }
+
+    public Location getHole1Location() {
+        return hole1Location;
+    }
+
+    public void setHole1Location(Location hole1Location) {
+        Object oldValue = this.hole1Location;
+        this.hole1Location = hole1Location;
+        firePropertyChange("hole1Location", oldValue, hole1Location);
+        resetCalibration();
+    }
+
+    public Location getHole2Location() {
+        return hole2Location;
+    }
+
+    public void setHole2Location(Location hole2Location) {
+        Object oldValue = this.hole2Location;
+        this.hole2Location = hole2Location;
+        firePropertyChange("hole2Location", oldValue, hole2Location);
+        resetCalibration();
+    }
+
+    public Length getPartPitch() {
+        return partPitch;
+    }
+
+    public void setPartPitch(Length partPitch) {
+        Object oldValue = this.partPitch;
+        this.partPitch = partPitch;
+        firePropertyChange("partPitch", oldValue, partPitch);
+    }
+
+    public Length getFeedPitch() {
+        return feedPitch;
+    }
+
+    public void setFeedPitch(Length feedPitch) {
+        Object oldValue = this.feedPitch;
+        this.feedPitch = feedPitch;
+        firePropertyChange("feedPitch", oldValue, feedPitch);
+    }
+
+
+    public long getFeedCount() {
+        return feedCount;
+    }
+
+    public void setFeedCount(long feedCount) {
+        long oldValue = this.feedCount;
+        this.feedCount = feedCount;
+        firePropertyChange("feedCount", oldValue, feedCount);
+    }
+
+    public CalibrationTrigger getCalibrationTrigger() {
+        return calibrationTrigger;
+    }
+
+    public void setCalibrationTrigger(CalibrationTrigger calibrationTrigger) {
+        Object oldValue = this.calibrationTrigger;
+        this.calibrationTrigger = calibrationTrigger;
+        firePropertyChange("calibrationTrigger", oldValue, calibrationTrigger);
+    }
+
+
+    public Length getPrecisionWanted() {
+        return precisionWanted;
+    }
+
+    public void setPrecisionWanted(Length precisionWanted) {
+        Object oldValue = this.precisionWanted;
+        this.precisionWanted = precisionWanted;
+        firePropertyChange("precisionWanted", oldValue, precisionWanted);
+    }
+
+    public int getCalibrationCount() {
+        return calibrationCount;
+    }
+
+    public void setCalibrationCount(int calibrationCount) {
+        int oldValue = this.calibrationCount;
+        Length oldPrecision = getPrecisionAverage();
+        Length oldConfidence = getPrecisionConfidenceLimit();
+        this.calibrationCount = calibrationCount;
+        firePropertyChange("calibrationCount", oldValue, calibrationCount);
+        if (oldValue !=  calibrationCount) {
+            // this also implicitly changes the stats
+            firePropertyChange("precisionAverage", oldPrecision, getPrecisionAverage());
+            firePropertyChange("precisionConfidenceLimit", oldConfidence, getPrecisionConfidenceLimit());
+        }
+    }
+
+    public Length getSumOfErrors() {
+        return sumOfErrors;
+    }
+
+    public void addCalibrationError(Length error) {
+        sumOfErrors = sumOfErrors.add(error);
+        // this is a bit dodgy as the true unit is actually the length unit squared, but we'll use the square root of that later, so it will be fine.
+        error = error.convertToUnits(sumOfErrorSquares.getUnits());
+        sumOfErrorSquares = sumOfErrorSquares.add(error.multiply(error.getValue()));
+        setCalibrationCount(getCalibrationCount()+1); // will also fire average and confidence prop change
+    }
+
+    public Length getPrecisionAverage() {
+        return calibrationCount > 0 ?
+                sumOfErrors.multiply(1.0/calibrationCount)
+                : new Length(0, LengthUnit.Millimeters);
+    }
+
+    public void setPrecisionAverage(Length precisionAverage) {
+        // swallow this
+    }
+
+    public Length getPrecisionConfidenceLimit() {
+        if (calibrationCount >= 2) {
+            // Note, we don't take the average of the error, because the error is already a distance that is distributed
+            // around the true sprocket holes center location i.e. distributed around zero i.e. zero is the mean
+            // (this is limited math knowledge speaking).
+            Length variance = sumOfErrorSquares.multiply(1.0/(calibrationCount-1));
+            Length scatter = new Length(Math.sqrt(variance.getValue()/Math.sqrt(calibrationCount)), variance.getUnits());
+            return scatter.multiply(1.64); // 95% confidence interval, normal distribution.
+        }
+        else {
+            return new Length(0, LengthUnit.Millimeters);
+        }
+    }
+
+    public void setPrecisionConfidenceLimit(Length precisionConfidenceLimit) {
+        // swallow this
+    }
+
+    public Length getPartsToSprocketHoleDistance() {
+        return new Length(getLocation().getLinearDistanceToLineSegment(getHole1Location(), getHole2Location()),
+                getLocation().getUnits());
+    }
+
+    public long getPartsPerFeedCycle() {
+        long feedsPerPart = (long)Math.ceil(getPartPitch().divide(getFeedPitch()));
+        return Math.round(1*Math.ceil(feedsPerPart*getFeedPitch().divide(getPartPitch())));
+    }
+
+    public void resetCalibrationStatistics() {
+        sumOfErrors = new Length(0, LengthUnit.Millimeters);
+        sumOfErrorSquares = new Length(0, LengthUnit.Millimeters);
+        setCalibrationCount(0);
+        resetCalibration();
+    }
+
+    public static Location forwardTransform(Location location, Location transform) {
+        return location.rotateXy(transform.getRotation()).addWithRotation(transform);
+    }
+
+    public static Location backwardTransform(Location location, Location transform) {
+        return location.subtractWithRotation(transform).rotateXy(-transform.getRotation());
+    }
+
+    protected Location getTransform(Location visionOffset) {
+        // Our local feeder coordinate system is relative to the EIA 481 standard tape orientation
+        // i.e. with the sprocket holes on top and the tape advancing to the right, which is our +X
+        // The pick location is on [0, 0] local, which corresponds to feeder.location global.
+        // The feeder.location.rotation contains the orientation of the tape on the machine.
+
+        // to make sure we get the right rotation, we update it from the sprocket holes
+        // instead of trusting the location.rotation. This might happen when the user fiddles
+        // with the locations manually.
+
+        Location unitVector = getHole1Location().unitVectorTo(getHole2Location());
+        if (!(Double.isFinite(unitVector.getX()) && Double.isFinite(unitVector.getY()))) {
+            // Catch (yet) undefined hole locations.
+            unitVector = new Location(getHole1Location().getUnits(), 0, 1, 0, 0);
+        }
+        double rotationTape = Math.atan2(unitVector.getY(), unitVector.getX())*180.0/Math.PI;
+        Location transform = getLocation().derive(null, null, null, rotationTape);
+        if (Math.abs(rotationTape - getLocation().getRotation()) > 0.1) {
+            // HACK: something is not up-to-date -> refresh
+            setLocation(transform);
+        }
+
+        if (visionOffset != null) {
+            transform = transform.subtractWithRotation(visionOffset);
+        }
+        return transform;
+    }
+
+    protected Location transformFeederToMachineLocation(Location feederLocation, Location visionOffset) {
+        return forwardTransform(feederLocation, getTransform(visionOffset));
+    }
+
+    protected Location transformMachineToFeederLocation(Location machineLocation, Location visionOffset) {
+        return backwardTransform(machineLocation, getTransform(visionOffset));
+    }
+
+    public Location getPickLocation(long partInCycle, Location visionOffset)  {
+        // If the feeder is advancing more than one part per feed cycle (e.g. with 2mm pitch tape or if a multiplier is
+        // given), we need to cycle through multiple pick locations. partInCycle is 1-based and goes to getPartsPerFeedCycle().
+        long offsetPitches = (getPartsPerFeedCycle() - partInCycle) % getPartsPerFeedCycle();
+        Location feederLocation = new Location(partPitch.getUnits(), partPitch.multiply((double)offsetPitches).getValue(),
+                0, 0, getRotationInFeeder());
+        Location machineLocation = transformFeederToMachineLocation(feederLocation, visionOffset);
+        return machineLocation;
+    }
+
+
+    public CvPipeline getPipeline() {
+        return pipeline;
+    }
+
+    public void setPipeline(CvPipeline pipeline) {
+        this.pipeline = pipeline;
+    }
+
+    public PipelineType getPipelineType() {
+        return pipelineType;
+    }
+
+    public void setPipelineType(PipelineType pipelineType) {
+        Object oldValue = this.pipelineType;
+        this.pipelineType = pipelineType;
+        firePropertyChange("pipelineType", oldValue, pipelineType);
+    }
+
+    public Location getVisionOffset() {
+        if (isVisionEnabled() && visionOffset != null) {
+            return visionOffset;
+        }
+        else {
+            return Location.origin;
+        }
+    }
+
+    public void setVisionOffset(Location visionOffset) {
+        this.visionOffset = visionOffset;
+    }
+
+    public void resetCalibration() {
+        setVisionOffset(null);
+    }
+
+    public void resetPipeline(PipelineType type) {
+        pipeline = createDefaultPipeline(type);
+        setPipelineType(type);
+    }
+
+    public Location getNominalVisionLocation() throws Exception {
+        if (!(hole1Location.isInitialized() && hole2Location.isInitialized())) {
+            // not yet initialized, just return the current camera location
+            return getCamera().getLocation();
+        }
+        else {
+            ensureCameraZ(getCamera(), false);
+            return getHole1Location().add(getHole2Location()).multiply(0.5)
+                    .deriveLengths(null, null, getLocation().getLengthZ(),
+                            getLocation().getRotation()+getRotationInFeeder());
+        }
+    }
+
+
+    public CvPipeline getCvPipeline(Camera camera, boolean clone, boolean autoSetup) {
+        try {
+            CvPipeline pipeline = getPipeline();
+            if (clone) {
+                pipeline = pipeline.clone();
+            }
+            pipeline.setProperty("camera", camera);
+            pipeline.setProperty("feeder", this);
+            pipeline.setProperty("sprocketHole.diameter", new Length(sprocketHoleDiameterMm, LengthUnit.Millimeters));
+            Length range;
+            if (autoSetup) {
+                // Auto-Setup: search Range is half camera.
+                Location upp = camera.getUnitsPerPixelAtZ();
+                range = camera.getWidth() > camera.getHeight() ?
+                        upp.getLengthY().multiply(camera.getHeight()/2)
+                        : upp.getLengthX().multiply(camera.getWidth()/2);
+            }
+            else {
+                // Normal mode: search range is half the distance between the holes plus one pitch.
+                range = getHole1Location().getLinearLengthTo(getHole2Location())
+                        .multiply(0.5)
+                        .add(new Length(sprocketHolePitchMm, LengthUnit.Millimeters));
+            }
+            pipeline.setProperty("sprocketHole.maxDistance", range);
+
+            return pipeline;
+        }
+        catch (CloneNotSupportedException e) {
+            throw new Error(e);
+        }
+    }
+
+
+    // Note: ReferencePushPullFeeder has different pipelines that include OCR.
+    protected CvPipeline createDefaultPipeline(PipelineType type) {
+        try {
+            String xml = (type == PipelineType.CircularSymmetry) ? xmlCircularSymmetryPipeline : xmlDefaultPipeline;
+            return new CvPipeline(xml);
+        }
+        catch (Exception e) {
+            throw new Error(e);
+        }
+    }
+
+    public void showFeatures() throws Exception {
+        Camera camera = getCamera();
+        ensureCameraZ(camera, true);
+        try (CvPipeline pipeline = getCvPipeline(camera, true, true)) {
+
+            // Process vision and show feature without applying anything
+            pipeline.process();
+            FeederVisionHelper tape = new FeederVisionHelper(camera, pipeline, 2000, null);
+            tape.findFeatures(normalizePickLocation, snapToAxis, partPitch, feedPitch, location, hole1Location, hole2Location, calibrationToleranceMm, sprocketHoleToleranceMm);
+        }
+    }
+
+    public void autoSetup() throws Exception {
+        Camera camera = getCamera();
+        if (calibrationTrigger == CalibrationTrigger.None) {
+            // Just assume the user wants it now
+            setCalibrationTrigger(CalibrationTrigger.UntilConfident);
+        }
+
+        ensureCameraZ(camera, true);
+        // Try with cloned pipeline.
+        Exception e = autoSetupPipeline(camera, null);
+        if (e != null) {
+            Logger.debug(e, "Auto-Setup: exception");
+            // Failed, try with pipeline type defaults.
+            for (PipelineType type : PipelineType.values()) {
+                Logger.debug("Auto-Setup: trying with stock pipeline type "+type);
+                e = autoSetupPipeline(camera, type);
+                if (e == null) {
+                    // Success.
+                    Logger.debug(e, "Auto-Setup: success");
+                    return;
+                }
+                Logger.debug(e, "Auto-Setup: exception");
+            }
+            // Still no luck, throw.
+            Logger.debug(e, "Auto-Setup: final exception");
+            throw e;
+        }
+    }
+
+    protected Exception autoSetupPipeline(Camera camera, PipelineType type) {
+        if (type != null) {
+            resetPipeline(type);
+        }
+        try (CvPipeline pipeline = getCvPipeline(camera, true, true)) {
+            // Process vision and get some features
+            pipeline.process();
+            FeederVisionHelper feature = new FeederVisionHelper(camera, pipeline, 2000, FindFeaturesMode.FromPickLocationGetHoles)
+                    .findFeatures(normalizePickLocation, snapToAxis, partPitch, feedPitch, location, hole1Location, hole2Location, calibrationToleranceMm, sprocketHoleToleranceMm);
+            // Store the initial vision based results
+            setLocation(feature.getCalibratedPickLocation());
+            setHole1Location(feature.getCalibratedHole1Location());
+            setHole2Location(feature.getCalibratedHole2Location());
+            setRotationInFeeder(feature.getCalibratedRotationInFeeder());
+            // As we've changed all this -> reset any stats
+            resetCalibrationStatistics();
+            try {
+                // Now run a sprocket hole calibration, make sure to change the part (not swap it)
+                performVisionOperations(camera, pipeline, true, true, false);
+            }
+            finally {
+                // Move the camera back to the pick location, including when there is an exception.
+                MovableUtils.moveToLocationAtSafeZ(camera, getLocation());
+                MovableUtils.fireTargetedUserAction(camera);
+            }
+            return null;
+        }
+        catch (Exception e) {
+            return e;
+        }
+    }
+
+    @Override
+    public Location getJobPreparationLocation() {
+        if (visionOffset == null
+            && (calibrationTrigger != CalibrationTrigger.None)) {
+            return getPickLocation(0, null);
+        }
+        else {
+            return null;
+        }
+    }
+
+    @Override
+    public void prepareForJob(boolean visit) throws Exception {
+        super.prepareForJob(visit);
+        if (visit && visionOffset == null) {
+            if (calibrationTrigger != CalibrationTrigger.None) {
+                // Calibrate the feeder.
+              performSprocketCalibration();
+            }
+            else {
+                assertCalibrated(false);
+            }
+        }
+    }
+
+
+    public void performSprocketCalibration() throws Exception {
+        Camera camera = getCamera();
+        try (CvPipeline pipeline = getCvPipeline(camera, true, false)) {
+            // run a sprocket hole calibration
+            performVisionOperations(camera, pipeline, false, false, true);
+        }
+    }
+
+
+    protected void performVisionOperations(Camera camera, CvPipeline pipeline,
+            boolean storeHoles, boolean storePickLocation, boolean storeVisionOffset) throws Exception {
+        Location runningHole1Location = getHole1Location();
+        Location runningHole2Location = getHole2Location();
+        Location runningPickLocation = getLocation();
+        Double   runningRotationInFeeder = getRotationInFeeder();
+        Location runningVisionOffset = getVisionOffset();
+        ensureCameraZ(camera, true);
+
+        FeederVisionHelper feature = null;
+
+        if (storeHoles || storePickLocation || storeVisionOffset) {
+            // Calibrate the exact hole locations by obtaining a mid-point lock on them,
+            // assuming that any camera lens and Z parallax distortion is symmetric.
+            for (int i = 0; i < calibrateMaxPasses; i++) {
+                // move the camera to the mid-point
+                Location midPoint = runningHole1Location.add(runningHole2Location).multiply(0.5, 0.5, 0, 0)
+                        .derive(camera.getLocation(), false, false, true, false)
+                        .derive(null, null, null, runningPickLocation.getRotation()+getRotationInFeeder());
+                Logger.debug("calibrating sprocket holes pass "+ i+ " midPoint is "+midPoint);
+                MovableUtils.moveToLocationAtSafeZ(camera, midPoint);
+                // take a new shot
+                pipeline.process();
+                feature = new FeederVisionHelper(camera, pipeline, 2000, FindFeaturesMode.CalibrateHoles)
+                        .findFeatures(storePickLocation, storeVisionOffset, partPitch, feedPitch, location, hole1Location, hole2Location);
+                runningHole1Location = feature.getCalibratedHole1Location();
+                runningHole2Location = feature.getCalibratedHole2Location();
+                runningPickLocation = feature.getCalibratedPickLocation();
+                runningRotationInFeeder = feature.getCalibratedRotationInFeeder();
+                // calculate the worst pick location delta this gives, cycle part 1 is the worst as it is farthest away
+                Location uncalibratedPick1Location = getPickLocation(1, runningVisionOffset);
+                Location calibratedPick1Location = getPickLocation(1, feature.getCalibratedVisionOffset());
+                Length error = calibratedPick1Location.getLinearLengthTo(uncalibratedPick1Location);
+                Logger.trace("new vision offset "+feature.getCalibratedVisionOffset()
+                        +" vs. previous vision offset "+runningVisionOffset+" results in error "+error+" at the (farthest) pick location");
+                // store data if requested
+                if (storeHoles) {
+                    setHole1Location(runningHole1Location);
+                    setHole2Location(runningHole2Location);
+                }
+                if (storePickLocation) {
+                    setLocation(runningPickLocation);
+                    setRotationInFeeder(runningRotationInFeeder);
+                }
+                if (storeVisionOffset) {
+                    // update the stats
+                    if (visionOffset != null) {
+                        // Only when a previous vision offset has been stored, should we store the error
+                        // because the feeder might have been moved physically. The user's actions are
+                        // not part of the calibration error. :-)
+                        addCalibrationError(error);
+                    }
+                    setVisionOffset(feature.getCalibratedVisionOffset());
+                }
+                // is it good enough? Compare with running offset.
+                if (error.convertToUnits(LengthUnit.Millimeters).getValue() < calibrateToleranceMm) {
+                    break;
+                }
+                runningVisionOffset = feature.getCalibratedVisionOffset();
+            }
+        }
+    }
+
+}

--- a/src/main/java/org/openpnp/machine/pandaplacer/BambooFeederAutoVision.java
+++ b/src/main/java/org/openpnp/machine/pandaplacer/BambooFeederAutoVision.java
@@ -1,0 +1,262 @@
+/*
+ * Copyright (C) 2024 <pandaplacer.ca@gmail.com>
+ * based on the ReferencePushPullFeeder
+ * Copyright (C) 2020 <mark@makr.zone>
+ * based on the ReferenceLeverFeeder
+ * Copyright (C) 2011 Jason von Nieda <jason@vonnieda.org>
+ *
+ * This file is part of OpenPnP.
+ *
+ * OpenPnP is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * OpenPnP is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with OpenPnP. If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * For more information about OpenPnP visit http://openpnp.org
+ */
+
+package org.openpnp.machine.pandaplacer;
+
+import javax.swing.Action;
+import org.openpnp.ConfigurationListener;
+import org.openpnp.gui.support.PropertySheetWizardAdapter;
+import org.openpnp.gui.support.Wizard;
+import org.openpnp.model.Configuration;
+import org.openpnp.spi.Actuator;
+import org.openpnp.spi.Head;
+import org.openpnp.spi.Machine;
+import org.openpnp.spi.MachineListener;
+import org.openpnp.spi.Nozzle;
+import org.openpnp.spi.PropertySheetHolder;
+import org.openpnp.util.MovableUtils;
+import org.pmw.tinylog.Logger;
+import org.simpleframework.xml.Attribute;
+import org.simpleframework.xml.core.Persist;
+
+public class BambooFeederAutoVision extends AbstractPandaplacerVisionFeeder {
+
+    @Attribute(required=false)
+    private String feedActuatorName;
+    protected Actuator feedActuator;
+
+    @Attribute(required=false)
+    protected double feedActuatorValue;
+
+    @Attribute(required=false)
+    private String postPickActuatorName;
+    protected Actuator postPickActuator;
+
+    @Attribute(required=false)
+    protected double postPickActuatorValue;
+
+    @Attribute(required=false)
+    protected boolean moveBeforeFeed = false;
+
+    public String getFeedActuatorName() {
+        return feedActuatorName;
+    }
+
+    public Actuator getFeedActuator() {
+        return this.feedActuator;
+    }
+
+    public void setFeedActuator(Actuator feedActuator) {
+        Object oldValue = this.feedActuator;
+        this.feedActuator = feedActuator;
+        firePropertyChange("feedActuator", oldValue, feedActuator);
+
+//        Object oldValue2 = this.feedActuatorName;
+        feedActuatorName = (feedActuator == null ? null : feedActuator.getName());
+//        firePropertyChange("feedActuatorName", oldValue2, feedActuatorName);
+    }
+
+    public double getFeedActuatorValue() {
+        return feedActuatorValue;
+    }
+
+    public void setFeedActuatorValue(double feedActuatorValue) {
+        this.feedActuatorValue = feedActuatorValue;
+    }
+
+    public String getPostPickActuatorName() {
+        return postPickActuatorName;
+    }
+
+    public Actuator getPostPickActuator() {
+        return this.postPickActuator;
+    }
+
+    public void setPostPickActuator(Actuator postPickActuator) {
+        Object oldValue = this.postPickActuator;
+        this.postPickActuator = postPickActuator;
+        firePropertyChange("postPickActuator", oldValue, postPickActuator);
+
+//        Object oldValue2 = this.postPickActuatorName;
+        postPickActuatorName = (postPickActuator == null ? null : postPickActuator.getName());
+//        firePropertyChange("postPickActuatorName", oldValue2, postPickActuatorName);
+    }
+
+    public double getPostPickActuatorValue() {
+        return postPickActuatorValue;
+    }
+
+    public void setPostPickActuatorValue(double postPickActuatorValue) {
+        this.postPickActuatorValue = postPickActuatorValue;
+    }
+
+    public boolean isMoveBeforeFeed() {
+    return moveBeforeFeed;
+  }
+
+  public void setMoveBeforeFeed(boolean moveBeforeFeed) {
+    this.moveBeforeFeed = moveBeforeFeed;
+  }
+
+
+  public BambooFeederAutoVision() {
+
+        Configuration.get().addListener(new ConfigurationListener.Adapter() {
+            @Override
+            public void configurationComplete(Configuration configuration) throws Exception {
+                // Resolve the actuators by name (legacy way).
+                Machine machine = Configuration.get().getMachine();
+                try {
+                    feedActuator = machine.getActuatorByName(feedActuatorName);
+                }
+                catch (Exception e) {
+                }
+                try {
+                  postPickActuator = machine.getActuatorByName(postPickActuatorName);
+                }
+                catch (Exception e) {
+                }
+                // Listen to the machine become unhomed to invalidate feeder calibration.
+                // Note that home()  first switches the machine isHomed() state off, then on again,
+                // so we also catch re-homing.
+                Configuration.get().getMachine().addListener(new MachineListener.Adapter() {
+
+                    @Override
+                    public void machineHeadActivity(Machine machine, Head head) {
+                        checkHomedState(machine);
+                    }
+
+                    @Override
+                    public void machineEnabled(Machine machine) {
+                        checkHomedState(machine);
+                    }
+                });
+            }
+        });
+
+  }
+
+  @Persist
+  private void persist() {
+    // Make sure the newest names are persisted (legacy way).
+    feedActuatorName = (feedActuator == null ? null : feedActuator.getName());
+    postPickActuatorName = (postPickActuator == null ? null : postPickActuator.getName());
+  }
+
+  // inherited from ReferenceFeeder
+  @Override
+  public void feed(Nozzle nozzle) throws Exception {
+      if (isMoveBeforeFeed()) {
+          MovableUtils.moveToLocationAtSafeZ(nozzle, getPickLocation().derive(null, null, Double.NaN, null));
+      }
+
+      Logger.debug("feed({})", nozzle);
+
+      Head head = nozzle.getHead();
+
+      if (getFeedCount() % getPartsPerFeedCycle() == 0) {
+          // Modulo of feed count is zero - no more parts there to pick, must feed
+
+          // Make sure we're calibrated
+          assertCalibrated(false);
+
+          long feedsPerPart = (long)Math.ceil(getPartPitch().divide(getFeedPitch()));
+          long n = feedsPerPart;
+          for (long i = 0; i < n; i++) {  // perform multiple feed actuations if required
+            // Actuate the tape once for the length equal to Tape Pitch
+            feedTape(nozzle, getFeedPitch().getValue());
+          }
+
+          head.moveToSafeZ();
+          // Make sure we're calibrated after type feed
+          assertCalibrated(true);
+      }
+      else {
+          Logger.debug("Multi parts feed: skipping tape feed at feed count " + getFeedCount());
+      }
+
+      // increment feed count
+      setFeedCount(getFeedCount()+1);
+  }
+
+  private void feedTape(Nozzle nozzle, Double feedPitch) throws Exception {
+    if (feedActuatorName == null || feedActuatorName.equals("")) {
+      throw new Exception("No actuatorName specified for feeder " + getName());
+        }
+        Actuator actuator = nozzle.getHead().getActuatorByName(feedActuatorName);
+        if (actuator == null) {
+            actuator = Configuration.get().getMachine().getActuatorByName(feedActuatorName);
+        }
+        if (actuator == null) {
+            throw new Exception("Feed failed. Unable to find an actuator named " + feedActuatorName);
+        }
+        // Note by using the Object generic method, the value will be properly interpreted according to actuator.valueType.
+        actuator.actuate((Object)feedActuatorValue);
+  }
+
+  @Override
+    public void postPick(Nozzle nozzle) throws Exception {
+        if (postPickActuatorName == null || postPickActuatorName.equals("")) {
+          Logger.debug("Post pick cancelled. Actuator not set for feeder " + getName());
+            return;
+        }
+        Actuator actuator = nozzle.getHead().getActuatorByName(postPickActuatorName);
+        if (actuator == null) {
+            actuator = Configuration.get().getMachine().getActuatorByName(postPickActuatorName);
+        }
+        if (actuator == null) {
+            throw new Exception("Post pick failed. Unable to find an actuator named " + postPickActuatorName);
+        }
+        // Note by using the Object generic method, the value will be properly interpreted according to actuator.valueType.
+        actuator.actuate((Object)postPickActuatorValue);
+    }
+
+// standard wizard overrides
+    @Override
+    public Wizard getConfigurationWizard() {
+        return new BambooFeederAutoVisionConfigurationWizard(this);
+    }
+
+    @Override
+    public String getPropertySheetHolderTitle() {
+        return getClass().getSimpleName() + " " + getName();
+    }
+
+    @Override
+    public PropertySheet[] getPropertySheets() {
+        return new PropertySheet[] {
+                new PropertySheetWizardAdapter(getConfigurationWizard(), "Configuration"),
+        };
+    }
+
+    @Override
+    public PropertySheetHolder[] getChildPropertySheetHolders() {
+        return null;
+    }
+
+    @Override
+    public Action[] getPropertySheetHolderActions() {
+        return null;
+    }
+
+}

--- a/src/main/java/org/openpnp/machine/pandaplacer/BambooFeederAutoVisionConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/pandaplacer/BambooFeederAutoVisionConfigurationWizard.java
@@ -1,0 +1,794 @@
+/*
+ * Copyright (C) 2024 <pandaplacer.ca@gmail.com>
+ * based on the ReferencePushPullFeeder
+ * Copyright (C) 2020 <mark@makr.zone>
+ * based on the ReferenceLeverFeeder
+ * Copyright (C) 2011 Jason von Nieda <jason@vonnieda.org>
+ *
+ * This file is part of OpenPnP.
+ *
+ * OpenPnP is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * OpenPnP is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with OpenPnP. If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * For more information about OpenPnP visit http://openpnp.org
+ */
+
+package org.openpnp.machine.pandaplacer;
+
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import javax.swing.AbstractAction;
+import javax.swing.Action;
+import javax.swing.BoxLayout;
+import javax.swing.JButton;
+import javax.swing.JCheckBox;
+import javax.swing.JComboBox;
+import javax.swing.JDialog;
+import javax.swing.JLabel;
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+import javax.swing.JTextField;
+import javax.swing.border.TitledBorder;
+import org.jdesktop.beansbinding.AutoBinding.UpdateStrategy;
+import org.openpnp.gui.MainFrame;
+import org.openpnp.gui.components.ComponentDecorators;
+import org.openpnp.gui.components.LocationButtonsPanel;
+import org.openpnp.gui.support.ActuatorsComboBoxModel;
+import org.openpnp.gui.support.DoubleConverter;
+import org.openpnp.gui.support.Icons;
+import org.openpnp.gui.support.IntegerConverter;
+import org.openpnp.gui.support.LengthConverter;
+import org.openpnp.gui.support.LongConverter;
+import org.openpnp.gui.support.MutableLocationProxy;
+import org.openpnp.gui.support.NamedConverter;
+import org.openpnp.machine.reference.feeder.wizards.AbstractReferenceFeederConfigurationWizard;
+import org.openpnp.machine.pandaplacer.BambooFeederAutoVision;
+import org.openpnp.machine.pandaplacer.AbstractPandaplacerVisionFeeder.CalibrationTrigger;
+import org.openpnp.machine.pandaplacer.AbstractPandaplacerVisionFeeder.PipelineType;
+import org.openpnp.model.Configuration;
+import org.openpnp.spi.Actuator;
+import org.openpnp.spi.Camera;
+import org.openpnp.util.UiUtils;
+import org.openpnp.vision.pipeline.CvPipeline;
+import org.openpnp.vision.pipeline.ui.CvPipelineEditor;
+import org.openpnp.vision.pipeline.ui.CvPipelineEditorDialog;
+import org.pmw.tinylog.Logger;
+
+import com.jgoodies.forms.layout.ColumnSpec;
+import com.jgoodies.forms.layout.FormLayout;
+import com.jgoodies.forms.layout.FormSpecs;
+import com.jgoodies.forms.layout.RowSpec;
+
+@SuppressWarnings("serial")
+public class BambooFeederAutoVisionConfigurationWizard
+extends AbstractReferenceFeederConfigurationWizard {
+    private final BambooFeederAutoVision feeder;
+
+    public BambooFeederAutoVisionConfigurationWizard(BambooFeederAutoVision feeder) {
+        super(feeder, false);
+        this.feeder = feeder;
+
+        JPanel panelFields = new JPanel();
+        panelFields.setLayout(new BoxLayout(panelFields, BoxLayout.Y_AXIS));
+
+// Panel: Tape Settings
+        panelLocations = new JPanel();
+        panelLocations.setBorder(new TitledBorder(null, "Tape Settings", TitledBorder.LEADING,
+                TitledBorder.TOP, null, null));
+
+        panelTape = new JPanel();
+        panelFields.add(panelTape);
+        panelTape.setBorder(new TitledBorder(null, "Tape Settings", TitledBorder.LEADING, TitledBorder.TOP, null));
+        panelTape.setLayout(new FormLayout(new ColumnSpec[] {
+                FormSpecs.RELATED_GAP_COLSPEC,
+                FormSpecs.DEFAULT_COLSPEC,
+                FormSpecs.RELATED_GAP_COLSPEC,
+                FormSpecs.DEFAULT_COLSPEC,
+                FormSpecs.RELATED_GAP_COLSPEC,
+                FormSpecs.DEFAULT_COLSPEC,
+                FormSpecs.RELATED_GAP_COLSPEC,
+                FormSpecs.DEFAULT_COLSPEC,
+                FormSpecs.RELATED_GAP_COLSPEC,
+                FormSpecs.DEFAULT_COLSPEC,},
+            new RowSpec[] {
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,}));
+
+        lblPartPitch = new JLabel("Part Pitch");
+        panelTape.add(lblPartPitch, "2, 2, right, default");
+        lblPartPitch.setToolTipText("Pitch of the parts in the tape (2mm, 4mm, 8mm, 12mm, etc.)");
+
+        textFieldPartPitch = new JTextField();
+        panelTape.add(textFieldPartPitch, "4, 2");
+        textFieldPartPitch.setToolTipText("Pitch of the parts in the tape (2mm, 4mm, 8mm, 12mm, etc.)");
+        textFieldPartPitch.setColumns(5);
+
+        lblFeedPitch = new JLabel("Feed Pitch");
+        panelTape.add(lblFeedPitch, "6, 2, right, default");
+        lblFeedPitch.setToolTipText("How much the tape will be advanced by one lever actuation (usually multiples of 4mm)");
+
+        textFieldFeedPitch = new JTextField();
+        panelTape.add(textFieldFeedPitch, "8, 2");
+        textFieldFeedPitch.setToolTipText("How much the tape will be advanced by one lever actuation (usually multiples of 4mm)");
+        textFieldFeedPitch.setColumns(10);
+
+        btnDiscardParts = new JButton(discardPartsAction);
+        btnDiscardParts.setToolTipText("<html>Discard parts left over in the (multi-part) feed cycle.<br/>\r\nStarts with a fresh feed cycle including vision calibration (if enabled). \r\n</html>");
+        panelTape.add(btnDiscardParts, "10, 2");
+
+        lblRotation = new JLabel("Rotation in Tape");
+        panelTape.add(lblRotation, "2, 4, right, default");
+        lblRotation.setToolTipText("<html>Rotation of the part inside the tape as seen when the sprocket holes <br/>\r\nare on top. Your E-CAD part orientation is the reference.<br/>\r\nSee also: \r\n<ul>\r\n<li>EIA-481</li>\r\n<li>Component Zero Orientations for CAD Libraries</li>\r\n</ul>\r\n</html>");
+
+        textFieldRotationInTape = new JTextField();
+        panelTape.add(textFieldRotationInTape, "4, 4");
+        textFieldRotationInTape.setToolTipText("<html>\n<p>The <strong>Rotation in Tape</strong> setting must be interpreted relative to the tape's orientation, <br/>\nregardless of how the feeder/tape is oriented on the machine. </p>\n<ol>\n<li>\n<p>Look at the <strong>neutral</strong> upright orientation of the part package/footprint <br/>\nas drawn inside your E-CAD <strong>library</strong>.</p>\n</li>\n<li>\n<p>Note how pin 1, polarity, cathode etc. are oriented.  <br/>\nThis is your 0° for the part.</p>\n</li>\n<li>\n<p>Look at the tape so that the sprocket holes are at the top. <br/>\nThis is your 0° tape orientation (per EIA-481 industry standard).</p>\n</li>\n<li>\n<p>Determine how the part is rotated inside the tape pocket, <em>relative</em> from  <br/>\nits upright orientation in (1).  Positive rotation goes counter-clockwise.<br/>\nThis is your <strong>Rotation in Tape</strong>.</p>\n</li>\n</ol>\n</html>");
+        textFieldRotationInTape.setColumns(10);
+
+        lblFeedCount = new JLabel("Feed Count");
+        panelTape.add(lblFeedCount, "6, 4, right, default");
+        lblFeedCount.setToolTipText("Total feed count of the feeder.");
+
+        textFieldFeedCount = new JTextField();
+        panelTape.add(textFieldFeedCount, "8, 4");
+        textFieldFeedCount.setToolTipText("Total feed count of the feeder.");
+        textFieldFeedCount.setColumns(10);
+
+        btnReset = new JButton(resetFeedCountAction);
+        panelTape.add(btnReset, "10, 4");
+
+// Panel End: Tape Settings
+
+// Panel: Locations
+        panelLocations = new JPanel();
+        panelLocations.setBorder(new TitledBorder(null, "Locations", TitledBorder.LEADING,
+                TitledBorder.TOP, null, null));
+
+        panelFields.add(panelLocations);
+        panelLocations.setLayout(new FormLayout(new ColumnSpec[] {
+                FormSpecs.RELATED_GAP_COLSPEC,
+                FormSpecs.DEFAULT_COLSPEC,
+                FormSpecs.RELATED_GAP_COLSPEC,
+                FormSpecs.DEFAULT_COLSPEC,
+                FormSpecs.RELATED_GAP_COLSPEC,
+                ColumnSpec.decode("max(26dlu;default)"),
+                FormSpecs.RELATED_GAP_COLSPEC,
+                FormSpecs.DEFAULT_COLSPEC,
+                FormSpecs.RELATED_GAP_COLSPEC,
+                ColumnSpec.decode("left:min"),
+                FormSpecs.RELATED_GAP_COLSPEC,
+                FormSpecs.DEFAULT_COLSPEC,},
+            new RowSpec[] {
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,}));
+
+        btnShowVisionFeatures = new JButton(showVisionFeaturesAction);
+        btnShowVisionFeatures.setToolTipText("Preview the features recognized by Computer Vision.");
+        btnShowVisionFeatures.setText("Preview Vision Features");
+        panelLocations.add(btnShowVisionFeatures, "2, 2, default, fill");
+
+        btnAutoSetup = new JButton(autoSetupAction);
+        panelLocations.add(btnAutoSetup, "4, 2, 5, 1");
+
+        lblX_1 = new JLabel("X");
+        panelLocations.add(lblX_1, "4, 4");
+
+        lblY_1 = new JLabel("Y");
+        panelLocations.add(lblY_1, "6, 4");
+
+        lblZ_1 = new JLabel("Z");
+        panelLocations.add(lblZ_1, "8, 4");
+
+        lblPickLocation = new JLabel("Pick Location");
+        lblPickLocation.setToolTipText("<html>Pick Location of the part. If multiple are produced by a feed operation<br/>\r\nthis must be the last one picked i.e. the one closest to the the tape reel.</html>");
+        panelLocations.add(lblPickLocation, "2, 6, right, default");
+
+        textFieldPickLocationX = new JTextField();
+        panelLocations.add(textFieldPickLocationX, "4, 6");
+        textFieldPickLocationX.setColumns(10);
+
+        textFieldPickLocationY = new JTextField();
+        panelLocations.add(textFieldPickLocationY, "6, 6");
+        textFieldPickLocationY.setColumns(10);
+
+        textFieldPickLocationZ = new JTextField();
+        panelLocations.add(textFieldPickLocationZ, "8, 6");
+        textFieldPickLocationZ.setColumns(10);
+
+        locationButtonsPanelFirstPick = new LocationButtonsPanel(textFieldPickLocationX, textFieldPickLocationY, textFieldPickLocationZ, null);
+        panelLocations.add(locationButtonsPanelFirstPick, "10, 6");
+
+        lblNormalizePickLocation = new JLabel("Normalize?");
+        panelLocations.add(lblNormalizePickLocation, "2, 8, right, default");
+        lblNormalizePickLocation.setToolTipText("Normalize the pick location relative to the sprocket holes according to the EIA-481 standard.");
+
+        checkBoxNormalizePickLocation = new JCheckBox("");
+        panelLocations.add(checkBoxNormalizePickLocation, "4, 8");
+        checkBoxNormalizePickLocation.setSelected(true);
+        checkBoxNormalizePickLocation.setToolTipText("Normalize the pick location relative to the sprocket holes according to the EIA-481 standard.");
+
+        lblHole1Location = new JLabel("Hole 1 Location");
+        lblHole1Location.setToolTipText("<html>Choose Hole 1 closer to the tape reel.<br/>\r\nIf possible choose two holes that bracket the part(s) to be picked.\r\n</html>");
+        panelLocations.add(lblHole1Location, "2, 10, right, default");
+
+        textFieldHole1LocationX = new JTextField();
+        panelLocations.add(textFieldHole1LocationX, "4, 10");
+        textFieldHole1LocationX.setColumns(10);
+
+        textFieldHole1LocationY = new JTextField();
+        panelLocations.add(textFieldHole1LocationY, "6, 10");
+        textFieldHole1LocationY.setColumns(10);
+
+        locationButtonsPanelHole1 = new LocationButtonsPanel(textFieldHole1LocationX, textFieldHole1LocationY, (JTextField) null, (JTextField) null);
+        panelLocations.add(locationButtonsPanelHole1, "10, 10");
+
+        lblHole2Location = new JLabel("Hole 2 Location");
+        lblHole2Location.setToolTipText("<html>Choose Hole 2 further away from the tape reel.<br/>\r\nIf possible choose two holes that bracket the part(s) to be picked.\r\n</html>");
+        panelLocations.add(lblHole2Location, "2, 12, right, default");
+
+        textFieldHole2LocationX = new JTextField();
+        panelLocations.add(textFieldHole2LocationX, "4, 12");
+        textFieldHole2LocationX.setColumns(10);
+
+        textFieldHole2LocationY = new JTextField();
+        panelLocations.add(textFieldHole2LocationY, "6, 12");
+        textFieldHole2LocationY.setColumns(10);
+
+        locationButtonsPanelHole2 = new LocationButtonsPanel(textFieldHole2LocationX, textFieldHole2LocationY, (JTextField) null, (JTextField) null);
+        panelLocations.add(locationButtonsPanelHole2, "10, 12");
+
+        lblSnapToAxis = new JLabel("Snap to Axis?");
+        lblSnapToAxis.setToolTipText("Snap rows of sprocket holes to the Axis parallel.");
+        panelLocations.add(lblSnapToAxis, "2, 14, right, default");
+
+        checkBoxSnapToAxis = new JCheckBox("");
+        checkBoxSnapToAxis.setToolTipText("Snap rows of sprocket holes to the Axis parallel.");
+        panelLocations.add(checkBoxSnapToAxis, "4, 14");
+// Panel End: Locations
+
+
+// Panel: Vision
+        panelVision = new JPanel();
+        panelVision.setBorder(new TitledBorder(null, "Vision", TitledBorder.LEADING,
+                TitledBorder.TOP, null, null));
+        panelFields.add(panelVision);
+        panelVision.setLayout(new BoxLayout(panelVision, BoxLayout.Y_AXIS));
+
+        panelVisionEnabled = new JPanel();
+        panelVision.add(panelVisionEnabled);
+        panelVisionEnabled.setLayout(new FormLayout(new ColumnSpec[] {
+                FormSpecs.LABEL_COMPONENT_GAP_COLSPEC,
+                FormSpecs.DEFAULT_COLSPEC,
+                FormSpecs.RELATED_GAP_COLSPEC,
+                FormSpecs.DEFAULT_COLSPEC,
+                FormSpecs.RELATED_GAP_COLSPEC,
+                FormSpecs.DEFAULT_COLSPEC,
+                FormSpecs.RELATED_GAP_COLSPEC,
+                FormSpecs.DEFAULT_COLSPEC,
+                FormSpecs.RELATED_GAP_COLSPEC,
+                FormSpecs.DEFAULT_COLSPEC,
+                FormSpecs.RELATED_GAP_COLSPEC,
+                FormSpecs.DEFAULT_COLSPEC,
+                FormSpecs.RELATED_GAP_COLSPEC,
+                FormSpecs.DEFAULT_COLSPEC,},
+            new RowSpec[] {
+                FormSpecs.LINE_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,}));
+
+        lblCalibrationTrigger = new JLabel("Calibration Trigger");
+        panelVisionEnabled.add(lblCalibrationTrigger, "2, 2, right, default");
+
+        comboBoxCalibrationTrigger = new JComboBox(CalibrationTrigger.values());
+        panelVisionEnabled.add(comboBoxCalibrationTrigger, "4, 2");
+
+        lblPrecisionAverage = new JLabel("Precision Average");
+        lblPrecisionAverage.setToolTipText("Obtained precision average i.e. offset of the pick location, as detected by the calibration");
+        panelVisionEnabled.add(lblPrecisionAverage, "8, 2, right, default");
+
+        textFieldPrecisionAverage = new JTextField();
+        textFieldPrecisionAverage.setToolTipText("Obtained precision average i.e. offset of the pick location, as detected by the calibration");
+        textFieldPrecisionAverage.setEditable(false);
+        panelVisionEnabled.add(textFieldPrecisionAverage, "10, 2");
+        textFieldPrecisionAverage.setColumns(10);
+
+        lblCalibrationCount = new JLabel("Calibration Count");
+        panelVisionEnabled.add(lblCalibrationCount, "12, 2, right, default");
+
+        textFieldCalibrationCount = new JTextField();
+        textFieldCalibrationCount.setEditable(false);
+        panelVisionEnabled.add(textFieldCalibrationCount, "14, 2");
+        textFieldCalibrationCount.setColumns(10);
+
+        lblPrecisionWanted = new JLabel("Precision wanted");
+        lblPrecisionWanted.setToolTipText("Precision wanted i.e. the tolerable pick location offset");
+        panelVisionEnabled.add(lblPrecisionWanted, "2, 4, right, default");
+
+        textFieldPrecisionWanted = new JTextField();
+        textFieldPrecisionWanted.setToolTipText("Precision wanted i.e. the tolerable pick location offset");
+        panelVisionEnabled.add(textFieldPrecisionWanted, "4, 4");
+        textFieldPrecisionWanted.setColumns(10);
+
+        lblPrecisionConfidenceLimit = new JLabel("Precision Confidence Limit");
+        lblPrecisionConfidenceLimit.setToolTipText("Precision obtained with 95% confidence (assuming normal distribution)");
+        panelVisionEnabled.add(lblPrecisionConfidenceLimit, "8, 4, right, default");
+
+        textFieldPrecisionConfidenceLimit = new JTextField();
+        textFieldPrecisionConfidenceLimit.setEditable(false);
+        panelVisionEnabled.add(textFieldPrecisionConfidenceLimit, "10, 4");
+        textFieldPrecisionConfidenceLimit.setColumns(10);
+
+        btnResetStatistics = new JButton(resetStatisticsAction);
+        panelVisionEnabled.add(btnResetStatistics, "12, 4, 3, 1");
+
+        btnEditPipeline = new JButton(editPipelineAction);
+        btnEditPipeline.addActionListener(new ActionListener() {
+            public void actionPerformed(ActionEvent e) {
+            }
+        });
+        panelVisionEnabled.add(btnEditPipeline, "2, 6");
+
+        lblVisionType = new JLabel("Vision Type");
+        lblVisionType.setToolTipText("<html>\r\n<p>Choose the vision type, then press <strong>Reset Pipeline</strong> to assign the<br/>\r\ndefault pipeline of that type. Sprocket holes are detected as follows:</p>\r\n<ul>\r\n<li><strong>ColorKeyed</strong>: the background under the holes must be of a vivid color<br/>\r\n(green by default).</li>\r\n<li><strong>CircularSymmetry</strong>: the shape of the holes must be circular, their<br/>\r\ninside/outside must be plain.</li>\r\n</ul>\r\n<p>Both types of pipeline will further assess detected holes by size, alignment, pitch<br/>\r\nand expected distance.</p>\r\n</html>");
+        panelVisionEnabled.add(lblVisionType, "8, 6, right, default");
+
+        pipelineType = new JComboBox(PipelineType.values());
+
+        panelVisionEnabled.add(pipelineType, "10, 6, fill, default");
+
+        btnResetPipeline = new JButton(resetPipelineAction);
+        panelVisionEnabled.add(btnResetPipeline, "12, 6, 3, 1");
+
+// Panel End: Vision
+
+
+// Panel: Actuators
+        panelActuator = new JPanel();
+        panelActuator.setBorder(new TitledBorder(null,
+                "Actuators", TitledBorder.LEADING, TitledBorder.TOP, null));
+        panelFields.add(panelActuator);
+        panelActuator.setLayout(new FormLayout(new ColumnSpec[] {
+                FormSpecs.RELATED_GAP_COLSPEC,
+                FormSpecs.DEFAULT_COLSPEC,
+                FormSpecs.RELATED_GAP_COLSPEC,
+                ColumnSpec.decode("max(52dlu;default)"), //ColumnSpec.decode("default:grow"),
+                FormSpecs.RELATED_GAP_COLSPEC,
+                FormSpecs.DEFAULT_COLSPEC,
+                FormSpecs.RELATED_GAP_COLSPEC,
+                FormSpecs.DEFAULT_COLSPEC,
+                FormSpecs.RELATED_GAP_COLSPEC,
+                FormSpecs.DEFAULT_COLSPEC,},
+                new RowSpec[] {
+                        FormSpecs.RELATED_GAP_ROWSPEC,
+                        FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC,
+                        FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC,
+                        FormSpecs.DEFAULT_ROWSPEC,
+                        FormSpecs.RELATED_GAP_ROWSPEC,
+                        FormSpecs.DEFAULT_ROWSPEC,}));
+
+        lblActuator = new JLabel("Actuator");
+        panelActuator.add(lblActuator, "4, 2, left, default");
+
+        lblActuatorValue = new JLabel("Actuator Value");
+        panelActuator.add(lblActuatorValue, "6, 2, left, default");
+
+        lblFeed = new JLabel("Feed");
+        panelActuator.add(lblFeed, "2, 4, right, default");
+        lblFeed.setToolTipText("Select the actuator for the feed action");
+
+
+        comboBoxFeedActuator = new JComboBox();
+        comboBoxFeedActuator.setModel(new ActuatorsComboBoxModel(Configuration.get().getMachine()));
+        panelActuator.add(comboBoxFeedActuator, "4, 4, fill, default");
+        comboBoxFeedActuator.setToolTipText("Select the actuator for the feed action");
+
+
+        feedActuatorValue = new JTextField();
+        panelActuator.add(feedActuatorValue, "6, 4");
+        feedActuatorValue.setColumns(10);
+        feedActuatorValue.setToolTipText("<html>\r\n<p>For Duble: numerical value<br/>\r\nFor Boolean: 1 = True, 0 = False</p></html>");
+
+
+        btnTestFeedActuator = new JButton(testFeedActuatorAction);
+        panelActuator.add(btnTestFeedActuator, "8, 4");
+
+        lblPostPick = new JLabel("Post Pick");
+        panelActuator.add(lblPostPick, "2, 6, right, default");
+        lblPostPick.setToolTipText("<html>\r\n<p>Select the actuator for the post pick action<br/>\r\nThis is optional: blank selection will skip the post pick operation\r\n</p></html>");
+
+
+        comboBoxPostPickActuator = new JComboBox();
+        comboBoxPostPickActuator.setModel(new ActuatorsComboBoxModel(Configuration.get().getMachine()));
+        panelActuator.add(comboBoxPostPickActuator, "4, 6, fill, default");
+        comboBoxPostPickActuator.setToolTipText("<html>\r\n<p>Select the actuator for the post pick action<br/>\r\nThis is optional: blank selection will skip the post pick operation\r\n</p></html>");
+
+
+        postPickActuatorValue = new JTextField();
+        postPickActuatorValue.setColumns(10);
+        panelActuator.add(postPickActuatorValue, "6, 6");
+        postPickActuatorValue.setToolTipText("<html>\r\n<p>For Duble: numerical value<br/>\r\nFor Boolean: 1 = True, 0 = False</p></html>");
+
+
+        btnTestPostPickActuator = new JButton(testPostPickActuatorAction);
+        panelActuator.add(btnTestPostPickActuator, "8, 6");
+
+        lblMoveBeforeFeed = new JLabel("Move before feed");
+        panelActuator.add(lblMoveBeforeFeed, "2, 8, right, default");
+        lblMoveBeforeFeed.setToolTipText("Move nozzle to pick location before actuating the feed actuator");
+
+        ckBoxMoveBeforeFeed = new JCheckBox();
+        panelActuator.add(ckBoxMoveBeforeFeed, "4, 8, left, default");
+        ckBoxMoveBeforeFeed.setToolTipText("Move nozzle to pick location before actuating the feed actuator");
+
+// Panel End: Actuators
+
+        contentPanel.add(panelFields);
+        initDataBindings();
+    }
+
+    @Override
+    public void createBindings() {
+        super.createBindings();
+        LengthConverter lengthConverter = new LengthConverter();
+        IntegerConverter intConverter = new IntegerConverter();
+        LongConverter longConverter = new LongConverter();
+        DoubleConverter doubleConverter =
+                new DoubleConverter(Configuration.get().getLengthDisplayFormat());
+        actuatorConverter = (new NamedConverter<>(Configuration.get().getMachine().getActuators()));
+
+        MutableLocationProxy firstPickLocation = new MutableLocationProxy();
+        bind(UpdateStrategy.READ_WRITE, feeder, "location", firstPickLocation, "location");
+        addWrappedBinding(firstPickLocation, "lengthX", textFieldPickLocationX, "text",
+                lengthConverter);
+        addWrappedBinding(firstPickLocation, "lengthY", textFieldPickLocationY, "text",
+                lengthConverter);
+        addWrappedBinding(firstPickLocation, "lengthZ", textFieldPickLocationZ, "text",
+                lengthConverter);
+
+        addWrappedBinding(feeder, "normalizePickLocation", checkBoxNormalizePickLocation, "selected");
+
+        addWrappedBinding(feeder, "rotationInFeeder", textFieldRotationInTape, "text",
+                doubleConverter);
+
+        MutableLocationProxy hole1Location = new MutableLocationProxy();
+        bind(UpdateStrategy.READ_WRITE, feeder, "hole1Location", hole1Location, "location");
+        addWrappedBinding(hole1Location, "lengthX", textFieldHole1LocationX, "text",
+                lengthConverter);
+        addWrappedBinding(hole1Location, "lengthY", textFieldHole1LocationY, "text",
+                lengthConverter);
+
+        MutableLocationProxy hole2Location = new MutableLocationProxy();
+        bind(UpdateStrategy.READ_WRITE, feeder, "hole2Location", hole2Location, "location");
+        addWrappedBinding(hole2Location, "lengthX", textFieldHole2LocationX, "text",
+                lengthConverter);
+        addWrappedBinding(hole2Location, "lengthY", textFieldHole2LocationY, "text",
+                lengthConverter);
+
+        addWrappedBinding(feeder, "snapToAxis", checkBoxSnapToAxis, "selected");
+
+        addWrappedBinding(feeder, "partPitch", textFieldPartPitch, "text", lengthConverter);
+        addWrappedBinding(feeder, "feedPitch", textFieldFeedPitch, "text", lengthConverter);
+        addWrappedBinding(feeder, "feedCount", textFieldFeedCount, "text", longConverter);
+
+
+        addWrappedBinding(feeder, "calibrationTrigger", comboBoxCalibrationTrigger, "selectedItem");
+
+        addWrappedBinding(feeder, "precisionWanted", textFieldPrecisionWanted, "text", lengthConverter);
+        addWrappedBinding(feeder, "calibrationCount", textFieldCalibrationCount, "text", intConverter);
+        addWrappedBinding(feeder, "precisionAverage", textFieldPrecisionAverage, "text", lengthConverter);
+        addWrappedBinding(feeder, "precisionConfidenceLimit", textFieldPrecisionConfidenceLimit, "text", lengthConverter);
+
+        addWrappedBinding(feeder, "pipelineType", pipelineType, "selectedItem");
+
+        addWrappedBinding(feeder, "feedActuator", comboBoxFeedActuator, "selectedItem", actuatorConverter);
+        addWrappedBinding(feeder, "feedActuatorValue", feedActuatorValue, "text", doubleConverter);
+
+        addWrappedBinding(feeder, "postPickActuator", comboBoxPostPickActuator, "selectedItem", actuatorConverter);
+        addWrappedBinding(feeder, "postPickActuatorValue", postPickActuatorValue, "text", doubleConverter);
+
+        addWrappedBinding(feeder, "moveBeforeFeed", ckBoxMoveBeforeFeed, "selected");
+
+
+        ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldPickLocationX);
+        ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldPickLocationY);
+        ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldPickLocationZ);
+        ComponentDecorators.decorateWithAutoSelect(textFieldRotationInTape);
+        ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldHole1LocationX);
+        ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldHole1LocationY);
+        ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldHole2LocationX);
+        ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldHole2LocationY);
+        ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldPartPitch);
+        ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldFeedPitch);
+        ComponentDecorators.decorateWithAutoSelect(feedActuatorValue);
+        ComponentDecorators.decorateWithAutoSelect(postPickActuatorValue);
+    }
+
+    private Action editPipelineAction =
+            new AbstractAction("Edit Pipeline") {
+        {
+            putValue(Action.SHORT_DESCRIPTION,
+                    "Edit the Pipeline to be used for all vision operations of this feeder.");
+        }
+
+        @Override
+        public void actionPerformed(ActionEvent e) {
+            UiUtils.messageBoxOnException(() -> {
+                UiUtils.confirmMoveToLocationAndAct(
+                        getTopLevelAncestor(),
+                        "move the camera to the proper feeder vision location before editing the pipeline",
+                        feeder.getCamera(),
+                        feeder.getNominalVisionLocation(),
+                        true, () -> {
+                            editPipeline();
+                        });
+            });
+        }
+    };
+
+    private Action resetPipelineAction =
+            new AbstractAction("Reset Pipeline") {
+        {
+            putValue(Action.SHORT_DESCRIPTION,
+                    "Reset the Pipeline for this feeder to the selected type default.");
+        }
+
+        @Override
+        public void actionPerformed(ActionEvent e) {
+            PipelineType type = (PipelineType) pipelineType.getSelectedItem();
+            int result = JOptionPane.showConfirmDialog(getTopLevelAncestor(),
+                    "This will reset the pipeline to the "+type+" type default. Are you sure?",
+                    null, JOptionPane.YES_NO_OPTION, JOptionPane.WARNING_MESSAGE);
+            if (result == JOptionPane.YES_OPTION) {
+                applyAction.actionPerformed(null);
+                UiUtils.messageBoxOnException(() -> {
+                    feeder.resetPipeline(type);
+                });
+            }
+        }
+    };
+
+    private Action resetStatisticsAction =
+            new AbstractAction("Reset Statistics") {
+        {
+            putValue(Action.SHORT_DESCRIPTION,
+                    "Reset the average obtained precision statistics.");
+        }
+
+        @Override
+        public void actionPerformed(ActionEvent e) {
+            UiUtils.messageBoxOnException(() -> {
+                feeder.resetCalibrationStatistics();
+            });
+        }
+    };
+
+    private Action resetFeedCountAction =
+            new AbstractAction("Reset Feed Count") {
+        {
+            putValue(Action.SHORT_DESCRIPTION,
+                    "Reset the feed count e.g. when a tape has been changed.");
+        }
+
+        @Override
+        public void actionPerformed(ActionEvent e) {
+            int result = JOptionPane.showConfirmDialog(getTopLevelAncestor(),
+                    "This will reset the recorded feed count of this feeder. Are you sure?",
+                    null, JOptionPane.YES_NO_OPTION, JOptionPane.WARNING_MESSAGE);
+            if (result == JOptionPane.YES_OPTION) {
+                UiUtils.messageBoxOnException(() -> {
+                    // we apply this because it is OpenPNP custom to do so
+                    applyAction.actionPerformed(e);
+                    // set it back to 0
+                    feeder.setFeedCount(0);
+                });
+            }
+        }
+    };
+    private Action discardPartsAction =
+            new AbstractAction("Discard Parts") {
+        {
+            putValue(Action.SHORT_DESCRIPTION,
+                    "Discard parts that have been produced by the last tape transport.");
+        }
+
+        @Override
+        public void actionPerformed(ActionEvent e) {
+            UiUtils.messageBoxOnException(() -> {
+                // we apply this because it is OpenPNP custom to do so
+                applyAction.actionPerformed(e);
+                // round the feed count up to the next multiple of the parts per feed operation
+                feeder.setFeedCount(((feeder.getFeedCount()-1)/feeder.getPartsPerFeedCycle()+1)*feeder.getPartsPerFeedCycle());
+                feeder.resetCalibration();
+            });
+        }
+    };
+    private Action showVisionFeaturesAction =
+            new AbstractAction("Preview Vision Features") {
+        {
+            putValue(Action.SHORT_DESCRIPTION,
+                    "Preview the features recognized by Computer Vision.");
+        }
+
+        @Override
+        public void actionPerformed(ActionEvent e) {
+            UiUtils.submitUiMachineTask(() -> {
+                feeder.showFeatures();
+            });
+        }
+    };
+    private Action autoSetupAction =
+            new AbstractAction("Auto-Setup with Camera at Pick Location", Icons.captureCamera) {
+        {
+            putValue(Action.SHORT_DESCRIPTION,
+                    "<html>Center the camera on the pick location and press this button to Auto-Setup <br/>"
+                            +"If there are multiple picks per feed cycle, choose the one closest to the tape reel.</html>");
+        }
+
+        @Override
+        public void actionPerformed(ActionEvent e) {
+            UiUtils.messageBoxOnException(() -> {
+                int result;
+                if (!feeder.getLocation().multiply(1, 1, 0, 0).isInitialized()) {
+                    // if the feeder.location X, Y is zero, we assume this is a freshly created feeder
+                    result = JOptionPane.YES_OPTION;
+                }
+                else {
+                    // ask the user
+                    result = JOptionPane.showConfirmDialog(getTopLevelAncestor(),
+                            "<html>"
+                            + "<p>This may overwrite all your current settings. Are you sure?</p>"
+                            + "</html>",
+                            null, JOptionPane.YES_NO_OPTION, JOptionPane.WARNING_MESSAGE);
+                }
+                if (result == JOptionPane.YES_OPTION) {
+                    applyAction.actionPerformed(e);
+                    UiUtils.submitUiMachineTask(() -> {
+                        feeder.autoSetup();
+                    });
+                }
+            });
+        }
+    };
+
+    private Action testFeedActuatorAction = new AbstractAction("Test feed") {
+        @Override
+        public void actionPerformed(ActionEvent arg0) {
+            UiUtils.submitUiMachineTask(() -> {
+                if (feeder.getFeedActuatorName() == null || feeder.getFeedActuatorName().equals("")) {
+                  throw new Exception("No feedActuatorName specified for feeder " + feeder.getName() + ".");
+                }
+                Actuator actuator = Configuration.get().getMachine().getActuatorByName(feeder.getFeedActuatorName());
+
+                if (actuator == null) {
+                    throw new Exception("Feed failed. Unable to find an actuator named " + feeder.getFeedActuatorName());
+                }
+                // Use the generic Object method to interpret the value as the actuator.valueType.
+                actuator.actuate((Object)feeder.getFeedActuatorValue());
+            });
+        }
+    };
+
+    private Action testPostPickActuatorAction = new AbstractAction("Test post pick") {
+        @Override
+        public void actionPerformed(ActionEvent arg0) {
+            UiUtils.submitUiMachineTask(() -> {
+                if (feeder.getPostPickActuatorName() == null || feeder.getPostPickActuatorName().equals("")) {
+                  throw new Exception("No postPickActuatorName specified for feeder " + feeder.getName() + ".");
+                }
+                Actuator actuator = Configuration.get().getMachine().getActuatorByName(feeder.getPostPickActuatorName());
+
+                if (actuator == null) {
+                    throw new Exception("Feed failed. Unable to find an actuator named " + feeder.getPostPickActuatorName());
+                }
+                // Use the generic Object method to interpret the value as the actuator.valueType.
+                actuator.actuate((Object)feeder.getPostPickActuatorValue());
+            });
+        }
+    };
+
+    private void editPipeline() throws Exception {
+        Camera camera = feeder.getCamera();
+        CvPipeline pipeline = feeder.getCvPipeline(camera, false, true);
+        CvPipelineEditor editor = new CvPipelineEditor(pipeline);
+        JDialog dialog = new CvPipelineEditorDialog(MainFrame.get(), feeder.getName() + " Pipeline", editor);
+        dialog.setVisible(true);
+    }
+
+    protected void initDataBindings() {
+    }
+
+    private JLabel lblPartPitch;
+    private JTextField textFieldPartPitch;
+    private JTextField textFieldFeedPitch;
+    private JLabel lblFeedPitch;
+    private JPanel panelLocations;
+    private JPanel panelTape;
+    private JPanel panelVision;
+    private JPanel panelVisionEnabled;
+    private LocationButtonsPanel locationButtonsPanelFirstPick;
+    private LocationButtonsPanel locationButtonsPanelHole1;
+    private LocationButtonsPanel locationButtonsPanelHole2;
+    private JLabel lblZ_1;
+    private JLabel lblRotation;
+    private JLabel lblY_1;
+    private JLabel lblX_1;
+    private JLabel lblPickLocation;
+    private JTextField textFieldPickLocationX;
+    private JTextField textFieldPickLocationY;
+    private JTextField textFieldPickLocationZ;
+    private JTextField textFieldRotationInTape;
+    private JLabel lblHole1Location;
+    private JTextField textFieldHole1LocationX;
+    private JTextField textFieldHole1LocationY;
+    private JTextField textFieldHole2LocationX;
+    private JTextField textFieldHole2LocationY;
+    private JButton btnEditPipeline;
+    private JButton btnResetPipeline;
+    private JLabel lblFeedCount;
+    private JTextField textFieldFeedCount;
+    private JButton btnReset;
+    private JButton btnDiscardParts;
+    private JLabel lblHole2Location;
+    private JButton btnShowVisionFeatures;
+    private JButton btnAutoSetup;
+    private JLabel lblCalibrationTrigger;
+    private JComboBox comboBoxCalibrationTrigger;
+    private JLabel lblCalibrationCount;
+    private JTextField textFieldCalibrationCount;
+    private JLabel lblPrecisionAverage;
+    private JTextField textFieldPrecisionAverage;
+    private JLabel lblPrecisionWanted;
+    private JTextField textFieldPrecisionWanted;
+    private JButton btnResetStatistics;
+    private JLabel lblPrecisionConfidenceLimit;
+    private JTextField textFieldPrecisionConfidenceLimit;
+    private JLabel lblNormalizePickLocation;
+    private JCheckBox checkBoxNormalizePickLocation;
+    private JLabel lblSnapToAxis;
+    private JCheckBox checkBoxSnapToAxis;
+    private JComboBox pipelineType;
+    private JLabel lblVisionType;
+    private JLabel lblActuator;
+    private JLabel lblActuatorValue;
+    private JPanel panelActuator;
+    private JLabel lblFeed;
+    private JComboBox comboBoxFeedActuator;
+    private JTextField feedActuatorValue;
+    private JComboBox comboBoxPostPickActuator;
+    private JTextField postPickActuatorValue;
+    private JButton btnTestFeedActuator;
+    private JButton btnTestPostPickActuator;
+    private JCheckBox ckBoxMoveBeforeFeed;
+    private JLabel lblPostPick;
+    private JLabel lblMoveBeforeFeed;
+    private NamedConverter<Actuator> actuatorConverter;
+}

--- a/src/main/java/org/openpnp/machine/pandaplacer/README.md
+++ b/src/main/java/org/openpnp/machine/pandaplacer/README.md
@@ -1,0 +1,10 @@
+# Pandaplacer
+
+This section is dedicated to the Pandaplacer machines provided by https://pandaplacer.com
+
+## Pandaplacer A1 Features
+
+- **All Metal** - All moving parts are made of metal to ensure high rigidity. Precisely machined aluminum profiles and high precision linear rails ensure accuracy and durability.
+- **Compact Design** - Highly optimized space utilization providing up to 65 8mm feeder mounting positions in a small body size, about the size of a large 3D printer.
+- **Full Features** - Dual-Head with high precision nozzles, TMC stepper drivers, vacuum sensors, easy to install cables, low-cost feeders and controllers, auto nozzle change, spool holders, etc.
+- **Designed for OpenPnP** - OpenPnP is powerful and highly flexible software, free and open source, with great community support.

--- a/src/main/java/org/openpnp/machine/reference/ReferenceMachine.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceMachine.java
@@ -38,6 +38,7 @@ import org.openpnp.machine.neoden4.Neoden4Camera;
 import org.openpnp.machine.neoden4.Neoden4Feeder;
 import org.openpnp.machine.neoden4.Neoden4Signaler;
 import org.openpnp.machine.neoden4.Neoden4SwitcherCamera;
+import org.openpnp.machine.pandaplacer.BambooFeederAutoVision;
 import org.openpnp.machine.photon.PhotonFeeder;
 import org.openpnp.machine.rapidplacer.RapidFeeder;
 import org.openpnp.machine.reference.actuator.ThermistorToLinearSensorActuator;
@@ -447,6 +448,7 @@ public class ReferenceMachine extends AbstractMachine {
         l.add(RapidFeeder.class);
         l.add(Neoden4Feeder.class);
         l.add(PhotonFeeder.class);
+        l.add(BambooFeederAutoVision.class);
         l.addAll(registeredFeederClasses);
         return l;
     }

--- a/src/main/java/org/openpnp/util/FeederVisionHelper.java
+++ b/src/main/java/org/openpnp/util/FeederVisionHelper.java
@@ -60,13 +60,13 @@ import org.pmw.tinylog.Logger;
 
 public class FeederVisionHelper {
 
-	public enum FindFeaturesMode {
-	    FromPickLocationGetHoles,
-	    CalibrateHoles,
-	    CheckOnly
-	}
+    public enum FindFeaturesMode {
+      FromPickLocationGetHoles,
+      CalibrateHoles,
+      CheckOnly
+    }
 
-	// initial calibration tolerance, i.e. how much the feeder can be shifted physically 
+    // initial calibration tolerance, i.e. how much the feeder can be shifted physically
     private double calibrationToleranceMm = 1.95;
     // vision and comparison sprocket hole tolerance (in size, position)
     private double sprocketHoleToleranceMm = 0.6;
@@ -79,7 +79,7 @@ public class FeederVisionHelper {
     // tape parameters
     private boolean normalizePickLocation = true;
     private boolean snapToAxis = false;
-    
+
     private Location partLocation = new Location(LengthUnit.Millimeters);
     private Location hole1Location = new Location(LengthUnit.Millimeters);
     private Location hole2Location = new Location(LengthUnit.Millimeters);
@@ -87,12 +87,12 @@ public class FeederVisionHelper {
     private Length partPitch = new Length(4, LengthUnit.Millimeters);
     private Length feedPitch = new Length(4, LengthUnit.Millimeters);
 
-	
+
     private Camera camera;
     private CvPipeline pipeline;
     private long showResultMilliseconds;
     private FindFeaturesMode autoSetupMode;
-    
+
     private Location calibratedVisionOffset;
     private Location calibratedHole1Location;
     private Location calibratedHole2Location;
@@ -112,66 +112,66 @@ public class FeederVisionHelper {
         this.showResultMilliseconds = showResultMilliseconds;
         this.autoSetupMode = autoSetupMode;
     }
-    
+
     private void setTapeSpecs(boolean normalizePickLocation, boolean snapToAxis, Length partPitch, Length feedPitch, Location partLocation, Location hole1Location, Location hole2Location) {
-    	this.normalizePickLocation = normalizePickLocation;
-    	this.snapToAxis = snapToAxis;
-    	this.partPitch = partPitch;
-    	this.feedPitch = feedPitch;
-    	this.hole1Location = hole1Location;
-    	this.hole2Location = hole2Location;
-    	this.partLocation = partLocation;
+      this.normalizePickLocation = normalizePickLocation;
+      this.snapToAxis = snapToAxis;
+      this.partPitch = partPitch;
+      this.feedPitch = feedPitch;
+      this.hole1Location = hole1Location;
+      this.hole2Location = hole2Location;
+      this.partLocation = partLocation;
     }
-    
+
     private void setCalibrationTolerance(double calibrationToleranceMm, double sprocketHoleToleranceMm) {
-    	this.calibrationToleranceMm = calibrationToleranceMm;
-    	this.sprocketHoleToleranceMm = sprocketHoleToleranceMm;
+      this.calibrationToleranceMm = calibrationToleranceMm;
+      this.sprocketHoleToleranceMm = sprocketHoleToleranceMm;
 }
-    
+
     public long getPartsPerFeedCycle() {
         long feedsPerPart = (long)Math.ceil(partPitch.divide(feedPitch));
         return Math.round(1*Math.ceil(feedsPerPart*feedPitch.divide(partPitch)));
     }
-    
+
     public Length getTapeWidth() {
-        // infer the tape width from EIA-481 where:
-    	// 1) tape edge to hole middle = 1.75mm
-    	// 2) hole middle to part middle is 3.5 / 5.5 / 7.5 / 11.5mm for tape of 8 / 12 / 16 / 24mm width
-    	// 3) therefore
-    	// 3) a) hole middle to part middle + 0.5mm = half of tape width
-    	// 3) b) (hole middle to part middle + 0.5mm) * 2 = tapeWidth
+      // infer the tape width from EIA-481 where:
+      // 1) tape edge to hole middle = 1.75mm
+      // 2) hole middle to part middle is 3.5 / 5.5 / 7.5 / 11.5mm for tape of 8 / 12 / 16 / 24mm width
+      // 3) therefore
+      // 3) a) hole middle to part middle + 0.5mm = half of tape width
+      // 3) b) (hole middle to part middle + 0.5mm) * 2 = tapeWidth
         Location hole1Location = transformMachineToFeederLocation(this.hole1Location, null)
                 .convertToUnits(LengthUnit.Millimeters);
         final double partToSprocketHoleHalfTapeWidthDiffMm = 0.5; // deducted from EIA-481
         double tapeWidth = Math.round(hole1Location.getY()+partToSprocketHoleHalfTapeWidthDiffMm)*2;
         return new Length(tapeWidth, LengthUnit.Millimeters);
     }
-    
+
     public Location getCalibratedVisionOffset() {
-    	return this.calibratedVisionOffset;
+      return this.calibratedVisionOffset;
     }
 
     public Location getCalibratedHole1Location() {
-    	return this.calibratedHole1Location;
+      return this.calibratedHole1Location;
     }
 
     public Location getCalibratedHole2Location() {
-    	return this.calibratedHole2Location;
+      return this.calibratedHole2Location;
     }
 
     public Location getCalibratedPickLocation() {
-    	return this.calibratedPickLocation;
+      return this.calibratedPickLocation;
     }
-    
+
     public Double getCalibratedRotationInFeeder() {
-    	return this.rotationInFeeder;
+      return this.rotationInFeeder;
     }
-    
+
     public SimpleOcr.OcrModel getDetectedOcrModel() {
-    	return this.detectedOcrModel;
+      return this.detectedOcrModel;
     }
-    
-    
+
+
     public static Location forwardTransform(Location location, Location transform) {
         return location.rotateXy(transform.getRotation()).addWithRotation(transform);
     }
@@ -216,16 +216,16 @@ public class FeederVisionHelper {
         return backwardTransform(machineLocation, getTransform(visionOffset));
     }
 
-    
+
     private Location getPartLocation(long partInCycle, Location visionOffset)  {
         // If the feeder is advancing more than one part per feed cycle (e.g. with 2mm pitch tape or if a multiplier is
         // given), we need to cycle through multiple pick locations. partInCycle is 1-based and goes to getPartsPerFeedCycle().
         long offsetPitches = (getPartsPerFeedCycle() - partInCycle) % getPartsPerFeedCycle();
-        Location feederLocation = new Location(partPitch.getUnits(), partPitch.multiply((double)offsetPitches).getValue(), 
+        Location feederLocation = new Location(partPitch.getUnits(), partPitch.multiply((double)offsetPitches).getValue(),
                 0, 0, getCalibratedRotationInFeeder());
         Location machineLocation = transformFeederToMachineLocation(feederLocation, visionOffset);
         return machineLocation;
-    } 
+    }
 
     public List<Result.Circle> getHoles() {
         return holes;
@@ -256,19 +256,19 @@ public class FeederVisionHelper {
 
     private void drawOcrText(Mat mat, Color color) {
         if (detectedOcrModel != null) {
-            Imgproc.putText(mat, detectedOcrModel.getText(), 
-                    new org.opencv.core.Point(20, mat.rows()-20), 
-                    Imgproc.FONT_HERSHEY_PLAIN, 
-                    3, 
+            Imgproc.putText(mat, detectedOcrModel.getText(),
+                    new org.opencv.core.Point(20, mat.rows()-20),
+                    Imgproc.FONT_HERSHEY_PLAIN,
+                    3,
                     FluentCv.colorToScalar(Color.black), 6, 0, false);
-            Imgproc.putText(mat, detectedOcrModel.getText(), 
-                    new org.opencv.core.Point(20, mat.rows()-20), 
-                    Imgproc.FONT_HERSHEY_PLAIN, 
-                    3, 
+            Imgproc.putText(mat, detectedOcrModel.getText(),
+                    new org.opencv.core.Point(20, mat.rows()-20),
+                    Imgproc.FONT_HERSHEY_PLAIN,
+                    3,
                     FluentCv.colorToScalar(color), 2, 0, false);
         }
     }
-    
+
     // number the parts in the pockets
     private void drawPartNumbers(Mat mat, Color color) {
         // make sure the numbers are not too dense
@@ -281,7 +281,7 @@ public class FeederVisionHelper {
 
         // calculate the diagonal text size
         double fontScale = 1.0;
-        Size size = Imgproc.getTextSize(String.valueOf(getPartsPerFeedCycle()), 
+        Size size = Imgproc.getTextSize(String.valueOf(getPartsPerFeedCycle()),
                 Imgproc.FONT_HERSHEY_PLAIN, fontScale, 2, baseLine);
         Location textSizeMm = camera.getUnitsPerPixelAtZ().multiply(size.width, size.height, 0., 0.)
                 .convertToUnits(LengthUnit.Millimeters);
@@ -308,7 +308,7 @@ public class FeederVisionHelper {
             // something must be wrong - feeder probably not set up correctly (yet)
             return;
         }
-        // go through all the parts, step-wise 
+        // go through all the parts, step-wise
         for (int i = step; i <= getPartsPerFeedCycle(); i += step) {
             String text = String.valueOf(i);
             Size textSize = Imgproc.getTextSize(text, Imgproc.FONT_HERSHEY_PLAIN, fontScale, 2, baseLine);
@@ -329,7 +329,7 @@ public class FeederVisionHelper {
                 // the alignment, in relation to the lower left corner of the text
                 double alignX, alignY;
                 if (Math.abs(dx) > Math.abs(dy)) {
-                    // more horizontal displacement 
+                    // more horizontal displacement
                     if (dx < 0) {
                         // to the left
                         alignX = -textSize.width;
@@ -354,29 +354,43 @@ public class FeederVisionHelper {
                         alignY = textSize.height;
                     }
                 }
-                Imgproc.putText(mat, text, 
-                        new org.opencv.core.Point(p.x + alignX, p.y + alignY), 
-                        Imgproc.FONT_HERSHEY_PLAIN, 
-                        fontScale, 
+                Imgproc.putText(mat, text,
+                        new org.opencv.core.Point(p.x + alignX, p.y + alignY),
+                        Imgproc.FONT_HERSHEY_PLAIN,
+                        fontScale,
                         FluentCv.colorToScalar(color), 2, 0, false);
             }
         }
     }
 
-    public FeederVisionHelper findFeatures(boolean normalizePickLocation, boolean snapToAxis, Length partPitch, Length feedPitch, Location partLocation, Location hole1Location, Location hole2Location) 
-    		throws Exception {
-    	return findFeatures(normalizePickLocation, snapToAxis, partPitch, feedPitch, partLocation, hole1Location, hole2Location
-        		,this.calibrationToleranceMm, this.sprocketHoleToleranceMm);
+    public FeederVisionHelper findFeatures(boolean normalizePickLocation, boolean snapToAxis, Length partPitch, Length feedPitch, Location partLocation, Location hole1Location, Location hole2Location)
+        throws Exception {
+      return findFeatures(normalizePickLocation, snapToAxis, partPitch, feedPitch, partLocation, hole1Location, hole2Location
+            ,this.calibrationToleranceMm, this.sprocketHoleToleranceMm);
     }
-    
 
+/*
+ * This method will use Computer Vision to detect and calculate EIA-481 standard tape features - holes & part pockets
+ * - detects the tape holes first as they are defined in the standard, 4mm apart
+ * - calculates the tape width based on the distance between the initial nozzle location and where the holes were found
+ * - determines the exact location for the part pocket center point based on EIA-481 specs and the input parameter partPitch
+ * Notes:
+ * - normalizePickLocation: Normalize the pick location relative to the tape holes according to the EIA-481 standard
+ * - snapToAxis: Snap rows of tape holes to the Axis parallel
+ * - partPitch: Pitch of the parts in the tape (2mm, 4mm, 8mm, 12mm, etc.)
+ * - feedPitch: How much the tape will be advanced by one actuation (usually multiples of 4mm)
+ *    - if partPitch > feedPitch then multiple actuations will be executed
+ * - partLocation: approximate location of the part pocket as set using jogging the head
+ * - hole1Location, hole2Location: provide if known (maybe from previous calibration), critical only to the "CheckOnly" mode
+ * - calibrationToleranceMm, sprocketHoleToleranceMm: calibration tolerance parameters, either used from internal constants or provided by the caller class
+ */
     public FeederVisionHelper findFeatures(boolean normalizePickLocation, boolean snapToAxis, Length partPitch, Length feedPitch, Location partLocation, Location hole1Location, Location hole2Location
-    		,double calibrationToleranceMm, double sprocketHoleToleranceMm) 
-    		throws Exception {
-    	setTapeSpecs(normalizePickLocation, snapToAxis, partPitch, feedPitch, partLocation, hole1Location, hole2Location);
-    	setCalibrationTolerance(calibrationToleranceMm, sprocketHoleToleranceMm);
-        List resultsList = null; 
-        
+        ,double calibrationToleranceMm, double sprocketHoleToleranceMm)
+        throws Exception {
+      setTapeSpecs(normalizePickLocation, snapToAxis, partPitch, feedPitch, partLocation, hole1Location, hole2Location);
+      setCalibrationTolerance(calibrationToleranceMm, sprocketHoleToleranceMm);
+        List resultsList = null;
+
         try {
             // in accordance with EIA-481 etc. we use all millimeters.
             Location mmScale = camera.getUnitsPerPixelAtZ()
@@ -394,10 +408,10 @@ public class FeederVisionHelper {
             else {
                 final double partPitchMinMm = 2;
                 final double sprocketHoleToPartMinMm = 3.5; // sprocket hole to part @ 8mm
-                final double sprocketHoleToPartGridMm = 2;  // +multiples of 2mm for wider tapes 
+                final double sprocketHoleToPartGridMm = 2;  // +multiples of 2mm for wider tapes
                 final double sprocketHoleDiameterPx = sprocketHoleDiameterMm/mmScale.getX();
                 final double sprocketHolePitchPx = sprocketHolePitchMm/mmScale.getX();
-                final double sprocketHoleTolerancePx = sprocketHoleToleranceMm/mmScale.getX(); 
+                final double sprocketHoleTolerancePx = sprocketHoleToleranceMm/mmScale.getX();
                 // Grab the results
                 resultsList = pipeline.getExpectedResult(VisionUtils.PIPELINE_RESULTS_NAME)
                         .getExpectedModel(List.class);
@@ -439,7 +453,7 @@ public class FeederVisionHelper {
                 for (Result.Circle circle : results) {
                     points.add(new Point(circle.x, circle.y));
                 }
-                List<Ransac.Line> ransacLines = Ransac.ransac(points, 100, sprocketHoleTolerancePx, 
+                List<Ransac.Line> ransacLines = Ransac.ransac(points, 100, sprocketHoleTolerancePx,
                         sprocketHolePitchPx, sprocketHoleTolerancePx, false);
                 if (ransacLines.isEmpty()) {
                     Logger.debug("Ransac algorithm has not found any lines of sprocket holes with "+sprocketHolePitchMm+"mm pitch, "
@@ -457,18 +471,18 @@ public class FeederVisionHelper {
                     Location bLocation = VisionUtils.getPixelLocation(camera, b.x, b.y);
 
                     // Checks the distance to the line.
-                    // In Auto-Setup/Preview mode we go from the pick location and there must be a minimum distance 
+                    // In Auto-Setup/Preview mode we go from the pick location and there must be a minimum distance
                     // in order not to confuse pockets for sprocket holes. But then take the closest one, in order not
-                    // to confuse with the neighboring tape's holes. We assume the pick location is always closer to our 
+                    // to confuse with the neighboring tape's holes. We assume the pick location is always closer to our
                     // sprocket holes than to the neighboring tape's holes.
                     // In Calibration mode we are between the the sprocket holes, and there is no minimum distance
                     // and the line must simply be within calibration tolerance.
                     double distanceMm = camera.getLocation().convertToUnits(LengthUnit.Millimeters)
                             .getLinearDistanceToLineSegment(aLocation, bLocation);
-                    double minDistanceMm = (autoSetupMode == FindFeaturesMode.CalibrateHoles ? 
-                            0 : minSprocketHolesDistanceMm) 
+                    double minDistanceMm = (autoSetupMode == FindFeaturesMode.CalibrateHoles ?
+                            0 : minSprocketHolesDistanceMm)
                             - sprocketHoleToleranceMm;
-                    double maxDistanceMm = (autoSetupMode == FindFeaturesMode.CalibrateHoles ? 
+                    double maxDistanceMm = (autoSetupMode == FindFeaturesMode.CalibrateHoles ?
                             calibrationToleranceMm : bestDistanceMm);
 
                     if (distanceMm >= minDistanceMm && distanceMm < maxDistanceMm) {
@@ -490,7 +504,7 @@ public class FeederVisionHelper {
 
                 if (autoSetupMode != null) {
                     if (bestLine == null) {
-                        throw new Exception("No line of sprocket holes can be recognized"); 
+                        throw new Exception("No line of sprocket holes can be recognized");
                     }
                 }
 
@@ -517,7 +531,7 @@ public class FeederVisionHelper {
                             || (autoSetupMode == null && !(hole1Location.isInitialized() && hole2Location.isInitialized()))) {
                         // because we sorted the holes by distance, the first two are our holes 1 and 2
                         if (holes.size() < 2) {
-                            throw new Exception("At least two sprocket holes need to be recognized"); 
+                            throw new Exception("At least two sprocket holes need to be recognized");
                         }
                         calibratedHole1Location = VisionUtils.getPixelLocation(camera, holes.get(0).x, holes.get(0).y)
                                 .convertToUnits(LengthUnit.Millimeters);
@@ -528,7 +542,7 @@ public class FeederVisionHelper {
                         double angle2 = Math.atan2(calibratedHole2Location.getY()-pocketLocation.getY(), calibratedHole2Location.getX()-pocketLocation.getX());
                         double angleDiff = Utils2D.angleNorm(Math.toDegrees(angle2-angle1), 180);
                         if (angleDiff > 0) {
-                            // The holes 1 and 2 must appear counter-clockwise from the part location, swap them! 
+                            // The holes 1 and 2 must appear counter-clockwise from the part location, swap them!
                             Location swap = calibratedHole2Location;
                             calibratedHole2Location = calibratedHole1Location;
                             calibratedHole1Location = swap;
@@ -546,12 +560,12 @@ public class FeederVisionHelper {
                                 .derive(null,  null, null, angleTape); // preliminary feeeder orientation
                     }
                     else {
-                        // find the two holes matching 
+                        // find the two holes matching
                         for (Result.Circle hole : holes) {
                             Location l = VisionUtils.getPixelLocation(camera, hole.x, hole.y)
                                     .convertToUnits(LengthUnit.Millimeters);
-                            double dist1Mm = l.getLinearDistanceTo(hole1Location); 
-                            double dist2Mm = l.getLinearDistanceTo(hole2Location); 
+                            double dist1Mm = l.getLinearDistanceTo(hole1Location);
+                            double dist2Mm = l.getLinearDistanceTo(hole2Location);
                             if (dist1Mm < calibrationToleranceMm && dist1Mm < dist2Mm) {
                                 calibratedHole1Location = l;
                             }
@@ -561,7 +575,7 @@ public class FeederVisionHelper {
                         }
                         if (calibratedHole1Location == null || calibratedHole2Location == null) {
                             if (autoSetupMode  == FindFeaturesMode.CalibrateHoles) {
-                                throw new Exception("The two reference sprocket holes cannot be recognized"); 
+                                throw new Exception("The two reference sprocket holes cannot be recognized");
                             }
                         }
                         else {
@@ -595,7 +609,7 @@ public class FeederVisionHelper {
                                 Location pickLocation = this.partLocation.convertToUnits(LengthUnit.Millimeters);
                                 Location relativePickLocation = pickLocation
                                         .subtract(hole1Location);
-                                // rotate from old angle 
+                                // rotate from old angle
                                 relativePickLocation =  relativePickLocation.rotateXy(-pickLocation.getRotation())
                                         .derive(null, null, null, 0.0);
                                 // normalize to a nominal local pick location according to EIA 481
@@ -605,7 +619,7 @@ public class FeederVisionHelper {
                                             -sprocketHoleToPartMinMm+Math.round((relativePickLocation.getY()+sprocketHoleToPartMinMm)/sprocketHoleToPartGridMm)*sprocketHoleToPartGridMm,
                                             0, 0);
                                 }
-                                // calculate the new pick location with the new hole 1 location and tape angle 
+                                // calculate the new pick location with the new hole 1 location and tape angle
                                 calibratedPickLocation = calibratedHole1Location.add(relativePickLocation.rotateXy(angleTape))
                                         .derive(null, null, pickLocation.getZ(), angleTape);
                             }
@@ -618,7 +632,7 @@ public class FeederVisionHelper {
                         calibratedVisionOffset = this.partLocation
                                 .subtractWithRotation(calibratedPickLocation)
                                 .derive(null, null, 0.0, null);
-                        Logger.debug("calibrated vision offset is: " + calibratedVisionOffset 
+                        Logger.debug("calibrated vision offset is: " + calibratedVisionOffset
                                 + ", length is: "+calibratedVisionOffset.getLinearLengthTo(Location.origin));
 
                         // Add tick marks for show
@@ -638,7 +652,7 @@ public class FeederVisionHelper {
                 }
             }
 
-            Result ocrStageResult = pipeline.getResult("OCR"); 
+            Result ocrStageResult = pipeline.getResult("OCR");
             if (ocrStageResult != null) {
                 detectedOcrModel = (SimpleOcr.OcrModel) ocrStageResult.model;
             }
@@ -651,9 +665,9 @@ public class FeederVisionHelper {
                 drawPartNumbers(resultMat, Color.orange);
                 drawOcrText(resultMat, Color.orange);
                 if (getHoles().isEmpty()) {
-                    Imgproc.line(resultMat, new Point(0, 0), new Point(resultMat.cols()-1, resultMat.rows()-1), 
+                    Imgproc.line(resultMat, new Point(0, 0), new Point(resultMat.cols()-1, resultMat.rows()-1),
                             FluentCv.colorToScalar(Color.red), 2, Imgproc.LINE_AA);
-                    Imgproc.line(resultMat, new Point(0, resultMat.rows()-1), new Point(resultMat.cols()-1, 0), 
+                    Imgproc.line(resultMat, new Point(0, resultMat.rows()-1), new Point(resultMat.cols()-1, 0),
                             FluentCv.colorToScalar(Color.red), 2, Imgproc.LINE_AA);
                 }
 

--- a/src/main/java/org/openpnp/util/FeederVisionHelper.java
+++ b/src/main/java/org/openpnp/util/FeederVisionHelper.java
@@ -1,0 +1,675 @@
+/*
+ * Copyright (C) 2024 <pandaplacer.ca@gmail.com>
+ * based on the ReferencePushPullFeeder
+ * Copyright (C) 2020 <mark@makr.zone>
+ * based on the ReferenceLeverFeeder
+ * Copyright (C) 2011 Jason von Nieda <jason@vonnieda.org>
+ *
+ * This file is part of OpenPnP.
+ *
+ * OpenPnP is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * OpenPnP is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with OpenPnP. If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * For more information about OpenPnP visit http://openpnp.org
+ */
+
+package org.openpnp.util;
+
+import java.awt.Color;
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import org.opencv.core.KeyPoint;
+import org.opencv.core.Mat;
+import org.opencv.core.Point;
+import org.opencv.core.RotatedRect;
+import org.opencv.core.Size;
+import org.opencv.imgcodecs.Imgcodecs;
+import org.opencv.imgproc.Imgproc;
+import org.openpnp.gui.MainFrame;
+import org.openpnp.model.Configuration;
+import org.openpnp.model.Length;
+import org.openpnp.model.LengthUnit;
+import org.openpnp.model.Location;
+import org.openpnp.spi.Camera;
+import org.openpnp.vision.FluentCv;
+import org.openpnp.vision.Ransac;
+import org.openpnp.vision.Ransac.Line;
+import org.openpnp.vision.pipeline.CvPipeline;
+import org.openpnp.vision.pipeline.CvStage;
+import org.openpnp.vision.pipeline.CvStage.Result;
+import org.openpnp.vision.pipeline.stages.SimpleOcr;
+import org.pmw.tinylog.Logger;
+
+/*
+ * This is a helper class for locating the tape holes and pockets.
+ * It is mostly used in feeders with large pick windows exposing at least two holes.
+ * Calculates the exact location of the part pocket according to the EIA 481 standard.
+ */
+
+public class FeederVisionHelper {
+
+	public enum FindFeaturesMode {
+	    FromPickLocationGetHoles,
+	    CalibrateHoles,
+	    CheckOnly
+	}
+
+	// initial calibration tolerance, i.e. how much the feeder can be shifted physically 
+    private double calibrationToleranceMm = 1.95;
+    // vision and comparison sprocket hole tolerance (in size, position)
+    private double sprocketHoleToleranceMm = 0.6;
+
+    // Some EIA 481 standard constants.
+    static final double sprocketHoleDiameterMm = 1.5;
+    static final double sprocketHolePitchMm = 4;
+    static final double minSprocketHolesDistanceMm = 3.5;
+
+    // tape parameters
+    private boolean normalizePickLocation = true;
+    private boolean snapToAxis = false;
+    
+    private Location partLocation = new Location(LengthUnit.Millimeters);
+    private Location hole1Location = new Location(LengthUnit.Millimeters);
+    private Location hole2Location = new Location(LengthUnit.Millimeters);
+
+    private Length partPitch = new Length(4, LengthUnit.Millimeters);
+    private Length feedPitch = new Length(4, LengthUnit.Millimeters);
+
+	
+    private Camera camera;
+    private CvPipeline pipeline;
+    private long showResultMilliseconds;
+    private FindFeaturesMode autoSetupMode;
+    
+    private Location calibratedVisionOffset;
+    private Location calibratedHole1Location;
+    private Location calibratedHole2Location;
+    private Location calibratedPickLocation;
+    // OCR detection
+    private SimpleOcr.OcrModel detectedOcrModel;
+    // Rotation of the part within the feeder (i.e. within the tape)
+    private Double rotationInFeeder = 0.0;
+
+    // recognized stuff
+    private List<Result.Circle> holes;
+    private List<Line> lines;
+
+    public FeederVisionHelper(Camera camera, CvPipeline pipeline, final long showResultMilliseconds, FindFeaturesMode autoSetupMode) {
+        this.camera = camera;
+        this.pipeline = pipeline;
+        this.showResultMilliseconds = showResultMilliseconds;
+        this.autoSetupMode = autoSetupMode;
+    }
+    
+    private void setTapeSpecs(boolean normalizePickLocation, boolean snapToAxis, Length partPitch, Length feedPitch, Location partLocation, Location hole1Location, Location hole2Location) {
+    	this.normalizePickLocation = normalizePickLocation;
+    	this.snapToAxis = snapToAxis;
+    	this.partPitch = partPitch;
+    	this.feedPitch = feedPitch;
+    	this.hole1Location = hole1Location;
+    	this.hole2Location = hole2Location;
+    	this.partLocation = partLocation;
+    }
+    
+    private void setCalibrationTolerance(double calibrationToleranceMm, double sprocketHoleToleranceMm) {
+    	this.calibrationToleranceMm = calibrationToleranceMm;
+    	this.sprocketHoleToleranceMm = sprocketHoleToleranceMm;
+}
+    
+    public long getPartsPerFeedCycle() {
+        long feedsPerPart = (long)Math.ceil(partPitch.divide(feedPitch));
+        return Math.round(1*Math.ceil(feedsPerPart*feedPitch.divide(partPitch)));
+    }
+    
+    public Length getTapeWidth() {
+        // infer the tape width from EIA-481 where:
+    	// 1) tape edge to hole middle = 1.75mm
+    	// 2) hole middle to part middle is 3.5 / 5.5 / 7.5 / 11.5mm for tape of 8 / 12 / 16 / 24mm width
+    	// 3) therefore
+    	// 3) a) hole middle to part middle + 0.5mm = half of tape width
+    	// 3) b) (hole middle to part middle + 0.5mm) * 2 = tapeWidth
+        Location hole1Location = transformMachineToFeederLocation(this.hole1Location, null)
+                .convertToUnits(LengthUnit.Millimeters);
+        final double partToSprocketHoleHalfTapeWidthDiffMm = 0.5; // deducted from EIA-481
+        double tapeWidth = Math.round(hole1Location.getY()+partToSprocketHoleHalfTapeWidthDiffMm)*2;
+        return new Length(tapeWidth, LengthUnit.Millimeters);
+    }
+    
+    public Location getCalibratedVisionOffset() {
+    	return this.calibratedVisionOffset;
+    }
+
+    public Location getCalibratedHole1Location() {
+    	return this.calibratedHole1Location;
+    }
+
+    public Location getCalibratedHole2Location() {
+    	return this.calibratedHole2Location;
+    }
+
+    public Location getCalibratedPickLocation() {
+    	return this.calibratedPickLocation;
+    }
+    
+    public Double getCalibratedRotationInFeeder() {
+    	return this.rotationInFeeder;
+    }
+    
+    public SimpleOcr.OcrModel getDetectedOcrModel() {
+    	return this.detectedOcrModel;
+    }
+    
+    
+    public static Location forwardTransform(Location location, Location transform) {
+        return location.rotateXy(transform.getRotation()).addWithRotation(transform);
+    }
+
+    public static Location backwardTransform(Location location, Location transform) {
+        return location.subtractWithRotation(transform).rotateXy(-transform.getRotation());
+    }
+
+    protected Location getTransform(Location visionOffset) {
+        // Our local feeder coordinate system is relative to the EIA 481 standard tape orientation
+        // i.e. with the sprocket holes on top and the tape advancing to the right, which is our +X
+        // The pick location is on [0, 0] local, which corresponds to feeder.location global.
+        // The feeder.location.rotation contains the orientation of the tape on the machine.
+
+        // to make sure we get the right rotation, we update it from the sprocket holes
+        // instead of trusting the location.rotation. This might happen when the user fiddles
+        // with the locations manually.
+
+        Location unitVector = hole1Location.unitVectorTo(hole2Location);
+        if (!(Double.isFinite(unitVector.getX()) && Double.isFinite(unitVector.getY()))) {
+            // Catch (yet) undefined hole locations.
+            unitVector = new Location(hole1Location.getUnits(), 0, 1, 0, 0);
+        }
+        double rotationTape = Math.atan2(unitVector.getY(), unitVector.getX())*180.0/Math.PI;
+        Location transform = this.partLocation.derive(null, null, null, rotationTape);
+        if (Math.abs(rotationTape - this.partLocation.getRotation()) > 0.1) {
+            // HACK: something is not up-to-date -> refresh
+            this.partLocation = transform;
+        }
+
+        if (visionOffset != null) {
+            transform = transform.subtractWithRotation(visionOffset);
+        }
+        return transform;
+    }
+
+    protected Location transformFeederToMachineLocation(Location feederLocation, Location visionOffset) {
+        return forwardTransform(feederLocation, getTransform(visionOffset));
+    }
+
+    protected Location transformMachineToFeederLocation(Location machineLocation, Location visionOffset) {
+        return backwardTransform(machineLocation, getTransform(visionOffset));
+    }
+
+    
+    private Location getPartLocation(long partInCycle, Location visionOffset)  {
+        // If the feeder is advancing more than one part per feed cycle (e.g. with 2mm pitch tape or if a multiplier is
+        // given), we need to cycle through multiple pick locations. partInCycle is 1-based and goes to getPartsPerFeedCycle().
+        long offsetPitches = (getPartsPerFeedCycle() - partInCycle) % getPartsPerFeedCycle();
+        Location feederLocation = new Location(partPitch.getUnits(), partPitch.multiply((double)offsetPitches).getValue(), 
+                0, 0, getCalibratedRotationInFeeder());
+        Location machineLocation = transformFeederToMachineLocation(feederLocation, visionOffset);
+        return machineLocation;
+    } 
+
+    public List<Result.Circle> getHoles() {
+        return holes;
+    }
+    public List<Line> getLines() {
+        return lines;
+    }
+
+    private void drawHoles(Mat mat, List<Result.Circle> features, Color color) {
+        if (features == null || features.isEmpty()) {
+            return;
+        }
+        for (Result.Circle circle : features) {
+            org.opencv.core.Point c =  new org.opencv.core.Point(circle.x, circle.y);
+            Imgproc.circle(mat, c, (int) (circle.diameter+0.5)/2, FluentCv.colorToScalar(color), 2, Imgproc.LINE_AA);
+            Imgproc.circle(mat, c, 1, FluentCv.colorToScalar(color), 3, Imgproc.LINE_AA);
+        }
+    }
+
+    private void drawLines(Mat mat, List<Line> lines, Color color) {
+        if (lines == null || lines.isEmpty()) {
+            return;
+        }
+        for (Line line : lines) {
+            Imgproc.line(mat, line.a, line.b, FluentCv.colorToScalar(color), 2, Imgproc.LINE_AA);
+        }
+    }
+
+    private void drawOcrText(Mat mat, Color color) {
+        if (detectedOcrModel != null) {
+            Imgproc.putText(mat, detectedOcrModel.getText(), 
+                    new org.opencv.core.Point(20, mat.rows()-20), 
+                    Imgproc.FONT_HERSHEY_PLAIN, 
+                    3, 
+                    FluentCv.colorToScalar(Color.black), 6, 0, false);
+            Imgproc.putText(mat, detectedOcrModel.getText(), 
+                    new org.opencv.core.Point(20, mat.rows()-20), 
+                    Imgproc.FONT_HERSHEY_PLAIN, 
+                    3, 
+                    FluentCv.colorToScalar(color), 2, 0, false);
+        }
+    }
+    
+    // number the parts in the pockets
+    private void drawPartNumbers(Mat mat, Color color) {
+        // make sure the numbers are not too dense
+        int [] baseLine = null;
+        double feederPocketPitchMm =  partPitch.convertToUnits(LengthUnit.Millimeters).getValue();
+        if (feederPocketPitchMm < 1.) {
+            // feeder not set up yet
+            return;
+        }
+
+        // calculate the diagonal text size
+        double fontScale = 1.0;
+        Size size = Imgproc.getTextSize(String.valueOf(getPartsPerFeedCycle()), 
+                Imgproc.FONT_HERSHEY_PLAIN, fontScale, 2, baseLine);
+        Location textSizeMm = camera.getUnitsPerPixelAtZ().multiply(size.width, size.height, 0., 0.)
+                .convertToUnits(LengthUnit.Millimeters);
+        if (textSizeMm.getY() < 0.0) {
+            textSizeMm = textSizeMm.multiply(1.0, -1.0, 0.0, 0.0);
+        }
+        final double minFontSizeMm = 0.6;
+        if (textSizeMm.getY() < minFontSizeMm) {
+            fontScale = minFontSizeMm / textSizeMm.getY();
+            textSizeMm = textSizeMm.multiply(fontScale, fontScale, 0.0, 0.0);
+        }
+        double textSizePitchCount = textSizeMm.getLinearDistanceTo(Location.origin)/feederPocketPitchMm;
+        int step;
+        if (textSizePitchCount < 0.75) {
+            step = 1;
+        }
+        else if (textSizePitchCount < 1.5) {
+            step = 2;
+        }
+        else if (textSizePitchCount < 4) {
+            step = 5;
+        }
+        else {
+            // something must be wrong - feeder probably not set up correctly (yet)
+            return;
+        }
+        // go through all the parts, step-wise 
+        for (int i = step; i <= getPartsPerFeedCycle(); i += step) {
+            String text = String.valueOf(i);
+            Size textSize = Imgproc.getTextSize(text, Imgproc.FONT_HERSHEY_PLAIN, fontScale, 2, baseLine);
+
+            Location partLocation = getPartLocation(i, calibratedVisionOffset)
+                    .convertToUnits(LengthUnit.Millimeters);
+            // TODO: go besides part
+            Location textLocation = transformMachineToFeederLocation(partLocation, calibratedVisionOffset);
+            textLocation = textLocation.add(new Location(LengthUnit.Millimeters, 0., -textSizeMm.getY()*0.25, 0., 0.));
+            textLocation = transformFeederToMachineLocation(textLocation, calibratedVisionOffset)
+                    .convertToUnits(LengthUnit.Millimeters);
+            org.openpnp.model.Point p = VisionUtils.getLocationPixels(camera, textLocation);
+            if (p.x > 0 && p.x < camera.getWidth() && p.y > 0 && p.y < camera.getHeight()) {
+                // roughly in the visible range - draw it
+                // determine the alignment based on where the text is located in relation to the pocket
+                double dx = textLocation.getX() - partLocation.getX();
+                double dy = textLocation.getY() - partLocation.getY();
+                // the alignment, in relation to the lower left corner of the text
+                double alignX, alignY;
+                if (Math.abs(dx) > Math.abs(dy)) {
+                    // more horizontal displacement 
+                    if (dx < 0) {
+                        // to the left
+                        alignX = -textSize.width;
+                        alignY = textSize.height/2;
+                    }
+                    else {
+                        // to the right
+                        alignX = 0.;
+                        alignY = textSize.height/2;
+                    }
+                }
+                else {
+                    // more vertical displacement
+                    if (dy > 0) {
+                        // above
+                        alignX = -textSize.width/2;
+                        alignY = 0.0;
+                    }
+                    else {
+                        // below
+                        alignX = -textSize.width/2;
+                        alignY = textSize.height;
+                    }
+                }
+                Imgproc.putText(mat, text, 
+                        new org.opencv.core.Point(p.x + alignX, p.y + alignY), 
+                        Imgproc.FONT_HERSHEY_PLAIN, 
+                        fontScale, 
+                        FluentCv.colorToScalar(color), 2, 0, false);
+            }
+        }
+    }
+
+    public FeederVisionHelper findFeatures(boolean normalizePickLocation, boolean snapToAxis, Length partPitch, Length feedPitch, Location partLocation, Location hole1Location, Location hole2Location) 
+    		throws Exception {
+    	return findFeatures(normalizePickLocation, snapToAxis, partPitch, feedPitch, partLocation, hole1Location, hole2Location
+        		,this.calibrationToleranceMm, this.sprocketHoleToleranceMm);
+    }
+    
+
+    public FeederVisionHelper findFeatures(boolean normalizePickLocation, boolean snapToAxis, Length partPitch, Length feedPitch, Location partLocation, Location hole1Location, Location hole2Location
+    		,double calibrationToleranceMm, double sprocketHoleToleranceMm) 
+    		throws Exception {
+    	setTapeSpecs(normalizePickLocation, snapToAxis, partPitch, feedPitch, partLocation, hole1Location, hole2Location);
+    	setCalibrationTolerance(calibrationToleranceMm, sprocketHoleToleranceMm);
+        List resultsList = null; 
+        
+        try {
+            // in accordance with EIA-481 etc. we use all millimeters.
+            Location mmScale = camera.getUnitsPerPixelAtZ()
+                    .convertToUnits(LengthUnit.Millimeters);
+            // reset the features
+            holes = new ArrayList<>();
+            lines = new ArrayList<>();
+
+            if (autoSetupMode == FindFeaturesMode.CheckOnly) {
+                // No vision calibration wanted - just copy the pre-set locations
+                calibratedHole1Location = hole1Location;
+                calibratedHole2Location = hole2Location;
+                calibratedPickLocation  = this.partLocation;
+            }
+            else {
+                final double partPitchMinMm = 2;
+                final double sprocketHoleToPartMinMm = 3.5; // sprocket hole to part @ 8mm
+                final double sprocketHoleToPartGridMm = 2;  // +multiples of 2mm for wider tapes 
+                final double sprocketHoleDiameterPx = sprocketHoleDiameterMm/mmScale.getX();
+                final double sprocketHolePitchPx = sprocketHolePitchMm/mmScale.getX();
+                final double sprocketHoleTolerancePx = sprocketHoleToleranceMm/mmScale.getX(); 
+                // Grab the results
+                resultsList = pipeline.getExpectedResult(VisionUtils.PIPELINE_RESULTS_NAME)
+                        .getExpectedModel(List.class);
+
+                // Convert eligible results into circles
+                List<CvStage.Result.Circle> results = new ArrayList<>();;
+                for (Object result : resultsList) {
+                    if ((result) instanceof Result.Circle) {
+                        Result.Circle circle = ((Result.Circle) result);
+                        if (Math.abs(circle.diameter*mmScale.getX() - sprocketHoleDiameterMm) < sprocketHoleToleranceMm) {
+                            results.add(circle);
+                        }
+                        else {
+                            Logger.debug("Dismissed Circle with non-compliant diameter "+(circle.diameter*mmScale.getX())+"mm, "
+                                    + "allowed tolerance is ±"+sprocketHoleToleranceMm+"mm");
+                        }
+                    }
+                    else if ((result) instanceof RotatedRect) {
+                        RotatedRect rect = ((RotatedRect) result);
+                        double diameter = (rect.size.width+rect.size.height)/2.0;
+                        if (Math.abs(rect.size.width*mmScale.getX() - sprocketHoleDiameterMm) < sprocketHoleToleranceMm
+                                && Math.abs(rect.size.height*mmScale.getX() - sprocketHoleDiameterMm) < sprocketHoleToleranceMm) {
+                            results.add(new Result.Circle(rect.center.x, rect.center.y, diameter));
+                        }
+                        else {
+                            Logger.debug("Dismissed RotatedRect with non-compliant width or height "
+                                    +(rect.size.width*mmScale.getX())+"mm x "+rect.size.height*mmScale.getX()+"mm, "
+                                            + "allowed tolerance is ±"+sprocketHoleToleranceMm+"mm");
+                        }
+                    }
+                    else if ((result) instanceof KeyPoint) {
+                        KeyPoint keyPoint = ((KeyPoint) result);
+                        results.add(new Result.Circle(keyPoint.pt.x, keyPoint.pt.y, sprocketHoleDiameterPx));
+                    }
+                }
+
+                // collect the circles into a list of points
+                List<Point> points = new ArrayList<>();
+                for (Result.Circle circle : results) {
+                    points.add(new Point(circle.x, circle.y));
+                }
+                List<Ransac.Line> ransacLines = Ransac.ransac(points, 100, sprocketHoleTolerancePx, 
+                        sprocketHolePitchPx, sprocketHoleTolerancePx, false);
+                if (ransacLines.isEmpty()) {
+                    Logger.debug("Ransac algorithm has not found any lines of sprocket holes with "+sprocketHolePitchMm+"mm pitch, "
+                            + "allowed pitch and line tolerance is ±"+sprocketHoleToleranceMm+"mm");
+                }
+                // Get the best line within the calibration tolerance
+                Ransac.Line bestLine = null;
+                Location bestUnitVector = null;
+                double bestDistanceMm = Double.MAX_VALUE;
+                for (Ransac.Line line : ransacLines) {
+                    Point a = line.a;
+                    Point b = line.b;
+
+                    Location aLocation = VisionUtils.getPixelLocation(camera, a.x, a.y);
+                    Location bLocation = VisionUtils.getPixelLocation(camera, b.x, b.y);
+
+                    // Checks the distance to the line.
+                    // In Auto-Setup/Preview mode we go from the pick location and there must be a minimum distance 
+                    // in order not to confuse pockets for sprocket holes. But then take the closest one, in order not
+                    // to confuse with the neighboring tape's holes. We assume the pick location is always closer to our 
+                    // sprocket holes than to the neighboring tape's holes.
+                    // In Calibration mode we are between the the sprocket holes, and there is no minimum distance
+                    // and the line must simply be within calibration tolerance.
+                    double distanceMm = camera.getLocation().convertToUnits(LengthUnit.Millimeters)
+                            .getLinearDistanceToLineSegment(aLocation, bLocation);
+                    double minDistanceMm = (autoSetupMode == FindFeaturesMode.CalibrateHoles ? 
+                            0 : minSprocketHolesDistanceMm) 
+                            - sprocketHoleToleranceMm;
+                    double maxDistanceMm = (autoSetupMode == FindFeaturesMode.CalibrateHoles ? 
+                            calibrationToleranceMm : bestDistanceMm);
+
+                    if (distanceMm >= minDistanceMm && distanceMm < maxDistanceMm) {
+                        bestLine = line;
+                        bestUnitVector = aLocation.unitVectorTo(bLocation);
+                        bestDistanceMm = distanceMm;
+                        lines.add(line);
+                        if (autoSetupMode == FindFeaturesMode.CalibrateHoles) {
+                            // Take the first line that is close enough, as the lines are ordered by length (descending).
+                            break;
+                        }
+                        // Otherwise take the closest line, go on.
+                    }
+                    else if (autoSetupMode == null) {
+                        lines.add(line);
+                        Logger.debug("Dismissed line by distance, "+(distanceMm)+"mm, not within "+minDistanceMm+"mm .. "+maxDistanceMm+"mm");
+                    }
+                }
+
+                if (autoSetupMode != null) {
+                    if (bestLine == null) {
+                        throw new Exception("No line of sprocket holes can be recognized"); 
+                    }
+                }
+
+                if (bestLine != null) {
+                    // Filter the circles by distance from the resulting line
+                    for (Result.Circle circle : results) {
+                        Point p = new Point(circle.x, circle.y);
+                        if (FluentCv.pointToLineDistance(bestLine.a, bestLine.b, p) <= sprocketHoleTolerancePx) {
+                            holes.add(circle);
+                        }
+                    }
+
+                    // Sort holes by distance from camera center.
+                    Collections.sort(holes, new Comparator<Result.Circle>() {
+                        @Override
+                        public int compare(Result.Circle o1, Result.Circle o2) {
+                            double d1 = VisionUtils.getPixelLocation(camera, o1.x, o1.y).getLinearDistanceTo(camera.getLocation());
+                            double d2 = VisionUtils.getPixelLocation(camera, o2.x, o2.y).getLinearDistanceTo(camera.getLocation());
+                            return Double.compare(d1, d2);
+                        }
+                    });
+
+                    if (autoSetupMode == FindFeaturesMode.FromPickLocationGetHoles
+                            || (autoSetupMode == null && !(hole1Location.isInitialized() && hole2Location.isInitialized()))) {
+                        // because we sorted the holes by distance, the first two are our holes 1 and 2
+                        if (holes.size() < 2) {
+                            throw new Exception("At least two sprocket holes need to be recognized"); 
+                        }
+                        calibratedHole1Location = VisionUtils.getPixelLocation(camera, holes.get(0).x, holes.get(0).y)
+                                .convertToUnits(LengthUnit.Millimeters);
+                        calibratedHole2Location = VisionUtils.getPixelLocation(camera, holes.get(1).x, holes.get(1).y)
+                                .convertToUnits(LengthUnit.Millimeters);
+                        Location pocketLocation = camera.getLocation().convertToUnits(LengthUnit.Millimeters);
+                        double angle1 = Math.atan2(calibratedHole1Location.getY()-pocketLocation.getY(), calibratedHole1Location.getX()-pocketLocation.getX());
+                        double angle2 = Math.atan2(calibratedHole2Location.getY()-pocketLocation.getY(), calibratedHole2Location.getX()-pocketLocation.getX());
+                        double angleDiff = Utils2D.angleNorm(Math.toDegrees(angle2-angle1), 180);
+                        if (angleDiff > 0) {
+                            // The holes 1 and 2 must appear counter-clockwise from the part location, swap them! 
+                            Location swap = calibratedHole2Location;
+                            calibratedHole2Location = calibratedHole1Location;
+                            calibratedHole1Location = swap;
+                        }
+                        if (calibratedHole1Location.unitVectorTo(calibratedHole2Location)
+                                .dotProduct(bestUnitVector).getValue() < 0.0) {
+                            // turn the unite vector around
+                            bestUnitVector = bestUnitVector.multiply(-1.0, -1.0, 0, 0);
+                        }
+                        // determine the correct transformation
+                        double angleTape = Math.atan2(bestUnitVector.getY(), bestUnitVector.getX())*180.0/Math.PI;
+                        // preliminary pick location
+                        calibratedPickLocation = camera.getLocation()
+                                .derive(this.partLocation, false, false, true, false) // previous Z
+                                .derive(null,  null, null, angleTape); // preliminary feeeder orientation
+                    }
+                    else {
+                        // find the two holes matching 
+                        for (Result.Circle hole : holes) {
+                            Location l = VisionUtils.getPixelLocation(camera, hole.x, hole.y)
+                                    .convertToUnits(LengthUnit.Millimeters);
+                            double dist1Mm = l.getLinearDistanceTo(hole1Location); 
+                            double dist2Mm = l.getLinearDistanceTo(hole2Location); 
+                            if (dist1Mm < calibrationToleranceMm && dist1Mm < dist2Mm) {
+                                calibratedHole1Location = l;
+                            }
+                            else if (dist2Mm < calibrationToleranceMm && dist2Mm < dist1Mm) {
+                                calibratedHole2Location = l;
+                            }
+                        }
+                        if (calibratedHole1Location == null || calibratedHole2Location == null) {
+                            if (autoSetupMode  == FindFeaturesMode.CalibrateHoles) {
+                                throw new Exception("The two reference sprocket holes cannot be recognized"); 
+                            }
+                        }
+                        else {
+                            if (calibratedHole1Location.unitVectorTo(calibratedHole2Location)
+                                    .dotProduct(bestUnitVector).getValue() < 0.0) {
+                                // turn the unit vector around
+                                bestUnitVector = bestUnitVector.multiply(-1.0, -1.0, 0, 0);
+                            }
+                            if (this.snapToAxis) {
+                                if (Math.abs(bestUnitVector.getX()) > Math.abs(bestUnitVector.getY())*5) {
+                                    // close enough, snap to X
+                                    bestUnitVector = new Location(LengthUnit.Millimeters, Math.signum(bestUnitVector.getX()), 0, 0, 0);
+                                }
+                                else if (Math.abs(bestUnitVector.getY()) > Math.abs(bestUnitVector.getX())*5) {
+                                    // close enough, snap to Y
+                                    bestUnitVector = new Location(LengthUnit.Millimeters, 0, Math.signum(bestUnitVector.getY()), 0, 0);
+                                }
+                            }
+                            // determine the correct transformation
+                            double angleTape = Math.atan2(bestUnitVector.getY(), bestUnitVector.getX())*180.0/Math.PI;
+                            // the new calibration target is really the mid-point
+                            Location midPoint = calibratedHole1Location.add(calibratedHole2Location).multiply(0.5, 0.5, 0, 0);
+                            // but let's project that back to the real hole positions with nominal pitch (undistorted by the camera lens and Z parallax)
+                            double distanceHolesMm = Math.round(calibratedHole1Location.getLinearDistanceTo(calibratedHole2Location)
+                                    /sprocketHolePitchMm)*sprocketHolePitchMm;
+                            calibratedHole1Location = midPoint.subtract(bestUnitVector.multiply(distanceHolesMm*0.5, distanceHolesMm*0.5, 0, 0));
+                            calibratedHole2Location = midPoint.add(bestUnitVector.multiply(distanceHolesMm*0.5, distanceHolesMm*0.5, 0, 0));
+                            Logger.trace("[TapeUtils] calibrated hole locations are: " + calibratedHole1Location + ", " +calibratedHole2Location);
+                            if (autoSetupMode  == FindFeaturesMode.CalibrateHoles) {
+                                // get the current pick location relative to hole 1
+                                Location pickLocation = this.partLocation.convertToUnits(LengthUnit.Millimeters);
+                                Location relativePickLocation = pickLocation
+                                        .subtract(hole1Location);
+                                // rotate from old angle 
+                                relativePickLocation =  relativePickLocation.rotateXy(-pickLocation.getRotation())
+                                        .derive(null, null, null, 0.0);
+                                // normalize to a nominal local pick location according to EIA 481
+                                if (this.normalizePickLocation) {
+                                    relativePickLocation = new Location(LengthUnit.Millimeters,
+                                            Math.round(relativePickLocation.getX()/partPitchMinMm)*partPitchMinMm,
+                                            -sprocketHoleToPartMinMm+Math.round((relativePickLocation.getY()+sprocketHoleToPartMinMm)/sprocketHoleToPartGridMm)*sprocketHoleToPartGridMm,
+                                            0, 0);
+                                }
+                                // calculate the new pick location with the new hole 1 location and tape angle 
+                                calibratedPickLocation = calibratedHole1Location.add(relativePickLocation.rotateXy(angleTape))
+                                        .derive(null, null, pickLocation.getZ(), angleTape);
+                            }
+                        }
+                    }
+
+                    if (calibratedHole1Location != null && calibratedPickLocation != null) {
+                        // we have our calibrated locations
+                        // Get the calibrated vision offset (with Z always 0)
+                        calibratedVisionOffset = this.partLocation
+                                .subtractWithRotation(calibratedPickLocation)
+                                .derive(null, null, 0.0, null);
+                        Logger.debug("calibrated vision offset is: " + calibratedVisionOffset 
+                                + ", length is: "+calibratedVisionOffset.getLinearLengthTo(Location.origin));
+
+                        // Add tick marks for show
+                        if (calibratedPickLocation != null) {
+                            org.openpnp.model.Point a;
+                            org.openpnp.model.Point b;
+                            Location tick = new Location(LengthUnit.Millimeters, -bestUnitVector.getY(), bestUnitVector.getX(), 0, 0);
+                            a = VisionUtils.getLocationPixels(camera, calibratedPickLocation.subtract(tick));
+                            b = VisionUtils.getLocationPixels(camera, calibratedPickLocation.add(tick));
+                            lines.add(new Ransac.Line(new Point(a.x, a.y), new Point(b.x, b.y)));
+                            a = VisionUtils.getLocationPixels(camera, calibratedPickLocation.subtract(bestUnitVector));
+                            b = VisionUtils.getLocationPixels(camera, calibratedPickLocation.add(bestUnitVector));
+                            lines.add(new Ransac.Line(new Point(a.x, a.y), new Point(b.x, b.y)));
+                            Logger.debug("calibrated pick location is: " + calibratedPickLocation);
+                        }
+                    }
+                }
+            }
+
+            Result ocrStageResult = pipeline.getResult("OCR"); 
+            if (ocrStageResult != null) {
+                detectedOcrModel = (SimpleOcr.OcrModel) ocrStageResult.model;
+            }
+
+            if (showResultMilliseconds > 0) {
+                // Draw the result onto the pipeline image.
+                Mat resultMat = pipeline.getWorkingImage().clone();
+                drawHoles(resultMat, getHoles(), Color.green);
+                drawLines(resultMat, getLines(), new Color(0, 0, 255));
+                drawPartNumbers(resultMat, Color.orange);
+                drawOcrText(resultMat, Color.orange);
+                if (getHoles().isEmpty()) {
+                    Imgproc.line(resultMat, new Point(0, 0), new Point(resultMat.cols()-1, resultMat.rows()-1), 
+                            FluentCv.colorToScalar(Color.red), 2, Imgproc.LINE_AA);
+                    Imgproc.line(resultMat, new Point(0, resultMat.rows()-1), new Point(resultMat.cols()-1, 0), 
+                            FluentCv.colorToScalar(Color.red), 2, Imgproc.LINE_AA);
+                }
+
+                if (Logger.getLevel() == org.pmw.tinylog.Level.DEBUG || Logger.getLevel() == org.pmw.tinylog.Level.TRACE) {
+                    File file = Configuration.get().createResourceFile(getClass(), "tape-utils", ".png");
+                    Imgcodecs.imwrite(file.getAbsolutePath(), resultMat);
+                }
+                BufferedImage showResult = OpenCvUtils.toBufferedImage(resultMat);
+                resultMat.release();
+                MainFrame.get().getCameraViews().getCameraView(camera)
+                .showFilteredImage(showResult, showResultMilliseconds);
+            }
+        }
+        catch (ClassCastException e) {
+            throw new Exception("Unrecognized result type (should be Result.Circle, RotatedRect, KeyPoint): " + resultsList);
+        }
+        return this;
+    }
+}


### PR DESCRIPTION
# Description
This PR adds a new feeder type named **`BambooFeederAutoVision`**. It combines the vision calibration initially implemented by the _ReferencePushPullFeeder_ with the standard 2 actuators in the _ReferenceAutoFeeder_.
This is extremely useful for auto feeders that have a larger pick window which exposes at least 2 tape holes, like the latest iterations of BambooFeeder AS1.

In addition:
* Creates a base abstract class `PandaplacerVisionFeeder` that implements the CV calibration and can be potentially reused in multiple feeders without code duplication. This is a stripped down version of the PushPull feeder.
* Creates the `TapeUtils` class dedicated to CV calibration of EIA Tape. It can be moved to `org.openpnp.util` to allow for more reuse. (this is the reworked inner class FindFeatures from the PushPull feeder)

# Justification
Multiple auto feeders expose a larger pick window where multiple tape holes are visible.
The new feeder type allows better calibration of the pick location.

# Instructions for Use
Create a new feeder of type `BambooFeederAutoVision` and configure as follows:
* Vision calibration parameters - same as `ReferencePushPullFeeder`
* Actuators - same as `ReferenceAutoFeeder`


# Implementation Details
1. How did you test the change? 
* Ran all the automated tests
* Tested the new feeder type on my personal hardware
2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)?
* Yes
3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing.
* No changes to `org.openpnp.spi` or `org.openpnp.model` packages
4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted.
* All tests passed
