### PR TITLE
AbstractPandaplacerVisionFeeder - Remove automatic cv pipeline reset

### DIFF
--- a/src/main/java/org/openpnp/machine/pandaplacer/AbstractPandaplacerVisionFeeder.java
+++ b/src/main/java/org/openpnp/machine/pandaplacer/AbstractPandaplacerVisionFeeder.java
@@ -532,31 +532,16 @@ public abstract class AbstractPandaplacerVisionFeeder extends ReferenceFeeder {
         }
 
         ensureCameraZ(camera, true);
-        // Try with cloned pipeline.
-        Exception e = autoSetupPipeline(camera, null);
+        // Try with the current pipeline.
+        Exception e = autoSetupPipeline(camera, this.pipelineType);
         if (e != null) {
-            Logger.debug(e, "Auto-Setup: exception");
-            // Failed, try with pipeline type defaults.
-            for (PipelineType type : PipelineType.values()) {
-                Logger.debug("Auto-Setup: trying with stock pipeline type "+type);
-                e = autoSetupPipeline(camera, type);
-                if (e == null) {
-                    // Success.
-                    Logger.debug(e, "Auto-Setup: success");
-                    return;
-                }
-                Logger.debug(e, "Auto-Setup: exception");
-            }
-            // Still no luck, throw.
+            // No luck, throw.
             Logger.debug(e, "Auto-Setup: final exception");
             throw e;
         }
     }
 
     protected Exception autoSetupPipeline(Camera camera, PipelineType type) {
-        if (type != null) {
-            resetPipeline(type);
-        }
         try (CvPipeline pipeline = getCvPipeline(camera, true, true)) {
             // Process vision and get some features
             FeederVisionHelper feature = new FeederVisionHelper(getVisionHelperParams(camera, pipeline))


### PR DESCRIPTION
# Description
In this feeder type, some code inherited from ReferencePushPullFeeder, specific to feeder cloning, was resetting the CV pipeline for each Auto Setup action.
This change removes the automatic reset so a custom vision pipeline can be used when needed for Auto Setup, since BambooFeeders do not implement cloning.

# Justification
Without the cloning functionality, it is not correct to reset the CV pipeline automatically when there is a dedicated button on the UI for it. The reset action should be intentional as the user requires.

# Instructions for Use
In the BambooFeeder objects, the Auto Setup button will no longer automatically reset the vision pipeline, therefore a customized pipeline can be used for both auto calibration and in-job calibration.

# Implementation Details
1. How did you test the change? Be descriptive. Untested code will not be accepted.
* Ran all tests and used it on my machine.
2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)?
* Yes
3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing.
* No changes
4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted.
* All tests passed