### PR TITLE
Fix GCode suggestion in case no previous GCode is available, causes a…

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/solutions/GcodeDriverSolutions.java
+++ b/src/main/java/org/openpnp/machine/reference/solutions/GcodeDriverSolutions.java
@@ -1116,10 +1116,10 @@ public class GcodeDriverSolutions implements Solutions.Subject {
                     if (suggestedCommand.isEmpty()) {
                         r += "<p>Delete it.</p>\n";
                     } else {
-                        r += "<p>Suggested cgode is:</p><pre>"+suggestedCommand+"</pre>\n";
+                        r += "<p>Suggested gcode is:</p><pre>"+suggestedCommand+"</pre>\n";
                     }
                     String prev = gcodeDriver.getCommand(headMountable, commandType);
-                    if(!prev.isEmpty()) {
+                    if(prev != null && !prev.isEmpty()) {
                         r += "<p>Current gcode is:</p><pre>"+prev+"</pre>\n";
                     }
                     r += "</html>";


### PR DESCRIPTION
# Description
Suggested G-Code solutions in the basic milestone can generate a null pointer dereference error if no previous G-Code is available. This PR fixes that.

# Justification
See https://groups.google.com/g/openpnp/c/0k8frYFxfEc/m/_BLcZwoODQAJ

# Implementation Details
1. How did you test the change? Be descriptive. Untested code will not be accepted. **yes, configured a machine from scratch**
2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)? **yes**
3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing. **no**
4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted. **yes**
