### PR TITLE
Add updated GStreamerCamera based on AbstractBroadcastingCamera

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -241,6 +241,11 @@
             <artifactId>commons-lang3</artifactId>
             <version>3.12.0</version>
         </dependency>
+        <dependency>
+            <groupId>org.freedesktop.gstreamer</groupId>
+            <artifactId>gst1-java-core</artifactId>
+            <version>1.4.0</version>
+        </dependency>
 	</dependencies>
 	<build>
 		<plugins>

--- a/src/main/java/org/openpnp/machine/reference/ReferenceMachine.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceMachine.java
@@ -48,6 +48,7 @@ import org.openpnp.machine.reference.axis.ReferenceControllerAxis;
 import org.openpnp.machine.reference.axis.ReferenceLinearTransformAxis;
 import org.openpnp.machine.reference.axis.ReferenceMappedAxis;
 import org.openpnp.machine.reference.axis.ReferenceVirtualAxis;
+import org.openpnp.machine.reference.camera.GstreamerCamera;
 import org.openpnp.machine.reference.camera.ImageCamera;
 import org.openpnp.machine.reference.camera.MjpgCaptureCamera;
 import org.openpnp.machine.reference.camera.OnvifIPCamera;
@@ -466,6 +467,7 @@ public class ReferenceMachine extends AbstractMachine {
         l.add(SwitcherCamera.class);
         l.add(SimulatedUpCamera.class);
         l.add(MjpgCaptureCamera.class);
+        l.add(GstreamerCamera.class);
         return l;
     }
 

--- a/src/main/java/org/openpnp/machine/reference/camera/GstreamerCamera.java
+++ b/src/main/java/org/openpnp/machine/reference/camera/GstreamerCamera.java
@@ -52,8 +52,8 @@ public class GstreamerCamera extends ReferenceCamera {
         Gst.init();
     }
 
-    @Attribute(name = "pipeline", required = true)
-    private String pipeString;
+    @Attribute(name = "gstPipeline", required = true)
+    private String gstPipeString;
 
     private BufferedImage currentImage;
     private AppSink videosink;
@@ -66,11 +66,12 @@ public class GstreamerCamera extends ReferenceCamera {
 
     @Override
     public synchronized BufferedImage internalCapture() {
-        if (! ensureOpen()) {
+        if (!ensureOpen()) {
             return null;
         }
 
-        // AbstractBroadcastingCamera uses atomic getAndSet on images along with hasNewFrame
+        // AbstractBroadcastingCamera uses atomic getAndSet on images along with
+        // hasNewFrame
         // Should be safe just to return the latest one here.
         newFrame.set(false);
         return currentImage;
@@ -86,20 +87,20 @@ public class GstreamerCamera extends ReferenceCamera {
         close();
         clearCalibrationCache();
 
-        if (pipeString == null) {
+        if (gstPipeString == null) {
             return;
         }
 
         Bin bin = null;
         try {
             // Create ghost src pad as we link the whole bin to the appsink
-            bin = Gst.parseBinFromDescription(pipeString, true);
+            bin = Gst.parseBinFromDescription(gstPipeString, true);
         } catch (Exception e) {
-            Logger.warn("Exception parsing pipeline {}", pipeString);
+            Logger.warn("Exception parsing pipeline {}", gstPipeString);
             return;
         }
         if (bin == null) {
-            Logger.warn("Failed parsing pipeline {}", pipeString);
+            Logger.warn("Failed parsing pipeline {}", gstPipeString);
             return;
         }
 
@@ -151,19 +152,19 @@ public class GstreamerCamera extends ReferenceCamera {
         currentImage = null;
     }
 
-    public String getPipeline() {
-        return pipeString;
+    public String getGstPipeline() {
+        return gstPipeString;
     }
 
-    public synchronized void setPipeline(String newPipeString) {
-        if (this.pipeString != null && pipe != null && !this.pipeString.equals(newPipeString)) {
+    public synchronized void setGstPipeline(String newPipeString) {
+        if (this.gstPipeString != null && pipe != null && !this.gstPipeString.equals(newPipeString)) {
             try {
                 close();
             } catch (Exception e) {
             }
         }
-        pipeString = newPipeString;
-        Logger.debug("Set pipeline: {}", pipeString);
+        gstPipeString = newPipeString;
+        Logger.debug("Set pipeline: {}", gstPipeString);
     }
 
     @Override

--- a/src/main/java/org/openpnp/machine/reference/camera/GstreamerCamera.java
+++ b/src/main/java/org/openpnp/machine/reference/camera/GstreamerCamera.java
@@ -1,0 +1,234 @@
+/*
+ * Copyright (C) 2020,2024 Ian Jamison <ian.dev@arkver.com>
+ *
+ * This file is part of OpenPnP.
+ *
+ * OpenPnP is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * OpenPnP is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with OpenPnP. If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * For more information about OpenPnP visit http://openpnp.org
+ */
+
+package org.openpnp.machine.reference.camera;
+
+import java.awt.image.BufferedImage;
+import java.awt.image.DataBufferInt;
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import java.nio.IntBuffer;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+import org.freedesktop.gstreamer.Structure;
+import org.freedesktop.gstreamer.elements.AppSink;
+import org.freedesktop.gstreamer.Buffer;
+import org.freedesktop.gstreamer.Caps;
+import org.freedesktop.gstreamer.FlowReturn;
+import org.freedesktop.gstreamer.Gst;
+import org.freedesktop.gstreamer.Bin;
+import org.freedesktop.gstreamer.Pipeline;
+import org.freedesktop.gstreamer.Sample;
+
+import org.openpnp.gui.support.Wizard;
+import org.openpnp.machine.reference.camera.wizards.GstreamerCameraConfigurationWizard;
+import org.openpnp.spi.PropertySheetHolder;
+import org.pmw.tinylog.Logger;
+import org.simpleframework.xml.Attribute;
+
+/**
+ * A Camera implementation based on an arbitrary gst_parse_launch pipeline.
+ */
+public class GstreamerCamera extends ReferenceCamera {
+    static {
+        Gst.init();
+    }
+
+    @Attribute(name = "pipeline", required = true)
+    private String pipeString;
+
+    private BufferedImage currentImage;
+    private AppSink videosink;
+    private Pipeline pipe;
+    private AtomicBoolean newFrame = new AtomicBoolean();
+
+    public GstreamerCamera() {
+        ensureOpen();
+    }
+
+    @Override
+    public synchronized BufferedImage internalCapture() {
+        if (! ensureOpen()) {
+            return null;
+        }
+
+        // AbstractBroadcastingCamera uses atomic getAndSet on images along with hasNewFrame
+        // Should be safe just to return the latest one here.
+        newFrame.set(false);
+        return currentImage;
+    }
+
+    @Override
+    public synchronized boolean hasNewFrame() {
+        return isOpen() && newFrame.get();
+    }
+
+    @Override
+    public synchronized void open() throws Exception {
+        close();
+        clearCalibrationCache();
+
+        if (pipeString == null) {
+            return;
+        }
+
+        Bin bin = null;
+        try {
+            // Create ghost src pad as we link the whole bin to the appsink
+            bin = Gst.parseBinFromDescription(pipeString, true);
+        } catch (Exception e) {
+            Logger.warn("Exception parsing pipeline {}", pipeString);
+            return;
+        }
+        if (bin == null) {
+            Logger.warn("Failed parsing pipeline {}", pipeString);
+            return;
+        }
+
+        try {
+            videosink = new AppSink("GstCamSink");
+
+            videosink.set("emit-signals", true);
+            AppSinkListener listener = new AppSinkListener();
+            videosink.connect((AppSink.NEW_SAMPLE) listener);
+            videosink.connect((AppSink.NEW_PREROLL) listener);
+            StringBuilder caps = new StringBuilder("video/x-raw,");
+            // JNA creates ByteBuffer using native byte order, set masks according to that.
+            if (ByteOrder.nativeOrder() == ByteOrder.LITTLE_ENDIAN) {
+                caps.append("format=BGRA");
+            } else {
+                caps.append("format=xRGB");
+            }
+            videosink.setCaps(new Caps(caps.toString()));
+
+            // XXX: What about bus messages? Don't we at least need to drain them?
+            pipe = new Pipeline();
+            pipe.addMany(bin, videosink);
+            Pipeline.linkMany(bin, videosink);
+            pipe.play();
+        } catch (Exception e) {
+            e.printStackTrace();
+            return;
+        }
+
+        super.open();
+    }
+
+    @Override
+    protected synchronized boolean isOpen() {
+        return super.isOpen()
+                && pipe != null;
+    }
+
+    @Override
+    public void close() throws IOException {
+        super.close();
+
+        if (pipe != null) {
+            pipe.stop();
+        }
+        // Dropping refs here hopefully causes gstreamer to dispose of the objects
+        pipe = null;
+        videosink = null;
+        currentImage = null;
+    }
+
+    public String getPipeline() {
+        return pipeString;
+    }
+
+    public synchronized void setPipeline(String newPipeString) {
+        if (this.pipeString != null && pipe != null && !this.pipeString.equals(newPipeString)) {
+            try {
+                close();
+            } catch (Exception e) {
+            }
+        }
+        pipeString = newPipeString;
+        Logger.debug("Set pipeline: {}", pipeString);
+    }
+
+    @Override
+    public Wizard getConfigurationWizard() {
+        return new GstreamerCameraConfigurationWizard(this);
+    }
+
+    @Override
+    public String getPropertySheetHolderTitle() {
+        return getClass().getSimpleName() + " " + getName();
+    }
+
+    @Override
+    public PropertySheetHolder[] getChildPropertySheetHolders() {
+        return null;
+    }
+
+    private BufferedImage getBufferedImage(int width, int height) {
+        if (currentImage != null && currentImage.getWidth() == width && currentImage.getHeight() == height) {
+            return currentImage;
+        }
+        if (currentImage != null) {
+            currentImage.flush();
+        }
+        currentImage = new BufferedImage(width, height, BufferedImage.TYPE_INT_RGB);
+        currentImage.setAccelerationPriority(0.0f);
+        return currentImage;
+    }
+
+    // Not sure if we need preroll samples, but the example code showed them anyway.
+    private class AppSinkListener implements AppSink.NEW_SAMPLE, AppSink.NEW_PREROLL {
+
+        public void rgbFrame(boolean isPrerollFrame, int width, int height, IntBuffer rgb) {
+            try {
+                final BufferedImage renderImage = getBufferedImage(width, height);
+                int[] pixels = ((DataBufferInt) renderImage.getRaster().getDataBuffer()).getData();
+                rgb.get(pixels, 0, width * height);
+            } finally {
+            }
+        }
+
+        private FlowReturn handleSample(Sample sample) {
+            Structure capsStruct = sample.getCaps().getStructure(0);
+            int w = capsStruct.getInteger("width");
+            int h = capsStruct.getInteger("height");
+            Buffer buffer = sample.getBuffer();
+            ByteBuffer bb = buffer.map(false);
+            if (bb != null) {
+                rgbFrame(false, w, h, bb.asIntBuffer());
+                buffer.unmap();
+                newFrame.set(true);
+            }
+            sample.dispose();
+            return FlowReturn.OK;
+        }
+
+        @Override
+        public FlowReturn newSample(AppSink elem) {
+            return handleSample(elem.pullSample());
+        }
+
+        @Override
+        public FlowReturn newPreroll(AppSink elem) {
+            return handleSample(elem.pullPreroll());
+        }
+
+    }
+}

--- a/src/main/java/org/openpnp/machine/reference/camera/wizards/GstreamerCameraConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/camera/wizards/GstreamerCameraConfigurationWizard.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2020,2024 Ian Jamison <ian.dev@arkver.com>
+ *
+ * Based on a Wizard which is
+ * Copyright (C) 2011 Jason von Nieda <jason@vonnieda.org>
+ *
+ * This file is part of OpenPnP.
+ *
+ * OpenPnP is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * OpenPnP is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with OpenPnP. If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * For more information about OpenPnP visit http://openpnp.org
+ */
+
+package org.openpnp.machine.reference.camera.wizards;
+
+import javax.swing.border.TitledBorder;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JTextField;
+
+import org.openpnp.gui.support.AbstractConfigurationWizard;
+import org.openpnp.machine.reference.camera.GstreamerCamera;
+
+import com.jgoodies.forms.layout.ColumnSpec;
+import com.jgoodies.forms.layout.FormLayout;
+import com.jgoodies.forms.layout.FormSpecs;
+import com.jgoodies.forms.layout.RowSpec;
+
+public class GstreamerCameraConfigurationWizard extends AbstractConfigurationWizard {
+    private static final long serialVersionUID = 1L;
+
+    private final GstreamerCamera camera;
+
+    private JPanel panelPipe;
+    private JTextField pipelineTextField;
+
+    public GstreamerCameraConfigurationWizard(GstreamerCamera camera) {
+        this.camera = camera;
+
+        panelPipe = new JPanel();
+        contentPanel.add(panelPipe);
+        panelPipe.setBorder(
+                new TitledBorder(null, "GStreamer Pipeline", TitledBorder.LEADING, TitledBorder.TOP, null, null));
+        panelPipe.setLayout(new FormLayout(
+                new ColumnSpec[] { FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,
+                        FormSpecs.RELATED_GAP_COLSPEC, ColumnSpec.decode("default:grow"), },
+                new RowSpec[] { FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC, }));
+
+        JLabel lblPipeline = new JLabel("Pipeline launch string");
+        panelPipe.add(lblPipeline, "2, 2, right, default");
+        pipelineTextField = new JTextField(40);
+        panelPipe.add(pipelineTextField, "4, 2, fill, default");
+        // pipelineTextField.setColumns(5);
+    }
+
+    @Override
+    public void createBindings() {
+        addWrappedBinding(camera, "pipeline", pipelineTextField, "text");
+    }
+
+}

--- a/src/main/java/org/openpnp/machine/reference/camera/wizards/GstreamerCameraConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/camera/wizards/GstreamerCameraConfigurationWizard.java
@@ -41,7 +41,7 @@ public class GstreamerCameraConfigurationWizard extends AbstractConfigurationWiz
     private final GstreamerCamera camera;
 
     private JPanel panelPipe;
-    private JTextField pipelineTextField;
+    private JTextField gstPipeTextField;
 
     public GstreamerCameraConfigurationWizard(GstreamerCamera camera) {
         this.camera = camera;
@@ -57,14 +57,14 @@ public class GstreamerCameraConfigurationWizard extends AbstractConfigurationWiz
 
         JLabel lblPipeline = new JLabel("Pipeline launch string");
         panelPipe.add(lblPipeline, "2, 2, right, default");
-        pipelineTextField = new JTextField(40);
-        panelPipe.add(pipelineTextField, "4, 2, fill, default");
-        // pipelineTextField.setColumns(5);
+        gstPipeTextField = new JTextField(40);
+        panelPipe.add(gstPipeTextField, "4, 2, fill, default");
+        gstPipeTextField.setColumns(5);
     }
 
     @Override
     public void createBindings() {
-        addWrappedBinding(camera, "pipeline", pipelineTextField, "text");
+        addWrappedBinding(camera, "gstPipeline", gstPipeTextField, "text");
     }
 
 }


### PR DESCRIPTION
This is a rebased and updated version of PR #1023 which was merged but later reverted.

It was reverted because at the time gstreamer dependencies broke the population of a dropdown selection option in OpenPnPCaptureCamera. Specifically the resolution dropdown for UVC cameras under Device Settings would set the value and it would be stored to machine.xml, but on restart of OpenPnP the dropdown would show the initial entry again.

Since some interest was shown in GStreamerCamera on the discord server, I retested and discovered that this is no longer the case. The dropdrown populates correctly with the stored value. I'm resubmitting a rebased version of the camera.

Original PR text follows, slightly tweaked...

---

This camera uses a textbox to specify an arbitrary gstreamer launch pipeline.

An appsink is appended to this pipeline and samples are pulled and fed to OpenPnP.

The pipeline should end with an explicit capsfilter element with caps of video/x-raw.

**Description**

Adds GstreamerCamera class, based on ReferenceCamera class which allows use of
an arbitrary gstreamer pipeline as a video source. This can be for example a v4l2src,
nvarguscamerasrc, rpicamsrc, rtsp receiver and decoder, media file reader and playbin, etc., etc.

**Justification**

Other camera sources are available which can read from v4l2 devices, perhaps even using
gstreamer to do so, however the pipelines used are fixed by the libraries. Although many
offer good controls, none allow arbitrary gstreamer sources to be used. This rules out their
use where a specific, non-standard camera source element is needed.

This camera source might also be useful for testing purposes where a pre-recorded video
sequence could be played back.

**Instructions for Use**

GstreamerCamera is added to the list of available camera sources. When added, a wizard is
available with a single text box under "Device Settings". This box is used to specify the gstreamer
launch pipeline, in normal gst-launch-1.0 syntax. The pipeline should be capable of producing
video/x-raw,format=BGRA on little-endian machines and xRGB on big-endian machines.
It should finish with a capsfilter element. An appsink is automatically linked to the end of the
pipeline with these caps.

It is recommended to use gst-launch-1.0 to test the pipeline. Once video is correctly working it can
be copy/pasted into OpenPnP. The pipeline string will be saved in machine.xml.

**Implementation Details**

A new dependency is added to pom.xml to bring in org.freedesktop.gstreamer bindings.
A new GstreamerCamera.java and GstreamerCameraConfigurationWizard.java are added.
The new class is added to the list of available camera types in ReferenceMachine.java.

I believe the new files conform to the coding style.
No spi or model changes are introduced.
Maven tests are not affected as they don't use this camera, however they continue to pass.

The camera has been tested on a Jetson Nano using both a MIPI camera with nvarguscamerasrc
and a USB camera with v4l2src, as well as on a PC using streamed H265 sources.
