### PR TITLE
Various size check and vision compositing fixes

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/vision/ReferenceBottomVision.java
+++ b/src/main/java/org/openpnp/machine/reference/vision/ReferenceBottomVision.java
@@ -346,11 +346,6 @@ public class ReferenceBottomVision extends AbstractPartAlignment {
             return true;
         }
 
-        // Make sure width is the longest dimension
-        if (partSize.getY() > partSize.getX()) {
-            partSize = new Location(partSize.getUnits(), partSize.getY(), partSize.getX(), 0, 0);
-        }
-
         double pxWidth = VisionUtils.toPixels(partSize.getLengthX(), camera);
         double pxLength = VisionUtils.toPixels(partSize.getLengthY(), camera);
 
@@ -358,13 +353,6 @@ public class ReferenceBottomVision extends AbstractPartAlignment {
         if (! (measuredSize.width>0 && measuredSize.height>0) ) {
             // This branch handles the case for zero size, negative size, and NaN size
             throw new Exception(String.format("Invalid measured size for size check.\nwidth=%s\nlength=%s",measuredSize.width,measuredSize.height));
-        }
-        // Make sure width is the longest dimension
-        if (measuredSize.height > measuredSize.width) {
-            double mLength = measuredSize.height;
-            double mWidth = measuredSize.width;
-            measuredSize.height = mWidth;
-            measuredSize.width = mLength;
         }
 
         double widthTolerance = pxWidth * 0.01 * (double) bottomVisionSettings.getCheckSizeTolerancePercent();

--- a/src/main/java/org/openpnp/machine/reference/vision/ReferenceBottomVision.java
+++ b/src/main/java/org/openpnp/machine/reference/vision/ReferenceBottomVision.java
@@ -354,8 +354,12 @@ public class ReferenceBottomVision extends AbstractPartAlignment {
         double pxWidth = VisionUtils.toPixels(partSize.getLengthX(), camera);
         double pxLength = VisionUtils.toPixels(partSize.getLengthY(), camera);
 
-        // Make sure width is the longest dimension
         Size measuredSize = partRect.size;
+        if (! (measuredSize.width>0 && measuredSize.height>0) ) {
+            // This branch handles the case for zero size, negative size, and NaN size
+            throw new Exception(String.format("Invalid measured size for size check.\nwidth=%s\nlength=%s",measuredSize.width,measuredSize.height));
+        }
+        // Make sure width is the longest dimension
         if (measuredSize.height > measuredSize.width) {
             double mLength = measuredSize.height;
             double mWidth = measuredSize.width;

--- a/src/main/java/org/openpnp/machine/reference/vision/ReferenceBottomVision.java
+++ b/src/main/java/org/openpnp/machine/reference/vision/ReferenceBottomVision.java
@@ -205,9 +205,10 @@ public class ReferenceBottomVision extends AbstractPartAlignment {
 
             // The running, iterative offset.
             Location offsets = new Location(nozzleLocation.getUnits());
+            RotatedRect rect;
             // Try getting a good fix on the part in multiple passes.
             for(int pass = 0;;) {
-                RotatedRect rect = processPipelineAndGetResult(pipeline, camera, part, nozzle,
+                rect = processPipelineAndGetResult(pipeline, camera, part, nozzle,
                         wantedLocation, nozzleLocation, bottomVisionSettings);
 
                 Logger.debug("Bottom vision part {} result rect {}", part.getId(), rect);
@@ -247,7 +248,6 @@ public class ReferenceBottomVision extends AbstractPartAlignment {
                 Location corner = VisionUtils.getPixelCenterOffsets(camera, corners[0].x, corners[0].y)
                         .convertToUnits(maxLinearOffset.getUnits());
                 Location cornerWithAngularOffset = corner.rotateXy(angleOffset);
-                partSizeCheck(part, bottomVisionSettings, rect, camera);
 
                 if (center.getLinearDistanceTo(offsets) > getMaxLinearOffset().getValue()) {
                     Logger.debug("Offsets too large {} : center offset {} > {}", 
@@ -269,6 +269,7 @@ public class ReferenceBottomVision extends AbstractPartAlignment {
                 // Not a good enough fix - try again with corrected position.
             }
             Logger.debug("Offsets accepted {}", offsets);
+
             // Calculate cumulative offsets over all the passes.  
             offsets = wantedLocation.subtractWithRotation(nozzleLocation);
 
@@ -277,6 +278,8 @@ public class ReferenceBottomVision extends AbstractPartAlignment {
 
             displayResult(OpenCvUtils.toBufferedImage(pipeline.getWorkingImage()), part, offsets, camera, nozzle);
             offsetsCheck(part, nozzle, offsets);
+
+            partSizeCheck(part, bottomVisionSettings, rect, camera);
 
             return new PartAlignment.PartAlignmentOffset(offsets, true);
         }

--- a/src/main/java/org/openpnp/machine/reference/vision/ReferenceBottomVision.java
+++ b/src/main/java/org/openpnp/machine/reference/vision/ReferenceBottomVision.java
@@ -555,7 +555,7 @@ public class ReferenceBottomVision extends AbstractPartAlignment {
                 }
 
                 @Override 
-                public Result processCompositeResult() {
+                public Result processCompositeResult() throws Exception {
                     composite.interpret();
                     return new Result(null, composite.getDetectedRotatedRect());
                 }

--- a/src/main/java/org/openpnp/model/VisionCompositing.java
+++ b/src/main/java/org/openpnp/model/VisionCompositing.java
@@ -20,6 +20,7 @@
  */
 
 package org.openpnp.model;
+import org.pmw.tinylog.Logger;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -1488,6 +1489,13 @@ public class VisionCompositing extends AbstractModelObject{
                                 .add(point3)
                                 .add(point4);
                         centerWeights += 4;
+                        Point mid12 = point1.add(point2).multiply(0.5);
+                        Point mid34 = point3.add(point4).multiply(0.5);
+                        Point diff = mid34.subtract(mid12);
+                        double distance = diff.distance();
+                        double dy = Math.abs(corner.ySymmetricBuddy.getY() - corner.getY());
+                        yScaleSum += distance;
+                        yScaleWeights += dy;
                     }
                 }
                 // Pair of mirrors in X
@@ -1503,6 +1511,13 @@ public class VisionCompositing extends AbstractModelObject{
                                 .add(point3)
                                 .add(point4);
                         centerWeights += 4;
+                        Point mid12 = point1.add(point2).multiply(0.5);
+                        Point mid34 = point3.add(point4).multiply(0.5);
+                        Point diff = mid34.subtract(mid12);
+                        double distance = diff.distance();
+                        double dx = Math.abs(corner.xSymmetricBuddy.getX() - corner.getX());
+                        xScaleSum += distance;
+                        xScaleWeights += dx;
                     }
                 }
                 // Aligned in X
@@ -1559,7 +1574,7 @@ public class VisionCompositing extends AbstractModelObject{
             detectedSize = new Point(
                     detectedScale.x*Math.max(-leftEdges.first(), rightEdges.last())*2,
                     detectedScale.y*Math.max(-bottomEdges.first(), topEdges.last())*2);
-            // For pipeline result compatibility, make the RotatedRect in OpenCv pixel coordinates. 
+            // For pipeline result compatibility, make the RotatedRect in OpenCv pixel coordinates.
             double angle = VisionUtils.getPixelAngle(camera, detectedAngle);
             org.opencv.core.Point center = new org.opencv.core.Point(
                     camera.getWidth()*0.5 + detectedCenter.x/upp.getX(), 

--- a/src/main/java/org/openpnp/model/VisionCompositing.java
+++ b/src/main/java/org/openpnp/model/VisionCompositing.java
@@ -1554,10 +1554,10 @@ public class VisionCompositing extends AbstractModelObject{
             }
             // Evaluate the stats.
             if(centerWeights==0) { // divide by zero ahead!
-                throw new Exception("Unable to calculate center from composite vision");
+                throw new Exception("Unable to calculate center from composite vision for package "+pkg.getId());
             }
             if(angleWeights==0) {
-                throw new Exception("Unable to calculate angle from composite vision");
+                throw new Exception("Unable to calculate angle from composite vision for package "+pkg.getId());
             }
             detectedCenter = centerSum.divide(centerWeights);
             detectedAngle = angleSum/angleWeights;

--- a/src/main/java/org/openpnp/model/VisionCompositing.java
+++ b/src/main/java/org/openpnp/model/VisionCompositing.java
@@ -1430,7 +1430,7 @@ public class VisionCompositing extends AbstractModelObject{
             }
         }
 
-        public void interpret() {
+        public void interpret() throws Exception {
             if (!compositingSolution.isAdvanced()) {
                 return;
             }
@@ -1538,9 +1538,21 @@ public class VisionCompositing extends AbstractModelObject{
                 }
             }
             // Evaluate the stats.
+            if(centerWeights==0) { // divide by zero ahead!
+                throw new Exception("Unable to calculate center from composite vision");
+            }
+            if(angleWeights==0) {
+                throw new Exception("Unable to calculate angle from composite vision");
+            }
             detectedCenter = centerSum.divide(centerWeights);
             detectedAngle = angleSum/angleWeights;
             detectedAngle += Math.round((expectedAngle - detectedAngle)/90)*90;
+            if(xScaleWeights==0) {
+                xScaleSum = xScaleWeights = 1.0; // We can not adjust x scale
+            }
+            if(yScaleWeights==0) {
+                yScaleSum = yScaleWeights = 1.0;
+            }
             detectedScale = new Point(
                     xScaleSum/xScaleWeights, 
                     yScaleSum/yScaleWeights); 

--- a/src/main/java/org/openpnp/model/VisionCompositing.java
+++ b/src/main/java/org/openpnp/model/VisionCompositing.java
@@ -1469,9 +1469,9 @@ public class VisionCompositing extends AbstractModelObject{
                             double distance = diff.distance();
                             double dx = Math.abs(corner.diagonalBuddy.getX() - corner.getX());
                             double dy = Math.abs(corner.diagonalBuddy.getY() - corner.getY());
-                            xScaleSum += distance;
+                            xScaleSum += distance / Math.sqrt(2);
                             xScaleWeights += dx;
-                            yScaleSum += distance;
+                            yScaleSum += distance / Math.sqrt(2);
                             yScaleWeights += dy;
                         }
                     }

--- a/src/main/java/org/openpnp/vision/pipeline/CvPipeline.java
+++ b/src/main/java/org/openpnp/vision/pipeline/CvPipeline.java
@@ -525,7 +525,7 @@ public class CvPipeline implements AutoCloseable {
          * Process the composite result of all the shots. 
          * Override this method to define custom operations.
          */
-        public abstract Result processCompositeResult();
+        public abstract Result processCompositeResult() throws Exception;
     }
 
     public List<PipelineShot> getPipelineShots() {

--- a/src/test/java/VisionCompositingTest.java
+++ b/src/test/java/VisionCompositingTest.java
@@ -29,6 +29,7 @@ import org.openpnp.machine.reference.ReferenceNozzleTip;
 import org.openpnp.machine.reference.camera.SimulatedUpCamera;
 import org.openpnp.machine.reference.driver.NullDriver;
 import org.openpnp.machine.reference.vision.ReferenceBottomVision;
+import org.openpnp.machine.reference.vision.ReferenceBottomVision.PartSizeCheckMethod;
 import org.openpnp.model.Configuration;
 import org.openpnp.model.Length;
 import org.openpnp.model.LengthUnit;
@@ -95,6 +96,9 @@ public class VisionCompositingTest {
         machine.execute(() -> {
             for (Part part: Configuration.get().getParts()) {
                 if (!part.getId().startsWith("FID")) {
+                    // Enable size test, to check that composite vision is measuring size correctly
+                    bottomVision.getInheritedVisionSettings(part).setCheckPartSizeMethod(ReferenceBottomVision.PartSizeCheckMethod.PadExtents);
+
                     Location error;
                     Location maxError;
                     if (part.getId().startsWith("SMALL")) {


### PR DESCRIPTION
**This is a provisional pull request** shared for review. So far this has only been tested in simulation and I want to test it on the machine.

# Description

This patch contains some bug fixes for vision compositing and part size checking, some defensive changes to prevent such bugs hiding in future, and some unit test extensions.

## Size check preconditions

The part size check logic was not previously validating the measured sizes. While there was not much scope for this to go wrong when its data was provided by minAreaRect,  some other bugs described below in composite vision were causing the measured size to be NaN. NaN size values lead to contradictory error messages from the part size check logic. This patch adds some validation.

## Vision compositing divide by zero

The final stages of vision compositing has various floating point divisions, without checking for a divide by zero. This would result in NaN values in the output.

The divisions relating to the calculation of angle and center point are pretty robust. I have not seen these go wrong, but I have added some defensive checks to raise an exception if the denominator is zero. That is better than allowing a NaN in the return value.

There are also divisions in calculating the scaling for part length and width. Previously the trapezoid vision solution would never collect this scaling information, so always triggered this divide by zero and NaN return value. While this case is fixed, I suspect there may be other valid vision solutions that do not collect scaling information. This patch prevents the divide by zero by assuming unity scale if the denominator is zero.

## Trapezoid vision solution scale

The trapezoid vision solution was previously processing center point, angle, and "width" scale, but not "length" scale. This was therefore triggering the divide by zero and NaN described above. This was the root cause of the bug I have been chasing here.

Width scale was measured in two ways: using the gap between the two corners on the base of the trapezoid, and the gap between the two corners at the top.

The fix for measuring trapezoid "length" scale involves:
* Find the midpoint between the two corners on the base of the trapezoid
* Find the midpoint between the two corners on the top of the trapezoid
* The distance between those two midpoints gives information about the length scale.

## Square vision solution scale

The square vision solution had a size bug. The measured distance is a hypotenuse, so the measured size was previously out by a factor of sqrt(2)

## Unit Test

A unit test for all of the above is achieved by enabling size checking when running the vision compositing unit test. This tests that the composite vision measures sizes correctly, and does not trigger any of those new defensive exceptions.

## Orientation

As discussed at https://groups.google.com/g/openpnp/c/Pd3wYWYiTTU
The part size check compares the longest side vs the longest measurement, and the shortest side vs the shortest measurement. This behaviour is described on https://github.com/openpnp/openpnp/pull/1135 with the rationale "to avoid problems with dimensions being swapped in the package".

The conclusion was to compare both dimensions in their orientation as is


# Justification
* This fixes some cases where vision compositing measured an incorrect size for a part
* This fixes some cases where vision compositing returned a NaN, leading to strange behaviour in other code
* This adds some defensive checks, to avoid strange behaviour if a similar problem arises again


# Implementation Details
1. How did you test the change? - Only in simulation so far (manual tests, and some extensions to the existing unit tests). I still need to test this on a machine with the parts that were previously causing my problems.
2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)? - yes
3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing.
4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted. - tests pass
