### PR TITLE
Shift key will decrease current distance movement by 100

### DIFF
--- a/src/main/java/org/openpnp/gui/JogControlsPanel.java
+++ b/src/main/java/org/openpnp/gui/JogControlsPanel.java
@@ -145,11 +145,15 @@ public class JogControlsPanel extends JPanel {
     }
 
     public double getJogIncrement() {
+        int val = sliderIncrements.getValue();
+        if (MainFrame.get().getShiftDown()) {
+            val = Math.max(1, val - 2);   // finer movement by 2 levels
+        }
         if (configuration.getSystemUnits() == LengthUnit.Millimeters) {
-            return 0.01 * Math.pow(10, sliderIncrements.getValue() - 1);
+            return 0.01 * Math.pow(10, val - 1);
         }
         else if (configuration.getSystemUnits() == LengthUnit.Inches) {
-            return 0.001 * Math.pow(10, sliderIncrements.getValue() - 1);
+            return 0.001 * Math.pow(10, val - 1);
         }
         else {
             throw new Error(
@@ -286,6 +290,7 @@ public class JogControlsPanel extends JPanel {
 
         JLabel lblDistance = new JLabel("<html>" + Translations.getString("JogControlsPanel.Label.Distance") + "<br>[" + configuration.getSystemUnits().getShortName() + "/deg]</html>"); //$NON-NLS-1$
         lblDistance.setFont(new Font("Lucida Grande", Font.PLAIN, 10)); //$NON-NLS-1$
+        lblDistance.setToolTipText(Translations.getString("JogControlsPanel.Label.Distance.toolTipText")); //$NON-NLS-1$
         panelControls.add(lblDistance, "18, 2, center, center"); //$NON-NLS-1$
 
         JLabel lblSpeed = new JLabel("<html>" + Translations.getString("JogControlsPanel.Label.Speed") + "<br>[%]</html>"); //$NON-NLS-1$

--- a/src/main/java/org/openpnp/gui/MainFrame.java
+++ b/src/main/java/org/openpnp/gui/MainFrame.java
@@ -36,6 +36,8 @@ import java.awt.event.ComponentListener;
 import java.awt.event.KeyEvent;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
+import java.awt.KeyEventDispatcher;
+import java.awt.KeyboardFocusManager;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.lang.reflect.Method;
@@ -279,6 +281,11 @@ public class MainFrame extends JFrame {
     private JMenuItem mnEditRemoveBoard;
     private JMenu mnEditAddBoard;
     private JMenuItem mnCaptureToolLocation;
+
+    private boolean isShiftDown;
+    public boolean getShiftDown() {
+        return isShiftDown;
+    }
 
     public MainFrame(Configuration configuration) {
         mainFrame = this;
@@ -544,8 +551,6 @@ public class MainFrame extends JFrame {
         // Add global hotkeys for the arrow keys
         hotkeyActionMap = new HashMap<>();
 
-        int mask = KeyEvent.CTRL_DOWN_MASK;
-
         Toolkit.getDefaultToolkit().getSystemEventQueue().push(new EventQueue() {
             @Override
             protected void dispatchEvent(AWTEvent event) {
@@ -628,28 +633,31 @@ public class MainFrame extends JFrame {
         mnCommands.add(new JMenuItem(machineControlsPanel.homeAction));
         mnCommands.add(new JMenuItem(machineControlsPanel.startStopMachineAction));
 
-        hotkeyActionMap.put(KeyStroke.getKeyStroke(KeyEvent.VK_UP, mask),
-                machineControlsPanel.getJogControlsPanel().yPlusAction);
-        hotkeyActionMap.put(KeyStroke.getKeyStroke(KeyEvent.VK_DOWN, mask),
-                machineControlsPanel.getJogControlsPanel().yMinusAction);
-        hotkeyActionMap.put(KeyStroke.getKeyStroke(KeyEvent.VK_LEFT, mask),
-                machineControlsPanel.getJogControlsPanel().xMinusAction);
-        hotkeyActionMap.put(KeyStroke.getKeyStroke(KeyEvent.VK_RIGHT, mask),
-                machineControlsPanel.getJogControlsPanel().xPlusAction);
-        hotkeyActionMap.put(KeyStroke.getKeyStroke(KeyEvent.VK_QUOTE, mask),
-                machineControlsPanel.getJogControlsPanel().zPlusAction);
-        hotkeyActionMap.put(KeyStroke.getKeyStroke(KeyEvent.VK_SLASH, mask),
-                machineControlsPanel.getJogControlsPanel().zMinusAction);
-        hotkeyActionMap.put(KeyStroke.getKeyStroke(KeyEvent.VK_COMMA, mask),
-                machineControlsPanel.getJogControlsPanel().cPlusAction);
-        hotkeyActionMap.put(KeyStroke.getKeyStroke(KeyEvent.VK_PERIOD, mask),
-                machineControlsPanel.getJogControlsPanel().cMinusAction);
-        hotkeyActionMap.put(KeyStroke.getKeyStroke(KeyEvent.VK_MINUS, mask),
-                machineControlsPanel.getJogControlsPanel().lowerIncrementAction);
-        hotkeyActionMap.put(KeyStroke.getKeyStroke(KeyEvent.VK_EQUALS, mask),
-                machineControlsPanel.getJogControlsPanel().raiseIncrementAction);
-        hotkeyActionMap.put(KeyStroke.getKeyStroke(KeyEvent.VK_H, mask),
-                machineControlsPanel.homeAction);
+        int[] ctrl_shift_mask = {KeyEvent.CTRL_DOWN_MASK, KeyEvent.CTRL_DOWN_MASK | KeyEvent.SHIFT_DOWN_MASK};
+        for (int mask : ctrl_shift_mask) {
+            hotkeyActionMap.put(KeyStroke.getKeyStroke(KeyEvent.VK_UP, mask),
+                    machineControlsPanel.getJogControlsPanel().yPlusAction);
+            hotkeyActionMap.put(KeyStroke.getKeyStroke(KeyEvent.VK_DOWN, mask),
+                    machineControlsPanel.getJogControlsPanel().yMinusAction);
+            hotkeyActionMap.put(KeyStroke.getKeyStroke(KeyEvent.VK_LEFT, mask),
+                    machineControlsPanel.getJogControlsPanel().xMinusAction);
+            hotkeyActionMap.put(KeyStroke.getKeyStroke(KeyEvent.VK_RIGHT, mask),
+                    machineControlsPanel.getJogControlsPanel().xPlusAction);
+            hotkeyActionMap.put(KeyStroke.getKeyStroke(KeyEvent.VK_QUOTE, mask),
+                    machineControlsPanel.getJogControlsPanel().zPlusAction);
+            hotkeyActionMap.put(KeyStroke.getKeyStroke(KeyEvent.VK_SLASH, mask),
+                    machineControlsPanel.getJogControlsPanel().zMinusAction);
+            hotkeyActionMap.put(KeyStroke.getKeyStroke(KeyEvent.VK_COMMA, mask),
+                    machineControlsPanel.getJogControlsPanel().cPlusAction);
+            hotkeyActionMap.put(KeyStroke.getKeyStroke(KeyEvent.VK_PERIOD, mask),
+                    machineControlsPanel.getJogControlsPanel().cMinusAction);
+            hotkeyActionMap.put(KeyStroke.getKeyStroke(KeyEvent.VK_MINUS, mask),
+                    machineControlsPanel.getJogControlsPanel().lowerIncrementAction);
+            hotkeyActionMap.put(KeyStroke.getKeyStroke(KeyEvent.VK_EQUALS, mask),
+                    machineControlsPanel.getJogControlsPanel().raiseIncrementAction);
+            hotkeyActionMap.put(KeyStroke.getKeyStroke(KeyEvent.VK_H, mask),
+                    machineControlsPanel.homeAction);
+        }
         hotkeyActionMap.put(KeyStroke.getKeyStroke(KeyEvent.VK_R, KeyEvent.CTRL_DOWN_MASK | KeyEvent.SHIFT_DOWN_MASK),
                 jobPanel.startPauseResumeJobAction); // Ctrl-Shift-R for Start
         hotkeyActionMap.put(KeyStroke.getKeyStroke(KeyEvent.VK_S, KeyEvent.CTRL_DOWN_MASK | KeyEvent.SHIFT_DOWN_MASK),
@@ -674,7 +682,16 @@ public class MainFrame extends JFrame {
                 machineControlsPanel.getJogControlsPanel().setIncrement4Action);
         hotkeyActionMap.put(KeyStroke.getKeyStroke(KeyEvent.VK_F5, KeyEvent.CTRL_DOWN_MASK | KeyEvent.SHIFT_DOWN_MASK),
                 machineControlsPanel.getJogControlsPanel().setIncrement5Action);
-				
+
+        isShiftDown = false;
+        KeyboardFocusManager.getCurrentKeyboardFocusManager().addKeyEventDispatcher(
+            new KeyEventDispatcher() {
+                public boolean dispatchKeyEvent(KeyEvent e) {
+                    isShiftDown = e.isShiftDown();
+                    return false;
+                }
+            });
+
         tabs = new JTabbedPane(JTabbedPane.TOP);
         splitPaneMachineAndTabs.setRightComponent(tabs);
 

--- a/src/main/resources/org/openpnp/translations.properties
+++ b/src/main/resources/org/openpnp/translations.properties
@@ -714,6 +714,7 @@ JogControlsPanel.Action.ThirdJogIncrement=Third Jog Increment
 JogControlsPanel.Action.positionCamera=Move camera to position of selected tool
 JogControlsPanel.Action.positionSelectedNozzle=Move last selected tool to camera position
 JogControlsPanel.Label.Distance=Distance
+JogControlsPanel.Label.Distance.toolTipText=Hold SHIFT key to divide slider distance by 100 to achieve finer jog movement
 JogControlsPanel.Label.BoardProtection=Board Protection
 JogControlsPanel.Label.BoardProtection.Description=Enable protection of the nozzle jogging closer than 1mm to any loaded board.
 JogControlsPanel.Label.Speed=Speed


### PR DESCRIPTION
# Description
Jog movement distance is 100 times finer when SHIFT key pressed together with main key or mouse button. So e.g. when distance slider is 100 then movement is 2 step finer, i.e. 1

# Justification
general usability improvement

# Instructions for Use
Check jog movement and press SHIFT key to see difference

# Implementation Details
1. manually tested with PnP machine
2. yes
3. no
4. yes mvn test passed
