### PR TITLE
FeederVisionHelper - Add Ransac lines debug message

### DIFF
--- a/src/main/java/org/openpnp/util/FeederVisionHelper.java
+++ b/src/main/java/org/openpnp/util/FeederVisionHelper.java
@@ -546,6 +546,7 @@ public class FeederVisionHelper {
                             - sprocketHoleToleranceMm;
                     double maxDistanceMm = (autoSetupMode == FindFeaturesMode.CalibrateHoles ?
                             calibrationToleranceMm : bestDistanceMm);
+                    Logger.debug("Found sprocket holes line with distance "+(distanceMm)+"mm [min: "+minDistanceMm+"mm, max: "+maxDistanceMm+"mm]");
 
                     if (distanceMm >= minDistanceMm && distanceMm < maxDistanceMm) {
                         bestLine = line;


### PR DESCRIPTION
# Description
This is a minor enhancement for debugging the search for ransac lines between sprocket holes

# Justification
When something is off about the lines found, only a generic debug error of "No line of sprocket holes can be recognized". This adds some additional details before that error.

# Instructions for Use
No change in usage.

# Implementation Details
1. How did you test the change? Be descriptive. Untested code will not be accepted.
* Ran all tests with mvn
2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)?
* Yes
3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing.
* No changes
4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted.
* All tests passed