### PR TITLE
remember the global best route in case a swap is accepted due to anne…

### DIFF
--- a/src/main/java/org/openpnp/util/TravellingSalesman.java
+++ b/src/main/java/org/openpnp/util/TravellingSalesman.java
@@ -276,8 +276,11 @@ public class TravellingSalesman<T> {
                             globalTravel = new ArrayList<>(this.travel);
                             copies++;
                         }
-                        swaps++;
-                        twists += twist ? 1 : 0;
+                        if (twist) {
+                            twists++;
+                        } else {
+                            swaps++;
+                        }
                     }
                     t *= coolingRate;
                 } else {

--- a/src/main/java/org/openpnp/util/TravellingSalesman.java
+++ b/src/main/java/org/openpnp/util/TravellingSalesman.java
@@ -278,8 +278,8 @@ public class TravellingSalesman<T> {
                 }
                 if (debugLevel > 0) {
                     if (i % 100000 == 0) {
-                        bestDistance = getTravellingDistance();
-                        System.out.println("Iterations #" + i +", temperature: "+t+", distance of travel:" + bestDistance + ", best distance to travel: " + globalBestDistance + ", swaps: "+swaps+", twists: "+twists);
+                        double distance = getTravellingDistance();
+                        System.out.println("Iterations #" + i +", temperature: "+t+", distance of travel:" + distance + ", best distance to travel: " + globalBestDistance + ", swaps: "+swaps+", twists: "+twists);
                         //System.out.println(this.asSvg());
                     }
                 }

--- a/src/main/java/org/openpnp/util/TravellingSalesman.java
+++ b/src/main/java/org/openpnp/util/TravellingSalesman.java
@@ -226,10 +226,10 @@ public class TravellingSalesman<T> {
             Random rnd = new java.util.Random(0);
             for (; i > 0; i--) {
                 if (t > 0.1) {
-                    int a = (int) (rnd.nextDouble() * this.travelSize);
+                    int a = rnd.nextInt(this.travelSize);
                     int b;
                     do {
-                        b = (int) (rnd.nextDouble() * this.travelSize);
+                        b = rnd.nextInt(this.travelSize);
                     }
                     while (b == a);
                     /* creates a locale emphasis when swapping
@@ -250,12 +250,12 @@ public class TravellingSalesman<T> {
 
                     if (debugLevel > 1) {
                         // validate the differential swapDistance
-                        bestDistance = getTravellingDistance();
+                        double oldDistance = getTravellingDistance();
                         this.swapLocations(a, b, twist);
                         double newDistance = getTravellingDistance();
                         this.swapLocations(a, b, twist);
-                        if (Math.abs((newDistance - bestDistance) - swapDistance) > 0.1) {
-                            System.err.println("** Swap distance wrong - newDistance:" + newDistance + ", bestDistance:" + bestDistance +", swapDistance: "+swapDistance + " != "+(newDistance - bestDistance)+", twist: "+twist);
+                        if (Math.abs((newDistance - oldDistance) - swapDistance) > 0.1) {
+                            System.err.println("** Swap distance wrong - newDistance:" + newDistance + ", oldDistance:" + oldDistance +", swapDistance: "+swapDistance + " != "+(newDistance - oldDistance)+", twist: "+twist);
                         }
                     }
 
@@ -265,7 +265,8 @@ public class TravellingSalesman<T> {
                         bestDistance += swapDistance;   // keep bestDistance up-to-date
                         // if the new route is better then the best, remember it
                         if (bestDistance < globalBestDistance) {
-                            globalBestDistance = bestDistance;
+                            // remember slightly worth distance do avoid excessive copies due to rounding effects
+                            globalBestDistance = 0.999 * bestDistance;
                             globalTravel = new ArrayList<>(this.travel);
                         }
                         swaps++;
@@ -278,7 +279,7 @@ public class TravellingSalesman<T> {
                 if (debugLevel > 0) {
                     if (i % 100000 == 0) {
                         bestDistance = getTravellingDistance();
-                        System.out.println("Iterations #" + i +", temperature: "+t+", distance of travel:" + bestDistance+", swaps: "+swaps+", twists: "+twists);
+                        System.out.println("Iterations #" + i +", temperature: "+t+", distance of travel:" + bestDistance + ", best distance to travel: " + globalBestDistance + ", swaps: "+swaps+", twists: "+twists);
                         //System.out.println(this.asSvg());
                     }
                 }

--- a/src/main/java/org/openpnp/util/TravellingSalesman.java
+++ b/src/main/java/org/openpnp/util/TravellingSalesman.java
@@ -219,18 +219,11 @@ public class TravellingSalesman<T> {
             System.out.println("Initial distance of travel: " + bestDistance);
         }
         if (this.travelSize > 1) {
-            List<TravelLocation> globalTravel = null;   // global best route, null if unset
-            double globalBestDistance = 0.0;            // cost of global best route (if defined)
-            Random rnd;
-            
-            if (debugLevel > 0) {
-                // make this repeatable by seeding the random generator
-                rnd = new java.util.Random(0);
-            }
-            else {
-                // if outside of debugging environment, do not seed the random number generate to generate true random number.
-                rnd = new java.util.Random();
-            }
+            List<TravelLocation> globalTravel = new ArrayList<>(this.travel);   // global best route
+            double globalBestDistance = bestDistance;                           // cost of global best route
+
+            // make this repeatable by seeding the random generator
+            Random rnd = new java.util.Random(0);
             for (; i > 0; i--) {
                 if (t > 0.1) {
                     int a = (int) (rnd.nextDouble() * this.travelSize);
@@ -268,23 +261,15 @@ public class TravellingSalesman<T> {
 
                     if (swapDistance < 0.0 || (Math.exp(-swapDistance / t) >= rnd.nextDouble())) {
                         // better or within annealing probability
-                        if (!(swapDistance < 0.0)) {
-                            // swap accepted due to annealiing probability only
-                            // -> remember current best route and it's cost
-                            if (globalTravel == null || globalBestDistance > bestDistance) {
-                                globalBestDistance = bestDistance;
-                                globalTravel = new ArrayList<>(this.travel);
-                            }
-                        }
                         this.swapLocations(a, b, twist);
                         bestDistance += swapDistance;   // keep bestDistance up-to-date
+                        // if the new route is better then the best, remember it
+                        if (bestDistance < globalBestDistance) {
+                            globalBestDistance = bestDistance;
+                            globalTravel = new ArrayList<>(this.travel);
+                        }
                         swaps++;
                         twists += twist ? 1 : 0;
-                        
-                        // reset the global best route if worth then local best
-                        if (globalTravel != null && globalBestDistance > bestDistance) {
-                            globalTravel = null;
-                        }
                     }
                     t *= coolingRate;
                 } else {
@@ -298,14 +283,9 @@ public class TravellingSalesman<T> {
                     }
                 }
             }
-            // if we have a global best route, test if its better then the local best route
-            if (globalTravel != null && globalBestDistance < bestDistance) {
-                // global best route is bettern the local, return global as result
-                this.travel.clear();
-                this.travel.addAll(globalTravel);
-                globalTravel = null;
-            }
-            
+            // global best route is always the best route we have
+            this.travel.clear();
+            this.travel.addAll(globalTravel);
         }
         bestDistance = getTravellingDistance();
         if (debugLevel > 0) {


### PR DESCRIPTION
# Description
According to the discussions on the [list](https://groups.google.com/g/openpnp/c/HXvHZ2NuCyg/m/f4I2I5TZAwAJ) the travelling salesman implementation requires fixing that in case a worth route is accepted due to the annealing probability, the best route still needs to be considered then returning. This PR intends to fix that.

# Implementation Details
1. How did you test the change? Be descriptive. Untested code will not be accepted. **using the automated test sequences**
2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)? **yes**
3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing. **no**
4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted. **yes**
