### PR TITLE
Avoid accidental leading or trailing whitespace in Part IDs etc

### DIFF
--- a/src/main/java/org/openpnp/gui/BoardPlacementsPanel.java
+++ b/src/main/java/org/openpnp/gui/BoardPlacementsPanel.java
@@ -484,7 +484,11 @@ public class BoardPlacementsPanel extends JPanel {
             if (id == null) {
                 return;
             }
-            
+            id = id.trim();
+            if (id.isEmpty()) {
+                return;
+            }
+
             // Check if the new placement ID is unique
             for(Placement compareplacement : board.getPlacements()) {
                 if (compareplacement.getId().equals(id)) {

--- a/src/main/java/org/openpnp/gui/JobPlacementsPanel.java
+++ b/src/main/java/org/openpnp/gui/JobPlacementsPanel.java
@@ -566,7 +566,11 @@ public class JobPlacementsPanel extends JPanel {
             if (id == null) {
                 return;
             }
-            
+            id = id.trim();
+            if (id.isEmpty()) {
+                return;
+            }
+
             // Check if the new placement ID is unique
             for(Placement compareplacement : boardOrPanelLocation.getPlacementsHolder().getPlacements()) {
             	if (compareplacement.getId().equals(id)) {

--- a/src/main/java/org/openpnp/gui/PackageVisionPanel.java
+++ b/src/main/java/org/openpnp/gui/PackageVisionPanel.java
@@ -293,6 +293,10 @@ public class PackageVisionPanel extends JPanel {
             String name;
             while ((name = JOptionPane.showInputDialog(getTopLevelAncestor(),
                     "Please enter a name for the new pad.")) != null) {
+                name = name.trim();
+                if (name.isEmpty()) {
+                    break;
+                }
                 Pad pad = new Pad();
                 pad.setName(name);
                 footprint.addPad(pad);

--- a/src/main/java/org/openpnp/gui/PackagesPanel.java
+++ b/src/main/java/org/openpnp/gui/PackagesPanel.java
@@ -284,6 +284,10 @@ public class PackagesPanel extends JPanel implements WizardContainer {
             String id;
             while ((id = JOptionPane.showInputDialog(frame,
                     "Please enter an ID for the new package.")) != null) {
+                id = id.trim();
+                if (id.isEmpty()) {
+                    break;
+                }
                 if (configuration.getPackage(id) != null) {
                     MessageBoxes.errorBox(frame, "Error", "Package ID " + id + " already exists.");
                     continue;
@@ -384,6 +388,10 @@ public class PackagesPanel extends JPanel implements WizardContainer {
             String id;
             while ((id = JOptionPane.showInputDialog(frame,
                     "Please enter an ID for the pasted package.")) != null) {
+                id = id.trim();
+                if (id.isEmpty()) {
+                    break;
+                }
                 if (configuration.getPackage(id) == null) {
                     break;
                 }

--- a/src/main/java/org/openpnp/gui/PanelDefinitionPanel.java
+++ b/src/main/java/org/openpnp/gui/PanelDefinitionPanel.java
@@ -595,7 +595,11 @@ public class PanelDefinitionPanel extends JPanel implements PropertyChangeListen
             if (id == null) {
                 return;
             }
-            
+            id = id.trim();
+            if (id.isEmpty()) {
+                return;
+            }
+
             // Check if the new placement ID is unique
             for(Placement comparePlacement : rootPanelLocation.getPanel().getPlacements()) {
                 if (comparePlacement.getId().equals(id)) {

--- a/src/main/java/org/openpnp/gui/PartsPanel.java
+++ b/src/main/java/org/openpnp/gui/PartsPanel.java
@@ -289,6 +289,10 @@ public class PartsPanel extends JPanel implements WizardContainer {
             String id;
             while ((id = JOptionPane.showInputDialog(frame,
                     "Please enter an ID for the new part.")) != null) {
+                id = id.trim();
+                if (id.isEmpty()) {
+                    break;
+                }
                 if (configuration.getPart(id) != null) {
                     MessageBoxes.errorBox(frame, "Error", "Part ID " + id + " already exists.");
                     continue;
@@ -402,6 +406,10 @@ public class PartsPanel extends JPanel implements WizardContainer {
             String id;
             while ((id = JOptionPane.showInputDialog(frame,
                     "Please enter an ID for the pasted part.")) != null) {
+                id = id.trim();
+                if (id.isEmpty()) {
+                    break;
+                }
                 if (configuration.getPart(id) == null) {
                     break;
                 }


### PR DESCRIPTION
# Description
This patch removes leading and trailing whitespace in part IDs etc which are created using the gui. It is easy to get extra whitespace when text is copy/paste from a source such as a datasheet, and undesirable to create an ID with leading and trailing whitespace.

# Implementation Details
This patch affects all uses of `JOptionPane.showInputDialog` where the input is used as an ID.
All existing uses already check for null input, which occurs when the cancel button is pressed.
This change uses `String.trim` to remove leading and trailing whitespace, after that null check.
Additionally, if that results in an empty string, it behaves the same as if `showInputDialog` returned null.
1. How did you test the change? - Tested manually, with entering empty strings, strings with some unwanted whitespace, and strings with no whitespace
2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)? - Yes
4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted. - Tests pass

Any pre-existing IDs are left unchanged. This only affects new IDs as they are created.

This change assumes that noone wants to intentionally create IDs with trailing and leading whitespace, or zero length IDs.