### PR TITLE
Save in XML relative path to another file when file resides in openpn…

### DIFF
--- a/src/main/java/org/openpnp/model/Job.java
+++ b/src/main/java/org/openpnp/model/Job.java
@@ -36,6 +36,7 @@ import org.simpleframework.xml.ElementList;
 import org.simpleframework.xml.ElementMap;
 import org.simpleframework.xml.Root;
 import org.simpleframework.xml.core.Persist;
+import org.simpleframework.xml.core.Resolve;
 
 /**
  * A Job specifies a list of one or more PanelLocations and/or BoardLocations.
@@ -97,6 +98,12 @@ public class Job extends AbstractModelObject implements PropertyChangeListener {
         boardLocations = null;
     }
     
+    @Resolve
+    private Object resolve() {
+        rootPanelLocation.setPanel(rootPanel);
+        return this;
+    }
+
     /**
      *
      * @return a flattened list of all BoardLocations held by the job


### PR DESCRIPTION
# Description
The path related from XML files are absolute even files reside in cfg directory subtree. It is issue when moving files between more locations, e.g. development PC and PnP or so.

# Justification
General usability improvement.

# Instructions for Use
Save panel or job. Related files have relative paths now

# Implementation Details
When saving configuration class make paths relative when are in cfg subtree. When loading then prefix is appended so there is  no internal difference.
Note: it does not solve issue when moving files between slash and backslash path delimiter filesystems. It should replace path to filesystem's path delimiter before opening file. Not sure if Java supports "slash" is universal delimiter to simplify.
