### PR TITLE
Refresh placement location after running Job.Placement.BeforeAssembly

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/ReferencePnpJobProcessor.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferencePnpJobProcessor.java
@@ -943,9 +943,10 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
             final Part part = placement.getPart();
             final BoardLocation boardLocation = plannedPlacement.jobPlacement.getBoardLocation();
 
-            Location placementLocation = getPlacementLocation(plannedPlacement);
+            scriptBeforeAssembly(plannedPlacement);
             
-            scriptBeforeAssembly(plannedPlacement, placementLocation);
+            // Calculate this after running the script, because the script might have fine-tuned the location data
+            Location placementLocation = getPlacementLocation(plannedPlacement);
 
             checkPartOn(nozzle);
             
@@ -1020,13 +1021,14 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
             }
         }
         
-        private void scriptBeforeAssembly(PlannedPlacement plannedPlacement, Location placementLocation) throws JobProcessorException {
+        private void scriptBeforeAssembly(PlannedPlacement plannedPlacement) throws JobProcessorException {
             final Nozzle nozzle = plannedPlacement.nozzle;
             final JobPlacement jobPlacement = plannedPlacement.jobPlacement;
             final Placement placement = jobPlacement.getPlacement();
             final Part part = placement.getPart();
             final BoardLocation boardLocation = plannedPlacement.jobPlacement.getBoardLocation();
             Length partHeight = part.getHeight();
+            Location placementLocation = getPlacementLocation(plannedPlacement);
             Location placementLocationPart = placementLocation.add(new Location(partHeight.getUnits(), 0, 0, partHeight.getValue(), 0));
             try {
                 HashMap<String, Object> params = new HashMap<>();


### PR DESCRIPTION
# Description
`scriptBeforeAssembly()` runs the `Job.Placement.BeforeAssembly` script before placing a part in a job. That is called by `Place.stepImpl()`.

`stepImp()` fetches the placement location from the model using `getPlacementLocation()`. The same value is passed as a parameter to the script, and then to `place()`.

But one valid use case for `Job.Placement.BeforeAssembly` is to tweak the placement location. This patch adds one line to  `stepImpl` to re-fetch the location from the model after running the script.

# Justification
Openpnp determines panel&board fiducial location at the start of a production run. This is used to calculate the board-specific transform. This transformation remains unchanged for the lifetime of the job, and this can lead to placement errors. I am seeing:
 1. Thermal drift I think.... An experiment using a `Job.Placement.Complete` script to monitor the position of my homing fiducial after every placement showed I get a 0.03mm drift during the first 30 minutes of the job.
 2. There is some slop on my 3d printed board holder. It moves a tiny amount if I touch the board by hand during a job.
Those movements are all tiny, but they add up to something significant when placing fine pitch components.

I am now using a `Job.Placement.BeforeAssembly` script to detect fine-pitch components with challenging placement tolerances, then rechecking the board fiducials immediately prior to placement. This is a big hammer to crack a small nut, but is giving me meaningful improvements to placement accuracy:

```
if is_this_a_fine_pitch_part(part):
    locator = machine.getFiducialLocator()
    locator.locatePlacementsHolder(boardLocation)

````

`getPlacementLocation()` is pretty cheap, so there is no problem with the duplicated call for the 99.999% of cases where there is no script.

# Testing

## Baseline Test
* Single step the simulated machine to just after it has completed vision checks on a part
* Offset the board x location by 1mm.
* Single step once more, to perform a placement.
* Observe that the crosshairs showing the placement location are 1mm out

## Without this patch
* Add the `Job.Placement.BeforeAssembly` script above (but without the "if" line, so it runs on every placement).
* Single step the simulated machine to just after it has completed vision checks on a part
* Offset the board x location by 1mm.
* Single step once more, to perform the scripted board fiducial check followed by the placement.
* Observe that the board x location has been changed back, indicating that it has been corrected by the fiducial check.
* Observe that the crosshairs showing the placement location are still 1mm out, indicating that the placement was not corrected.

## With this patch
* Add the `Job.Placement.BeforeAssembly` script above (but without the "if" line, so it runs on every placement).
* Single step the simulated machine to just after it has completed vision checks on a part
* Offset the board x location by 1mm.
* Single step once more, to perform the scripted board fiducial check followed by the placement.
* Observe that the board x location has been changed back.
* Observe that the crosshairs showing the placement location is centred on the footprint, indicating that the placement location was corrected too.

# Implementation Details
4. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)? - yes
5. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing. - no
6. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted. - all test pass
