### PR TITLE
Issues solutions guidance

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/ContactProbeNozzle.java
+++ b/src/main/java/org/openpnp/machine/reference/ContactProbeNozzle.java
@@ -928,7 +928,7 @@ public class ContactProbeNozzle extends ReferenceNozzle {
                         }
                         if (suggestedCommand != null) {
                             GcodeDriverSolutions.suggestGcodeCommand(gcodeDriver, contactProbeActuator, solutions, 
-                                    GcodeDriver.CommandType.ACTUATE_BOOLEAN_COMMAND, suggestedCommand, false, false);
+                                    GcodeDriver.CommandType.ACTUATE_BOOLEAN_COMMAND, suggestedCommand, false, false, null);
                         }
                         else {
                             String currentCommand = gcodeDriver.getCommand(contactProbeActuator, GcodeDriver.CommandType.ACTUATE_BOOLEAN_COMMAND);

--- a/src/main/java/org/openpnp/machine/reference/solutions/GcodeDriverSolutions.java
+++ b/src/main/java/org/openpnp/machine/reference/solutions/GcodeDriverSolutions.java
@@ -1100,7 +1100,7 @@ public class GcodeDriverSolutions implements Solutions.Subject {
                 public String getExtendedDescription() {
                     String r = "<html>\n";
                     if (rationale!=null && !rationale.isEmpty()) {
-                        r += "<p><b>"+rationale+"</b></p>\n";
+                        r += "<p><strong>"+rationale+"</strong></p>\n";
                     }
                     if (suggestedCommand.isEmpty()) {
                         r += "<p>Delete it.</p>\n";

--- a/src/main/java/org/openpnp/machine/reference/solutions/GcodeDriverSolutions.java
+++ b/src/main/java/org/openpnp/machine/reference/solutions/GcodeDriverSolutions.java
@@ -772,6 +772,7 @@ public class GcodeDriverSolutions implements Solutions.Subject {
         for (CommandType commandType : gcodeDriver.isSpeakingGcode() ?
                 CommandType.values() 
                 : new CommandType[] { CommandType.CONNECT_COMMAND }) {
+            String rationale = "";
             String command = gcodeDriver.getCommand(null, commandType);
             String commandBuilt = null;
             boolean disallowHeadMountables = false;
@@ -797,24 +798,28 @@ public class GcodeDriverSolutions implements Solutions.Subject {
                     else {
                         if (gcodeDriver.getUnits() == LengthUnit.Millimeters) {
                             if (command.contains("G20 ")) {
+                                rationale += "Replace G20 (inches) with G21 (millimeters). ";
                                 commandBuilt = command
                                         .replace("G20 ", "G21 ")
                                         .replace("inches", "millimeters");
                             }
                             else if (! command.contains("G21 "))
-                            { commandBuilt = "G21 ; Set millimeters mode \n" 
-                                    + command;
+                            {
+                                rationale += "Explicitly set millimeters mode. ";
+                                commandBuilt = "G21 ; Set millimeters mode \n" + command;
                             }
                         }
                         else if (gcodeDriver.getUnits() == LengthUnit.Inches) {
                             if (command.contains("G21 ")) {
+                                rationale += "Replace G21 (millimeters) with G20 (inches). ";
                                 commandBuilt = command
                                         .replace("G21 ", "G20 ")
                                         .replace("millimeters", "inches");
                             }
                             else if (! command.contains("G20 "))
-                            { commandBuilt = "G20 ; Set inches mode \n"
-                                    + command;
+                            {
+                                rationale += "Explicitly set inches mode. ";
+                                commandBuilt = "G20 ; Set inches mode \n" + command;
                             }
                         }
                         else {
@@ -1027,7 +1032,7 @@ public class GcodeDriverSolutions implements Solutions.Subject {
                     break;
             }
             suggestGcodeCommand(gcodeDriver, null, solutions, commandType, commandBuilt, commandModified,
-                    disallowHeadMountables);
+                    disallowHeadMountables, rationale);
         }
     }
 
@@ -1066,14 +1071,22 @@ public class GcodeDriverSolutions implements Solutions.Subject {
      */
     public static void suggestGcodeCommand(GcodeDriver gcodeDriver, HeadMountable headMountable, Solutions solutions,
             CommandType commandType, String suggestedCommand, boolean commandModified,
-            boolean disallowHeadMountables) {
+            boolean disallowHeadMountables, String rationale) {
         String currentCommand = gcodeDriver.getCommand(headMountable, commandType);
         if (suggestedCommand != null && !suggestedCommand.equals(currentCommand)) {
+            String solution = "";
+            if (suggestedCommand.isEmpty()) {
+                solution = "Delete it.";
+            } else if (commandModified) {
+                solution = "Modify it.";
+            } else {
+                solution = "Change it.";
+            }
             solutions.add(new Solutions.Issue(
                     (headMountable != null ? headMountable : gcodeDriver),
                     commandType.name()+(suggestedCommand.isEmpty() ? " obsolete." : (commandModified ? " modification suggested." : " suggested."))
                     + (gcodeDriver.isSpeakingGcode() ? "" : " Accept if this is a true Gcode controller."),
-                    (suggestedCommand.isEmpty() ? "Delete it." : suggestedCommand),
+                    solution,
                     suggestedCommand.isEmpty() ? Severity.Warning
                             : (gcodeDriver.isSpeakingGcode() ? Severity.Suggestion : Severity.Fundamental),
                     "https://github.com/openpnp/openpnp/wiki/Advanced-Motion-Control#migration-from-a-previous-version") {
@@ -1082,6 +1095,24 @@ public class GcodeDriverSolutions implements Solutions.Subject {
                 public void setState(Solutions.State state) throws Exception {
                     gcodeDriver.setCommand(headMountable, commandType, (state == Solutions.State.Solved) ? suggestedCommand : currentCommand);
                     super.setState(state);
+                }
+                @Override
+                public String getExtendedDescription() {
+                    String r = "<html>\n";
+                    if (rationale!=null && !rationale.isEmpty()) {
+                        r += "<p><b>"+rationale+"</b></p>\n";
+                    }
+                    if (suggestedCommand.isEmpty()) {
+                        r += "<p>Delete it.</p>\n";
+                    } else {
+                        r += "<p>Suggested cgode is:</p><pre>"+suggestedCommand+"</pre>\n";
+                    }
+                    String prev = gcodeDriver.getCommand(headMountable, commandType);
+                    if(!prev.isEmpty()) {
+                        r += "<p>Current gcode is:</p><pre>"+prev+"</pre>\n";
+                    }
+                    r += "</html>";
+                    return r;
                 }
             });
         }

--- a/src/main/java/org/openpnp/machine/reference/solutions/KinematicSolutions.java
+++ b/src/main/java/org/openpnp/machine/reference/solutions/KinematicSolutions.java
@@ -185,10 +185,11 @@ public class KinematicSolutions implements Solutions.Subject {
                                     final Length oldLimitHigh = axisZ.getSafeZoneHigh();  
                                     final boolean oldEnableLow = axisZ.isSafeZoneLowEnabled(); 
                                     final boolean oldEnableHigh = axisZ.isSafeZoneHighEnabled();
+                                    final boolean bothSafeZoneHighAndLowEnabled = oldEnableHigh && oldEnableLow;
                                     boolean safeZSolved = false;
 
-                                    if (axisZ.isSafeZoneLowEnabled() && axisZ.isSafeZoneHighEnabled()
-                                            && axisZ.getSafeZoneLow().compareTo(axisZ.getSafeZoneHigh()) > 0) {
+                                    if (bothSafeZoneHighAndLowEnabled
+                                        && axisZ.getSafeZoneLow().compareTo(axisZ.getSafeZoneHigh()) > 0) {
                                         solutions.add(new Solutions.Issue(
                                                 axisZ, 
                                                 "Invalid Safe Z Zone on "+axisZ.getName()+".", 
@@ -203,25 +204,25 @@ public class KinematicSolutions implements Solutions.Subject {
                                             }
                                         });
                                     }
-                                    else if (axisZ.isSafeZoneLowEnabled() && axisZ.isSafeZoneHighEnabled()
-                                            && hm.getSafeZ().convertToUnits(LengthUnit.Millimeters).getValue() > 2.0) {
-                                        solutions.add(new Solutions.Issue(
-                                                hm,
-                                                "Unconventional Z Axis on "+hm.getName()+".",
-                                                "The Safe Z of "+hm.getName()+" is positive, which is unconventional. "+
-                                                "OpenPnp typically uses Z coordinates that have Z=0 when the nozzle is retracted, with the PCB surface in the negative Z range. "+
-                                                "Please read the Wiki to understand the implications of not following this convention.",
-                                                Solutions.Severity.Warning,
-                                                "https://github.com/openpnp/openpnp/wiki/Machine-Axes#a-word-about-z-coordinates") {
-                                            @Override
-                                            public void setState(Solutions.State state) throws Exception {
-                                                axisZ.setSafeZoneLowEnabled(state != State.Solved);
-                                                axisZ.setSafeZoneHighEnabled(state != State.Solved);
-                                                MainFrame.get().getIssuesAndSolutionsTab().findIssuesAndSolutions();
-                                            }
-                                        });
-                                    }
                                     else {
+                                        if (bothSafeZoneHighAndLowEnabled
+                                            && hm.getSafeZ().convertToUnits(LengthUnit.Millimeters).getValue() > 2.0) {
+                                            solutions.add(new Solutions.Issue(
+                                                    hm,
+                                                    "Unconventional Z Axis on "+hm.getName()+".",
+                                                    "The Safe Z of "+hm.getName()+" is positive, which is unconventional. "+
+                                                    "OpenPnp typically uses Z coordinates that have Z=0 when the nozzle is retracted, with the PCB surface in the negative Z range. "+
+                                                    "Please read the Wiki to understand the implications of not following this convention.",
+                                                    Solutions.Severity.Warning,
+                                                    "https://github.com/openpnp/openpnp/wiki/Machine-Axes#a-word-about-z-coordinates") {
+                                                @Override
+                                                public void setState(Solutions.State state) throws Exception {
+                                                    axisZ.setSafeZoneLowEnabled(state != State.Solved);
+                                                    axisZ.setSafeZoneHighEnabled(state != State.Solved);
+                                                    MainFrame.get().getIssuesAndSolutionsTab().findIssuesAndSolutions();
+                                                }
+                                            });
+                                        }
 
                                         safeZSolved = solutions.add(new Solutions.Issue(
                                                 hm, 

--- a/src/main/java/org/openpnp/machine/reference/solutions/KinematicSolutions.java
+++ b/src/main/java/org/openpnp/machine/reference/solutions/KinematicSolutions.java
@@ -203,6 +203,24 @@ public class KinematicSolutions implements Solutions.Subject {
                                             }
                                         });
                                     }
+                                    else if (axisZ.isSafeZoneLowEnabled() && axisZ.isSafeZoneHighEnabled()
+                                            && hm.getSafeZ().convertToUnits(LengthUnit.Millimeters).getValue() > 2.0) {
+                                        solutions.add(new Solutions.Issue(
+                                                hm,
+                                                "Unconventional Z Axis on "+hm.getName()+".",
+                                                "The Safe Z of "+hm.getName()+" is positive, which is unconventional. "+
+                                                "OpenPnp typically uses Z coordinates that have Z=0 when the nozzle is retracted, with the PCB surface in the negative Z range. "+
+                                                "Please read the Wiki to understand the implications of not following this convention.",
+                                                Solutions.Severity.Warning,
+                                                "https://github.com/openpnp/openpnp/wiki/Machine-Axes#a-word-about-z-coordinates") {
+                                            @Override
+                                            public void setState(Solutions.State state) throws Exception {
+                                                axisZ.setSafeZoneLowEnabled(state != State.Solved);
+                                                axisZ.setSafeZoneHighEnabled(state != State.Solved);
+                                                MainFrame.get().getIssuesAndSolutionsTab().findIssuesAndSolutions();
+                                            }
+                                        });
+                                    }
                                     else {
 
                                         safeZSolved = solutions.add(new Solutions.Issue(


### PR DESCRIPTION
# Description
I have recently been redoing my machine setup and calibration using Issues&Solutions, where previously I had followed the opulo-recommended manual method. The end result is very much better with I&S.

However the I&S process was not exactly smooth. I had a few false starts which I was able to correct myself, and a few major misunderstandings which where corrected by the helpful participants on the mailing list. I have made a few changes to the wiki to help the next user following my footsteps; for example noting that there is a maximum diameter for the nozzle-offset-calibration confetti. This patch contains a couple of messages which I think are best delivered through the software.

## 1. Unconventional Z Axis

Mark pointed me to [the convention that working Z is negative](https://github.com/openpnp/openpnp/wiki/Machine-Axes#a-word-about-z-coordinates), which was very helpful. After calibrating Z, this patch adds a warning message with a link to the wiki if a calibration fiducial is at positive Z.

## 2. Tool changer

Changing axis calibration is likely to break any automatic tip changer configuration. This patch adds a warning message if automatic tip changers are enabled before performing any axis calibration.

# Justification

## a. No regressions

* This patch does not change the I&S calibration logic. There is no numerical or process change.

* If a user reads the wiki and follows its guidance meticulously, then they will not see any new messages. This patch adds warnings which are only shown for users who are diverging from the best practice.

## b. Helpfulness

These warning messages would have saved me from a few days of confusion, and having to reprint my tool changer. These are not mistakes that everyone will make, but I feel they are mistakes that any new user could make.

# Instructions for Use

No instructions needed - its just a warning message.

# Implementation Details
1. How did you test the change? Be descriptive. 
    * With positive and negative Z coordinates on both the real machine and simulated machine
    * With automatic toolchangers enabled on 0, 1, then 2 nozzles on the real machine.
3. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)? - yes
4. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing. - no changes
5. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted. - tests pass
