### PR TITLE
Fix broken Camera permissions on macOS

### DIFF
--- a/OpenPnP.install4j
+++ b/OpenPnP.install4j
@@ -69,11 +69,8 @@
           <directory name="native/${compiler:native_path}" />
         </nativeLibraryDirectories>
       </java>
-      <infoPlist>
-&lt;key&gt;NSCameraUsageDescription&lt;/key&gt;
-&lt;string&gt;openpnp-capture needs permission to access the camera to capture images.&lt;/string&gt;
-
-</infoPlist>
+      <infoPlist>&lt;key&gt;NSCameraUsageDescription&lt;/key&gt;
+&lt;string&gt;openpnp-capture needs permission to access the camera to capture images.&lt;/string&gt;</infoPlist>
       <iconImageFiles>
         <file path="./src/main/resources/icons/OpenPnP-logo.iconset/icon_32x32.png" />
         <file path="./src/main/resources/icons/OpenPnP-logo.iconset/icon_128x128.png" />


### PR DESCRIPTION
# Description
Attempt to fix camera entitlement on macOS Monterey - Sonoma.

# Justification
The Test build does not request access to Camera devices at least on macOS Monterey and Sonoma and the app crashes with the message `This app has crashed because it attempted to access privacy-sensitive data without a usage description. The app's Info.plist must contain an com.apple.security.device.camera key with a string value explaining to the user how the app uses this data.`

However, the `NSCameraUsageDescription` key is present and while testing I noticed a difference between having whitespaces vs not in Info.plist. There is also a difference about these carriage returns between the Test build and the Develop build, where Develop doesn't have them and works as expected.

The whitespace was introduced in https://github.com/openpnp/openpnp/pull/1534

# Instructions for Use
No special usage instructions.

# Implementation Details
1. How did you test the change? Be descriptive. Untested code will not be accepted.

- Tested on local macOS Monterey machine

2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)?

- Yes

3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing.

- no changes in this space

4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted.

- tests passed
