### PR TITLE
Most script events do nothing

### DIFF
--- a/src/main/java/org/openpnp/scripting/ScriptFileWatcher.java
+++ b/src/main/java/org/openpnp/scripting/ScriptFileWatcher.java
@@ -117,7 +117,7 @@ public class ScriptFileWatcher {
         menu.addMenuListener(new MenuListener() {
             @Override
             public void menuSelected(MenuEvent e) {
-                btnClearPool.setEnabled(scripting.getScriptingEnginePoolObjectCount() > 0);
+                btnClearPool.setEnabled(scripting.enableClearScriptingEnginePool());
             }
 
             @Override

--- a/src/main/java/org/openpnp/scripting/Scripting.java
+++ b/src/main/java/org/openpnp/scripting/Scripting.java
@@ -34,10 +34,12 @@ public class Scripting {
     private final File eventsDirectory;
     private final HashMap<String, String> extensionToEngineNameMap;
     private final GenericKeyedObjectPool<String, ScriptEngine> enginePool;
+    private final HashSet<String> eventsWithoutScripts;
 
     public Scripting(File scriptsDirectory) {
         this.scriptsDirectory = scriptsDirectory;
         extensionToEngineNameMap = new HashMap<>();
+        eventsWithoutScripts = new HashSet<>();
         enginePool = new GenericKeyedObjectPool<>(
                 new ScriptEngineKeyedPooledObjectFactory(this.manager));
         // Allow unlimited engines, but evict all but five per key after a short idle time
@@ -202,11 +204,34 @@ public class Scripting {
         }
     }
 
+    // This function returns false if event has some scripts, or if we do not yet know.
+    // It returns true if and only if we have found there to be no scripts
+    // associated with this event
+    public Boolean hasNoScript(String event) {
+        if (eventsDirectory == null) {
+            return true;
+        }
+
+        if(eventsWithoutScripts.contains(event)) {
+            // We know for certain that this event will not run any scripts.
+            // This might enable some optimisation where a client can avoid
+            // preparing all the script parameters if it knows there is no
+            // script to receive them.
+            return true;
+        } else {
+            return false;
+        }
+    }
+
     public void on(String event, Map<String, Object> globals) throws Exception {
         Logger.trace("Scripting.on " + event);
         if (eventsDirectory == null) {
             return;
         }
+        if (hasNoScript(event)) {
+            return;
+        }
+        Boolean foundEventScript = false;
         for (File script : FileUtils.listFiles(eventsDirectory, getExtensions(), false)) {
             if (!script.isFile()) {
                 continue;
@@ -214,12 +239,25 @@ public class Scripting {
             if (FilenameUtils.getBaseName(script.getName())
                              .equals(event)) {
                 Logger.trace("Scripting.on found " + script.getName());
+                foundEventScript = true;
                 execute(script, globals);
             }
         }
+        if (!foundEventScript) {
+            // Remember that this event does not have any scripts. This saves
+            // having to iterate over the directory when the same event
+            // is triggered subsequently
+            eventsWithoutScripts.add(event);
+        }
+    }
+
+    public Boolean enableClearScriptingEnginePool() {
+        return (getScriptingEnginePoolObjectCount() > 0) || (!eventsWithoutScripts.isEmpty());
     }
 
     public void clearScriptingEnginePool() {
+        eventsWithoutScripts.clear();
+
         if (enginePool.listAllObjects()
                       .size() == 0) {
             Logger.info("No scripting engines in pool, nothing to do");


### PR DESCRIPTION
# Description

In PR #1688, Jan noted that in more than 99% of all events, no script will run. This patch introduces 2 optimisations for this common case.

# Justification

## Optimisation 1

Openpnp has to do quite a bit of work to establish that no script will be run. It has to open the `~/.openpnp2/scripts/Events/` directory, iterate over *all* the file entries in the directory, and process the file names.

In this patch, the event name is added to a HashSet if that iteration completes without finding any matching script files. When the same event is triggered a subsequent time, the HashSet allows it to skip the (relatively) expensive filesystem IO work.

Timing with java `System.nanoTime()` shows that this saves approximately 40µs on a system with no event scripts, on each call to `Scripting.on()`. Each saving is tiny, but it adds up. Note there are now lots of script events for micro-operations: Feeder.BeforeFeed, Feeder.AfterFeed, Nozzle.BeforePick, Nozzle.AfterPick, etc. This saves 40µs on each one.

One nice feature of this optimisation is that the implementation impact is limited to the Scripting class. The `feed()` method is 80µs faster (in the common case) with no changes.

The "Clear Scripting Engine Pool" menu handler has been extended to clear this HashMap too. This menu is now needed when adding a script. That will be familiar to script users, who currently need to use this menu after changing a script. I will add this to the wiki after merge.

## Optimisation 2

A client subsystem wishing to trigger a scripting event needs to prepare a HashMap of script parameters.

In most cases this is a very quick operation, and no optimisation is justified. However, if the process of preparing a HashMap is expensive then the caller can use a new method which allows it to skip the whole process if the scripting subsystem already knows that there are no scripts.

This optimisation is used by the caller of Job.Placement.BeforeAssembly, saving 110µs in the common case.

# Instructions for Use

The only user-visible change is noted above; the need to use the "Clear Scripting Engine Pool" menu after adding a script, not just when changing a script.

# Implementation Details
1. How did you test the change? Be descriptive. Untested code will not be accepted. -- tested on simulated machine. performance testing using `nanoTime()`
2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)? -- yes
3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing. -- no changes
4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted. -- tests pass
