### PR TITLE
Fix / Background Calibration: Greyscale vs. HSV value

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/camera/SimulatedUpCamera.java
+++ b/src/main/java/org/openpnp/machine/reference/camera/SimulatedUpCamera.java
@@ -71,7 +71,10 @@ public class SimulatedUpCamera extends ReferenceCamera {
         Black(0x000000, 0x00FF00),
         Dark(0x222222, 0x00DD00),
         Green(0x22AA22, 0x00DD00),
-        Magenta(0xAA22AA, 0x444444);
+        Magenta(0xAA22AA, 0x444444),
+        BlackAndDark(0x000000, 0x444444),
+        DarkAndGrey(0x222222, 0x666666),
+        DarkAndBlueTint(0x222222, 0x4444AA);
 
         final private int rgb;
         final private int rgbNozzleTip;

--- a/src/main/resources/org/openpnp/machine/reference/vision/ReferenceBottomVision-DefaultPipeline.xml
+++ b/src/main/resources/org/openpnp/machine/reference/vision/ReferenceBottomVision-DefaultPipeline.xml
@@ -1,7 +1,7 @@
 <cv-pipeline>
     <stages>
       <cv-stage class="org.openpnp.vision.pipeline.stages.ParameterNumeric" name="pThreshold" enabled="true" parameter-label="Threshold" 
-          parameter-description="Set the brightness threshold that isolates the shiny contacts of a part." stage-name="threshold" property-name="valueMax" effect-stage-name="threshold" preview-result="true" minimum-value="1.0" maximum-value="254.0" default-value="100.0" numeric-type="Integer"/>
+          parameter-description="Set the brightness threshold that isolates the shiny contacts of a part." stage-name="threshold" property-name="threshold" effect-stage-name="threshold" preview-result="true" minimum-value="1.0" maximum-value="254.0" default-value="100.0" numeric-type="Integer"/>
       <cv-stage class="org.openpnp.vision.pipeline.stages.ParameterNumeric" name="pDetail" enabled="true" parameter-label="Min. Detail Size" parameter-description="Minimal size of a detail that should be included in the detected shape." stage-name="filterContours" property-name="minArea" effect-stage-name="contours" preview-result="true" minimum-value="0.0" maximum-value="0.25" default-value="0.01" numeric-type="SquareMillimetersToPixels"/>
       <cv-stage class="org.openpnp.vision.pipeline.stages.ImageCapture" name="0" enabled="true" default-light="true" settle-first="true" count="1"/>
       <cv-stage class="org.openpnp.vision.pipeline.stages.ImageWriteDebug" name="deb0" enabled="true" prefix="bv_source_" suffix=".png"/>
@@ -10,9 +10,9 @@
       <cv-stage class="org.openpnp.vision.pipeline.stages.MaskCircle" name="4b" enabled="true" diameter="100000" property-name="partmask"/>
       <cv-stage class="org.openpnp.vision.pipeline.stages.ConvertColor" name="5" enabled="true" conversion="Bgr2HsvFull"/>
       <cv-stage class="org.openpnp.vision.pipeline.stages.MaskHsv" name="6" enabled="true" auto="false" fraction-to-mask="0.0" hue-min="60" hue-max="130" saturation-min="32" saturation-max="255" value-min="64" value-max="255" invert="false" binary-mask="false" property-name="MaskHsv"/>
-      <cv-stage class="org.openpnp.vision.pipeline.stages.MaskHsv" name="threshold" enabled="true" auto="false" fraction-to-mask="0.0" hue-min="0" hue-max="255" saturation-min="0" saturation-max="255" value-min="0" value-max="128" invert="false" binary-mask="false" property-name=""/>
       <cv-stage class="org.openpnp.vision.pipeline.stages.ConvertColor" name="7" enabled="true" conversion="Hsv2BgrFull"/>
       <cv-stage class="org.openpnp.vision.pipeline.stages.ConvertColor" name="8" enabled="true" conversion="Bgr2Gray"/>
+      <cv-stage class="org.openpnp.vision.pipeline.stages.Threshold" name="threshold" enabled="true" threshold="100" auto="false" invert="false"/>
       <cv-stage class="org.openpnp.vision.pipeline.stages.FindContours" name="findCountours" enabled="true" retrieval-mode="List" approximation-method="None"/>
       <cv-stage class="org.openpnp.vision.pipeline.stages.FilterContours" name="filterContours" enabled="true" contours-stage-name="findCountours" min-area="0.01" max-area="900000.0" property-name="FilterContours"/>
       <cv-stage class="org.openpnp.vision.pipeline.stages.MaskCircle" name="11" enabled="true" diameter="0" property-name=""/>


### PR DESCRIPTION
# Description

In [Nozzle Tip Background Calibration](https://github.com/openpnp/openpnp/wiki/Nozzle-Tip-Background-Calibration), the **Brightness** method worked with a grayscale image, but then used the **HSV Value** channel for masking. The **Value** channel is not the same as grayscale brightness, i.e., it boosts colorful elements, fully saturated colors even reach the maximum value (255). Therefore, in case of background elements being rather colorful,  the pipeline failed to mask them properly.

## Bugfix

This PR fixes this bug by also using the **HSV Value** channel for calibration, so the two always match.

## HSV Value vs. True Brightness Masking

Note: arguably, the **HSV Value** channel is not ideal for masking the background in the **Brightness** mode, i.e. it does not truly indicate "brightness". Vivid colors will show as too bright and trigger a warning. 

![Too bright](https://github.com/user-attachments/assets/8834bb15-3e75-47bd-ada9-2730059abdc5)

However, it was concluded that this warning is actually beneficial. Such backgrounds indicate that there is a problem, either the user mistakenly chose the **Brightness** over the **BrightnessAndKeyColor** mode when they used a green Juki nozzle (or similar), or they should fix another underlying problem of having a colorful background in the first place, like missing  [Camera White Balance](https://github.com/openpnp/openpnp/wiki/Camera-White-Balance) or similar. 

Furthermore, an overall change to the possibly more suitable HLS model (where the Luminosity channel truly indicates brightness) was considered too disruptive with regard to existing code, and compatibility with stored pipelines and configurations in the field.

## True Brightness Slider Threshold 

On the other hand, the manual threshold slider now controls the true brightness in the new stock pipeline, and no longer the HSV Value. By combining the HSV model for background elimination, with the true brightness slider threshold, we get the best of both color models. It allows us to combine the advantages of the two models in terms of discriminating background and dark part elements from the bright contacts. Note, if pipelines in the field are left unchanged they will still work as before, and stored threshold slider values will remain correct.

## Testing Grey and Blue-Tinted Nozzle Tips

This PR also added dark and blue-tinted simulation nozzle tips for testing.

![Blue tinted nozzle tip](https://github.com/user-attachments/assets/ad0519a6-d2e2-4507-8f34-d11a7369f018)


# Justification
User report:
https://groups.google.com/g/openpnp/c/b9vgZJmQZkM/m/0GlZcpCEAwAJ

# Instructions for Use
To enable the new stock pipeline, use the instruction in the Wiki.
https://github.com/openpnp/openpnp/wiki/Computer-Vision#using-new-stock-pipelines

Otherwise the usage remains the same (just a bugfix, and improvement).

# Implementation Details
1. Tested in simulation, using simulated dark grey and blue-tinted nozzle tips.
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. Successful `mvn test` before submitting the Pull Request.
