### PR TITLE
Copy vision provider when I&S replaces cameras

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/solutions/CameraSolutions.java
+++ b/src/main/java/org/openpnp/machine/reference/solutions/CameraSolutions.java
@@ -589,6 +589,7 @@ public class CameraSolutions implements Solutions.Subject  {
         camera.setAfterCaptureLightOff(oldCamera.isAfterCaptureLightOff());
         camera.setUserActionLightOn(oldCamera.isUserActionLightOn());
         camera.setAntiGlareLightOff(oldCamera.isAntiGlareLightOff());
+        camera.setVisionProvider(oldCamera.getVisionProvider());
         return camera;
     }
 


### PR DESCRIPTION
# Description
When Issues & Solutions replaces the default ImageCamera with the OpenPnpCaptureCamera, the new replacement does not have a vision provider assigned.  This change corrects that by copying the image provider from the old camera to the replacement camera.

# Justification
If an operator starts with a clean configuration (no machine.xml) and follows the I&S steps, the cameras end up without any vision provider assigned to them. This problem is not obvious until the vision provider is requested when certain feeders (ReferenceLeverFeeder for one) are used.

# Instructions for Use
No special instructions, just use I&S as usual.

# Implementation Details
1. How did you test the change? Be descriptive. Untested code will not be accepted. **Started OpenPnP without a machine.xml file and proceeded through the I&S steps until images from the real machine cameras were visible. Then exited OpenPnP and examined the machine.xml file to verify that a vision provider was assigned to each camera.**
2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)? **Yes**
3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing. **No changes.**
4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted. **All tests ran and passed.**
