### PR TITLE
Pandaplacer Feeder - use full camera image for auto setup

### DIFF
--- a/src/main/java/org/openpnp/machine/pandaplacer/AbstractPandaplacerVisionFeeder.java
+++ b/src/main/java/org/openpnp/machine/pandaplacer/AbstractPandaplacerVisionFeeder.java
@@ -491,11 +491,13 @@ public abstract class AbstractPandaplacerVisionFeeder extends ReferenceFeeder {
             pipeline.setProperty("sprocketHole.diameter", new Length(sprocketHoleDiameterMm, LengthUnit.Millimeters));
             Length range;
             if (autoSetup) {
-                // Auto-Setup: search Range is half camera.
+                // Auto-Setup: search range is set to be full camera resolution (bigger dimension is used)
+                // to be able to detect sprocket holes at the edge of the image. Search range defines circle's
+                // radius with origin in center. Full resolution is used as radius to cover image corners.
                 Location upp = camera.getUnitsPerPixelAtZ();
                 range = camera.getWidth() > camera.getHeight() ?
-                        upp.getLengthY().multiply(camera.getHeight()/2)
-                        : upp.getLengthX().multiply(camera.getWidth()/2);
+                        upp.getLengthX().multiply(camera.getHeight())
+                        : upp.getLengthY().multiply(camera.getWidth());
             }
             else {
                 // Normal mode: search range is half the distance between the holes plus one pitch.


### PR DESCRIPTION
# Description
Update to Pandaplacer feeder in sync with this: https://github.com/openpnp/openpnp/pull/1673

# Justification
Like PR1673, the Pandaplacer feeders will work for more use cases.

# Instructions for Use
no change

This is documentation for a user, not for a developer.

# Implementation Details
1. How did you test the change? 
- Same as PR1673
2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)? 
- Yes
3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing.
- no changes
4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted.
- done
