### PR TITLE
Clear the cameraViews to prevent duplicate camera view's

### DIFF
--- a/openpnp.bat
+++ b/openpnp.bat
@@ -2,7 +2,12 @@
 
 set archi=%PROCESSOR_ARCHITECTURE%
 
-if not x%archi:86=%==x%archi% java --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.desktop/java.awt=ALL-UNNAMED --add-opens=java.desktop/java.awt.color=ALL-UNNAMED -jar target\openpnp-gui-0.0.1-alpha-SNAPSHOT.jar
-if not x%archi:64=%==x%archi% java --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.desktop/java.awt=ALL-UNNAMED --add-opens=java.desktop/java.awt.color=ALL-UNNAMED -jar target\openpnp-gui-0.0.1-alpha-SNAPSHOT.jar
+:run_application
+if not x%archi:86=%==x%archi% java --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.desktop/java.awt=ALL-UNNAMED --add-opens=java.desktop.java.awt.color=ALL-UNNAMED -jar target\openpnp-gui-0.0.1-alpha-SNAPSHOT.jar
+if not x%archi:64=%==x%archi% java --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.desktop.java.awt=ALL-UNNAMED --add-opens=java.desktop.java.awt.color=ALL-UNNAMED -jar target\openpnp-gui-0.0.1-alpha-SNAPSHOT.jar
 
-
+set exit_code=%ERRORLEVEL%
+if %exit_code% == 127 (
+    echo Application exited with code 127. Restarting...
+    goto run_application
+)

--- a/openpnp.sh
+++ b/openpnp.sh
@@ -13,11 +13,23 @@ case "$unamestr" in
 	;;
 esac
 
-case "$platform" in
-	mac)
-		java -Xdock:name=OpenPnP --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.desktop/java.awt=ALL-UNNAMED --add-opens=java.desktop/java.awt.color=ALL-UNNAMED -jar $rootdir/target/openpnp-gui-0.0.1-alpha-SNAPSHOT.jar
-	;;
-	linux)
-		java $1 --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.desktop/java.awt=ALL-UNNAMED --add-opens=java.desktop/java.awt.color=ALL-UNNAMED -jar $rootdir/target/openpnp-gui-0.0.1-alpha-SNAPSHOT.jar
-	;;
-esac
+run_application() {
+  case "$platform" in
+    mac)
+      java -Xdock:name=OpenPnP --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.desktop/java.awt=ALL-UNNAMED --add-opens=java.desktop/java.awt.color=ALL-UNNAMED -jar $rootdir/target/openpnp-gui-0.0.1-alpha-SNAPSHOT.jar
+      ;;
+    linux)
+      java $1 --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.desktop/java.awt=ALL-UNNAMED --add-opens=java.desktop/java.awt.color=ALL-UNNAMED -jar $rootdir/target/openpnp-gui-0.0.1-alpha-SNAPSHOT.jar
+      ;;
+  esac
+}
+
+while true; do
+  run_application
+  exit_code=$?
+  echo "Application exited with code $exit_code."
+  if [ $exit_code -ne 127 ]; then
+    break
+  fi
+  echo "Application exited with code 127. Restarting..."
+done

--- a/src/main/java/org/openpnp/gui/MainFrame.java
+++ b/src/main/java/org/openpnp/gui/MainFrame.java
@@ -352,6 +352,7 @@ public class MainFrame extends JFrame {
         if (!macOsXMenus) {
             mnFile.addSeparator();
             mnFile.add(new JMenuItem(quitAction));
+            mnFile.add(new JMenuItem(restartAction));
         }
 
         // Edit
@@ -1049,8 +1050,27 @@ public class MainFrame extends JFrame {
         return true;
     }
 
+    public boolean restart() {
+        Logger.info("Restarting..."); //$NON-NLS-1$
+        if( exit(false) ) {
+            Logger.info("Shutdown complete, restarting."); //$NON-NLS-1$
+            System.exit(127);
+            return true;
+        }
+        return false;
+    }
+
     public boolean quit() {
         Logger.info("Shutting down..."); //$NON-NLS-1$
+        if( exit(true) ) {
+            Logger.info("Shutdown complete, exiting."); //$NON-NLS-1$
+            System.exit(0);
+            return true;
+        }
+        return false;
+    }
+
+    private boolean exit(boolean saveConfig) {
         try {
             Preferences.userRoot().flush();
         }
@@ -1060,7 +1080,9 @@ public class MainFrame extends JFrame {
 
         // Save the configuration
         try {
-            configuration.save();
+            if( saveConfig ) {
+                configuration.save();
+            }
         }
         catch (Exception e) {
             String message = "There was a problem saving the configuration. The reason was:\n\n" //$NON-NLS-1$
@@ -1091,8 +1113,6 @@ public class MainFrame extends JFrame {
         catch (Exception e) {
             e.printStackTrace();
         }
-        Logger.info("Shutdown complete, exiting."); //$NON-NLS-1$
-        System.exit(0);
         return true;
     }
 
@@ -1238,6 +1258,17 @@ public class MainFrame extends JFrame {
         @Override
         public void actionPerformed(ActionEvent arg0) {
             quit();
+        }
+    };
+
+    private Action restartAction = new AbstractAction(Translations.getString("Menu.File.Restart")) { //$NON-NLS-1$
+        {
+            //putValue(MNEMONIC_KEY, KeyEvent.VK_X);
+        }
+
+        @Override
+        public void actionPerformed(ActionEvent arg0) {
+            restart();
         }
     };
 

--- a/src/main/java/org/openpnp/gui/components/CameraPanel.java
+++ b/src/main/java/org/openpnp/gui/components/CameraPanel.java
@@ -69,7 +69,6 @@ public class CameraPanel extends JPanel {
             @Override
             public void configurationComplete(Configuration configuration) throws Exception {
             	SwingUtilities.invokeLater(() -> {
-                    cameraViews.clear();
                     for (Camera camera : configuration.getMachine().getAllCameras()) {
                         addCamera(camera);
                     }

--- a/src/main/java/org/openpnp/gui/components/CameraPanel.java
+++ b/src/main/java/org/openpnp/gui/components/CameraPanel.java
@@ -69,6 +69,7 @@ public class CameraPanel extends JPanel {
             @Override
             public void configurationComplete(Configuration configuration) throws Exception {
             	SwingUtilities.invokeLater(() -> {
+                    cameraViews.clear();
                     for (Camera camera : configuration.getMachine().getAllCameras()) {
                         addCamera(camera);
                     }

--- a/src/main/resources/org/openpnp/translations.properties
+++ b/src/main/resources/org/openpnp/translations.properties
@@ -816,6 +816,7 @@ Menu.Edit.Redo=Redo
 Menu.Edit.Undo=Undo
 Menu.File=File
 Menu.File.Exit=Exit
+Menu.File.Restart=Restart (don't save Configuration)
 Menu.File.ImportBoard=Import Board
 Menu.File.SaveConfiguration=Save Configuration
 Menu.Help=Help

--- a/src/main/resources/org/openpnp/translations_es.properties
+++ b/src/main/resources/org/openpnp/translations_es.properties
@@ -4,6 +4,7 @@ General.Next=Siguiente
 
 Menu.File=Archivo
 Menu.File.Exit=Salir
+Menu.File.Restart=Restart (don't save Configuration)
 Menu.File.ImportBoard=Importar Placa
 Menu.File.SaveConfiguration=Guardar Configuración
 Menu.Edit=Editar

--- a/src/main/resources/org/openpnp/translations_fr.properties
+++ b/src/main/resources/org/openpnp/translations_fr.properties
@@ -2,6 +2,7 @@ Menu.Edit=Editer
 Menu.File=Fichier
 Menu.File.ImportBoard=Importer une carte
 Menu.File.Exit=Quitter
+Menu.File.Restart=Restart (don't save Configuration)
 Menu.File.SaveConfiguration=Enregistrer la configuration
 Menu.Help.SubmitDiagnostics=Envoyer un diagnostique
 Menu.Help.About=A propos ...

--- a/src/main/resources/org/openpnp/translations_it.properties
+++ b/src/main/resources/org/openpnp/translations_it.properties
@@ -2,6 +2,7 @@ Menu.Help.ChangeLog=Registro delle modifiche
 Menu.File=File
 JogControlsPanel.Action.positionSelectedNozzle=Sposta l'ugello selezionato nella posizione della videocamera
 Menu.File.Exit=Esci
+Menu.File.Restart=Restart (don't save Configuration)
 JogControlsPanel.Action.HeadSafeZ=Testa in sicura Z
 MachineSetup.JobProcessors.ReferencePnpJobProcessor.Label.AutoSaveConfiguration=Salva la configurazione periodicamente
 General.Cancel=Cancella

--- a/src/main/resources/org/openpnp/translations_ru.properties
+++ b/src/main/resources/org/openpnp/translations_ru.properties
@@ -171,6 +171,7 @@ Menu.Edit=Редактирование
 Menu.Edit.Undo=Отменить
 Menu.Edit.Redo=Повторить
 Menu.File.Exit=Выход
+Menu.File.Restart=Restart (don't save Configuration)
 Menu.File.ImportBoard=Импортировать плату
 Menu.File.SaveConfiguration=Сохранить настройки
 Menu.File=Файл

--- a/src/main/resources/org/openpnp/translations_zh_CN.properties
+++ b/src/main/resources/org/openpnp/translations_zh_CN.properties
@@ -778,6 +778,7 @@ Menu.Edit.Redo=重做
 Menu.Edit.Undo=撤消
 Menu.Edit=编辑
 Menu.File.Exit=退出OpenPnP
+Menu.File.Restart=Restart (don't save Configuration)
 Menu.File.ImportBoard=导入电路板
 Menu.File.SaveConfiguration=保存配置
 Menu.File=文件


### PR DESCRIPTION
# Description
When reloading the config, the camera's appear multiple times in the UI

# Justification
Fixes https://github.com/openpnp/openpnp/issues/1674

# Implementation Details
To reproduce:
1. Start OpenPnP
2. Create a (js) script with the contents:
``` config.load(); ```
3. Run the script
