### PR TITLE
Temporary disable signing of MacOS builds

### DIFF
--- a/OpenPnP.install4j
+++ b/OpenPnP.install4j
@@ -6,7 +6,7 @@
       <variable name="native_path" />
       <variable name="mediaFileVersion" value="${compiler:sys.version}" />
     </variables>
-    <codeSigning macEnabled="true" macPkcs12File=".github/OpenPnP-Developer-ID-Application.p12" />
+    <codeSigning macEnabled="false" macPkcs12File=".github/OpenPnP-Developer-ID-Application.p12" />
     <jreBundles jdkProviderId="AdoptOpenJDK" release="17/jdk-17.0.8.1+1" />
   </application>
   <files>


### PR DESCRIPTION
# Description
Currently the builds for MacOS are broken as notarization is needed as determined by @vonnieda here: https://github.com/openpnp/openpnp/pull/1628#issuecomment-2142761793

This change disables signing for MacOS builds temporarily until the permanent fix is rolled out.

# Justification
Temporarily enables valid builds for MacOS providing unsigned bundles, but fully functional that do ask for correct camera permissions.

# Instructions for Use
A user should accept in MacOS the dialog about the application not being signed with a valid developer certificate.

# Implementation Details
1. How did you test the change? Be descriptive. Untested code will not be accepted.
* Changed the install4j config file on my machine and ran the build code successfully
2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)?
* Yes
3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing.
* No change
4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted.
* Ran all tests