### PR TITLE
Actuator coordination

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/ContactProbeNozzle.java
+++ b/src/main/java/org/openpnp/machine/reference/ContactProbeNozzle.java
@@ -819,18 +819,18 @@ public class ContactProbeNozzle extends ReferenceNozzle {
                 }
                 else if (getContactProbeActuator() instanceof AbstractActuator) {
                     AbstractActuator contactProbeActuator = (AbstractActuator) getContactProbeActuator();
-                    if (contactProbeActuator.getCoordinatedAfterActuateEnum() != ActuatorCoordinationEnumType.WaitForStillstand) {
+                    if (contactProbeActuator.getCoordinatedAfterActuateEnum() != ActuatorCoordinationEnumType.WaitForUnconditionalCoordination) {
                         solutions.add(new Solutions.Issue(
                                 contactProbeActuator, 
-                                "Contact probe actuator needs machine coordination after actuation.", 
-                                "Enable After Actuation machine coordination.", 
+                                "Contact probe actuator needs unconditional machine coordination after actuation.", 
+                                "Set After Actuation machine coordination to WaitForUnconditionalCoordination.", 
                                 Severity.Error,
                                 "https://github.com/openpnp/openpnp/wiki/Motion-Planner#actuator-machine-coordination") {
 
                             @Override
                             public void setState(Solutions.State state) throws Exception {
                                 if (state == Solutions.State.Solved) {
-                                    contactProbeActuator.setCoordinatedAfterActuateEnum(ActuatorCoordinationEnumType.WaitForStillstand);
+                                    contactProbeActuator.setCoordinatedAfterActuateEnum(ActuatorCoordinationEnumType.WaitForUnconditionalCoordination);
                                 }
                                 super.setState(state);
                             }

--- a/src/main/java/org/openpnp/machine/reference/ContactProbeNozzle.java
+++ b/src/main/java/org/openpnp/machine/reference/ContactProbeNozzle.java
@@ -53,6 +53,7 @@ import org.openpnp.spi.Machine;
 import org.openpnp.spi.Nozzle;
 import org.openpnp.spi.NozzleTip;
 import org.openpnp.spi.base.AbstractActuator;
+import org.openpnp.spi.base.AbstractActuator.ActuatorCoordinationEnumType;
 import org.openpnp.spi.base.AbstractHead;
 import org.openpnp.util.Collect;
 import org.openpnp.util.MovableUtils;
@@ -818,7 +819,7 @@ public class ContactProbeNozzle extends ReferenceNozzle {
                 }
                 else if (getContactProbeActuator() instanceof AbstractActuator) {
                     AbstractActuator contactProbeActuator = (AbstractActuator) getContactProbeActuator();
-                    if (!contactProbeActuator.isCoordinatedAfterActuate()) {
+                    if (contactProbeActuator.getCoordinatedAfterActuateEnum() != ActuatorCoordinationEnumType.WaitForStillstand) {
                         solutions.add(new Solutions.Issue(
                                 contactProbeActuator, 
                                 "Contact probe actuator needs machine coordination after actuation.", 
@@ -828,7 +829,9 @@ public class ContactProbeNozzle extends ReferenceNozzle {
 
                             @Override
                             public void setState(Solutions.State state) throws Exception {
-                                contactProbeActuator.setCoordinatedAfterActuate((state == Solutions.State.Solved));
+                                if (state == Solutions.State.Solved) {
+                                    contactProbeActuator.setCoordinatedAfterActuateEnum(ActuatorCoordinationEnumType.WaitForStillstand);
+                                }
                                 super.setState(state);
                             }
                         });

--- a/src/main/java/org/openpnp/machine/reference/HttpActuator.java
+++ b/src/main/java/org/openpnp/machine/reference/HttpActuator.java
@@ -132,10 +132,7 @@ public class HttpActuator extends ReferenceActuator {
 
     @Override
     public String read() throws Exception {
-        if (isCoordinatedBeforeRead()) {
-            coordinateWithMachine(false);
-        }
-        
+        coordinateWithMachineBeforeRead();
         
         // getDriver().actuate(this, on);
         URL obj = null;
@@ -167,9 +164,7 @@ public class HttpActuator extends ReferenceActuator {
         }
         in.close();
 
-        if (isCoordinatedAfterActuate()) {
-            coordinateWithMachine(true);
-        }
+        coordinateWithMachineAfterActuate();
         getMachine().fireMachineHeadActivity(head);
 
         return response.toString();

--- a/src/main/java/org/openpnp/machine/reference/ReferenceActuator.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceActuator.java
@@ -257,15 +257,11 @@ public class ReferenceActuator extends AbstractActuator implements HeadMountable
             actuate((Object)on);
         }
         else {
-            if (isCoordinatedBeforeActuate()) {
-                coordinateWithMachine(false);
-            }
+            coordinateWithMachineBeforeActuate();
             Logger.debug("{}.actuate({})", getName(), on);
             driveActuation(on);
             setLastActuationValue(on);
-            if (isCoordinatedAfterActuate()) {
-                coordinateWithMachine(true);
-            }
+            coordinateWithMachineAfterActuate();
             getMachine().fireMachineHeadActivity(head);
         }
     }
@@ -276,15 +272,11 @@ public class ReferenceActuator extends AbstractActuator implements HeadMountable
 
     @Override
     public void actuate(double value) throws Exception {
-        if (isCoordinatedBeforeActuate()) {
-            coordinateWithMachine(false);
-        }
+        coordinateWithMachineBeforeActuate();
         Logger.debug("{}.actuate({})", getName(), value);
         driveActuation(value);
         setLastActuationValue(value);
-        if (isCoordinatedAfterActuate()) {
-            coordinateWithMachine(true);
-        }
+        coordinateWithMachineAfterActuate();
         getMachine().fireMachineHeadActivity(head);
     }
 
@@ -294,15 +286,11 @@ public class ReferenceActuator extends AbstractActuator implements HeadMountable
 
     @Override
     public void actuate(String value) throws Exception {
-        if (isCoordinatedBeforeActuate()) {
-            coordinateWithMachine(false);
-        }
+        coordinateWithMachineBeforeActuate();
         Logger.debug("{}.actuate({})", getName(), value);
         driveActuation(value);
         setLastActuationValue(value);
-        if (isCoordinatedAfterActuate()) {
-            coordinateWithMachine(true);
-        }
+        coordinateWithMachineAfterActuate();
         getMachine().fireMachineHeadActivity(head);
     }
 
@@ -326,23 +314,17 @@ public class ReferenceActuator extends AbstractActuator implements HeadMountable
 
     @Override
     public String read() throws Exception {
-        if (isCoordinatedBeforeRead()) {
-            coordinateWithMachine(false);
-        }
+        coordinateWithMachineBeforeRead();
         String value = getDriver().actuatorRead(this);
         Logger.debug("{}.read(): {}", getName(), value);
-        if (isCoordinatedAfterActuate()) {
-            coordinateWithMachine(true);
-        }
+        coordinateWithMachineAfterActuate();
         getMachine().fireMachineHeadActivity(head);
         return value;
     }
 
     @Override
     public String read(Object parameter) throws Exception {
-        if (isCoordinatedBeforeRead()) {
-            coordinateWithMachine(false);
-        }
+        coordinateWithMachineBeforeRead();
         String value = getDriver().actuatorRead(this, parameter);
         Logger.debug("{}.readWithParameter({}): {}", getName(), parameter, value);
         getMachine().fireMachineHeadActivity(head);

--- a/src/main/java/org/openpnp/machine/reference/ReferenceNozzle.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceNozzle.java
@@ -1141,6 +1141,8 @@ public class ReferenceNozzle extends AbstractNozzle implements HeadMountable {
         }
         else {
             // simple method, just dwell
+            // if dwelling is handled via Thread.sleep() full machine coordination with wait for stillstand is required
+            waitForCompletion(CompletionType.WaitForStillstand);
             Logger.trace(getName()+" dwell for pick vacuum "+milliseconds+"ms");
             delay(milliseconds);
         }
@@ -1176,6 +1178,8 @@ public class ReferenceNozzle extends AbstractNozzle implements HeadMountable {
         }
         else {
             // simple method, just dwell
+            // if dwelling is handled via Thread.sleep() full machine coordination with wait for stillstand is required
+            waitForCompletion(CompletionType.WaitForStillstand);
             Logger.trace(getName()+" dwell for place vacuum dissipation "+milliseconds+"ms");
             delay(milliseconds);
         }
@@ -1234,7 +1238,9 @@ public class ReferenceNozzle extends AbstractNozzle implements HeadMountable {
                 }
             }
             else {
-                // simple method, just dwell 
+                // simple method, just dwell
+                // if dwelling is handled via Thread.sleep() full machine coordination with wait for stillstand is required
+                waitForCompletion(CompletionType.WaitForStillstand);
                 Logger.trace(getName()+" dwell for part off probing, open valve "+probingMilliseconds+"ms");
                 delay(probingMilliseconds);
                 if (dwellMilliseconds <= 0) {
@@ -1274,6 +1280,8 @@ public class ReferenceNozzle extends AbstractNozzle implements HeadMountable {
         else {
             // simple method, just dwell and then read the level
             if (dwellMilliseconds > 0) {
+                // if dwelling is handled via Thread.sleep() full machine coordination with wait for stillstand is required
+                waitForCompletion(CompletionType.WaitForStillstand);
                 Logger.trace(getName()+" dwell for part off probing, closed valve "+dwellMilliseconds+"ms");
                 delay(dwellMilliseconds);
                 returnedVacuumLevel = readVacuumLevel();

--- a/src/main/java/org/openpnp/machine/reference/ReferenceNozzle.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceNozzle.java
@@ -1141,8 +1141,6 @@ public class ReferenceNozzle extends AbstractNozzle implements HeadMountable {
         }
         else {
             // simple method, just dwell
-            // if dwelling is handled via Thread.sleep() full machine coordination with wait for stillstand is required
-            waitForCompletion(CompletionType.WaitForStillstand);
             Logger.trace(getName()+" dwell for pick vacuum "+milliseconds+"ms");
             delay(milliseconds);
         }
@@ -1178,8 +1176,6 @@ public class ReferenceNozzle extends AbstractNozzle implements HeadMountable {
         }
         else {
             // simple method, just dwell
-            // if dwelling is handled via Thread.sleep() full machine coordination with wait for stillstand is required
-            waitForCompletion(CompletionType.WaitForStillstand);
             Logger.trace(getName()+" dwell for place vacuum dissipation "+milliseconds+"ms");
             delay(milliseconds);
         }
@@ -1238,9 +1234,7 @@ public class ReferenceNozzle extends AbstractNozzle implements HeadMountable {
                 }
             }
             else {
-                // simple method, just dwell
-                // if dwelling is handled via Thread.sleep() full machine coordination with wait for stillstand is required
-                waitForCompletion(CompletionType.WaitForStillstand);
+                // simple method, just dwell 
                 Logger.trace(getName()+" dwell for part off probing, open valve "+probingMilliseconds+"ms");
                 delay(probingMilliseconds);
                 if (dwellMilliseconds <= 0) {
@@ -1280,8 +1274,6 @@ public class ReferenceNozzle extends AbstractNozzle implements HeadMountable {
         else {
             // simple method, just dwell and then read the level
             if (dwellMilliseconds > 0) {
-                // if dwelling is handled via Thread.sleep() full machine coordination with wait for stillstand is required
-                waitForCompletion(CompletionType.WaitForStillstand);
                 Logger.trace(getName()+" dwell for part off probing, closed valve "+dwellMilliseconds+"ms");
                 delay(dwellMilliseconds);
                 returnedVacuumLevel = readVacuumLevel();

--- a/src/main/java/org/openpnp/machine/reference/wizards/AbstractActuatorConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/wizards/AbstractActuatorConfigurationWizard.java
@@ -255,8 +255,8 @@ public abstract class AbstractActuatorConfigurationWizard extends AbstractConfig
                 "AbstractActuatorConfigurationWizard.CoordinationPanel.BeforeActuationLabel.toolTipText")); //$NON-NLS-1$
         panelCoordination.add(lblBeforeActuation, "2, 2, right, default");
         
-        coordinatedBeforeActuate = new JComboBox<ActuatorCoordinationEnumType>(ActuatorCoordinationEnumType.values());
-        panelCoordination.add(coordinatedBeforeActuate, "4, 2, center, bottom");
+        coordinatedBeforeActuate = new JComboBox<ActuatorCoordinationEnumType>(getCoordinatedBeforeActuateOptions());
+        panelCoordination.add(coordinatedBeforeActuate, "4, 2");
         
         lblAfterActuation = new JLabel(Translations.getString(
                 "AbstractActuatorConfigurationWizard.CoordinationPanel.AfterActuationLabel.text")); //$NON-NLS-1$
@@ -264,7 +264,7 @@ public abstract class AbstractActuatorConfigurationWizard extends AbstractConfig
                 "AbstractActuatorConfigurationWizard.CoordinationPanel.AfterActuationLabel.toolTipText")); //$NON-NLS-1$
         panelCoordination.add(lblAfterActuation, "2, 4, right, default");
         
-        coordinatedAfterActuate = new JComboBox<ActuatorCoordinationEnumType>(ActuatorCoordinationEnumType.values());
+        coordinatedAfterActuate = new JComboBox<ActuatorCoordinationEnumType>(getCoordinatedAfterActuateOptions());
         panelCoordination.add(coordinatedAfterActuate, "4, 4");
         
         lblBeforeRead = new JLabel(Translations.getString(
@@ -273,7 +273,7 @@ public abstract class AbstractActuatorConfigurationWizard extends AbstractConfig
                 "AbstractActuatorConfigurationWizard.CoordinationPanel.BeforeReadLabel.toolTipText")); //$NON-NLS-1$
         panelCoordination.add(lblBeforeRead, "2, 6, right, default");
         
-        coordinatedBeforeRead = new JComboBox<ActuatorCoordinationEnumType>(ActuatorCoordinationEnumType.values());
+        coordinatedBeforeRead = new JComboBox<ActuatorCoordinationEnumType>(getCoordinatedBeforeReadOptions());
         panelCoordination.add(coordinatedBeforeRead, "4, 6");
         
         generalPanel = new JPanel();
@@ -399,6 +399,24 @@ public abstract class AbstractActuatorConfigurationWizard extends AbstractConfig
         }
     }
 
+    // return all options the user can choose from when specifying coordination the
+    private ActuatorCoordinationEnumType[] getCoordinatedBeforeActuateOptions() {
+        return new ActuatorCoordinationEnumType[] { 
+                ActuatorCoordinationEnumType.None, 
+                ActuatorCoordinationEnumType.CommandStillstand,
+                ActuatorCoordinationEnumType.WaitForStillstand };
+    }
+    private ActuatorCoordinationEnumType[] getCoordinatedAfterActuateOptions() {
+        return new ActuatorCoordinationEnumType[] { 
+                ActuatorCoordinationEnumType.None, 
+                ActuatorCoordinationEnumType.WaitForUnconditionalCoordination };
+    }
+    private ActuatorCoordinationEnumType[] getCoordinatedBeforeReadOptions() {
+        return new ActuatorCoordinationEnumType[] { 
+                ActuatorCoordinationEnumType.None, 
+                ActuatorCoordinationEnumType.WaitForStillstand };
+    }
+    
     protected void adaptDialog() {
         boolean isDouble = (valueType.getSelectedItem() == ActuatorValueType.Double);
         lblOnDouble.setVisible(isDouble);

--- a/src/main/java/org/openpnp/machine/reference/wizards/AbstractActuatorConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/wizards/AbstractActuatorConfigurationWizard.java
@@ -46,6 +46,7 @@ import org.openpnp.model.Configuration;
 import org.openpnp.spi.Actuator;
 import org.openpnp.spi.Axis;
 import org.openpnp.spi.Actuator.ActuatorValueType;
+import org.openpnp.spi.base.AbstractActuator.ActuatorCoordinationEnumType;
 import org.openpnp.spi.base.AbstractAxis;
 import org.openpnp.spi.base.AbstractMachine;
 
@@ -69,28 +70,28 @@ public abstract class AbstractActuatorConfigurationWizard extends AbstractConfig
     private JPanel generalPanel;
     private JLabel lblIndex;
     private JTextField indexTextField;
-    private JComboBox axisX;
-    private JComboBox axisY;
-    private JComboBox axisZ;
+    private JComboBox<AxesComboBoxModel> axisX;
+    private JComboBox<AxesComboBoxModel> axisY;
+    private JComboBox<AxesComboBoxModel> axisZ;
     private JLabel lblRotation;
-    private JComboBox axisRotation;
+    private JComboBox<AxesComboBoxModel> axisRotation;
     private JTextField locationRotation;
     private JLabel lblAxis;
     private JLabel lblOffset;
 
     private JPanel panelCoordination;
-    private JCheckBox coordinatedBeforeActuate;
     private JLabel lblBeforeActuation;
+    private JComboBox<ActuatorCoordinationEnumType> coordinatedBeforeActuate;
     private JLabel lblAfterActuation;
-    private JCheckBox coordinatedAfterActuate;
+    private JComboBox<ActuatorCoordinationEnumType> coordinatedAfterActuate;
     private JLabel lblBeforeRead;
-    private JCheckBox coordinatedBeforeRead;
+    private JComboBox<ActuatorCoordinationEnumType> coordinatedBeforeRead;
 
     private boolean reloadWizard;
     private JLabel lblAxisInterlock;
     private JCheckBox interlockActuator;
     private JLabel lblValueType;
-    protected JComboBox valueType;
+    protected JComboBox<Actuator.ActuatorValueType> valueType;
     private JTextField defaultOnDouble;
     private JLabel lblOnDouble;
     private JLabel lblOffDouble;
@@ -100,11 +101,11 @@ public abstract class AbstractActuatorConfigurationWizard extends AbstractConfig
     private JTextField defaultOnString;
     private JTextField defaultOffString;
     private JLabel lblHomingActuation;
-    private JComboBox homedActuation;
+    private JComboBox<ReferenceActuator.MachineStateActuation> homedActuation;
     private JLabel lblEnableActuation;
+    private JComboBox<ReferenceActuator.MachineStateActuation> enabledActuation;
     private JLabel lblDisableActuation;
-    private JComboBox enabledActuation;
-    private JComboBox disabledActuation;
+    private JComboBox<ReferenceActuator.MachineStateActuation> disabledActuation;
     private JLabel lblMachineStateActuation;
     private JLabel lblMachineState;
 
@@ -161,16 +162,16 @@ public abstract class AbstractActuatorConfigurationWizard extends AbstractConfig
                 "AbstractActuatorConfigurationWizard.CoordinateSystemPanel.AxisLabel.text")); //$NON-NLS-1$
         panelOffsets.add(lblAxis, "2, 4, right, default");
 
-        axisX = new JComboBox(new AxesComboBoxModel(machine, AbstractAxis.class, Axis.Type.X, true));
+        axisX = new JComboBox<AxesComboBoxModel>(new AxesComboBoxModel(machine, AbstractAxis.class, Axis.Type.X, true));
         panelOffsets.add(axisX, "4, 4, fill, default");
 
-        axisY = new JComboBox(new AxesComboBoxModel(machine, AbstractAxis.class, Axis.Type.Y, true));
+        axisY = new JComboBox<AxesComboBoxModel>(new AxesComboBoxModel(machine, AbstractAxis.class, Axis.Type.Y, true));
         panelOffsets.add(axisY, "6, 4, fill, default");
 
-        axisZ = new JComboBox(new AxesComboBoxModel(machine, AbstractAxis.class, Axis.Type.Z, true));
+        axisZ = new JComboBox<AxesComboBoxModel>(new AxesComboBoxModel(machine, AbstractAxis.class, Axis.Type.Z, true));
         panelOffsets.add(axisZ, "8, 4, fill, default");
 
-        axisRotation = new JComboBox(new AxesComboBoxModel(machine, AbstractAxis.class, Axis.Type.Rotation, true));
+        axisRotation = new JComboBox<AxesComboBoxModel>(new AxesComboBoxModel(machine, AbstractAxis.class, Axis.Type.Rotation, true));
         panelOffsets.add(axisRotation, "10, 4, fill, default");
 
         lblOffset = new JLabel(Translations.getString(
@@ -254,7 +255,7 @@ public abstract class AbstractActuatorConfigurationWizard extends AbstractConfig
                 "AbstractActuatorConfigurationWizard.CoordinationPanel.BeforeActuationLabel.toolTipText")); //$NON-NLS-1$
         panelCoordination.add(lblBeforeActuation, "2, 2, right, default");
         
-        coordinatedBeforeActuate = new JCheckBox("");
+        coordinatedBeforeActuate = new JComboBox<ActuatorCoordinationEnumType>(ActuatorCoordinationEnumType.values());
         panelCoordination.add(coordinatedBeforeActuate, "4, 2, center, bottom");
         
         lblAfterActuation = new JLabel(Translations.getString(
@@ -263,7 +264,7 @@ public abstract class AbstractActuatorConfigurationWizard extends AbstractConfig
                 "AbstractActuatorConfigurationWizard.CoordinationPanel.AfterActuationLabel.toolTipText")); //$NON-NLS-1$
         panelCoordination.add(lblAfterActuation, "2, 4, right, default");
         
-        coordinatedAfterActuate = new JCheckBox("");
+        coordinatedAfterActuate = new JComboBox<ActuatorCoordinationEnumType>(ActuatorCoordinationEnumType.values());
         panelCoordination.add(coordinatedAfterActuate, "4, 4");
         
         lblBeforeRead = new JLabel(Translations.getString(
@@ -272,7 +273,7 @@ public abstract class AbstractActuatorConfigurationWizard extends AbstractConfig
                 "AbstractActuatorConfigurationWizard.CoordinationPanel.BeforeReadLabel.toolTipText")); //$NON-NLS-1$
         panelCoordination.add(lblBeforeRead, "2, 6, right, default");
         
-        coordinatedBeforeRead = new JCheckBox("");
+        coordinatedBeforeRead = new JComboBox<ActuatorCoordinationEnumType>(ActuatorCoordinationEnumType.values());
         panelCoordination.add(coordinatedBeforeRead, "4, 6");
         
         generalPanel = new JPanel();
@@ -312,7 +313,7 @@ public abstract class AbstractActuatorConfigurationWizard extends AbstractConfig
                 "AbstractActuatorConfigurationWizard.GeneralPanel.ValueTypeLabel.toolTipText")); //$NON-NLS-1$
         generalPanel.add(lblValueType, "2, 2, right, default");
         
-        valueType = new JComboBox(Actuator.ActuatorValueType.values());
+        valueType = new JComboBox<Actuator.ActuatorValueType>(Actuator.ActuatorValueType.values());
         valueType.addItemListener(new ItemListener() {
             public void itemStateChanged(ItemEvent e) {
                 reloadWizard = true;
@@ -376,13 +377,13 @@ public abstract class AbstractActuatorConfigurationWizard extends AbstractConfig
                 "AbstractActuatorConfigurationWizard.GeneralPanel.ActuationLabel.toolTipText")); //$NON-NLS-1$
         generalPanel.add(lblMachineStateActuation, "2, 11, right, default");
         
-        enabledActuation = new JComboBox(ReferenceActuator.MachineStateActuation.values());
+        enabledActuation = new JComboBox<ReferenceActuator.MachineStateActuation>(ReferenceActuator.MachineStateActuation.values());
         generalPanel.add(enabledActuation, "4, 11, fill, default");
         
-        homedActuation = new JComboBox(ReferenceActuator.MachineStateActuation.values());
+        homedActuation = new JComboBox<ReferenceActuator.MachineStateActuation>(ReferenceActuator.MachineStateActuation.values());
         generalPanel.add(homedActuation, "6, 11, fill, default");
         
-        disabledActuation = new JComboBox(ReferenceActuator.MachineStateActuation.values());
+        disabledActuation = new JComboBox<ReferenceActuator.MachineStateActuation>(ReferenceActuator.MachineStateActuation.values());
         generalPanel.add(disabledActuation, "8, 11, fill, default");
         
         lblIndex = new JLabel(Translations.getString(
@@ -435,9 +436,9 @@ public abstract class AbstractActuatorConfigurationWizard extends AbstractConfig
 
         addWrappedBinding(actuator, "safeZ", textFieldSafeZ, "text", lengthConverter);
 
-        addWrappedBinding(actuator, "coordinatedBeforeActuate", coordinatedBeforeActuate, "selected");
-        addWrappedBinding(actuator, "coordinatedAfterActuate", coordinatedAfterActuate, "selected");
-        addWrappedBinding(actuator, "coordinatedBeforeRead", coordinatedBeforeRead, "selected");
+        addWrappedBinding(actuator, "coordinatedBeforeActuateEnum", coordinatedBeforeActuate, "selectedItem");
+        addWrappedBinding(actuator, "coordinatedAfterActuateEnum", coordinatedAfterActuate, "selectedItem");
+        addWrappedBinding(actuator, "coordinatedBeforeReadEnum", coordinatedBeforeRead, "selectedItem");
 
         addWrappedBinding(actuator, "valueType", valueType, "selectedItem");
         addWrappedBinding(actuator, "defaultOnDouble", defaultOnDouble, "text", doubleConverter);

--- a/src/main/java/org/openpnp/spi/Actuator.java
+++ b/src/main/java/org/openpnp/spi/Actuator.java
@@ -142,12 +142,6 @@ public interface Actuator
 
     public String read(Object value) throws Exception;
 
-    boolean isCoordinatedBeforeActuate();
-
-    boolean isCoordinatedAfterActuate();
-
-    boolean isCoordinatedBeforeRead();
-
     /**
      * The InterlockMonitor controls an actuator to perform an interlock functions in the course of machine motion. 
      * It can actuate its actuator according to specific axis positions or movements. Or it can read its actuator to 

--- a/src/main/java/org/openpnp/spi/base/AbstractActuator.java
+++ b/src/main/java/org/openpnp/spi/base/AbstractActuator.java
@@ -72,7 +72,7 @@ public abstract class AbstractActuator extends AbstractHeadMountable implements 
         None,
         CommandStillstand,
         WaitForStillstand,
-        WaitForStillstandIndefinitely;
+        WaitForUnconditionalCoordination;
     }
     
     @Attribute(required = false)
@@ -97,7 +97,7 @@ public abstract class AbstractActuator extends AbstractHeadMountable implements 
         switch (upgradeDone) {
         case None:
             setCoordinatedBeforeActuateEnum(coordinatedBeforeActuate ? ActuatorCoordinationEnumType.WaitForStillstand : ActuatorCoordinationEnumType.None);
-            setCoordinatedAfterActuateEnum(coordinatedAfterActuate ? ActuatorCoordinationEnumType.WaitForStillstand : ActuatorCoordinationEnumType.None);
+            setCoordinatedAfterActuateEnum(coordinatedAfterActuate ? ActuatorCoordinationEnumType.WaitForUnconditionalCoordination : ActuatorCoordinationEnumType.None);
             setCoordinatedBeforeReadEnum(coordinatedBeforeRead ? ActuatorCoordinationEnumType.WaitForStillstand : ActuatorCoordinationEnumType.None);
             upgradeDone = UpgradeDone.CoordinationBooleanToEnum;
             Logger.info(getName() + " coordination configuration upgraded");
@@ -436,8 +436,8 @@ public abstract class AbstractActuator extends AbstractHeadMountable implements 
                 case WaitForStillstand:
                     completionType = CompletionType.WaitForStillstand;
                     break;
-                case WaitForStillstandIndefinitely:
-                    completionType = CompletionType.WaitForStillstandIndefinitely;
+                case WaitForUnconditionalCoordination:
+                    completionType = CompletionType.WaitForUnconditionalCoordination;
                     break;
             }
 

--- a/src/main/java/org/openpnp/spi/base/AbstractActuator.java
+++ b/src/main/java/org/openpnp/spi/base/AbstractActuator.java
@@ -363,7 +363,7 @@ public abstract class AbstractActuator extends AbstractHeadMountable implements 
      */
     protected void coordinateWithMachineBeforeActuate() throws Exception {
         if (isCoordinatedBeforeActuate()) {
-            coordinateWithMachine(CompletionType.WaitForStillstand);
+            coordinateWithMachine(CompletionType.CommandStillstand);
         }
     }
     protected void coordinateWithMachineAfterActuate() throws Exception {


### PR DESCRIPTION
# Description
This PR changed the "Before Actuation?" coordination to CommandStillstand as WaitForStillstand is not required.

# Justification
As discussed on the mailing list, CommandStillstand is sufficient for actuator SET operations and provides a better machine utilization and hence a better performance.

# Instructions for Use
this optimization will work immediately. However, in case of miss configurations where an actuator is actuated and read, the addition "Before Read?" coordination is required where before the "Before Acutation?" was sufficient.

This PR will cause merge conflicts with PR #1699 because both change the implementation of ReferenceNozzle for static dwell time handling.

# Implementation Details
1. How did you test the change? Be descriptive. Untested code will not be accepted. **This code was used for the tests and demonstration discussed on the mailing list using a physical machine and a real job.**
2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)? **yes**
3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing. **yes: the coordination handling has been relocated**
4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted. **yes**
