### PR TITLE
ParameterNumeric vision pipeline parameter types

### DIFF
--- a/src/main/java/org/openpnp/vision/pipeline/stages/ParameterNumeric.java
+++ b/src/main/java/org/openpnp/vision/pipeline/stages/ParameterNumeric.java
@@ -132,7 +132,7 @@ public class ParameterNumeric extends CvAbstractScalarParameterStage {
 
     @Override
     public Object defaultParameterValue() {
-        return defaultValue;
+        return numericType.asTyped(defaultValue);
     }
 
     @Override


### PR DESCRIPTION
# Description

This patch fixes a type bug in ParameterNumeric.

Parameters of type `MillimetersToPixels` and `SquareMillimetersToPixels` need to be converted using camera data before the pipeline is run. The `appliedValue` function checks the value type is `Length` or `Area` before doing this conversion. But there is a scenario where the value will not have picked up the correct type. If it is using the default value; that is, if the slider in the vision configuration GUI has never been moved, so that the `ParameterNumeric` `process()` is using the default value rather than the user's value.

This bug can be observed using the "Min Detail Size" parameter in stock bottom vision:
1. Start with an clean `.openpnp2` directory
2. Start the simulated machine
3. Select a part, and edit its bottom vision pipeline
4. Click on the `filterContours` stage `minArea` parameter, and observe that this is "controlled by pipeline caller" and the value is 0.01. This is a value that the default pipeline specified in square millimeters, but here is being interpreted as a pixel area.
5. Close the pipeline editor, nudge the "Min Detail Size" slider, and reopen. Observe that the `minArea` has changed to approximately 50 (pixels).
6. Repeat all of the above with this patch, and observe that `minArea` is 55.38 pixels

# Justification

This is a bug fix.

I do have some **backwards compatibility concerns** as far as this fix applies to the "Min Detail Size" control for the bottom vision pipeline. Any user who has never touched that slider has been running with effectively no filtering of small details. Those pipelines will behave differently after an upgrade including this fix. Feedback would be appreciated.

# Instructions for Use

n/a

# Implementation Details
1. How did you test the change?
      * Tested on the simulated machine as described above.
      * Tested on a real machine in relation to another new feature; PR to follow.
3. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)? -- yes
4. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing. -- no changes
7. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted. -- tests pass
