### PR TITLE
Check if nozzle tip is empty, i.e. no part, when feed command is trig…

### DIFF
--- a/src/main/java/org/openpnp/gui/FeedersPanel.java
+++ b/src/main/java/org/openpnp/gui/FeedersPanel.java
@@ -600,7 +600,7 @@ public class FeedersPanel extends JPanel implements WizardContainer {
             UiUtils.submitUiMachineTask(() -> {
                 Feeder feeder = getSelection();
                 // Do the feed and get the nozzle that would be used for the subsequent pick. 
-                Nozzle nozzle = feedFeeder(feeder);
+                Nozzle nozzle = feedFeeder(feeder, true);
             });
         }
     };
@@ -626,20 +626,25 @@ public class FeedersPanel extends JPanel implements WizardContainer {
      * Perform a job-like feed operations sequence. 
      * 
      * @param feeder
+     * @param allowPartOnTip check if tip is empty and raise exception if part is loaded on tip
      * @return the nozzle to be used for a subsequent pick.
      * @throws Exception
      */
-    public static Nozzle feedFeeder(Feeder feeder) throws Exception {
+    public static Nozzle feedFeeder(Feeder feeder, boolean allowPartOnTip) throws Exception {
         if (feeder.getPart() == null) {
             throw new Exception("Feeder "+feeder.getName()+" has no part.");
         }
+
+        Nozzle nozzle = getCompatibleNozzleAndTip(feeder, true);
+        if (!allowPartOnTip && nozzle.getPart() != null) {
+            throw new Exception("Nozzle "+nozzle.getName()+" has loaded part.");
+        }
+
         // Simulate a "one feeder" job, prepare the feeder.
         if (feeder.getJobPreparationLocation() != null) {
             feeder.prepareForJob(true);
         }
         feeder.prepareForJob(false);
-
-        Nozzle nozzle = getCompatibleNozzleAndTip(feeder, true);
 
         // Like in the JobProcessor, make sure it is calibrated.
         if (!nozzle.isCalibrated()) {
@@ -668,7 +673,7 @@ public class FeedersPanel extends JPanel implements WizardContainer {
      */
     public static void pickFeeder(Feeder feeder) throws Exception, JobProcessorException {
         // Do the feed an get the nozzle for the pick.
-        Nozzle nozzle = feedFeeder(feeder);
+        Nozzle nozzle = feedFeeder(feeder, false);
 
         // Perform the vacuum check, if enabled.
         if (nozzle.isPartOffEnabled(Nozzle.PartOffStep.BeforePick)) {


### PR DESCRIPTION
# Description
Do not allow feed on nozzle tip when part is already loaded on tip. 
Typically: 
When PnP something wrong happens in multi nozzle scenario, e.g. BCAM part not detected on Nozzle1 but Nozzle2 has been 
meanwhile loaded then is no option to retry step in job as next step succeeded. But it is still possible manully put part on tip, which is tricky when orientation is important or part is too small, or trigger manually feed command on Feeder/Part panel. This works (not sure about orientation) but it does blindly feeds part on selected nozzle even is correctly loaded. Usually I forget to double check what nozzle is selected above jog in combo box and it breaks Nozzle2 as well.

# Justification
UI improvement

# Instructions for Use
Load part on nozzle and try to run feed command on Part/Feeder panel

# Implementation Details
1. manual test with machine
2. yes
3. no
4. yes
