### PR TITLE
further fix FeedersPanel right-click menu Translation-related 

### DIFF
--- a/src/main/java/org/openpnp/gui/FeedersPanel.java
+++ b/src/main/java/org/openpnp/gui/FeedersPanel.java
@@ -845,7 +845,7 @@ public class FeedersPanel extends JPanel implements WizardContainer {
                     Translations.getString("General.Enabled") :  //$NON-NLS-1$
                     Translations.getString("General.Disabled"); //$NON-NLS-1$
             putValue(NAME, name);
-            putValue(SHORT_DESCRIPTION, Translations.getString("FeedersPanel.Action.SetEnabled.ToolTip") + " " + value); //$NON-NLS-1$ //$NON-NLS-2$
+            putValue(SHORT_DESCRIPTION, Translations.getString("FeedersPanel.Action.SetEnabled.ToolTip") + " " + name); //$NON-NLS-1$ //$NON-NLS-2$
         }
 
         @Override


### PR DESCRIPTION
# Description
Change the code parameter 'value' to ‘name’，let ‘Set feeder(s) enabled to Enable&Disabled’，not ‘Set feeder(s) enabled to true&false’.
Base on the [PR-1696:](https://github.com/openpnp/openpnp/pull/1696)

# Justification
Before fix, when use **'value'** at the end.
`putValue(SHORT_DESCRIPTION, Translations.getString("FeedersPanel.Action.SetEnabled.ToolTip") + " " + value);`

![feederspanel-beforefix](https://github.com/user-attachments/assets/b08d7251-4504-48ce-9c41-ccc199ff2a15)

After fix, when use **'name'** at the end.
`putValue(SHORT_DESCRIPTION, Translations.getString("FeedersPanel.Action.SetEnabled.ToolTip") + " " + name);`

![feederspanel-afterfix](https://github.com/user-attachments/assets/9587bf46-3dd5-4319-9bc7-4f2ffc5f4f5b)


# Instructions for Use
Further fix the FeedersPanel`s right-click menu.

# Implementation Details
1. How did you test the change? Be descriptive. Untested code will not be accepted.
Tested in my Eclipse.
2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)?
Yes.
3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing.
N/A.
4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted.
Tested in my Eclipse.
