### PR TITLE
Fix / Wrong end of the Safe Z Zone.

### DIFF
--- a/src/main/java/org/openpnp/gui/JogControlsPanel.java
+++ b/src/main/java/org/openpnp/gui/JogControlsPanel.java
@@ -556,17 +556,16 @@ public class JogControlsPanel extends JPanel {
         public void actionPerformed(ActionEvent arg0) {
             UiUtils.submitUiMachineTask(() -> {
                 HeadMountable hm = machineControlsPanel.getSelectedTool();
-                // Note, we don't just moveToSafeZ(), because this will just sit still, if we're already in the Safe Z Zone.
-                // instead we explicitly move to the Safe Z coordinate i.e. the lower bound of the Safe Z Zone, applicable
-                // for this hm.
-                Location location = hm.getLocation();
-                Length safeZLength = hm.getSafeZ();
-                double safeZ = (safeZLength != null ? safeZLength.convertToUnits(location.getUnits()).getValue() : Double.NaN);
-                location = location.derive(null, null, safeZ, null);
                 if (Configuration.get().getMachine().isSafeZPark()) {
                     // All other head-mountables must also be moved to safe Z.
                     hm.getHead().moveToSafeZ();
                 }
+                // Note, we don't just moveToSafeZ(), because this will just sit still, if we're already in the Safe Z Zone.
+                // instead we explicitly move to the effective Safe Z coordinate i.e. the lower bound of the Safe Z Zone, applicable
+                // for this hm (and in case of Dynamic Safe Z with the part height accounted for).
+                Location location = hm.getLocation();
+                Length safeZLength = hm.getEffectiveSafeZ();
+                location = location.deriveLengths(null, null, safeZLength, null);
                 hm.moveTo(location);
                 MovableUtils.fireTargetedUserAction(hm);
             });

--- a/src/main/java/org/openpnp/spi/base/AbstractHeadMountable.java
+++ b/src/main/java/org/openpnp/spi/base/AbstractHeadMountable.java
@@ -268,12 +268,8 @@ public abstract class AbstractHeadMountable extends AbstractModelObject implemen
                 }
                 else {
                     // Must be below Safe Z. Move it.
-                    effectiveSafeZ = getSafeZZone()[1];
-                    if (effectiveSafeZ != null) {
-                        effectiveSafeZ = effectiveSafeZ.convertToUnits(l.getUnits());
-                        l = l.deriveLengths(null, null, effectiveSafeZ, null);
-                        moveTo(l, speed);
-                    }
+                    l = l.deriveLengths(null, null, effectiveSafeZ, null);
+                    moveTo(l, speed);
                 }
             }
         }


### PR DESCRIPTION
# Description
Fixes the fix of #1656, I took the wrong end of the Safe Z Zone (some old code mistakenly left over).  :sweat_smile:

Also made the Z axis `P` button jog to the _effective_ Safe Z (i.e. Dynamic Safe Z with part height accounted for) instead of the Safe Z.

# Justification
See #1656.

# Instructions for Use
See #1656.

# Implementation Details
See #1656.

Quickly tested with `P` button.