### PR TITLE
Default bottom vision pipeline inaccuracy due to contour thickness

### DIFF
--- a/src/main/resources/org/openpnp/machine/reference/vision/ReferenceBottomVision-BodyPipeline.xml
+++ b/src/main/resources/org/openpnp/machine/reference/vision/ReferenceBottomVision-BodyPipeline.xml
@@ -11,7 +11,7 @@
       <cv-stage class="org.openpnp.vision.pipeline.stages.FindContours" name="findCountours" enabled="true" retrieval-mode="List" approximation-method="None"/>
       <cv-stage class="org.openpnp.vision.pipeline.stages.FilterContours" name="filterContours" enabled="true" contours-stage-name="findCountours" min-area="0.01" max-area="900000.0" property-name="FilterContours"/>
       <cv-stage class="org.openpnp.vision.pipeline.stages.MaskCircle" name="11" enabled="true" diameter="0" property-name=""/>
-      <cv-stage class="org.openpnp.vision.pipeline.stages.DrawContours" name="contours" enabled="true" contours-stage-name="filterContours" thickness="2" index="-1">
+      <cv-stage class="org.openpnp.vision.pipeline.stages.DrawContours" name="contours" enabled="true" contours-stage-name="filterContours" thickness="1" index="-1">
          <color r="255" g="255" b="255" a="255"/>
       </cv-stage>
       <cv-stage class="org.openpnp.vision.pipeline.stages.MinAreaRect" name="results" enabled="true" threshold-min="100" threshold-max="255" expected-angle="0.0" search-angle="45.0" left-edge="true" right-edge="true" top-edge="true" bottom-edge="true" diagnostics="false" property-name="MinAreaRect"/>

--- a/src/main/resources/org/openpnp/machine/reference/vision/ReferenceBottomVision-DefaultPipeline.xml
+++ b/src/main/resources/org/openpnp/machine/reference/vision/ReferenceBottomVision-DefaultPipeline.xml
@@ -16,7 +16,7 @@
       <cv-stage class="org.openpnp.vision.pipeline.stages.FindContours" name="findCountours" enabled="true" retrieval-mode="List" approximation-method="None"/>
       <cv-stage class="org.openpnp.vision.pipeline.stages.FilterContours" name="filterContours" enabled="true" contours-stage-name="findCountours" min-area="0.01" max-area="900000.0" property-name="FilterContours"/>
       <cv-stage class="org.openpnp.vision.pipeline.stages.MaskCircle" name="11" enabled="true" diameter="0" property-name=""/>
-      <cv-stage class="org.openpnp.vision.pipeline.stages.DrawContours" name="contours" enabled="true" contours-stage-name="filterContours" thickness="2" index="-1">
+      <cv-stage class="org.openpnp.vision.pipeline.stages.DrawContours" name="contours" enabled="true" contours-stage-name="filterContours" thickness="1" index="-1">
          <color r="255" g="255" b="255" a="255"/>
       </cv-stage>
       <cv-stage class="org.openpnp.vision.pipeline.stages.MinAreaRect" name="results" enabled="true" threshold-min="100" threshold-max="255"/>


### PR DESCRIPTION
# Description

The default bottom vision pipeline operates by
* using thresholds to find  some interesting shapes
* finding contours for those shapes
* eliminating some contours where the area is too small to be interesting
* drawing the outline of those contours to recreate the shapes

The current pipeline redraws the contours using a line thickness of 2 pixels, which artificially inflates the shapes. This leads to a (small) inaccuracy in component size and position.

It is better to redraw the contours with a line thickness of 1 pixel, to accurately reproduce the original shapes and eliminate this unexpected inaccuracy.

Note this affects the line thickness used during the vision pipeline processing. A different line thickness is used for user feedback.

# Justification
Openpnp aims for sub-pixel accuracy elsewhere.

# Implementation Details
1. How did you test the change? - Tested on the machine today.
2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)? - yes
4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted. - tests pass
