### PR TITLE
A menu to copy the machine position to the clipboard

### DIFF
--- a/src/main/resources/org/openpnp/translations.properties
+++ b/src/main/resources/org/openpnp/translations.properties
@@ -791,6 +791,7 @@ LogPanel.SettingsPanel.Border.title=Global Logging Settings
 MachineControls.Action.Home=Home
 MachineControls.Action.Start=Start
 MachineControls.Action.Stop=Stop
+MachineControls.Action.Copy=Copy
 MachineControls.Label=Machine Controls
 MachineSetup.JobProcessors.ReferencePnpJobProcessor.Label.JobOrder=Job order
 MachineSetup.JobProcessors.ReferencePnpJobProcessor.lblPlannerStrategy.text=Nozzle tip loading strategy


### PR DESCRIPTION
# Description

The main window status bar shows the DRO machine position: `X:0.000     Y:0.000     Z:0.000     C:0.000    `

This patch adds this right-click popup menu, with a single "Copy" menu item to copy that text on to the clipboard.

![image](https://github.com/user-attachments/assets/7d85d44d-9943-49e7-a347-c9cefc10fae5)

# Justification
It is sometimes useful to share machine positions outside of Openpnp.

# Instructions for Use
A right-click menu should be discovered by anyone needing this feature.

# Backwards Compatibility
Previously a mouse click with any button would toggle the DRO "tare" feature. This changes the right-click button behavior.

# Implementation Details
1. How did you test the change? Be descriptive. Untested code will not be accepted.
    * The function for updating the DRO on screen has been refactored, with a new function for calculating the DRO string. This display feature has been manually tested
    * The left-click (and middle-click!) tare feature work
    * The right-click copy menu has been manually tested by pasting the DRO text.
    * I manually confirmed the pasted DRO text matched the DRO display.
3. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)? -- yes
4. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing. -- no changes
5. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted. -- test pass
