### PR TITLE
Fix/Issues & Solutions: Axis letter fallback for generic drivers

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/solutions/GcodeDriverSolutions.java
+++ b/src/main/java/org/openpnp/machine/reference/solutions/GcodeDriverSolutions.java
@@ -23,6 +23,8 @@ package org.openpnp.machine.reference.solutions;
 
 import java.io.StringReader;
 import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -981,7 +983,12 @@ public class GcodeDriverSolutions implements Solutions.Subject {
                             int axisIndex = 0;
                             int lastAxisIndex = 26;
                             String pattern = "";
-                            for (String axisLetter: gcodeDriver.getReportedAxesLetters()) {
+                            List<String> letters = gcodeDriver.getReportedAxesLetters();
+                            if (letters.isEmpty()) {
+                                // we don't have reported letters, take a theoretical set
+                                letters = new ArrayList<>(Arrays.asList(AxisSolutions.VALID_AXIS_LETTERS));
+                            }
+                            for (String axisLetter : letters) {
                                 for (String variable : gcodeDriver.getAxisVariables(machine)) {
                                     if (variable.equals(axisLetter)) {
                                         if (lastAxisIndex < axisIndex-1) {


### PR DESCRIPTION
# Description
The user may choose to use a generic G-code setup instead of using `M115` to try and auto-discover [known controller firmwares](https://github.com/openpnp/openpnp/wiki/Motion-Controller-Firmwares):

![Generic G-code](https://github.com/user-attachments/assets/ea102a44-4b16-44f1-bffe-7857e0fe9bd6)

https://github.com/openpnp/openpnp/wiki/Issues-and-Solutions#connect-milestone

As a side effect, there is also no `M114` (report position) pattern detection taking place. Therefore the valid axis letters of the controller are not available to Issues & Solutions. As a consequence it cannot suggest the `POSITION_REPORT_REGEX` correctly. Instead it proposes an invalid empty regex with no axes.

This bug will be fixed by the PR. 

To still get a decent `POSITION_REPORT_REGEX` proposition, all the usually available axis letters conformant with [NIST RS274NGC](https://www.nist.gov/publications/nist-rs274ngc-interpreter-version-3) are assumed, in an order that seems logical: `X Y Z U V W A B C D E`. 

As long as the user configured their axis letters right, and as long as those are reported in the logical order, it will work. 

Example proposal with reporting user's `machine.xml`:

![Fixed POSITION_REPORT_REGEX](https://github.com/user-attachments/assets/b77e0288-cd99-453f-b02d-955de01a397e)

# Justification
See user report:
https://groups.google.com/g/openpnp/c/fplvl7p9dQY/m/fyqQzl2NCgAJ

# Instructions for Use
Just use [Issues & Solution](https://github.com/openpnp/openpnp/wiki/Issues-and-Solutions#connect-milestone).

# Implementation Details
1. Tested with reporting user's `machine.xml`.
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. No changes in the `org.openpnp.spi` or `org.openpnp.model`.
4. Successful `mvn test` before submitting the Pull Request.
