### PR TITLE
ReferencePushPullFeeder - use full camera image for auto setup

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/feeder/ReferencePushPullFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/ReferencePushPullFeeder.java
@@ -1194,12 +1194,14 @@ public class ReferencePushPullFeeder extends ReferenceFeeder {
             pipeline.setProperty("feeder", this);
             pipeline.setProperty("sprocketHole.diameter", new Length(sprocketHoleDiameterMm, LengthUnit.Millimeters));
             Length range;
-            if (autoSetup) { 
-                // Auto-Setup: search Range is half camera. 
+            if (autoSetup) {
+                // Auto-Setup: search range is set to be full camera resolution (bigger dimension is used)
+                // to be able to detect sprocket holes at the edge of the image. Search range defines circle's
+                // radius with origin in center. Full resolution is used as radius to cover image corners.
                 Location upp = camera.getUnitsPerPixelAtZ();
-                range = camera.getWidth() > camera.getHeight() ? 
-                        upp.getLengthY().multiply(camera.getHeight()/2)
-                        : upp.getLengthX().multiply(camera.getWidth()/2);
+                range = camera.getWidth() > camera.getHeight() ?
+                        upp.getLengthX().multiply(camera.getHeight())
+                        : upp.getLengthY().multiply(camera.getWidth());
             }
             else {
                 // Normal mode: search range is half the distance between the holes plus one pitch. 


### PR DESCRIPTION
# Description
Auto setup for ReferencePushPullFeeder is limiting search range to half of the camera resolution (smaller dimension). Therefore it doesn't find sprocket holes when tape is to wide or camera view too narrow:

![push_pull_result_1722421181859694218](https://github.com/user-attachments/assets/ef383106-5fde-48a9-976c-ade04367c819)

Modified code searches in the whole image and sprocket holes as correctly detected:

![push_pull_result_1722425343885603611](https://github.com/user-attachments/assets/2cc36d6c-fa6e-4fb8-bac8-a17e03c350dc)

This was discussed in [this Google Group thread](https://groups.google.com/g/openpnp/c/GMY_KY-rupk/m/BxCpMxsXAQAJ).

# Justification
ReferencePushPullFeeder will work for more use cases and machines.

# Instructions for Use

# Implementation Details
The bigger camera resolution is used as search range to cover the whole image, including corners. Change was tested on LumenPnP machine without problems.
