### PR TITLE
Jobviewer board selection support to visualize particular boards

### DIFF
--- a/src/main/java/org/openpnp/gui/BoardPlacementsPanel.java
+++ b/src/main/java/org/openpnp/gui/BoardPlacementsPanel.java
@@ -656,7 +656,7 @@ public class BoardPlacementsPanel extends JPanel {
         @Override
         public void actionPerformed(ActionEvent arg0) {
             if (boardViewer == null) {
-                boardViewer = new PlacementsHolderLocationViewerDialog(new BoardLocation(board), false);
+                boardViewer = new PlacementsHolderLocationViewerDialog(new BoardLocation(board), false, null);
                 boardViewer.addWindowListener(new WindowAdapter() {
                     @Override
                     public void windowClosing(WindowEvent e) {

--- a/src/main/java/org/openpnp/gui/JobPanel.java
+++ b/src/main/java/org/openpnp/gui/JobPanel.java
@@ -75,6 +75,7 @@ import org.openpnp.events.PlacementsHolderLocationSelectedEvent;
 import org.openpnp.events.JobLoadedEvent;
 import org.openpnp.events.PlacementSelectedEvent;
 import org.openpnp.events.PlacementsHolderLocationChangedEvent;
+import org.openpnp.gui.JobPanel.OpenRecentJobAction;
 import org.openpnp.gui.components.AutoSelectTextTable;
 import org.openpnp.gui.components.ExistingBoardOrPanelDialog;
 import org.openpnp.gui.processes.MultiPlacementBoardLocationProcess;
@@ -174,22 +175,22 @@ public class JobPanel extends JPanel {
                 new ActionGroup(captureToolBoardLocationAction, moveCameraToBoardLocationAction,
                         moveCameraToBoardLocationNextAction, moveToolToBoardLocationAction,
                         twoPointLocateBoardLocationAction, fiducialCheckAction,
-                        setEnabledAction, setCheckFidsAction, setSideAction);
+                        setEnabledAction, setCheckFidsAction, setSideAction, viewerAction);
         singleSelectionActionGroup.setEnabled(false);
         
         multiSelectionActionGroup = new ActionGroup(captureToolBoardLocationAction, setEnabledAction, 
-                setCheckFidsAction, setSideAction);
+                setCheckFidsAction, setSideAction, viewerAction);
         multiSelectionActionGroup.setEnabled(false);
         
         singleTopLevelSelectionActionGroup = new ActionGroup(captureToolBoardLocationAction, removeBoardAction, captureCameraBoardLocationAction,
                 moveCameraToBoardLocationAction,
                 moveCameraToBoardLocationNextAction, moveToolToBoardLocationAction,
                 twoPointLocateBoardLocationAction, fiducialCheckAction,
-                setEnabledAction, setCheckFidsAction, setSideAction);
+                setEnabledAction, setCheckFidsAction, setSideAction, viewerAction);
         singleTopLevelSelectionActionGroup.setEnabled(false);
         
         multiTopLevelSelectionActionGroup = new ActionGroup(captureToolBoardLocationAction, removeBoardAction, setEnabledAction, 
-                setCheckFidsAction, setSideAction);
+                setCheckFidsAction, setSideAction, viewerAction);
         multiTopLevelSelectionActionGroup.setEnabled(false);
         
         jobTableModel = new PlacementsHolderLocationsTableModel(configuration);
@@ -341,6 +342,9 @@ public class JobPanel extends JPanel {
                             }
                         }
                         MainFrame.get().updateMenuState(JobPanel.this);
+                        if (jobViewer != null) {
+                            jobViewer.setPlacementsHolder(job.getRootPanelLocation().getPlacementsHolder(), getSelections());
+                        }
                     }
                 });
 
@@ -568,7 +572,7 @@ public class JobPanel extends JPanel {
         updateJobActions();
         jobPlacementsPanel.updateActivePlacements();
         if (jobViewer != null) {
-            jobViewer.setPlacementsHolder(job.getRootPanelLocation().getPlacementsHolder());
+            jobViewer.setPlacementsHolder(job.getRootPanelLocation().getPlacementsHolder(), getSelections());
         }
         Configuration.get().getBus().post(new JobLoadedEvent(job));
     }
@@ -1500,9 +1504,9 @@ public class JobPanel extends JPanel {
         }
 
         @Override
-        public void actionPerformed(ActionEvent arg0) {
+        public void actionPerformed(ActionEvent arg0) {            
             if (jobViewer == null) {
-                jobViewer = new PlacementsHolderLocationViewerDialog(job.getRootPanelLocation(), true);
+                jobViewer = new PlacementsHolderLocationViewerDialog(job.getRootPanelLocation(), true, getSelections());
                 jobViewer.addWindowListener(new WindowAdapter() {
                     @Override
                     public void windowClosing(WindowEvent e) {
@@ -1511,6 +1515,7 @@ public class JobPanel extends JPanel {
                 });
             }
             else {
+                jobViewer.setPlacementsHolder(job.getRootPanelLocation().getPlacementsHolder(), getSelections());
                 jobViewer.setExtendedState(Frame.NORMAL);
             }
             jobViewer.setVisible(true);

--- a/src/main/java/org/openpnp/gui/JobPanel.java
+++ b/src/main/java/org/openpnp/gui/JobPanel.java
@@ -175,22 +175,22 @@ public class JobPanel extends JPanel {
                 new ActionGroup(captureToolBoardLocationAction, moveCameraToBoardLocationAction,
                         moveCameraToBoardLocationNextAction, moveToolToBoardLocationAction,
                         twoPointLocateBoardLocationAction, fiducialCheckAction,
-                        setEnabledAction, setCheckFidsAction, setSideAction, viewerAction);
+                        setEnabledAction, setCheckFidsAction, setSideAction);
         singleSelectionActionGroup.setEnabled(false);
         
         multiSelectionActionGroup = new ActionGroup(captureToolBoardLocationAction, setEnabledAction, 
-                setCheckFidsAction, setSideAction, viewerAction);
+                setCheckFidsAction, setSideAction);
         multiSelectionActionGroup.setEnabled(false);
         
         singleTopLevelSelectionActionGroup = new ActionGroup(captureToolBoardLocationAction, removeBoardAction, captureCameraBoardLocationAction,
                 moveCameraToBoardLocationAction,
                 moveCameraToBoardLocationNextAction, moveToolToBoardLocationAction,
                 twoPointLocateBoardLocationAction, fiducialCheckAction,
-                setEnabledAction, setCheckFidsAction, setSideAction, viewerAction);
+                setEnabledAction, setCheckFidsAction, setSideAction);
         singleTopLevelSelectionActionGroup.setEnabled(false);
         
         multiTopLevelSelectionActionGroup = new ActionGroup(captureToolBoardLocationAction, removeBoardAction, setEnabledAction, 
-                setCheckFidsAction, setSideAction, viewerAction);
+                setCheckFidsAction, setSideAction);
         multiTopLevelSelectionActionGroup.setEnabled(false);
         
         jobTableModel = new PlacementsHolderLocationsTableModel(configuration);

--- a/src/main/java/org/openpnp/gui/PanelDefinitionPanel.java
+++ b/src/main/java/org/openpnp/gui/PanelDefinitionPanel.java
@@ -925,7 +925,7 @@ public class PanelDefinitionPanel extends JPanel implements PropertyChangeListen
         @Override
         public void actionPerformed(ActionEvent arg0) {
             if (panelViewer == null) {
-                panelViewer = new PlacementsHolderLocationViewerDialog(rootPanelLocation, false);
+                panelViewer = new PlacementsHolderLocationViewerDialog(rootPanelLocation, false, null);
                 panelViewer.addWindowListener(new WindowAdapter() {
                     @Override
                     public void windowClosing(WindowEvent e) {

--- a/src/main/java/org/openpnp/gui/panelization/PanelArrayBuilderDialog.java
+++ b/src/main/java/org/openpnp/gui/panelization/PanelArrayBuilderDialog.java
@@ -609,7 +609,7 @@ public class PanelArrayBuilderDialog extends JDialog {
                 }
             }
             {
-                panelLayout = new PlacementsHolderLocationViewer(panelLocation, false);
+                panelLayout = new PlacementsHolderLocationViewer(panelLocation, false, null);
                 panelLayout.setArrayRoot(rootChildLocation);
                 panelLayout.setShowLocations(false);
                 panelLayout.setShowReticle(false);

--- a/src/main/java/org/openpnp/gui/viewers/PlacementsHolderLocationViewer.java
+++ b/src/main/java/org/openpnp/gui/viewers/PlacementsHolderLocationViewer.java
@@ -298,7 +298,7 @@ public class PlacementsHolderLocationViewer extends JPanel implements PropertyCh
         });
         cbxViewingOptions.setVisible(placementsHolderLocation instanceof PanelLocation);
         cbxViewingOptions.setMaximumSize(cbxViewingOptions.getPreferredSize());
-        panel.add(Box.createVerticalStrut(5));
+        panel.add(Box.createVerticalStrut(15));
         panel.add(cbxViewingOptions);
         
         Component verticalStrut = Box.createVerticalStrut(15);

--- a/src/main/java/org/openpnp/gui/viewers/PlacementsHolderLocationViewer.java
+++ b/src/main/java/org/openpnp/gui/viewers/PlacementsHolderLocationViewer.java
@@ -34,7 +34,6 @@ import java.awt.Shape;
 import java.awt.Toolkit;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
-import java.awt.event.ItemEvent;
 import java.awt.event.ComponentAdapter;
 import java.awt.event.ComponentEvent;
 import java.awt.event.MouseAdapter;
@@ -285,6 +284,7 @@ public class PlacementsHolderLocationViewer extends JPanel implements PropertyCh
         cbxViewingOptions.setToolTipText(Translations.getString("PlacementsHolderLocationViewer.ViewingOption.ToolTip"));
         cbxViewingOptions.addItem(ViewingOption.ALL);
         cbxViewingOptions.addItem(ViewingOption.CHILDREN);
+        cbxViewingOptions.setAlignmentX(Component.LEFT_ALIGNMENT);
         if (isJob) {
             cbxViewingOptions.addItem(ViewingOption.SELECTED);
         }
@@ -298,6 +298,7 @@ public class PlacementsHolderLocationViewer extends JPanel implements PropertyCh
         });
         cbxViewingOptions.setVisible(placementsHolderLocation instanceof PanelLocation);
         cbxViewingOptions.setMaximumSize(cbxViewingOptions.getPreferredSize());
+        panel.add(Box.createVerticalStrut(5));
         panel.add(cbxViewingOptions);
         
         Component verticalStrut = Box.createVerticalStrut(15);

--- a/src/main/java/org/openpnp/gui/viewers/PlacementsHolderLocationViewerDialog.java
+++ b/src/main/java/org/openpnp/gui/viewers/PlacementsHolderLocationViewerDialog.java
@@ -25,6 +25,7 @@ import java.awt.event.ComponentEvent;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
 import java.util.prefs.Preferences;
+import java.util.List;
 
 import javax.swing.JFrame;
 import javax.swing.SwingUtilities;
@@ -54,9 +55,10 @@ public class PlacementsHolderLocationViewerDialog extends JFrame {
     private String prefsSuffix;
     
     /**
-     * Create the frame.
+     * Create the frame with filter.
      */
-    public PlacementsHolderLocationViewerDialog(PlacementsHolderLocation<?> placementsHolderLocation, boolean isJob) {
+    public PlacementsHolderLocationViewerDialog(PlacementsHolderLocation<?> placementsHolderLocation, boolean isJob, List<PlacementsHolderLocation<?>> selections) {
+
         this.isJob = isJob;
         
         setTitle(placementsHolderLocation.getPlacementsHolder());
@@ -104,7 +106,7 @@ public class PlacementsHolderLocationViewerDialog extends JFrame {
             }
         });
 
-        contentPane = new PlacementsHolderLocationViewer(placementsHolderLocation, isJob);
+        contentPane = new PlacementsHolderLocationViewer(placementsHolderLocation, isJob, selections);
         setContentPane(contentPane);
     }
 
@@ -125,9 +127,13 @@ public class PlacementsHolderLocationViewerDialog extends JFrame {
             prefsSuffix = ".Panel"; //$NON-NLS-1$
         }
     }
-    
+
     public void setPlacementsHolder(PlacementsHolder<?> placementsHolder) {
-        contentPane.setPlacementsHolder(placementsHolder);
+        setPlacementsHolder(placementsHolder, null);
+    }
+
+    public void setPlacementsHolder(PlacementsHolder<?> placementsHolder, List<PlacementsHolderLocation<?>> selections) {
+        contentPane.setPlacementsHolder(placementsHolder, selections);
         SwingUtilities.invokeLater(() -> {
             setTitle(placementsHolder);
         });

--- a/src/main/resources/org/openpnp/translations.properties
+++ b/src/main/resources/org/openpnp/translations.properties
@@ -1092,7 +1092,7 @@ PlacementsHolderLocationViewer.TitleType.Job=Job Viewer
 PlacementsHolderLocationViewer.TitleType.Panel=Panel Viewer
 PlacementsHolderLocationViewer.ViewingOption.AllDescendants=Viewing All Descendants
 PlacementsHolderLocationViewer.ViewingOption.ChildrenOnly=Viewing Children Only
-PlacementsHolderLocationViewer.ViewingOption.SelectedOnly=Selected Only
+PlacementsHolderLocationViewer.ViewingOption.SelectedOnly=Viewing Selected Only
 PlacementsHolderLocationViewer.ViewingOption.Fiducials=Fiducials
 PlacementsHolderLocationViewer.ViewingOption.Fiducials.ToolTip=<Html><body style\='width\: 400'>Overlays a 1mm diameter circle filled with a <span style\='background-color\: black; color\: \#E89961'><b>copper color</span> at each fiducial location. A plus symbol indicates the fiducial's center.</html>
 PlacementsHolderLocationViewer.ViewingOption.Locations=Board/Panel Locations

--- a/src/main/resources/org/openpnp/translations.properties
+++ b/src/main/resources/org/openpnp/translations.properties
@@ -1092,6 +1092,7 @@ PlacementsHolderLocationViewer.TitleType.Job=Job Viewer
 PlacementsHolderLocationViewer.TitleType.Panel=Panel Viewer
 PlacementsHolderLocationViewer.ViewingOption.AllDescendants=Viewing All Descendants
 PlacementsHolderLocationViewer.ViewingOption.ChildrenOnly=Viewing Children Only
+PlacementsHolderLocationViewer.ViewingOption.SelectedOnly=Selected Only
 PlacementsHolderLocationViewer.ViewingOption.Fiducials=Fiducials
 PlacementsHolderLocationViewer.ViewingOption.Fiducials.ToolTip=<Html><body style\='width\: 400'>Overlays a 1mm diameter circle filled with a <span style\='background-color\: black; color\: \#E89961'><b>copper color</span> at each fiducial location. A plus symbol indicates the fiducial's center.</html>
 PlacementsHolderLocationViewer.ViewingOption.Locations=Board/Panel Locations
@@ -1102,7 +1103,7 @@ PlacementsHolderLocationViewer.ViewingOption.Placements=Placements
 PlacementsHolderLocationViewer.ViewingOption.Placements.ToolTip=<Html><body style\='width\: 400'>Overlays a 1mm square at the location of each visible Placement. The square is white if the Placement is enabled and gray if disabled. In addition a small plus symbol marks the center of the placement with the positive Y direction indicated by the <span style\='background-color\: black; color\: \#00FFFF'><b>cyan colored</span> leg similar to the camera view crosshairs. This indicates the location where the camera should move if directed to the location of the Placement.</html>
 PlacementsHolderLocationViewer.ViewingOption.Reticle=Reticle
 PlacementsHolderLocationViewer.ViewingOption.Reticle.ToolTip=Overlays a grid reticle over the image</html>
-PlacementsHolderLocationViewer.ViewingOption.ToolTip=Toggles between showing only the direct children or all of the descendants
+PlacementsHolderLocationViewer.ViewingOption.ToolTip=Toggles between showing only the direct children, all of the descendants or selected in job grid
 PlacementsHolderLocationViewer.ViewingSide.Bottom=Viewing From Bottom
 PlacementsHolderLocationViewer.ViewingSide.ToolTip=Toggles between viewing from the top or bottom
 PlacementsHolderLocationViewer.ViewingSide.Top=Viewing From Top


### PR DESCRIPTION
# Description
Board placement preview did show all placement for all boards in jobs. But when e.g. PnP boards depanelized from panel in one job then all placement are generated in the same area because boards are placed in machine origin position. So selection what placement should be displayed is welcome

# Justification
General GUI usability improvement. 

# Instructions for Use
Job panel grid row selection is passed to job viewer. So user can precisely select what to inspect.
Note: the board rectangles are displayed at original panel (KiCAD) location as there is no way how to get what is origin of particular subboard. I suggest add new parameter in list ... board origin. In this case the viewer can display correct board borders. Also PnP command "go to board origin" could move head to correct position.

# Implementation Details
JobViewer is extended to support selection argument. Jobpanel icon is enabled/disable by selection state of grid. Works also with panels and subboards.

Note: alternate implementation to display only enabled boards is more affecting as changing job configuration itself by clicking checkboxes. Selection is only visual action.

- How did you test the change?
manually test job panel with/without related jobviewer with boads, panels, child boards

- Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)?
yes

- org.openpnp.spi or org.openpnp.model packages
no change

- mvn test
yes
