### PR TITLE
Fiducial multi-pass center point

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/vision/ReferenceFiducialLocator.java
+++ b/src/main/java/org/openpnp/machine/reference/vision/ReferenceFiducialLocator.java
@@ -557,12 +557,12 @@ public class ReferenceFiducialLocator extends AbstractPartSettingsHolder impleme
         try(CvPipeline pipeline = getFiducialPipeline(camera, partSettingsHolder, nominalLocation)) {
             int repeatFiducialRecognition = visionSettings.getMaxVisionPasses();
             for (int i = 0; i < repeatFiducialRecognition; i++) {
-                Location newLocation = detectFiducialFromViewpoint(camera, location, pipeline,
+                Location newLocation = detectFiducialFromViewpoint(camera, nominalLocation, pipeline,
                         partSettingsHolder);
                 if (parallaxOperation) {
                     Location viewPointLocation2 = location.subtract(parallaxDisplacement);
                     camera.moveTo(viewPointLocation2);
-                    Location newLocation2 = detectFiducialFromViewpoint(camera, location, pipeline,
+                    Location newLocation2 = detectFiducialFromViewpoint(camera, nominalLocation, pipeline,
                             partSettingsHolder);
                     // Mid-point is the detected location, canceling out any errors.
                     newLocation = newLocation.add(newLocation2).multiply(0.5);
@@ -604,9 +604,6 @@ public class ReferenceFiducialLocator extends AbstractPartSettingsHolder impleme
                     sumY / matchedLocations.size(), null, null);
 
             Logger.debug("{} averaged location is at {}", partSettingsHolder.getId(), location);
-        }
-        if (location.convertToUnits(maxDistance.getUnits()).getLinearDistanceTo(nominalLocation) > maxDistance.getValue()) {
-            throw new Exception("Fiducial "+partSettingsHolder.getShortName()+ " detected too far away.");
         }
         return location;
     }


### PR DESCRIPTION
(my apologies for the errors on the first PR)

# Description

I have been looking at the max-distance limit for the fiducial locator. If it is working correctly then the multi-pass process causes the camera to incrementally step towards the fiducial center, which is necessary to avoid parallax errors. When it works, it works well.

But it can go wrong if the maxDistance property is not set correctly, and one possible outcome is confusing and surprising. The fiducial locator can chase from one visual distraction to the next, and travel outside the expected search area.

The fiducial locator code predates the `DetectCircularSymmetry.center` property override mechanism, and therefore each step of the multi-pass process was using a vision pipeline with a new search area centered on the new camera view point. The original fiducial locator code blocks any false-positive output by calculating the distance between starting and ending point, and it raises an exception if it exceeds the specified maximum.

The code here changed when the parallax fiducial method was added.  This added explicit control of the search area using a `DetectCircularSymmetry.center` property override, but this change did not affect the underlying logic. The search area center point still walked with each step of the multi-pass process, and it can still chase distractions outside of the expected boundary.

This patch simplifies the process by always using the nominal location as the search area center point. (Or, if the parallax method is enabled, the center point is a parallax offset from the nominal location). This is better because:
* Every stage of the multi-pass process is constrained to same search area.
* While each step of the multi-pass process moves the camera location, it does not change the search area. There is a different viewpoint, but looking at the same board features.
* It is no longer possible for the multi-pass process to walk outside the specified maximum distance. Each run of the pipeline can only return a feature which conforms to the maximum distance specification. The camera only moves within the specified maximum distance.
 
# Justification

## Usability Justification

This change makes the system behave in a more predictable manner if the fiducial maximum distance limit is not quite right. The camera does not move beyond the specified maximum distance.

I have not found any scenario where its behavior will be less good.

## Software Engineering Justification

It is more cohesive to have the the maximum distance processed entirely by the pipeline. Previously it was processed by the vision pipeline, but then checked by the fiducial locator. This cohesion becomes more important when there are other ways to specify the fiducial maximum distance (I have another PR to follow)

# Instructions for Use

This is refining the behavior of an existing feature.

# Implementation Details
1. How did you test the change?
    * On a real machine
    * Testing fiducial scans on my production boards
    * Testing boundary conditions: maximum distance, misalignment, and nearby distractions.
3. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)? -- yes
4. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing. -- no changes
5. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted. -- test pass
