### PR TITLE
Issues & Solutions: Still use the Z from captured nozzle offsets 

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/solutions/VisionSolutions.java
+++ b/src/main/java/org/openpnp/machine/reference/solutions/VisionSolutions.java
@@ -945,22 +945,22 @@ public class VisionSolutions implements Solutions.Subject {
                                         }
                                         if (primary) {
                                             // Determine the nozzle head offset.
-                                            // Note 1: Remember, we reset the head offset to zero above, so the nozzle now shows the true offset.
-                                            // Note 2: The Z fiducial location Z was set to the default nozzle location Z (see above), so the Z offset will  
-                                            // be 0 for the default nozzle, but equalize Z for any other nozzle. 
+                                            // Note 1: Remember, we reset the head offsets to zero above, so the nozzle now shows the true offset.
+                                            // Note 2: The Z fiducial location Z was set to the default nozzle location Z (see above), so the Z offset will
+                                            // be 0 for the default nozzle, but equalize Z for any other nozzle.
                                             Location headOffsets = head.getCalibrationPrimaryFiducialLocation().subtract(nozzleLocation);
                                             if (headOffsetsBefore.getLinearLengthTo(headOffsets)
                                                     .compareTo(head.getCalibrationPrimaryFiducialDiameter().multiply(0.5)) < 0) {
-                                                // Offsets that are too close (inside the fiducial) are not updated. They might already have been calibrated and we want 
-                                                // to keep them so i.e. these rough nozzle-aimed offsets are likely worse. 
-                                                Logger.info("Not setting nozzle "+nozzle.getName()+" head offsets to rough "+headOffsets+" as these are close to "
-                                                        + "existing offsets "+headOffsetsBefore+" and existing offsets might already have been calibrated.");
-                                                nozzle.setHeadOffsets(headOffsetsBefore);
+                                                // Offsets that are too close (inside the fiducial) are not updated. They might already have been
+                                                // auto-calibrated precisely, and we want to keep them over these "guestimated" offsets we get from looking at a
+                                                // nozzle tip from the side here.
+                                                Logger.info("Not setting nozzle "+nozzle.getName()+" head X, Y offsets to rough "+headOffsets+" as these are close to "
+                                                        + "existing offsets "+headOffsetsBefore+" and existing offsets might already have been auto-calibrated. Only setting Z.");
+                                                // Just use the Z.
+                                                headOffsets = headOffsetsBefore.deriveLengths(null, null, headOffsets.getLengthZ(), null);
                                             }
-                                            else {
-                                                nozzle.setHeadOffsets(headOffsets);
-                                                Logger.info("Set nozzle "+nozzle.getName()+" head offsets to "+headOffsets+" (previously "+headOffsetsBefore+")");
-                                            }
+                                            nozzle.setHeadOffsets(headOffsets);
+                                            Logger.info("Set nozzle "+nozzle.getName()+" head offsets to "+headOffsets+" (previously "+headOffsetsBefore+")");
                                         }
                                         return true;
                                     },


### PR DESCRIPTION
# Description
In **Issues & Solutions**, preliminary nozzle offsets are captured by looking from the side at a nozzle tip manually centered on a fiducial. 

- Watch a (somewhat outdated) [video of that step](https://youtu.be/md68n_J7uto?feature=shared&t=109).

   ![solution](https://github.com/user-attachments/assets/78e1aa4d-96f9-4490-bbad-4f3484e939d2)


We can only get a very rough X, Y (gu)estimate from that, which is later refined by precision nozzle offset calibration (a.k.a. ["confetti calibration"](https://github.com/openpnp/openpnp/wiki/Calibration-Solutions#calibrating-precision-camera-to-nozzle-offsets)). 

Side note: the manually captured preliminary nozzle offsets are required to perform the confetti calibration in the first place, i.e. it would otherwise not know at what offsets to pick the confetti that was centered in the camera.

Sometimes it becomes necessary to reopen/redo the preliminary nozzle offsets solutions later. In this case, the rough X, Y coordinates should not overwrite the already precision-calibrated X, Y coordinates, unless they are decidedly different, say after a change of the machine geometry. 

The old code already avoided overwriting precision calibrated X, Y, but by doing so, it forgot that the Z coordinate can change too, and independently, due to change of Z reference (homing switch, head geometry, controller config, etc.). Wanting/needing to adjust Z is usually the reason the solution was actually reopened.

This PR remedies that: Z is now always adjusted in this solution. 

Side note: the Z offset of the second, third, etc. nozzle is actually _definitively_ calibrated by that solution, unlike for X, Y, there is no follow up solution.

# Justification
User report:
https://groups.google.com/g/openpnp/c/NcqDL2vKusA/m/d-XKBchaAAAJ

# Instructions for Use
No change in usage.

See the log for how the offsets in X, Y and Z are, or are not applied. 

# Implementation Details
1. Hoping to enlist reporting user to do some tests.
2. Did follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style).
3. No changes in the `org.openpnp.spi` or `org.openpnp.model` packages.
4. Successful `mvn test` before submitting the Pull Request.