### PR TITLE
Fix / BlindsFeeder: Brackets Error In Cover Actuation

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/feeder/BlindsFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/BlindsFeeder.java
@@ -1614,13 +1614,13 @@ public class BlindsFeeder extends ReferenceFeeder {
                 // Calculate the motion for the cover to be pushed in feeder local coordinates. 
                 Length feederX0 = (openState ^ isBlindsCoverAlignmentReversed() ? 
                         edgeOpenDistance.multiply(-1.0)
-                        .subtract(pocketPitch).multiply(0.5)
+                        .subtract(pocketPitch.multiply(0.5))
                         .subtract(sprocketPitch.multiply(0.5)) // go half sprocket too far back
                         .subtract(nozzleTipDiameter.multiply(0.5)) 
                         : 
                             edgeClosedDistance
                             .add(tapeLength) 
-                            .add(pocketPitch).multiply(0.5)
+                            .add(pocketPitch.multiply(0.5))
                             .add(sprocketPitch.multiply(0.5)) // go half sprocket too far
                             .add(nozzleTipDiameter.multiply(0.5)))
                         .convertToUnits(location.getUnits());


### PR DESCRIPTION
# Description
This fixes my shoddy fix in #1418 in BlindsFeeder cover actuation. Simple brackets error.

![cover opening](https://github.com/user-attachments/assets/b6d4f843-c6e5-4750-8bba-1813fc3760c2)


# Justification
User report:
https://groups.google.com/g/openpnp/c/Wi39lDw7jT0/m/BcOVXiR6BQAJ

# Instructions for Use
No change in use.

# Implementation Details
1. Did not test  the change but reporting user Jen did on exact same code change.
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. Successful `mvn test` before submitting the Pull Request.
