### PR TITLE
Trigger the update to the placement counter on the status bar after c…

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@ a complete change list, only those that may directly interest or affect users.
 ## Bug Fixes
 
 * Fix bug causing manual nozzle tip changes to get swallowed if the corresponding placement is set to defer errors. [PR 1741](https://github.com/openpnp/openpnp/pull/1741)
+* Fix bug preventing the status bar "Placements N / M" from updating when viewing the wrong tab in the main window. [PR 1724](https://github.com/openpnp/openpnp/pull/1724)
 
 
 # 2024 Q4

--- a/src/main/java/org/openpnp/gui/tablemodel/PlacementsHolderPlacementsTableModel.java
+++ b/src/main/java/org/openpnp/gui/tablemodel/PlacementsHolderPlacementsTableModel.java
@@ -401,7 +401,6 @@ public class PlacementsHolderPlacementsTableModel extends AbstractObjectTableMod
                 // TODO STOPSHIP: Both of these are huge performance hogs and do not belong
                 // in the render process. At the least we should cache this information but it
                 // would be better if the information was updated out of band by a listener.
-                jobPlacementsPanel.updateActivePlacements();
                 return MainFrame.get().getJobTab().getJob()
                         .retrievePlacedStatus(placementsHolderLocation, placement.getId());
             case 9:

--- a/src/main/java/org/openpnp/machine/reference/ReferencePnpJobProcessor.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferencePnpJobProcessor.java
@@ -1130,6 +1130,14 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
             totalPartsPlaced++;
             
             scriptComplete(plannedPlacement, placementLocation);
+
+            // update placements within the UI thread (we are currently in a machine thread)
+            SwingUtilities.invokeLater(() -> {
+                MainFrame f = MainFrame.get();
+                if (f != null) {
+                    f.getJobTab().getJobPlacementsPanel().updateActivePlacements();
+                }
+            });
             
             return this;
         }


### PR DESCRIPTION
# Description

This status bar was unreliable.

It was updating when the Job tab is open. But, if the user switches to a different tab, this data was frozen even though placements were progressing.

![image](https://github.com/user-attachments/assets/3d8676f0-b5ca-4dba-9f35-c55f21305748)

Previously the update to this status was triggered by the *rendering* of the job table 😵‍💫 The table is not rendered when viewing a different tab, so no status bar update was triggered.

This patch moves the trigger to the job processor, after completing a placement.

# Justification

The status bar was misleading when it did not update. This fix helps all users.

# Instructions for Use

No instructions are required; it fixes a feature to work as expected.

# Implementation Details
1. How did you test the change? Be descriptive. Untested code will not be accepted.
   * Only tested on a simulated machine so far
   * Various regressions tests: The GUI interactions update this status as expected (for example ticking a placement as complete, or enabled/disabled). The status updates when viewing the job tab during job activity.
   * The status updates when viewing the part tab during job activity too. Previously it would have been frozen in this tab.
3. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)? -- yes
4. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing. -- no changes
5. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted. -- all tests pass
