### PR TITLE
Feature / Change labels in simulated cameras

### DIFF
--- a/src/main/resources/org/openpnp/translations.properties
+++ b/src/main/resources/org/openpnp/translations.properties
@@ -1,5 +1,5 @@
 #Eclipse messages class
-#Sun Jun 25 19:36:06 CEST 2023
+#Tue Jun 18 16:04:03 CEST 2024
 AbstractActuatorConfigurationWizard.CoordinateSystemPanel.AxisInterlockLabel.text=Axis Interlock?
 AbstractActuatorConfigurationWizard.CoordinateSystemPanel.AxisInterlockLabel.toolTipText=Enable to get an extra Wizard tab to configure an Axis Interlocking Actuator
 AbstractActuatorConfigurationWizard.CoordinateSystemPanel.AxisLabel.text=Axis
@@ -510,7 +510,7 @@ ImageCamera.Issue=The simulation ImageCamera can be replaced with a OpenPnpCaptu
 ImageCamera.Solution=Replace with OpenPnpCaptureCamera.
 ImageCameraConfigurationWizard.Action.Browse=Browse
 ImageCameraConfigurationWizard.Action.Browse.Description=Browse
-ImageCameraConfigurationWizard.GeneralPanel.Border.title=General
+ImageCameraConfigurationWizard.GeneralPanel.Border.title=Camera Simulation
 ImageCameraConfigurationWizard.GeneralPanel.DistortionLabel.text=Distortion [%]
 ImageCameraConfigurationWizard.GeneralPanel.DistortionLabel.toolTipText=<html>Simulated lens distortion. Positive values create Barrel distortion, negative values create a Pincushion distortion.</html>
 ImageCameraConfigurationWizard.GeneralPanel.ExtraPanel.Border.title=Simulated Calibration Rig
@@ -524,7 +524,7 @@ ImageCameraConfigurationWizard.GeneralPanel.MirroredViewLabel.text=View mirrored
 ImageCameraConfigurationWizard.GeneralPanel.MirroredViewLabel.toolTipText=Simulate the camera as showing a mirrored view
 ImageCameraConfigurationWizard.GeneralPanel.PixelDimensionLabel.text=Pixel Dimension
 ImageCameraConfigurationWizard.GeneralPanel.SourceUrlLabel.text=Source URL
-ImageCameraConfigurationWizard.GeneralPanel.UnitsPerPixelLabel.text=Units per Pixel
+ImageCameraConfigurationWizard.GeneralPanel.UnitsPerPixelLabel.text=Simulated Units per Pixel
 ImageCameraConfigurationWizard.GeneralPanel.UnitsPerPixelLabel.toolTipText=To allow simulation of Unit per Pixel calibration, the true Units per Pixel of the image must be stored independently.
 ImageCameraConfigurationWizard.GeneralPanel.OffsetLabel.text=Offset
 ImageCameraConfigurationWizard.GeneralPanel.OffsetLabel.toolTipText=Offset applied between calculated and used pixel in picture. Used to shift the image if required.
@@ -1679,7 +1679,7 @@ SignalersPropertySheetHolder.SelectionDialog.description=Please select a Signale
 SignalersPropertySheetHolder.SelectionDialog.title=Select Signaler...
 SimulatedUpCamera.Issue=The SimulatedUpCamera can be replaced with a OpenPnpCaptureCamera to connect to a real USB camera.
 SimulatedUpCamera.Solution=Replace with OpenPnpCaptureCamera.
-SimulatedUpCameraConfigurationWizard.GeneralPanel.Border.title=General
+SimulatedUpCameraConfigurationWizard.GeneralPanel.Border.title=Camera Simulation
 SimulatedUpCameraConfigurationWizard.GeneralPanel.CameraLocationLabel.text=Camera Location
 SimulatedUpCameraConfigurationWizard.GeneralPanel.CameraLocationLabel.toolTipText=<html>\nThe Camera simulated location.<br/>\n<strong>Note\:</strong>  In order to test calibration procedures, we cannot use the regular camera location.\n</html>
 SimulatedUpCameraConfigurationWizard.GeneralPanel.FocalBlurLabel.text=Simulate Focal Blur?
@@ -1692,7 +1692,7 @@ SimulatedUpCameraConfigurationWizard.GeneralPanel.PickErrorOffsetsLabel.toolTipT
 SimulatedUpCameraConfigurationWizard.GeneralPanel.PixelDimensionLabel.text=Pixel Dimension
 SimulatedUpCameraConfigurationWizard.GeneralPanel.RotationLabel.text=Rotation
 SimulatedUpCameraConfigurationWizard.GeneralPanel.SensorDiagonalLabel.text=Sensor Diagonal
-SimulatedUpCameraConfigurationWizard.GeneralPanel.UnitsPerPixelLabel.text=Units per Pixel
+SimulatedUpCameraConfigurationWizard.GeneralPanel.UnitsPerPixelLabel.text=Simulated Units per Pixel
 SimulatedUpCameraConfigurationWizard.GeneralPanel.UnitsPerPixelLabel.toolTipText=<html>\nThe camera simulated units per pixel.<br/>\n<strong>Note\:</strong>  In order to test calibration procedures, we cannot use the regular units per pixel.\n</html>
 SimulatedUpCameraConfigurationWizard.lblBackgroundColor.text=Background Scenario
 SimulatedUpCameraConfigurationWizard.lblBackgroundColor.toolTipText=Choose a background scenario. It simulates a background shade and nozzle tip color.


### PR DESCRIPTION
# Description
Changes some labels in simulated camera Wizards for clarity.

![up-looking](https://github.com/openpnp/openpnp/assets/9963310/3178ca8c-6b6d-4bd2-b7c2-bd0d1d9815a5)

![down-looking](https://github.com/openpnp/openpnp/assets/9963310/bfcf01c0-8e48-4c3f-8485-4e5a8a9327e6)

# Justification
See #1636.

# Instructions for Use
No change.

# Implementation Details
1. No separate tests for translations only.
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. Successful `mvn test` before submitting the Pull Request.
