### PR TITLE
change Length class to be immutable

### DIFF
--- a/src/main/java/org/openpnp/gui/components/ComponentDecorators.java
+++ b/src/main/java/org/openpnp/gui/components/ComponentDecorators.java
@@ -76,12 +76,9 @@ public class ComponentDecorators {
     }
 
     private static void convertLength(JTextField textField, String format) {
-        Length length = Length.parse(textField.getText(), false);
+        Length length = Length.parseWithDefaultUnits(textField.getText(), Configuration.get().getSystemUnits());
         if (length == null) {
             return;
-        }
-        if (length.getUnits() == null) {
-            length = length.changeUnits(Configuration.get().getSystemUnits());
         }
         length = length.convertToUnits(Configuration.get().getSystemUnits());
         textField.setText(String.format(Locale.US, format, length.getValue()));

--- a/src/main/java/org/openpnp/gui/components/ComponentDecorators.java
+++ b/src/main/java/org/openpnp/gui/components/ComponentDecorators.java
@@ -81,7 +81,7 @@ public class ComponentDecorators {
             return;
         }
         if (length.getUnits() == null) {
-            length.setUnits(Configuration.get().getSystemUnits());
+            length = length.changeUnits(Configuration.get().getSystemUnits());
         }
         length = length.convertToUnits(Configuration.get().getSystemUnits());
         textField.setText(String.format(Locale.US, format, length.getValue()));

--- a/src/main/java/org/openpnp/gui/support/LengthConverter.java
+++ b/src/main/java/org/openpnp/gui/support/LengthConverter.java
@@ -44,12 +44,9 @@ public class LengthConverter extends Converter<Length, String> {
 
     @Override
     public Length convertReverse(String s) {
-        Length length = Length.parse(s, false);
+        Length length = Length.parseWithDefaultUnits(s, Configuration.get().getSystemUnits());
         if (length == null) {
             throw new RuntimeException("Unable to parse " + s);
-        }
-        if (length.getUnits() == null) {
-            length = length.changeUnits(Configuration.get().getSystemUnits());
         }
         return length;
     }

--- a/src/main/java/org/openpnp/gui/support/LengthConverter.java
+++ b/src/main/java/org/openpnp/gui/support/LengthConverter.java
@@ -49,7 +49,7 @@ public class LengthConverter extends Converter<Length, String> {
             throw new RuntimeException("Unable to parse " + s);
         }
         if (length.getUnits() == null) {
-            length.setUnits(Configuration.get().getSystemUnits());
+            length = length.changeUnits(Configuration.get().getSystemUnits());
         }
         return length;
     }

--- a/src/main/java/org/openpnp/gui/tablemodel/FootprintTableModel.java
+++ b/src/main/java/org/openpnp/gui/tablemodel/FootprintTableModel.java
@@ -92,39 +92,19 @@ public class FootprintTableModel extends AbstractTableModel {
             }
             else if (columnIndex == 1) {
                 LengthCellValue value = (LengthCellValue) aValue;
-                Length length = value.getLength();
-                if (length.getUnits() == null) {
-                    length = length.changeUnits(footprint.getUnits());
-                }
-                length = length.convertToUnits(footprint.getUnits());
-                pad.setX(length.getValue());
+                pad.setX(lengthValueFromLengthCellValue(value));
             }
             else if (columnIndex == 2) {
                 LengthCellValue value = (LengthCellValue) aValue;
-                Length length = value.getLength();
-                if (length.getUnits() == null) {
-                    length = length.changeUnits(footprint.getUnits());
-                }
-                length = length.convertToUnits(footprint.getUnits());
-                pad.setY(length.getValue());
+                pad.setY(lengthValueFromLengthCellValue(value));
             }
             else if (columnIndex == 3) {
                 LengthCellValue value = (LengthCellValue) aValue;
-                Length length = value.getLength();
-                if (length.getUnits() == null) {
-                    length = length.changeUnits(footprint.getUnits());
-                }
-                length = length.convertToUnits(footprint.getUnits());
-                pad.setWidth(length.getValue());
+                pad.setWidth(lengthValueFromLengthCellValue(value));
             }
             else if (columnIndex == 4) {
                 LengthCellValue value = (LengthCellValue) aValue;
-                Length length = value.getLength();
-                if (length.getUnits() == null) {
-                    length = length.changeUnits(footprint.getUnits());
-                }
-                length = length.convertToUnits(footprint.getUnits());
-                pad.setHeight(length.getValue());
+                pad.setHeight(lengthValueFromLengthCellValue(value));
             }
             else if (columnIndex == 5) {
                 pad.setRotation(Double.parseDouble(aValue.toString()));
@@ -140,6 +120,13 @@ public class FootprintTableModel extends AbstractTableModel {
         catch (Exception e) {
             // TODO: dialog, bad input
         }
+    }
+
+    private double lengthValueFromLengthCellValue(LengthCellValue value) {
+        Length length = value.getLength();
+        length = length.changeUnitsIfUnspecified(footprint.getUnits());
+        length = length.convertToUnits(footprint.getUnits());
+        return length.getValue();
     }
 
     public Object getValueAt(int row, int col) {

--- a/src/main/java/org/openpnp/gui/tablemodel/FootprintTableModel.java
+++ b/src/main/java/org/openpnp/gui/tablemodel/FootprintTableModel.java
@@ -94,7 +94,7 @@ public class FootprintTableModel extends AbstractTableModel {
                 LengthCellValue value = (LengthCellValue) aValue;
                 Length length = value.getLength();
                 if (length.getUnits() == null) {
-                    length.setUnits(footprint.getUnits());
+                    length = length.changeUnits(footprint.getUnits());
                 }
                 length = length.convertToUnits(footprint.getUnits());
                 pad.setX(length.getValue());
@@ -103,7 +103,7 @@ public class FootprintTableModel extends AbstractTableModel {
                 LengthCellValue value = (LengthCellValue) aValue;
                 Length length = value.getLength();
                 if (length.getUnits() == null) {
-                    length.setUnits(footprint.getUnits());
+                    length = length.changeUnits(footprint.getUnits());
                 }
                 length = length.convertToUnits(footprint.getUnits());
                 pad.setY(length.getValue());
@@ -112,7 +112,7 @@ public class FootprintTableModel extends AbstractTableModel {
                 LengthCellValue value = (LengthCellValue) aValue;
                 Length length = value.getLength();
                 if (length.getUnits() == null) {
-                    length.setUnits(footprint.getUnits());
+                    length = length.changeUnits(footprint.getUnits());
                 }
                 length = length.convertToUnits(footprint.getUnits());
                 pad.setWidth(length.getValue());
@@ -121,7 +121,7 @@ public class FootprintTableModel extends AbstractTableModel {
                 LengthCellValue value = (LengthCellValue) aValue;
                 Length length = value.getLength();
                 if (length.getUnits() == null) {
-                    length.setUnits(footprint.getUnits());
+                    length = length.changeUnits(footprint.getUnits());
                 }
                 length = length.convertToUnits(footprint.getUnits());
                 pad.setHeight(length.getValue());

--- a/src/main/java/org/openpnp/gui/tablemodel/PartsTableModel.java
+++ b/src/main/java/org/openpnp/gui/tablemodel/PartsTableModel.java
@@ -104,10 +104,10 @@ public class PartsTableModel extends AbstractObjectTableModel implements Propert
                 Length oldLength = part.getHeight();
                 if (length.getUnits() == null) {
                     if (oldLength != null) {
-                        length.setUnits(oldLength.getUnits());
+                        length = length.changeUnits(oldLength.getUnits());
                     }
                     if (length.getUnits() == null) {
-                        length.setUnits(Configuration.get().getSystemUnits());
+                        length = length.changeUnits(Configuration.get().getSystemUnits());
                     }
                 }
                 part.setHeight(length);

--- a/src/main/java/org/openpnp/gui/tablemodel/PartsTableModel.java
+++ b/src/main/java/org/openpnp/gui/tablemodel/PartsTableModel.java
@@ -102,14 +102,10 @@ public class PartsTableModel extends AbstractObjectTableModel implements Propert
                 value.setDisplayNativeUnits(true);
                 Length length = value.getLength();
                 Length oldLength = part.getHeight();
-                if (length.getUnits() == null) {
-                    if (oldLength != null) {
-                        length = length.changeUnits(oldLength.getUnits());
-                    }
-                    if (length.getUnits() == null) {
-                        length = length.changeUnits(Configuration.get().getSystemUnits());
-                    }
+                if (oldLength != null) {
+                    length = length.changeUnitsIfUnspecified(oldLength.getUnits());
                 }
+                length = length.changeUnitsIfUnspecified(Configuration.get().getSystemUnits());
                 part.setHeight(length);
             }
             else if (columnIndex == 3) {

--- a/src/main/java/org/openpnp/machine/reference/feeder/wizards/ReferenceStripFeederConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/wizards/ReferenceStripFeederConfigurationWizard.java
@@ -669,7 +669,7 @@ public class ReferenceStripFeederConfigurationWizard extends AbstractConfigurati
                                  if (standardPitchIncrements == 0) {
                                      throw new Exception("The same part was selected both times");
                                  }
-                                 partPitchMM.setValue(2.0 * standardPitchIncrements);
+                                 partPitchMM = new Length(2.0 * standardPitchIncrements,LengthUnit.Millimeters);
 
                                  final Length partPitch_ = partPitchMM.convertToUnits(firstPartLocation.getUnits());
                                  SwingUtilities.invokeLater(new Runnable() {

--- a/src/main/java/org/openpnp/model/Length.java
+++ b/src/main/java/org/openpnp/model/Length.java
@@ -36,7 +36,8 @@ public class Length {
     private LengthUnit units;
 
     public Length() {
-
+        this.value = 0;
+        this.units = null;
     }
 
     public Length(double value, LengthUnit units) {
@@ -89,16 +90,12 @@ public class Length {
         return value;
     }
 
-    public void setValue(double value) {
-        this.value = value;
-    }
-
     public LengthUnit getUnits() {
         return units;
     }
 
-    public void setUnits(LengthUnit units) {
-        this.units = units;
+    public Length changeUnits(LengthUnit units) {
+        return new Length(value,units);
     }
 
     public Length convertToUnits(LengthUnit units) {
@@ -180,7 +177,7 @@ public class Length {
 
         s = s.trim();
 
-        Length length = new Length(0, null);
+        LengthUnit units = null;
         // find the index of the first character that is not a -, . or digit.
         int startOfUnits = -1;
         for (int i = 0; i < s.length(); i++) {
@@ -199,7 +196,7 @@ public class Length {
             unitsString = unitsString.replace('u', 'μ'); //convert u to μ
             for (LengthUnit lengthUnit : LengthUnit.values()) {
                 if (lengthUnit.getShortName().equalsIgnoreCase(unitsString)) {
-                    length.setUnits(lengthUnit);
+                    units = lengthUnit;
                     break;
                 }
             }
@@ -208,19 +205,17 @@ public class Length {
             valueString = s;
         }
 
-        if (requireUnits && length.getUnits() == null) {
+        if (requireUnits && units == null) {
             return null;
         }
 
         try {
             double value = Double.parseDouble(valueString);
-            length.setValue(value);
+            return new Length(value,units);
         }
         catch (Exception e) {
             return null;
         }
-
-        return length;
     }
 
     @Override
@@ -289,10 +284,10 @@ public class Length {
         }
         if (length.getUnits() == null) {
             if (defaultToOldUnits) {
-                length.setUnits(oldLength.getUnits());
+                length = length.changeUnits(oldLength.getUnits());
             }
             if (length.getUnits() == null) {
-                length.setUnits(configuration.getSystemUnits());
+                length = length.changeUnits(configuration.getSystemUnits());
             }
         }
         if (location.getUnits() == null) {

--- a/src/main/java/org/openpnp/model/Length.java
+++ b/src/main/java/org/openpnp/model/Length.java
@@ -94,8 +94,12 @@ public class Length {
         return units;
     }
 
-    public Length changeUnits(LengthUnit units) {
-        return new Length(value,units);
+    public Length changeUnitsIfUnspecified(LengthUnit units) {
+        if (this.units == null) {
+            return new Length(value,units);
+        } else {
+            return this;
+        }
     }
 
     public Length convertToUnits(LengthUnit units) {
@@ -159,6 +163,14 @@ public class Length {
 
     public static double convertToUnits(double value, LengthUnit fromUnits, LengthUnit toUnits) {
         return new Length(value, fromUnits).convertToUnits(toUnits).getValue();
+    }
+
+    public static Length parseWithDefaultUnits(String s,LengthUnit units) {
+        Length length = parse(s);
+        if (length!=null) {
+            length = length.changeUnitsIfUnspecified(units);
+        }
+        return length;
     }
 
     public static Length parse(String s) {
@@ -282,14 +294,10 @@ public class Length {
         else if (field == Field.Z) {
             oldLength = location.getLengthZ();
         }
-        if (length.getUnits() == null) {
-            if (defaultToOldUnits) {
-                length = length.changeUnits(oldLength.getUnits());
-            }
-            if (length.getUnits() == null) {
-                length = length.changeUnits(configuration.getSystemUnits());
-            }
+        if (defaultToOldUnits) {
+            length = length.changeUnitsIfUnspecified(oldLength.getUnits());
         }
+        length = length.changeUnitsIfUnspecified(configuration.getSystemUnits());
         if (location.getUnits() == null) {
             throw new Error("This can't happen!");
         }


### PR DESCRIPTION
# Description

There is lots of code which is written as if the `Length` class is immutable. But, to my great surprise, it is not! This patch removes the Length methods which change its value. It changes a small amount of code which uses those methods to use alternatives which return a new `Length` object.

# Justification

## Justification in code that uses Length

For example, class `ReferenceNozzleTip` has `public Length getMaxPartHeight()` to allow other code to access an attribute.

It also has `public void setMaxPartHeight(Length maxPartHeight)` to allow other code to change that attribute.

It is somewhat surprising that this property could also be changed by code such as `tip.getMaxPartHeight().setValue()`. Thats not how we want this API to be used, and it is not how we want future APIs (exposing a `Length` attribute) to be written. The presence of methods  `Length.setValue` and `Length.setUnits` feels like a bug in the architecture.

## Justification within Length

If `Length` was intended to be a mutable shareable object, then various optimisations inside `Length` are confusing and unsafe. For example, `convertToUnits` has   `if(this.units==units) return this;` which means the return value is sometimes shared, and sometimes not.

## Justification of consistency

The `Location` class has a similar interface, and is used in a similar manner, and it **is** immutable. I find it surprising for these two classes to be different.

# Instructions for Use

There is no end user impact.

# Implementation Details
1. How did you test the change? Be descriptive. Untested code will not be accepted. -- unit tests pass
2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)? -- yes
3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing. -- Yes, and `org.openpnp.model.Length` is one of the lowest level classes!
4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted. -- unit tests pass.
