### PR TITLE
Fix / Safe Z and Bottom Vision Issues

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/vision/ReferenceBottomVision.java
+++ b/src/main/java/org/openpnp/machine/reference/vision/ReferenceBottomVision.java
@@ -41,7 +41,6 @@ import org.openpnp.spi.PartAlignment;
 import org.openpnp.spi.PropertySheetHolder;
 import org.openpnp.util.MovableUtils;
 import org.openpnp.util.OpenCvUtils;
-import org.openpnp.util.UiUtils;
 import org.openpnp.util.Utils2D;
 import org.openpnp.util.VisionUtils;
 import org.openpnp.vision.pipeline.CvPipeline;
@@ -533,18 +532,17 @@ public class ReferenceBottomVision extends AbstractPartAlignment {
                     .addWithRotation(adjustedNozzleLocation.subtractWithRotation(wantedLocation)); 
             pipeline.new PipelineShot() {
                 @Override
-                public void apply() {
-                    UiUtils.messageBoxOnException(() -> {
-                        if (nozzle.getLocation().getLinearLengthTo(camera.getLocation())
-                                .compareTo(camera.getRoamingRadius()) > 0) {
-                            // Nozzle is not yet in camera roaming radius. Move at safe Z.
-                            MovableUtils.moveToLocationAtSafeZ(nozzle, shotLocation);
-                        }
-                        else {
-                            nozzle.moveTo(shotLocation);
-                        }
-                        super.apply();
-                    });
+                public void apply() throws Exception {
+                    if (nozzle.getLocation().getLinearLengthTo(camera.getLocation())
+                            .compareTo(camera.getRoamingRadius()
+                                    .add(nozzleTip.getMaxPickTolerance())) > 0) {
+                        // Nozzle is not yet in camera roaming radius. Move at safe Z.
+                        MovableUtils.moveToLocationAtSafeZ(nozzle, shotLocation);
+                    }
+                    else {
+                        nozzle.moveTo(shotLocation);
+                    }
+                    super.apply();
                 }
 
                 @Override 

--- a/src/main/java/org/openpnp/machine/reference/vision/ReferenceBottomVision.java
+++ b/src/main/java/org/openpnp/machine/reference/vision/ReferenceBottomVision.java
@@ -533,7 +533,7 @@ public class ReferenceBottomVision extends AbstractPartAlignment {
             pipeline.new PipelineShot() {
                 @Override
                 public void apply() throws Exception {
-                    if (nozzle.getLocation().getLinearLengthTo(camera.getLocation())
+                    if (nozzle.getLocation().getLinearLengthTo(camera.getLocation(nozzle))
                             .compareTo(camera.getRoamingRadius()
                                     .add(nozzleTip.getMaxPickTolerance())) > 0) {
                         // Nozzle is not yet in camera roaming radius. Move at safe Z.


### PR DESCRIPTION
# Description
This PR addresses several issues:

## Move to Safe Z with shared axes
A move to safe Z is usually performed by the head, for all its attached nozzles (theoretically, all kinds of `HeadMountable`, e.g. Actuators too). In the order they are defined in the Machine Setup, each is moved to the Safe Z Zone. For nozzles with shared Z axes (cam and negated axis), the Safe Z Zone is two-sided, i.e., it has a lower and a upper limit. If a nozzle was _above_ the safe Z zone, it was previously _also_ brought down into the Safe Z zone. This happened when the _other_ nozzle sharing its Z axis was currently positioned below Safe Z. This second nozzle therefore gets no say in that effective move to Safe Z. With Dynamic Safe Z (where the part height is added to the safe Z coordinate), this resulted in an insufficient move to Safe Z. A second move was then generated by the second nozzle, once it got its turn. 

Side note: these two moves in Z would normally be folded into one by the motion controller. But with **ModeratedConstantAcceleration** motion control, and a **Jerk** value set (not zero) on the Z axis (which is not recommended) it would shape the acceleration lower. 

It only happened if it goes against nozzle order, e.g. for a two-nozzle machine it would only happen when nozzle 2 is positioned down.

With this PR, OpenPnP now only moves each nozzle (HeadMountable), if _below_ the Safe Z Zone. It is assumed that the _other_ nozzle sharing the Z axis will be handled in its turn, by the head.

## Bottom vision adjustment moves
Bottom vision adjustment moves should not go via Safe Z (too slow). In order for OpenPnP to know when this is the case, it measures the 2D distance from the nozzle's current location to the bottom camera location. If it is within the configured **Roaming Radius**, the move goes directly, not via Safe Z.

However, for those not using **Vision Compositing**, a.k.a. multi-shot bottom vision, the **Roaming Radius** is configured as zero.

Therefore this PR adds the **Max. Pick Tolerance** (given by the nozzle tip) as the allowed roaming distance without going via Safe Z. Furthermore, it uses the tool specific camera location, with any Z tilt error applied, so this is not counted in the tolerance. Both are also the right thing to do in case of multi-shot, as the roaming radius defines the nominal (net) distance without any tolerances applied.
 
## Exception handling in machine tasks 
This PR also removes the `UiUtils.messageBoxOnException()` wrapper around the vision adjustment move, which is misplaced here. It must not be used inside a machine task, i.e., exceptions would be suppressed, should the move ever fail. 

Conversely, there is already such a `UiUtils.messageBoxOnException()` wrapper in the Pipeline Editor `stepNextShotAction()`, which takes care of the intended error reporting.

# Justification
See the user report:
https://groups.google.com/g/openpnp/c/3Glo3Rjlo7w/m/qe3t3Dn1AQAJ

# Instructions for Use
No change in usage.

# Implementation Details
1. Tested with mvn test only. Intention is a quick test by the user, reporting the issue (justified by `test` branch).
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. Successful `mvn test` before submitting the Pull Request.
