### PR TITLE
Fix PandaplacerVisionFeeder pick calibrated position calculation

### DIFF
--- a/src/main/java/org/openpnp/util/FeederVisionHelper.java
+++ b/src/main/java/org/openpnp/util/FeederVisionHelper.java
@@ -672,14 +672,24 @@ public class FeederVisionHelper {
                                 Location pickLocation = partLocation.convertToUnits(LengthUnit.Millimeters);
                                 Location relativePickLocation = pickLocation
                                         .subtract(hole1Location);
-                                // rotate from old angle
-                                relativePickLocation =  relativePickLocation.rotateXy(-pickLocation.getRotation())
+                                // rotate by tape angle, so dX multiply of partPitchMinMm, and dY pick-hole line distance
+                                relativePickLocation =  relativePickLocation.rotateXy(-angleTape)
                                         .derive(null, null, null, 0.0);
                                 // normalize to a nominal local pick location according to EIA 481
+                                // vertical hole to part distances are 3.5, 5.5, 7.5, 11.5mm for 8, 12, 16, 24mm tapes
                                 if (normalizePickLocation) {
+                                    double dY = Math.abs(relativePickLocation.getY());
+                                    if (dY > sprocketHoleToPartGridMm / 2) {
+                                        dY = Math.round((dY - sprocketHoleToPartMinMm)/sprocketHoleToPartGridMm)*sprocketHoleToPartGridMm + sprocketHoleToPartMinMm;
+                                        if (relativePickLocation.getY() < 0) {
+                                            dY = -dY;
+                                        }
+                                    } else {
+                                        dY = relativePickLocation.getY();
+                                    }
                                     relativePickLocation = new Location(LengthUnit.Millimeters,
                                             Math.round(relativePickLocation.getX()/partPitchMinMm)*partPitchMinMm,
-                                            -sprocketHoleToPartMinMm+Math.round((relativePickLocation.getY()+sprocketHoleToPartMinMm)/sprocketHoleToPartGridMm)*sprocketHoleToPartGridMm,
+                                            dY,
                                             0, 0);
                                 }
                                 // calculate the new pick location with the new hole 1 location and tape angle


### PR DESCRIPTION
# Description
PandaplacerVisionFeeder wrongly calculates calibrated pick position under some circumstances related to angle rotation.
3 issues:
- typo angleTape vs. part rotation angle
- wrong logic for rounding 3.5, 5.5, 7.5, (9.5), 11.5mm distance
- rounding provides also wrong result for negative distance (because of tape angle)

Table of rounding pick-to-hole distance
relativePickLocation.getY() | Required result| Old algorithm| Fixed
-- | -- | -- | --
0 |   | 0,5 | -0,5
0,4 |   | 0,5 | -0,5
0,7 |   | 0,5 | 1,5
1 |   | 0,5 | 1,5
1,4 |   | 0,5 | 1,5
1,6 |   | 2,5 | 1,5
2 |   | 2,5 | 1,5
2,4 |   | 2,5 | 1,5
2,6 | 3,5 | 2,5 | 3,5
3 | 3,5 | 2,5 | 3,5
3,4 | 3,5 | 2,5 | 3,5
3,5 | 3,5 | 4,5 | 3,5
3,6 | 3,5 | 4,5 | 3,5
4 | 3,5 | 4,5 | 3,5
4,4 | 3,5 | 4,5 | 3,5
4,6 | 5,5 | 4,5 | 5,5
5 | 5,5 | 4,5 | 5,5
5,4 | 5,5 | 4,5 | 5,5
5,6 | 5,5 | 6,5 | 5,5
6 | 5,5 | 6,5 | 5,5
6,4 | 5,5 | 6,5 | 5,5
6,6 | 7,5 | 6,5 | 7,5
7 | 7,5 | 6,5 | 7,5
7,4 | 7,5 | 6,5 | 7,5
7,6 | 7,5 | 8,5 | 7,5
8 | 7,5 | 8,5 | 7,5
9 |   | 8,5 | 9,5
10 | 11,5 | 10,5 | 9,5
11 | 11,5 | 10,5 | 11,5
12 | 11,5 | 12,5 | 11,5

# Justification
General bugfix

# Instructions for Use
Use Pandaplacer and test calibrated pick position to see that now should not pick beyond feeder

# Implementation Details
1. Use Pandaplacer feeder in different rack positions and check different part angles to see that now should work, i.e. calibrated position is intended
2. yes
3. no
4. yes
