### PR TITLE
Fix for mirrored vision compositing preview

### DIFF
--- a/src/main/java/org/openpnp/gui/components/VisionCompositingPreview.java
+++ b/src/main/java/org/openpnp/gui/components/VisionCompositingPreview.java
@@ -98,11 +98,6 @@ public class VisionCompositingPreview extends JComponent implements MouseMotionL
             // Get the shape.
             Shape bodyShape = footprint.getBodyShape();
             Shape padsShape = footprint.getPadsShape();
-            // Transform to right-hand coordinate system.
-            AffineTransform txShape = new AffineTransform();
-            txShape.scale(1, -1);
-            padsShape = txShape.createTransformedShape(padsShape);
-            bodyShape = txShape.createTransformedShape(bodyShape);
             Path2D.Double unionShape = new Path2D.Double();
             unionShape.append(bodyShape, false);
             unionShape.append(padsShape, false);
@@ -120,7 +115,7 @@ public class VisionCompositingPreview extends JComponent implements MouseMotionL
             // Create a transform to scale the shape by
             AffineTransform tx = new AffineTransform(txOld);
             tx.translate(width/2, height/2);
-            tx.scale(scale, scale);
+            tx.scale(scale, -scale); // to left-hand coordinate system for Graphics2D
             g2d.setTransform(tx);
 
             // Draw the package.
@@ -155,7 +150,7 @@ public class VisionCompositingPreview extends JComponent implements MouseMotionL
                     // check if mouse over
                     if (xMouse != null && yMouse != null) {
                         double xMouse = (this.xMouse - width/2.0)/scale;
-                        double yMouse = (this.yMouse - height/2.0)/scale;
+                        double yMouse = (height/2.0 - this.yMouse)/scale;
                         double distance = Math.hypot(xMouse - shot.getX(), yMouse - shot.getY());
                         if (distance < shot.getMaxMaskRadius()
                                 && bestDistance > distance) {


### PR DESCRIPTION
# Description
fixes #1669

This makes the problem go away. The visual appearance of the preview is now correct.

I have not confirmed that real vision still works - I am away from the machine at the moment. But the only changes are to xxxx*Preview*.java so this should be ok.

I dont have great confidence that I have found exactly the right places to add/remove the -1, and maintained the comments correctly. Feedback would be appreciated.

# Implementation Details
1. How did you test the change? - manual test, using the problem packages in issue 1669
2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)? - yes
4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted. - all tests pass
