### PR TITLE
this warning should be a PlainIssue

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/solutions/KinematicSolutions.java
+++ b/src/main/java/org/openpnp/machine/reference/solutions/KinematicSolutions.java
@@ -207,21 +207,14 @@ public class KinematicSolutions implements Solutions.Subject {
                                     else {
                                         if (bothSafeZoneHighAndLowEnabled
                                             && hm.getSafeZ().convertToUnits(LengthUnit.Millimeters).getValue() > 2.0) {
-                                            solutions.add(new Solutions.Issue(
+                                            solutions.add(new Solutions.PlainIssue(
                                                     hm,
                                                     "Unconventional Z Axis on "+hm.getName()+".",
                                                     "The Safe Z of "+hm.getName()+" is positive, which is unconventional. "+
                                                     "OpenPnp typically uses Z coordinates that have Z=0 when the nozzle is retracted, with the PCB surface in the negative Z range. "+
                                                     "Please read the Wiki to understand the implications of not following this convention.",
                                                     Solutions.Severity.Warning,
-                                                    "https://github.com/openpnp/openpnp/wiki/Machine-Axes#a-word-about-z-coordinates") {
-                                                @Override
-                                                public void setState(Solutions.State state) throws Exception {
-                                                    axisZ.setSafeZoneLowEnabled(state != State.Solved);
-                                                    axisZ.setSafeZoneHighEnabled(state != State.Solved);
-                                                    MainFrame.get().getIssuesAndSolutionsTab().findIssuesAndSolutions();
-                                                }
-                                            });
+                                                    "https://github.com/openpnp/openpnp/wiki/Machine-Axes#a-word-about-z-coordinates"));
                                         }
 
                                         safeZSolved = solutions.add(new Solutions.Issue(


### PR DESCRIPTION
# Description

This fixes issue #1735. A bug where the "unconventional Z axis" I&S warning could not be dismissed.

The bug was introduced in my PR #1682. In that PR markmaker suggested I make this warning message its own Solution, and pointed out some code to copy. But I copied too much of the surrounding code.

The fix mostly involves deleting code. Changing the class to `PlainIssue` makes this a warning that can be dismissed, rather than an issue with code that implements its own status changes.

# Justification
I propose including this bug fix in the imminent release. Issue #1735 turns this warning into a hard error, which is problematic for users affected by this situation. We want to warn them that their approach is unconventional, but not block them from continuing.

It would be good for the user who found this bug to confirm he is satisfied using a daily build

# Instructions for Use
n/a.

# Implementation Details
1. How did you test the change?
   * tested on my machine with my normal configuration - the warning is not shown
   * I set a limited safe z zone, which is indicative of the unconventional z axis configuration. The warning was shown
   * Pressing the "dismiss" button changes the I&S 
3. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)? -- yes
4. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing. -- no changes
5. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted. -- tests pass
