### PR TITLE
Fix the camera view Highest Quality Rendering option so that the image always fits in the view

### DIFF
--- a/src/main/java/org/openpnp/gui/components/CameraView.java
+++ b/src/main/java/org/openpnp/gui/components/CameraView.java
@@ -600,8 +600,8 @@ public class CameraView extends JComponent implements CameraListener {
         if (renderingQuality == RenderingQuality.BestScale) {
             // Bring to an integral scaling factor.
             double scalingFactor = lastSourceWidth > scaledWidth ? 
-                    1./Math.max(1, Math.round(lastSourceWidth/scaledWidth))
-                    : Math.max(1, Math.round(scaledWidth/lastSourceWidth));
+                    1./Math.max(1, Math.ceil(lastSourceWidth/scaledWidth))
+                    : Math.max(1, Math.floor(scaledWidth/lastSourceWidth));
             scaledWidth = (int)(lastSourceWidth*scalingFactor);
             scaledHeight = (int)(lastSourceHeight*scalingFactor);
         }


### PR DESCRIPTION
# Description
This corrects the image scaling when the highest quality rendering option is selected so that the un-zoomed image always fits within the camera view pane regardless of how the camera view pane is sized by the operator. This change only effects what is visible to the operator on the GUI and has no effect on the machine vision performed internally by OpenPnP. 

# Justification
Prior to this change, depending on how the camera view pane was sized, it was possible for portions of the camera image to extend beyond the border of the camera view pane and thus be hidden from the operator even when the image is zoomed all the way out. 

# Instructions for Use
Right click in the camera view and select Rendering Quality -> Highest Quality (best scale), the camera images will now be scaled so that they always fit within the camera view pane regardless of how the viewing pane is sized. This will in most cases make the image smaller than what the operator may have previously seen but at least the entire image will now always be visible. Note, to make the image as large as possible but still fit within the camera view pane, select Rendering Quality -> High Quality instead (this behavior is unchanged by this PR).

# Implementation Details
1. How did you test the change? **Observed the camera image as the camera view pane was resized and verified that the entire image always remained visible. This was verified with all three Rendering Quality settings.**
2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)? **Yes**
3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing. **No changes.**
4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted. **All tests ran and all passed.**
