### PR TITLE
Feature  / Vision Compositing Part Mask

### DIFF
--- a/src/main/java/org/openpnp/gui/components/VisionCompositingPreview.java
+++ b/src/main/java/org/openpnp/gui/components/VisionCompositingPreview.java
@@ -155,7 +155,7 @@ public class VisionCompositingPreview extends JComponent implements MouseMotionL
                     // check if mouse over
                     if (xMouse != null && yMouse != null) {
                         double xMouse = (this.xMouse - width/2.0)/scale;
-                        double yMouse = (this.yMouse - height/2.0)/-scale;
+                        double yMouse = (this.yMouse - height/2.0)/scale;
                         double distance = Math.hypot(xMouse - shot.getX(), yMouse - shot.getY());
                         if (distance < shot.getMaxMaskRadius()
                                 && bestDistance > distance) {

--- a/src/main/java/org/openpnp/machine/reference/vision/ReferenceBottomVision.java
+++ b/src/main/java/org/openpnp/machine/reference/vision/ReferenceBottomVision.java
@@ -478,12 +478,6 @@ public class ReferenceBottomVision extends AbstractPartAlignment {
                     .multiply(1.2)); // Allow for some tolerance, we will check the result later.
             // mask the corner
             pipeline.setProperty("MaskCircle.diameter", new Length(shot.getMaxMaskRadius()*2, composite.getUnits()));
-            // mask the whole part
-            pipeline.setProperty("partmask.diameter", new Length(composite.getMaxCornerRadius(), composite.getUnits())
-                    .add(nozzleTip.getMaxPickTolerance()).multiply(2));
-            pipeline.setProperty("partmask.center", camera.getLocation()
-                    .subtract(new Location(composite.getUnits(), shot.getX(), shot.getY(), 0., 0.)
-                            .rotateXy(wantedLocation.getRotation())));
             if (nozzleTip instanceof ReferenceNozzleTip) {
                 ReferenceNozzleTipCalibration calibration = ((ReferenceNozzleTip) nozzleTip).getCalibration();
                 if (calibration != null 
@@ -520,6 +514,12 @@ public class ReferenceBottomVision extends AbstractPartAlignment {
                     .add(samplingSize.multiply(2)));
 
             if (composite.getCompositingSolution().isAdvanced()) {
+                // mask the whole part
+                pipeline.setProperty("partmask.diameter", new Length(composite.getMaxPadRadius(), composite.getUnits())
+                        .add(nozzleTip.getMaxPickTolerance()).multiply(2));
+                pipeline.setProperty("partmask.center", camera.getLocation()
+                        .subtract(new Location(composite.getUnits(), shot.getX(), shot.getY(), 0., 0.)
+                                .rotateXy(wantedLocation.getRotation())));
                 pipeline.setProperty("MinAreaRect.leftEdge", shot.hasLeftEdge());
                 pipeline.setProperty("MinAreaRect.rightEdge", shot.hasRightEdge());
                 pipeline.setProperty("MinAreaRect.topEdge", shot.hasTopEdge());

--- a/src/main/java/org/openpnp/machine/reference/vision/ReferenceBottomVision.java
+++ b/src/main/java/org/openpnp/machine/reference/vision/ReferenceBottomVision.java
@@ -476,7 +476,14 @@ public class ReferenceBottomVision extends AbstractPartAlignment {
             // Set the background removal properties.
             pipeline.setProperty("DetectRectlinearSymmetry.searchDistance", nozzleTip.getMaxPickTolerance()
                     .multiply(1.2)); // Allow for some tolerance, we will check the result later.
+            // mask the corner
             pipeline.setProperty("MaskCircle.diameter", new Length(shot.getMaxMaskRadius()*2, composite.getUnits()));
+            // mask the whole part
+            pipeline.setProperty("partmask.diameter", new Length(composite.getMaxCornerRadius(), composite.getUnits())
+                    .add(nozzleTip.getMaxPickTolerance()).multiply(2));
+            pipeline.setProperty("partmask.center", camera.getLocation()
+                    .subtract(new Location(composite.getUnits(), shot.getX(), shot.getY(), 0., 0.)
+                            .rotateXy(wantedLocation.getRotation())));
             if (nozzleTip instanceof ReferenceNozzleTip) {
                 ReferenceNozzleTipCalibration calibration = ((ReferenceNozzleTip) nozzleTip).getCalibration();
                 if (calibration != null 

--- a/src/main/java/org/openpnp/model/VisionCompositing.java
+++ b/src/main/java/org/openpnp/model/VisionCompositing.java
@@ -749,6 +749,10 @@ public class VisionCompositing extends AbstractModelObject{
             return locationAndRotation;
         }
 
+        public double getMaxPadRadius() {
+            return maxPadRadius;
+        }
+
         public List<Footprint.Pad> getRectifiedPads() {
             if (rectifiedPads == null) {
                 return null;
@@ -795,7 +799,8 @@ public class VisionCompositing extends AbstractModelObject{
         private final double invHypot = 1/Math.hypot(1, 1); 
         private final double[] xOctogonalHullSign = new double[] { -invHypot,  0, +invHypot, -1, +1, -invHypot,  0, +invHypot };
         private final double[] yOctogonalHullSign = new double[] { -invHypot, -1, -invHypot,  0,  0, +invHypot, +1, +invHypot };
-        
+
+        private double maxPadRadius = 0;
         private double octogonalHull[] = new double[8]; 
         private LengthConverter lengthConverter = new LengthConverter();
 
@@ -1023,6 +1028,10 @@ public class VisionCompositing extends AbstractModelObject{
          * @param pad
          */
         protected void addPadToOctogalHull(Footprint.Pad pad) {
+            for (Point pt : pad.corners()) {
+                double r = Math.hypot(pt.x, pt.y);
+                maxPadRadius = Math.max(maxPadRadius, r);
+            }
             for (int i = 0; i < 8; i++) {
                 double h = pad.getX()*xOctogonalHullSign[i] + pad.getWidth()*Math.abs(xOctogonalHullSign[i])*0.5
                          + pad.getY()*yOctogonalHullSign[i] + pad.getHeight()*Math.abs(yOctogonalHullSign[i])*0.5;

--- a/src/main/resources/org/openpnp/machine/reference/vision/ReferenceBottomVision-BodyPipeline.xml
+++ b/src/main/resources/org/openpnp/machine/reference/vision/ReferenceBottomVision-BodyPipeline.xml
@@ -7,6 +7,7 @@
       <cv-stage class="org.openpnp.vision.pipeline.stages.ConvertColor" name="5" enabled="true" conversion="Bgr2HsvFull"/>
       <cv-stage class="org.openpnp.vision.pipeline.stages.MaskHsv" name="threshold" enabled="true" auto="false" fraction-to-mask="0.0" hue-min="60" hue-max="130" saturation-min="32" saturation-max="255" value-min="64" value-max="100" soft-edge="0" soft-factor="1.0" invert="false" binary-mask="true" property-name="MaskHsv"/>
       <cv-stage class="org.openpnp.vision.pipeline.stages.MaskCircle" name="4" enabled="true" diameter="525" property-name="MaskCircle"/>
+      <cv-stage class="org.openpnp.vision.pipeline.stages.MaskCircle" name="4b" enabled="true" diameter="100000" property-name="partmask"/>
       <cv-stage class="org.openpnp.vision.pipeline.stages.FindContours" name="findCountours" enabled="true" retrieval-mode="List" approximation-method="None"/>
       <cv-stage class="org.openpnp.vision.pipeline.stages.FilterContours" name="filterContours" enabled="true" contours-stage-name="findCountours" min-area="0.01" max-area="900000.0" property-name="FilterContours"/>
       <cv-stage class="org.openpnp.vision.pipeline.stages.MaskCircle" name="11" enabled="true" diameter="0" property-name=""/>

--- a/src/main/resources/org/openpnp/machine/reference/vision/ReferenceBottomVision-DefaultPipeline.xml
+++ b/src/main/resources/org/openpnp/machine/reference/vision/ReferenceBottomVision-DefaultPipeline.xml
@@ -7,6 +7,7 @@
       <cv-stage class="org.openpnp.vision.pipeline.stages.ImageWriteDebug" name="deb0" enabled="true" prefix="bv_source_" suffix=".png"/>
       <cv-stage class="org.openpnp.vision.pipeline.stages.BlurGaussian" name="3" enabled="true" kernel-size="9" property-name="BlurGaussian"/>
       <cv-stage class="org.openpnp.vision.pipeline.stages.MaskCircle" name="4" enabled="true" diameter="525" property-name="MaskCircle"/>
+      <cv-stage class="org.openpnp.vision.pipeline.stages.MaskCircle" name="4b" enabled="true" diameter="100000" property-name="partmask"/>
       <cv-stage class="org.openpnp.vision.pipeline.stages.ConvertColor" name="5" enabled="true" conversion="Bgr2HsvFull"/>
       <cv-stage class="org.openpnp.vision.pipeline.stages.MaskHsv" name="6" enabled="true" auto="false" fraction-to-mask="0.0" hue-min="60" hue-max="130" saturation-min="32" saturation-max="255" value-min="64" value-max="255" invert="false" binary-mask="false" property-name="MaskHsv"/>
       <cv-stage class="org.openpnp.vision.pipeline.stages.MaskHsv" name="threshold" enabled="true" auto="false" fraction-to-mask="0.0" hue-min="0" hue-max="255" saturation-min="0" saturation-max="255" value-min="0" value-max="128" invert="false" binary-mask="false" property-name=""/>

--- a/src/test/java/VisionCompositingTest.java
+++ b/src/test/java/VisionCompositingTest.java
@@ -65,7 +65,7 @@ public class VisionCompositingTest {
 
         Configurator
         .currentConfig()
-        .level(Level.DEBUG) // change this for other log levels.
+        .level(Level.INFO) // change this for other log levels.
         .activate();
 
     }

--- a/src/test/java/VisionCompositingTest.java
+++ b/src/test/java/VisionCompositingTest.java
@@ -65,7 +65,7 @@ public class VisionCompositingTest {
 
         Configurator
         .currentConfig()
-        .level(Level.INFO) // change this for other log levels.
+        .level(Level.DEBUG) // change this for other log levels.
         .activate();
 
     }


### PR DESCRIPTION
# Description
In [Vision Compositing](https://github.com/openpnp/openpnp/wiki/Vision-Compositing) a.k.a. multi-shot bottom vision, the corner shots are done with the nozzle holding the part off-center of the camera, so the corner is above the camera center. This means that another nozzle (with part) might come into the view of the camera and disrupt the detection, as illustrated in this user shot: 

![Detection disrupted by part on second nozzle](https://github.com/openpnp/openpnp/assets/9963310/a28c3537-b64e-4779-aa96-290d8d298342)
Credits: Krzysztof Kozłowski

Similarly, some machines might have a limited backdrop shade, so unwanted bright reflections etc. might enter the view from the side.

Making corner shots almost always means that only half the camera view is actually used for detection. This PR exploits this and adds a "part mask" to the pipeline to mask off the unwanted side of the camera view. The new mask is applied _in addition_ to the already present corner mask, as shown in this animation:

![Combined Masks](https://github.com/openpnp/openpnp/assets/9963310/d0c2eb5b-625f-4eaf-b78d-de40b8623a9b)

Ideally it will blot out any disruptive elements. 

# Justification
See the user report:
https://groups.google.com/g/openpnp/c/X2I-48rCesE/m/_nvwi2dGAAAJ

# Instructions for Use
The new mask is automatically included in the new stock pipeline. Therefore to enable it, you need to make sure your Vision Settings are using the new pipeline. [Read the Wiki](https://github.com/openpnp/openpnp/wiki/Bottom-Vision#using-the-stock-vision-settings).

# Implementation Details
1. Tested in simulation.
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. Successful `mvn test` before submitting the Pull Request.
