### PR TITLE
bug fix: Search angle in minAreaRect

### DIFF
--- a/src/main/java/org/openpnp/vision/pipeline/stages/MinAreaRect.java
+++ b/src/main/java/org/openpnp/vision/pipeline/stages/MinAreaRect.java
@@ -241,7 +241,7 @@ public class MinAreaRect extends CvStage {
             return null;
         }
         RotatedRect r;
-        if (leftEdge && rightEdge && bottomEdge && topEdge) {
+        if (leftEdge && rightEdge && bottomEdge && topEdge && searchAngle==45) {
             // All edges, use OpenCv method.
             MatOfPoint2f pointsMat = new MatOfPoint2f(points.toArray(new Point[points.size()]));
             r = Imgproc.minAreaRect(pointsMat);

--- a/src/main/java/org/openpnp/vision/pipeline/stages/MinAreaRect.java
+++ b/src/main/java/org/openpnp/vision/pipeline/stages/MinAreaRect.java
@@ -241,7 +241,7 @@ public class MinAreaRect extends CvStage {
             return null;
         }
         RotatedRect r;
-        if (leftEdge && rightEdge && bottomEdge && topEdge && Math.abs(searchAngle-45)<angularResolution) {
+        if (leftEdge && rightEdge && bottomEdge && topEdge && searchAngle>=45-angularResolution) {
             // All edges, use OpenCv method.
             // This is slightly faster; 30µs per call, compared to 210µs for the java method in the other branch
             MatOfPoint2f pointsMat = new MatOfPoint2f(points.toArray(new Point[points.size()]));

--- a/src/main/java/org/openpnp/vision/pipeline/stages/MinAreaRect.java
+++ b/src/main/java/org/openpnp/vision/pipeline/stages/MinAreaRect.java
@@ -241,8 +241,9 @@ public class MinAreaRect extends CvStage {
             return null;
         }
         RotatedRect r;
-        if (leftEdge && rightEdge && bottomEdge && topEdge && searchAngle==45) {
+        if (leftEdge && rightEdge && bottomEdge && topEdge && Math.abs(searchAngle-45)<angularResolution) {
             // All edges, use OpenCv method.
+            // This is slightly faster; 30µs per call, compared to 210µs for the java method in the other branch
             MatOfPoint2f pointsMat = new MatOfPoint2f(points.toArray(new Point[points.size()]));
             r = Imgproc.minAreaRect(pointsMat);
             pointsMat.release();


### PR DESCRIPTION
# Description

This is a bug fix

Openpnp has two implementations inside the minAreaRect vision stage. The first implementation hands over to opencv. The second implementation, in java, supports extra parameters leftEdge, rightEdge, topEdge, bottomEdge, and searchAngle.

The switch between the two implementations only checks the first four parameters. If a non-default `searchAngle` is specified (and the other four parameters have the default true value) then it uses the opencv implementation, and ignores the users specified searchAngle.

This fix checks for a non-default searchAngle as a reason to use the full-featured implementation.

# Justification

Is it useful for a vision pipeline to specify a non-default searchAngle?

I occasionally see misdetection of sot23 components.... sot23 are approximately triangular, and there are three possible orientations for packing a triangle into a rectangle.  I was hoping that specifying searchAngle of 15° would force the bottom vision to pick the bounding box with approximately horizontal orientation. A better bottom camera would help too of course. I have not yet proven whether this patch is a good solution for my sot23 bottom vision, but this vision stage now behaves as expected when given a non-default searchAngle.

# Implementation Details
1. How did you test the change?
   a. Manually tested with bottom vision, changing component orientation and reducing searchAngle from the default to prove it finds the expected rectangle.
   b. Leaving the default searchAngle, and proving the default behaviour is unchanged.
3. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)? - Yes
4. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing. - no changes
5. test pass
