### PR TITLE
Automatically selecting nozzles and linked tables after a job interruption

### DIFF
--- a/src/main/java/org/openpnp/gui/BoardPlacementsPanel.java
+++ b/src/main/java/org/openpnp/gui/BoardPlacementsPanel.java
@@ -248,12 +248,7 @@ public class BoardPlacementsPanel extends JPanel {
                                     selectedComponent == mainFrame.getBoardsTab())
                             && configuration.getTablesLinked() == TablesLinked.Linked) {
                         Part selectedPart = getSelection().getPart();
-                        mainFrame.getPartsTab().selectPartInTable(selectedPart);
-                        if (selectedPart != null) {
-                            mainFrame.getPackagesTab().selectPackageInTable(selectedPart.getPackage());
-                        }
-                        mainFrame.getFeedersTab().selectFeederForPart(selectedPart);
-                        mainFrame.getVisionSettingsTab().selectVisionSettingsInTable(selectedPart);
+                        mainFrame.getPartsTab().selectPartInTableAndUpdateLinks(selectedPart);
                     }
                 }
             }

--- a/src/main/java/org/openpnp/gui/FeedersPanel.java
+++ b/src/main/java/org/openpnp/gui/FeedersPanel.java
@@ -296,9 +296,7 @@ public class FeedersPanel extends JPanel implements WizardContainer {
                         if (mainFrame.getTabs().getSelectedComponent() == mainFrame.getFeedersTab()
                               &&  Configuration.get().getTablesLinked() == TablesLinked.Linked
                               && feeder.getPart() != null) {
-                            mainFrame.getPartsTab().selectPartInTable(feeder.getPart());
-                            mainFrame.getPackagesTab().selectPackageInTable(feeder.getPart().getPackage());
-                            mainFrame.getVisionSettingsTab().selectVisionSettingsInTable(feeder.getPart());
+                            mainFrame.getPartsTab().selectPartInTableAndUpdateLinks(feeder.getPart());
                         }
                     }
 
@@ -678,8 +676,7 @@ public class FeedersPanel extends JPanel implements WizardContainer {
         MovableUtils.fireTargetedUserAction(nozzle);
         if (MainFrame.get().getTabs().getSelectedComponent() == MainFrame.get().getFeedersTab() 
                 && Configuration.get().getTablesLinked() == TablesLinked.Linked) {
-            MainFrame.get().getPartsTab().selectPartInTable(feeder.getPart());
-            MainFrame.get().getPackagesTab().selectPackageInTable(feeder.getPart().getPackage());
+            MainFrame.get().getPartsTab().selectPartInTableAndUpdateLinks(feeder.getPart());
         }
     }
 

--- a/src/main/java/org/openpnp/gui/JobPanel.java
+++ b/src/main/java/org/openpnp/gui/JobPanel.java
@@ -980,7 +980,10 @@ public class JobPanel extends JPanel {
 
     private void selectJobProcessorExceptionSource(Object source,boolean primary) {
         // decode the source of the exception and try to select as much as possible
-        if (source instanceof BoardLocation) {
+        if (source==null)
+        {
+        }
+        else if (source instanceof BoardLocation) {
             BoardLocation b = (BoardLocation)source;
             Logger.debug("Exception source is board location: {}", b);
             // select the board
@@ -1011,7 +1014,7 @@ public class JobPanel extends JPanel {
             Part p = (Part)source;
             Logger.debug("Exception source is part: {}", p);
             // select part in parts tab
-            MainFrame.get().getPartsTab().selectPartInTable(p);
+            MainFrame.get().getPartsTab().selectPartInTableAndUpdateLinks(p);
             if(primary) {
                 // focus the parts tab
                 MainFrame.get().getTabs().setSelectedComponent(MainFrame.get().getPartsTab());
@@ -1030,7 +1033,7 @@ public class JobPanel extends JPanel {
             Logger.debug("Exception source is nozzle: {}", n);
             // select the nozzle and part in the table
             MainFrame.get().getMachineControls().setSelectedTool(n);
-            MainFrame.get().getPartsTab().selectPartInTable(n.getPart());
+            MainFrame.get().getPartsTab().selectPartInTableAndUpdateLinks(n.getPart());
         } else {
             Logger.debug("Exception contains an unsupported source: {}", source.getClass());
         }

--- a/src/main/java/org/openpnp/gui/JobPanel.java
+++ b/src/main/java/org/openpnp/gui/JobPanel.java
@@ -115,6 +115,7 @@ import org.openpnp.spi.JobProcessor.TextStatusListener;
 import org.openpnp.spi.Machine;
 import org.openpnp.spi.MachineListener;
 import org.openpnp.spi.MotionPlanner;
+import org.openpnp.spi.Nozzle;
 import org.openpnp.util.MovableUtils;
 import org.openpnp.util.UiUtils;
 import org.pmw.tinylog.Logger;
@@ -960,45 +961,8 @@ public class JobPanel extends JPanel {
              */
             if (t instanceof JobProcessorException) {
                 JobProcessorException jpe = (JobProcessorException)t;
-                Object source = jpe.getSource();
-                
-                // decode the source of the exception and try to select as much as possible
-                if (source instanceof BoardLocation) {
-                    BoardLocation b = (BoardLocation)source;
-                    // select the board
-                    Helpers.selectObjectTableRow(jobTable, b);
-                    // focus the job tab
-                    MainFrame.get().getTabs().setSelectedComponent(MainFrame.get().getJobTab());
-                } else if (source instanceof Placement) {
-                    Placement p = (Placement)source;
-
-                    // select the board this placement belongs to
-                    for (BoardLocation boardLocation : job.getBoardLocations()) {
-                        if (boardLocation.getBoard().getPlacements().contains(p)) {
-                            // this is the board, that contains the placement that caused the error
-                            Helpers.selectObjectTableRow(jobTable, boardLocation);
-                        }
-                    }
-
-                    // select the placement itself
-                    Helpers.selectObjectTableRow(jobPlacementsPanel.getTable(), p);
-                    // focus the job tab
-                    MainFrame.get().getTabs().setSelectedComponent(MainFrame.get().getJobTab());
-                } else if (source instanceof Part) {
-                    Part p = (Part)source;
-                    // select part in parts tab
-                    MainFrame.get().getPartsTab().selectPartInTable(p);
-                    // focus the parts tab
-                    MainFrame.get().getTabs().setSelectedComponent(MainFrame.get().getPartsTab());
-                } else if (source instanceof Feeder) {
-                    Feeder f = (Feeder)source;
-                    // select the feeder in the feeders tab
-                    MainFrame.get().getFeedersTab().selectFeederInTable(f);
-                    // focus the feeder tab
-                    MainFrame.get().getTabs().setSelectedComponent(MainFrame.get().getFeedersTab());
-                } else {
-                    Logger.debug("Exception contains an unsupported source: {}", source.getClass());
-                }
+                selectJobProcessorExceptionSource(jpe.getSecondarySource(),false);
+                selectJobProcessorExceptionSource(jpe.getSource(),true);
             }
             
             // update the state before showing the error to allow exceptions with continuations to change it
@@ -1012,6 +976,64 @@ public class JobPanel extends JPanel {
             // call showError() to support exceptions with continuation
             UiUtils.showError(getTopLevelAncestor(), Translations.getString("JobPanel.JobRun.Error.ErrorBox.Title"), t); //$NON-NLS-1$
         });
+    }
+
+    private void selectJobProcessorExceptionSource(Object source,boolean primary) {
+        // decode the source of the exception and try to select as much as possible
+        if (source instanceof BoardLocation) {
+            BoardLocation b = (BoardLocation)source;
+            Logger.debug("Exception source is board location: {}", b);
+            // select the board
+            Helpers.selectObjectTableRow(jobTable, b);
+            if(primary) {
+                // focus the job tab
+                MainFrame.get().getTabs().setSelectedComponent(MainFrame.get().getJobTab());
+            }
+        } else if (source instanceof Placement) {
+            Placement p = (Placement)source;
+            Logger.debug("Exception source is placement: {}", p);
+
+            // select the board this placement belongs to
+            for (BoardLocation boardLocation : job.getBoardLocations()) {
+                if (boardLocation.getBoard().getPlacements().contains(p)) {
+                    // this is the board, that contains the placement that caused the error
+                    Helpers.selectObjectTableRow(jobTable, boardLocation);
+                }
+            }
+
+            // select the placement itself
+            Helpers.selectObjectTableRow(jobPlacementsPanel.getTable(), p);
+            if(primary) {
+                // focus the job tab
+                MainFrame.get().getTabs().setSelectedComponent(MainFrame.get().getJobTab());
+            }
+        } else if (source instanceof Part) {
+            Part p = (Part)source;
+            Logger.debug("Exception source is part: {}", p);
+            // select part in parts tab
+            MainFrame.get().getPartsTab().selectPartInTable(p);
+            if(primary) {
+                // focus the parts tab
+                MainFrame.get().getTabs().setSelectedComponent(MainFrame.get().getPartsTab());
+            }
+        } else if (source instanceof Feeder) {
+            Feeder f = (Feeder)source;
+            Logger.debug("Exception source is feeder: {}", f);
+            // select the feeder in the feeders tab
+            MainFrame.get().getFeedersTab().selectFeederInTable(f);
+            if(primary) {
+                // focus the feeder tab
+                MainFrame.get().getTabs().setSelectedComponent(MainFrame.get().getFeedersTab());
+            }
+        } else if (source instanceof Nozzle) {
+            Nozzle n = (Nozzle)source;
+            Logger.debug("Exception source is nozzle: {}", n);
+            // select the nozzle and part in the table
+            MainFrame.get().getMachineControls().setSelectedTool(n);
+            MainFrame.get().getPartsTab().selectPartInTable(n.getPart());
+        } else {
+            Logger.debug("Exception contains an unsupported source: {}", source.getClass());
+        }
     }
 
     private void jobAbort() {

--- a/src/main/java/org/openpnp/gui/JobPlacementsPanel.java
+++ b/src/main/java/org/openpnp/gui/JobPlacementsPanel.java
@@ -253,12 +253,7 @@ public class JobPlacementsPanel extends JPanel {
                     MainFrame mainFrame = MainFrame.get();
                     if (getSelection() != null && updateLinkedTables) {
                         Part selectedPart = getSelection().getPart();
-                        if (selectedPart != null) {
-                            mainFrame.getPartsTab().selectPartInTable(selectedPart);
-                            mainFrame.getPackagesTab().selectPackageInTable(selectedPart.getPackage());
-                            mainFrame.getFeedersTab().selectFeederForPart(selectedPart);
-                            mainFrame.getVisionSettingsTab().selectVisionSettingsInTable(selectedPart);
-                        }
+                        mainFrame.getPartsTab().selectPartInTableAndUpdateLinks(selectedPart);
                     }
                 }
             }

--- a/src/main/java/org/openpnp/gui/PartsPanel.java
+++ b/src/main/java/org/openpnp/gui/PartsPanel.java
@@ -501,6 +501,21 @@ public class PartsPanel extends JPanel implements WizardContainer {
 
     }
 
+    public void selectPartInTableAndUpdateLinks(Part part) {
+        selectPartInTable(part);
+
+        if(Configuration.get().getTablesLinked() == TablesLinked.Linked)
+        {
+            MainFrame mainFrame = MainFrame.get();
+            mainFrame.getPartsTab().selectPartInTable(part);
+            if (part != null) {
+                mainFrame.getPackagesTab().selectPackageInTable(part.getPackage());
+            }
+            mainFrame.getFeedersTab().selectFeederForPart(part);
+            mainFrame.getVisionSettingsTab().selectVisionSettingsInTable(part);
+        }
+    }
+
     public void selectPartInTable(Part part) {
         if (getSelectedPart() != part) {
             Helpers.selectObjectTableRow(table, part);

--- a/src/main/java/org/openpnp/machine/reference/ReferencePnpJobProcessor.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferencePnpJobProcessor.java
@@ -947,7 +947,7 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
             
             scriptBeforeAssembly(plannedPlacement, placementLocation);
 
-            checkPartOn(nozzle);
+            checkPartOn(nozzle, part);
             
             place(nozzle, part, placement, placementLocation);
             
@@ -985,38 +985,43 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
             }
         }
         
-        private void checkPartOn(Nozzle nozzle) throws JobProcessorException {
-            if (!nozzle.isPartOnEnabled(Nozzle.PartOnStep.BeforePlace)) {
-                return;
+        private void checkPartOn(Nozzle nozzle, Part part) throws JobProcessorException {
+            if (part == null || nozzle.getPart() == null) {
+                throw new JobProcessorException(part, nozzle, "No part on nozzle before place.");
             }
-            try {
-                if (!nozzle.isPartOn()) {
-                    throw new JobProcessorException(nozzle, "No part vacuum-detected on nozzle before place.");
+            if (part != nozzle.getPart()) {
+                throw new JobProcessorException(part, nozzle, "Part mismatch with part on nozzle before place.");
+            }
+
+            if (nozzle.isPartOnEnabled(Nozzle.PartOnStep.BeforePlace)) {
+                try {
+                    if (!nozzle.isPartOn()) {
+                        throw new JobProcessorException(nozzle, "No part vacuum-detected on nozzle before place.");
+                    }
                 }
-            }
-            catch (JobProcessorException e) {
-                throw e;
-            }
-            catch (Exception e) {
-                throw new JobProcessorException(nozzle, e);
+                catch (JobProcessorException e) {
+                    throw e;
+                }
+                catch (Exception e) {
+                    throw new JobProcessorException(nozzle, e);
+                }
             }
         }
         
         private void checkPartOff(Nozzle nozzle, Part part) throws JobProcessorException {
-            if (!nozzle.isPartOffEnabled(Nozzle.PartOffStep.AfterPlace)) {
-                return;
-            }
-            try {
-                // Note, we 're already at safe Z, see place().
-                if (!nozzle.isPartOff()) {
-                    throw new JobProcessorException(nozzle, "Part vacuum-detected on nozzle after place.");
+            if (nozzle.isPartOffEnabled(Nozzle.PartOffStep.AfterPlace)) {
+                try {
+                    // Note, we 're already at safe Z, see place().
+                    if (!nozzle.isPartOff()) {
+                        throw new JobProcessorException(nozzle, "Part vacuum-detected on nozzle after place.");
+                    }
                 }
-            }
-            catch (JobProcessorException e) {
-                throw e;
-            }
-            catch (Exception e) {
-                throw new JobProcessorException(nozzle, e);
+                catch (JobProcessorException e) {
+                    throw e;
+                }
+                catch (Exception e) {
+                    throw new JobProcessorException(nozzle, e);
+                }
             }
         }
         

--- a/src/main/java/org/openpnp/machine/reference/ReferencePnpJobProcessor.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferencePnpJobProcessor.java
@@ -732,14 +732,14 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
                 // may move the nozzle to (near) the pick location i.e. down in Z in feed().
                 nozzle.moveToSafeZ();
                 if (!nozzle.isPartOff()) {
-                    throw new JobProcessorException(nozzle, "Part vacuum-detected on nozzle before pick.");
+                    throw new JobProcessorException(nozzle, part, "Part vacuum-detected on nozzle before pick.");
                 }
             }
             catch (JobProcessorException e) {
                 throw e;
             }
             catch (Exception e) {
-                throw new JobProcessorException(nozzle, e);
+                throw new JobProcessorException(nozzle, part, e);
             }
         }
         
@@ -756,7 +756,7 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
                     lastException = e;
                 }
             }
-            throw new JobProcessorException(feeder, lastException);
+            throw new JobProcessorException(feeder, nozzle, lastException);
         }
         
         private void pick(Nozzle nozzle, Feeder feeder, JobPlacement jobPlacement, Part part) throws JobProcessorException {
@@ -787,7 +787,7 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
                 feeder.postPick(nozzle);
             }
             catch (Exception e) {
-                throw new JobProcessorException(feeder, e);
+                throw new JobProcessorException(feeder, nozzle, e);
             }
         }
         
@@ -884,7 +884,7 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
                     lastException = e;
                 }
             }
-            throw new JobProcessorException(part, lastException);
+            throw new JobProcessorException(part, nozzle, lastException);
         }
         
         private void checkPartOn(Nozzle nozzle) throws JobProcessorException {

--- a/src/main/java/org/openpnp/spi/JobProcessor.java
+++ b/src/main/java/org/openpnp/spi/JobProcessor.java
@@ -26,6 +26,7 @@ public interface JobProcessor extends PropertySheetHolder, WizardConfigurable {
         private static final long serialVersionUID = 1L;
 
         private final Object source;
+        private Object secondarySource = null;
         private boolean interrupting = false;
 
         private static String getThrowableMessage(Throwable throwable) {
@@ -44,13 +45,33 @@ public interface JobProcessor extends PropertySheetHolder, WizardConfigurable {
             super(getThrowableMessage(throwable), throwable);
             this.source = source;
             if (throwable instanceof JobProcessorException) {
-                this.interrupting = ((JobProcessorException) throwable).isInterrupting();
+                JobProcessorException e = ((JobProcessorException) throwable);
+                this.interrupting = e.isInterrupting();
+                if (e.secondarySource !=null) {
+                    this.secondarySource = e.secondarySource;
+                }
             }
+        }
+
+        public JobProcessorException(Object source, Object secondarySource, Throwable throwable) {
+            super(getThrowableMessage(throwable), throwable);
+            this.source = source;
+            if (throwable instanceof JobProcessorException) {
+                JobProcessorException e = ((JobProcessorException) throwable);
+                this.interrupting = e.isInterrupting();
+            }
+            this.secondarySource = secondarySource;
         }
 
         public JobProcessorException(Object source, String message) {
             super(message);
             this.source = source;
+        }
+
+        public JobProcessorException(Object source, Object secondarySource, String message) {
+            super(message);
+            this.source = source;
+            this.secondarySource = source;
         }
 
         public JobProcessorException(Object source, String message, boolean interrupting) {
@@ -67,6 +88,10 @@ public interface JobProcessor extends PropertySheetHolder, WizardConfigurable {
 
         public Object getSource() {
             return source;
+        }
+
+        public Object getSecondarySource() {
+            return secondarySource;
         }
 
         public boolean isInterrupting() {


### PR DESCRIPTION
This is a preliminary Pull Request. I have tested on simulated machine, but would like to test on a real machine before merging.

# Description
This is based on a discussion at https://groups.google.com/g/openpnp/c/7bxPtQ3MpdA/m/jW3iQIgVBQAJ

> There is one aspect of my placement workflow that feels more complicated than it should be.
> Openpnp alerts if a mis-pick is detected by bottom vision. If I see there is genuinely no part on the nozzle then I want to redo the pick. Is there an easy way to do that? My best solution at the moment involves manually finding the right feeder, checking that the right nozzle is selected, pressing the "feed and pick" button, and restarting the job. But that feels all very manual, and error-prone. Is there an easier way?

This patch automatically selects the UI features ready for the user to resolve the problem.

This patch introduces several changes.

1. It refactors the "linked tables" logic. There were several copies of the 5 lines of code to update linked parts, feeders, vision, and package. I did not want to add another copy, so moved all that into a new function `selectPartInTableAndUpdateLinks` in `PartsPanel`.
2. `JobProcessorException` is the exception which records which object was the source of the job problem. The purpose of recording the source object is to select it in the UI when showing an error message. But a single source object is not enough detail - it sometimes needs two. So `JobProcessorException` has been extended to record a `secondarySourceObject`. When reporting the vision error example described above, the Part is the primary source object and the Nozzle is the secondary source object.
3. There was code in `JobPanel` to select the appropriate UI for the source of the error. I pulled that into a new function `selectJobProcessorExceptionSource` and extended it in several ways:
   * If the source is a Part, it now updates linked tables too (if linked tables are enabled). Previously it would select the part, but never update linked tables.
   * It now handles the case where the source object is a Nozzle, and selects the nozzle.
   * That function is called twice, because there are now two source objects.
4. That previously error-prone UI had led me to place incorrect components through interacting with the wrong nozzle. openpnp checks that the right part is present on the nozzle before performing vision checks, but there are no equivalent checks prior to placing. This has been added to `checkPartOn`. You can demonstrate this on the simulated machine:
  a. Single step a job, but pause before placement.
  b. Discard the part
  c. Manually pick a //wrong// part.
  d. Start the job. Previously it silently placed the wrong part. With this patch it reports the error.

# Justification
This makes the workflow for responding to a job error significantly less error-prone.

# Implementation Details
1. How did you test the change? - on the simulated machine so far. test with real hardware to follow
4. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)? - yes
6. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing. - **yes!!!!** `JobProcessorException` has an extra attribute to record a second source object.
7. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted. - tests pass
