### PR TITLE
Support compressed position report

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/solutions/GcodeDriverSolutions.java
+++ b/src/main/java/org/openpnp/machine/reference/solutions/GcodeDriverSolutions.java
@@ -28,6 +28,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import org.openpnp.gui.support.Icons;
 import org.openpnp.machine.reference.ReferenceMachine;
@@ -993,6 +994,10 @@ public class GcodeDriverSolutions implements Solutions.Subject {
                             if (letters.isEmpty()) {
                                 // we don't have reported letters, take a theoretical set
                                 letters = new ArrayList<>(Arrays.asList(AxisSolutions.VALID_AXIS_LETTERS));
+                            }
+                            // if the reportedAxes contains "C:" before the first axis letter, add it to the pattern
+                            if (gcodeDriver.getReportedAxes().matches("^.*C:\\s*[" + Arrays.stream(AxisSolutions.VALID_AXIS_LETTERS).collect(Collectors.joining()) + "].*")) {
+                                commandBuilt += "C:\\s*";
                             }
                             for (String axisLetter : letters) {
                                 for (String variable : gcodeDriver.getAxisVariables(machine)) {

--- a/src/main/java/org/openpnp/machine/reference/solutions/GcodeDriverSolutions.java
+++ b/src/main/java/org/openpnp/machine/reference/solutions/GcodeDriverSolutions.java
@@ -987,6 +987,7 @@ public class GcodeDriverSolutions implements Solutions.Subject {
                             commandBuilt = "^.*";
                             int axisIndex = 0;
                             int lastAxisIndex = 26;
+                            int axesAdded = 0;
                             String pattern = "";
                             List<String> letters = gcodeDriver.getReportedAxesLetters();
                             if (letters.isEmpty()) {
@@ -1000,7 +1001,12 @@ public class GcodeDriverSolutions implements Solutions.Subject {
                                             // Skipped some axes, add a wild.card.
                                             commandBuilt += ".*";
                                         }
-                                        commandBuilt += variable+":(?<"+variable+">-?\\d+\\.\\d+) ";
+                                        if (axesAdded > 0) {
+                                            // if any axis as been added, allow any number of whitespace
+                                            commandBuilt += "\\s*";
+                                        }
+                                        commandBuilt += variable+":(?<"+variable+">-?\\d+\\.\\d+)";
+                                        axesAdded++;
                                         pattern += variable+" ";
                                         lastAxisIndex = axisIndex;
                                     }


### PR DESCRIPTION
# Description
This PR changes the POSITION_REPORT_REGEX Issues & Solutions suggests by allowing any number of whitespaces between axes.

# Justification
If controllers send compressed position reports without whitespaces between the axes, the default regex does not match. With this modified version compressed reports are matched as well.

# Implementation Details
1. How did you test the change? Be descriptive. Untested code will not be accepted. **using my physical machine**
2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)? **yes**
3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing. **no**
4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted. **yes**
