### PR TITLE
Save current distance value to preferences and restore when started

### DIFF
--- a/src/main/java/org/openpnp/gui/JogControlsPanel.java
+++ b/src/main/java/org/openpnp/gui/JogControlsPanel.java
@@ -296,11 +296,21 @@ public class JogControlsPanel extends JPanel {
         panelControls.add(sliderIncrements, "18, 3, 1, 10"); //$NON-NLS-1$
         sliderIncrements.setOrientation(SwingConstants.VERTICAL);
         sliderIncrements.setMajorTickSpacing(1);
-        sliderIncrements.setValue(1);
+        sliderIncrements.setValue(configuration.getDistance());
         sliderIncrements.setSnapToTicks(true);
         sliderIncrements.setPaintLabels(true);
         sliderIncrements.setMinimum(1);
         sliderIncrements.setMaximum(5);
+        sliderIncrements.addChangeListener(new ChangeListener() {
+            int oldValue = configuration.getDistance();
+            @Override
+            public void stateChanged(ChangeEvent e) {
+                if (sliderIncrements.getValue() != oldValue) {
+                    oldValue = sliderIncrements.getValue();
+                    configuration.setDistance(oldValue);
+                }
+            }
+        });
 
         JButton yPlusButton = new JButton(yPlusAction);
         yPlusButton.setHideActionText(true);

--- a/src/main/java/org/openpnp/model/Configuration.java
+++ b/src/main/java/org/openpnp/model/Configuration.java
@@ -79,6 +79,9 @@ public class Configuration extends AbstractModelObject {
     private static final String PREF_UNITS = "Configuration.units";
     private static final String PREF_UNITS_DEF = "Millimeters";
 
+    private static final String PREF_DISTANCE = "Configuration.distance";
+    private static final int PREF_DISTANCE_DEF = 2;
+
     private static final String PREF_TABLE_LINKS = "Configuration.tableLinks";
 
     private static final String PREF_THEME_INFO = "Configuration.theme.info";
@@ -196,6 +199,14 @@ public class Configuration extends AbstractModelObject {
 
     public void setSystemUnits(LengthUnit lengthUnit) {
         prefs.put(PREF_UNITS, lengthUnit.name());
+    }
+
+    public void setDistance(int distance) {
+        prefs.putInt(PREF_DISTANCE, distance);
+    }
+
+    public int getDistance() {
+        return prefs.getInt(PREF_DISTANCE, PREF_DISTANCE_DEF);
     }
 
     public TablesLinked getTablesLinked() {


### PR DESCRIPTION
# Description
Distance slider position is not stored and when restarting it is hardcoded to finest 0.01 position

# Justification
General GUI usability improvement.

# Instructions for Use
Set distance and restart sw. The slider should be reverted to previous position

# Implementation Details
Value is saved in preferences (not in XML as it is related to manual jog control)-
