### PR TITLE
Do not show table cell editor immediately when click on unselected cell

### DIFF
--- a/src/main/java/org/openpnp/gui/components/AutoSelectTextTable.java
+++ b/src/main/java/org/openpnp/gui/components/AutoSelectTextTable.java
@@ -22,6 +22,7 @@ import javax.swing.SortOrder;
 import javax.swing.SwingUtilities;
 import javax.swing.table.DefaultTableModel;
 import javax.swing.table.TableColumnModel;
+import javax.swing.table.TableCellEditor;
 import javax.swing.table.TableModel;
 import javax.swing.text.JTextComponent;
 
@@ -157,6 +158,11 @@ public class AutoSelectTextTable extends JTable {
      * Override to provide Select All editing functionality
      */
     public boolean editCellAt(int row, int column, EventObject e) {
+        TableCellEditor editor = getCellEditor(row, column);
+        if (!isCellSelected(row, column)) {
+            // do not show editor when clicked cell from outside. First select cell and next open editor
+            return false;
+        }
         boolean result = super.editCellAt(row, column, e);
 
         if (isSelectAllForMouseEvent || isSelectAllForActionEvent || isSelectAllForKeyEvent) {


### PR DESCRIPTION
# Description
When selecting row/cell in a JTable object, Parts, Packages, Jobs, .... then first click on any cell beyond current column opens cell editor or makes checkbox action. It is potentially dangerous because majority of clicks are for row selection. Especially at Job tab to select particular part where unless clicked on a "safe" cell then typically opens combobox list where can be made unintended change. Now the editor opens when cell is selected.

# Justification
General usability improvement

# Instructions for Use
Open e.g. Parts tab, click on a Package cell. Only row/cell is selected. Next click will open combobox list

# Implementation Details
1. How did you test the change? manually in GUI
2. Did you follow the ? yes
3. no
4. yes
