### PR TITLE
prolong tooltip delay from 4s to 60sec.

### DIFF
--- a/src/main/java/org/openpnp/Main.java
+++ b/src/main/java/org/openpnp/Main.java
@@ -23,6 +23,7 @@ import java.awt.EventQueue;
 import java.io.File;
 import java.util.Locale;
 
+import javax.swing.ToolTipManager;
 import javax.swing.UIManager;
 
 import org.openpnp.gui.MainFrame;
@@ -166,6 +167,7 @@ public class Main {
         ThemeInfo theme = configuration.getThemeInfo();
         new ThemeSettingsPanel().setTheme(theme, configuration.getFontSize(), configuration.isAlternateRows());
         ThemeDialog.getInstance().setOldTheme(theme);
+        ToolTipManager.sharedInstance().setDismissDelay(60000);
 
         EventQueue.invokeLater(new Runnable() {
             public void run() {


### PR DESCRIPTION
# Description
Tooltip timeout 4s is too short to read long texts

# Justification
General GUI usability improvement.

# Instructions for Use
Mouse over a control with tooltip

# Implementation Details
Timeout is prolonged to 1min. The text are rather long and require focus on info so long dismiss timeout (or move mouse away to disappear immediately)