### PR TITLE
Skip auto-focus on up-looking camera calibration

### DIFF
--- a/src/main/java/org/openpnp/gui/components/IssuePanel.java
+++ b/src/main/java/org/openpnp/gui/components/IssuePanel.java
@@ -35,6 +35,7 @@ import java.awt.event.MouseListener;
 import javax.swing.ButtonGroup;
 import javax.swing.DefaultComboBoxModel;
 import javax.swing.JButton;
+import javax.swing.JCheckBox;
 import javax.swing.JComboBox;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
@@ -68,6 +69,7 @@ import org.openpnp.model.Solutions;
 import org.openpnp.model.Solutions.Issue;
 import org.openpnp.model.Solutions.Issue.ActionProperty;
 import org.openpnp.model.Solutions.Issue.DoubleProperty;
+import org.openpnp.model.Solutions.Issue.BooleanProperty;
 import org.openpnp.model.Solutions.Issue.IntegerProperty;
 import org.openpnp.model.Solutions.Issue.LengthProperty;
 import org.openpnp.model.Solutions.Issue.MultiLineTextProperty;
@@ -324,6 +326,30 @@ public class IssuePanel extends JPanel {
                     textField.setEnabled(issue.getState() == Solutions.State.Open);
                     panel.add(textField, "4, "+(formRow*2)+", left, default");
                 }
+            }
+            else if (property instanceof BooleanProperty) {
+                BooleanProperty booleanProperty = (BooleanProperty) property;
+                JLabel lbl = new JLabel(property.getLabel());
+                lbl.setToolTipText(property.getToolTip());
+                panel.add(lbl, "2, "+(formRow*2)+", right, default");
+                JCheckBox button = new JCheckBox();
+                button.addChangeListener(new ChangeListener() {
+                    public void stateChanged(ChangeEvent e) {
+                        boolean state = (boolean) button.isSelected();
+                        UiUtils.messageBoxOnException(() -> {
+                            booleanProperty.set(state);
+                        });
+                        boolean newState = booleanProperty.get();
+                        if (newState != state) {
+                            button.setSelected(newState);
+                        }
+                    }
+                });
+                boolean state = booleanProperty.get();
+                button.setSelected(state);
+                button.setToolTipText(property.getToolTip());
+                button.setEnabled(issue.getState() == Solutions.State.Open);
+                panel.add(button, "4, "+(formRow*2)+", left, default");
             }
             else if (property instanceof IntegerProperty) {
                 IntegerProperty intProperty = (IntegerProperty) property;

--- a/src/main/java/org/openpnp/machine/reference/solutions/VisionSolutions.java
+++ b/src/main/java/org/openpnp/machine/reference/solutions/VisionSolutions.java
@@ -417,11 +417,12 @@ public class VisionSolutions implements Solutions.Subject {
             return new Solutions.Issue.Choice[]{
                 new Solutions.Issue.Choice(true,  
                                   "<html><h3>Use Auto-Focus</h3>" 
+                                + "<p>This is the recommended setting.</p>"
                                 + "</html>", 
                                 null), 
                 new Solutions.Issue.Choice(false,  
                                   "<html><h3>Use nozzle Z location</h3>" 
-                                + "<p><b>CAUTION</b> This will invalidate part height auto detection using auto focus.</p>" 
+                                + "<p><span style=\"color:red;\">CAUTION:</span> This will invalidate part height auto detection using auto focus.</p>" 
                                 + "</html>", 
                                 null), 
             };

--- a/src/main/java/org/openpnp/model/Solutions.java
+++ b/src/main/java/org/openpnp/model/Solutions.java
@@ -405,6 +405,13 @@ public class Solutions extends AbstractTableModel {
                 super(label, toolTip);
             }
         }
+        public abstract class BooleanProperty extends CustomProperty {
+            public BooleanProperty(String label, String toolTip) {
+                super(label, toolTip);
+            }
+            public abstract boolean get();
+            public abstract void set(boolean value);
+        }
         public abstract class IntegerProperty extends CustomProperty {
             private final int min;
             private final int max;


### PR DESCRIPTION
# Description
This PR provides the option to skip auto-focus calibration of the up looking camera via issues & solutions.

# Justification
At present there is no convenient option for force bottom vision to take place at a certain Z level because issues & solutions always uses auto-focus to set the camera Z.

# Instructions for Use
A checkbox has been added to the solution allowing to disable auto-focus. There is no other impact.

# Implementation Details
1. How did you test the change? Be descriptive. Untested code will not be accepted. **on my physical machine**
2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)? **yes**
3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing. **no**
4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted. **yes**
