### PR TITLE
Optimize selection of the placement for the N+1's nozzle

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/ReferencePnpJobProcessor.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferencePnpJobProcessor.java
@@ -105,9 +105,9 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
 
     protected Head head;
 
-    protected Locator pickLocator;
-    protected Locator alignLocator;
-    protected Locator placeLocator;
+    protected static Locator pickLocator;
+    protected static Locator alignLocator;
+    protected static Locator placeLocator;
     
     protected List<JobPlacement> jobPlacements = new ArrayList<>();
 
@@ -1297,29 +1297,6 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
             this.plannedPlacements = plannedPlacements;
         }
 
-        private Location calcCenterLocation(TravellingSalesman.Locator<PlannedPlacement> locator) {
-            Location centerLocation = null;
-            if (locator != null) {
-                centerLocation = new Location(LengthUnit.Millimeters);
-                int cnt = 0;
-                for (PlannedPlacement p : plannedPlacements) {
-                    Location l = locator.getLocation(p);
-                    if (l != null) {
-                        centerLocation = centerLocation.add(l);
-                        cnt++;
-                    }
-                }
-                
-                if (cnt > 0) {
-                    centerLocation = centerLocation.multiply(1.0 / cnt);
-                } else {
-                    centerLocation = null;
-                }
-            }
-            
-            return centerLocation;
-        }
-        
         /**
          * Sort the list of planned placements for better performance
          * this is done by first collecting the locations where the head will move
@@ -1360,7 +1337,7 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
             start = sortLocator.convertToHeadLocation(nozzle, nozzle.getLocation());
             
             // b) calculate end location as center between all locations of the next step
-            Location endLocation = calcCenterLocation(endLocator);
+            Location endLocation = calcCenterLocation(plannedPlacements, endLocator);
             
             // c) sort PlanndPlacements according to sortLocation
             // Use a traveling salesman algorithm to optimize the path to visit the placements
@@ -1393,6 +1370,36 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
             return optimizedPlannedPlacements;
         }
     }
+
+    /**
+     * Calculate the center location between a given set of PlannedPlacements using the given locator.
+     * 
+     * @param plannedPlacements
+     * @param locator
+     * @return
+     */
+    private static Location calcCenterLocation(List<PlannedPlacement> plannedPlacements, Locator locator) {
+        Location centerLocation = null;
+        if (locator != null) {
+            centerLocation = new Location(LengthUnit.Millimeters);
+            int cnt = 0;
+            for (PlannedPlacement p : plannedPlacements) {
+                Location l = locator.getLocation(p);
+                if (l != null) {
+                    centerLocation = centerLocation.add(l);
+                    cnt++;
+                }
+            }
+            
+            if (cnt > 0) {
+                centerLocation = centerLocation.multiply(1.0 / cnt);
+            } else {
+                centerLocation = null;
+            }
+        }
+        
+        return centerLocation;
+    }
     
     /**
      * create a class to group all pick, align an placement locator functions and to get rid of
@@ -1404,7 +1411,12 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
          * The location is in the reference system of the head in order to compare it with others
          * or to apply math like calculating the center between them.
          */
-        abstract public Location getLocation(PlannedPlacement p);
+        abstract public Location getLocation(JobPlacement jobPlacement, Nozzle nozzle);
+        public Location getLocation(PlannedPlacement plannedPlacement) {
+            final Nozzle nozzle = plannedPlacement.nozzle;
+            final JobPlacement jobPlacement = plannedPlacement.jobPlacement;
+            return getLocation(jobPlacement, nozzle);
+        }
         
         /**
          * toString is used in log messages to generate meaningful messages where it locator as been used.
@@ -1431,10 +1443,8 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
     }
     
     private class PickLocator extends Locator {
-        public Location getLocation(PlannedPlacement p) {
+        public Location getLocation(JobPlacement jobPlacement, Nozzle nozzle) {
             Location location;
-            final Nozzle nozzle = p.nozzle;
-            final JobPlacement jobPlacement = p.jobPlacement;
             final Placement placement = jobPlacement.getPlacement();
             final Part part = placement.getPart();
 
@@ -1457,10 +1467,9 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
     }
     
     private class AlignLocator extends Locator {
-        public Location getLocation(PlannedPlacement p) {
+        public Location getLocation(JobPlacement jobPlacement, Nozzle nozzle) {
             Location location;
             final Camera camera;
-            final Nozzle nozzle = p.nozzle;
 
             // try to get the location where the alignment will take place
             try {
@@ -1481,9 +1490,7 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
     }
     
     private class PlaceLocator extends Locator {
-        public Location getLocation(PlannedPlacement p) {
-            final Nozzle nozzle = p.nozzle;
-            final JobPlacement jobPlacement = p.jobPlacement;
+        public Location getLocation(JobPlacement jobPlacement, Nozzle nozzle) {
             final Placement placement = jobPlacement.getPlacement();
             final BoardLocation boardLocation = jobPlacement.getBoardLocation();
         
@@ -1726,7 +1733,8 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
                  * respective lists so that we don't plan the same one again.
                  */
                 for (Nozzle nozzle : new ArrayList<>(nozzles)) {
-                    PlannedPlacement plannedPlacement = planWithoutNozzleTipChange(nozzle, jobPlacements);
+                    PlannedPlacement plannedPlacement = planWithoutNozzleTipChange(nozzle, 
+                            nozzle.getNozzleTip(), jobPlacements, plannedPlacements);
                     if (plannedPlacement != null) {
                         plannedPlacements.add(plannedPlacement);
                         jobPlacements.remove(plannedPlacement.jobPlacement);
@@ -1739,11 +1747,12 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
             
             /**
              * Now we'll try to plan any nozzles that didn't get planned on the first pass by
-             * seeing if a nozzle change helps. This is nearly the same as above, except this
+             * seeing if a nozzle tip change helps. This is nearly the same as above, except this
              * time we allow a nozzle tip change to happen.
              */
             for (Nozzle nozzle : new ArrayList<>(nozzles)) {
-                PlannedPlacement plannedPlacement = planWithNozzleTipChange(nozzle, jobPlacements, nozzleTips);
+                PlannedPlacement plannedPlacement = planWithNozzleTipChange(nozzle, jobPlacements, 
+                        nozzleTips, plannedPlacements);
                 if (plannedPlacement != null) {
                     plannedPlacements.add(plannedPlacement);
                     jobPlacements.remove(plannedPlacement.jobPlacement);
@@ -1772,21 +1781,40 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
          * @param jobPlacements
          * @return
          */
-        protected PlannedPlacement planWithoutNozzleTipChange(Nozzle nozzle, 
-                List<JobPlacement> jobPlacements) {
-            if (nozzle.getNozzleTip() == null) {
+        protected PlannedPlacement planWithoutNozzleTipChange(Nozzle nozzle, NozzleTip nozzleTip,
+                List<JobPlacement> jobPlacements, List<PlannedPlacement>plannedPlacements) {
+            if (nozzleTip == null) {
                 return null;
             }
-            for (JobPlacement jobPlacement : jobPlacements) {
-                Placement placement = jobPlacement.getPlacement();
-                Part part = placement.getPart();
-                org.openpnp.model.Package pkg = part.getPackage();
-                NozzleTip nozzleTip = nozzle.getNozzleTip();
-                if (pkg.getCompatibleNozzleTips().contains(nozzleTip)) {
-                    return new PlannedPlacement(nozzle, nozzleTip, jobPlacement);
-                }
+            // collect all placements that are compatible with the loaded nozzle tip
+            List <JobPlacement> compatibleJobPlacements = jobPlacements
+                    .stream()
+                    .filter(jobPlacement -> {
+                        Placement placement = jobPlacement.getPlacement();
+                        Part part = placement.getPart();
+                        org.openpnp.model.Package pkg = part.getPackage();
+                        return pkg.getCompatibleNozzleTips().contains(nozzleTip);
+                    })
+                    .collect(Collectors.toList());
+
+            // if there are no compatible job placements, leave now
+            if (compatibleJobPlacements.isEmpty()) {
+                return null;
             }
-            return null;
+            
+            // if other placements have been planned, select the next by distance
+            if (plannedPlacements != null && !plannedPlacements.isEmpty()) {
+                //Locator placeLocator = new PlaceLocator();
+                Location averagePlaceLocation = calcCenterLocation(plannedPlacements, placeLocator);
+                
+                // now sort compatibleJobPlacements by distance to averagePlaceLocation
+                compatibleJobPlacements.sort(Comparator.comparing(jobPlacement -> { 
+                    return placeLocator.getLocation(jobPlacement, nozzle).getLinearDistanceTo(averagePlaceLocation); 
+                }));
+            }
+            
+            // return the first of the list
+            return new PlannedPlacement(nozzle, nozzleTip, compatibleJobPlacements.get(0));
         }
 
         /**
@@ -1801,7 +1829,7 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
          */
         protected PlannedPlacement planWithNozzleTipChange(Nozzle nozzle, 
                 List<JobPlacement> jobPlacements,
-                List<NozzleTip> nozzleTips) {
+                List<NozzleTip> nozzleTips, List<PlannedPlacement> plannedPlacements) {
             for (JobPlacement jobPlacement : jobPlacements) {
                 Placement placement = jobPlacement.getPlacement();
                 Part part = placement.getPart();
@@ -1818,7 +1846,8 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
                         })
                         .collect(Collectors.toList());
                 if (!goodNozzleTips.isEmpty()) {
-                    return new PlannedPlacement(nozzle, goodNozzleTips.get(0), jobPlacement);
+                    // plan again with the selected nozzle tip using the same strategy as without nozzle tip change
+                    return planWithoutNozzleTipChange(nozzle, goodNozzleTips.get(0), jobPlacements, plannedPlacements);
                 }
             }
             return null;


### PR DESCRIPTION
# Description
This PR changes the SimplePnpJobPlanner to choose the placement for the N+1's nozzle such, that the distance for the head to travel is minimized.
For this purpose it reuses the pickLocator and other code that is already used for optimization.

# Justification
After all the other optimizations to the JobProcessor, it makes sense to also optimize the N+1's placement. This implementation respects the sorting strategy applied by the JobProcessor by choosing the next compatible placement for the first nozzle and the next compatible nozzle tip for any nozzle. It's just the placement for the N+1's nozzle (with and without nozzle tip change) that is chosen based on the distance to the already planned placements.

# Instructions for Use
The optimization is always active.

# Developers:
Due to the fact, that the SimplePnPJobPlanner is declared static, I had to apply static to the placeLocator as well and I was not able to check for optimizeForMultipleNozzles to disable this optimization. Please advice.
The method calcCenterLocation() had to be relocated to reuse it.

# Implementation Details
1. How did you test the change? Be descriptive. Untested code will not be accepted. **using simulation and physical machine**
2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)? **yes**
3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing. **no**
4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted. **yes**
