### PR TITLE
draw the yellow footprint reticle on the bottom camera too. This is u…

### DIFF
--- a/src/main/java/org/openpnp/gui/PackageVisionPanel.java
+++ b/src/main/java/org/openpnp/gui/PackageVisionPanel.java
@@ -257,18 +257,24 @@ public class PackageVisionPanel extends JPanel {
 
     private void showReticle() {
         try {
-            Camera camera = Configuration.get().getMachine().getDefaultHead().getDefaultCamera();
-            CameraView cameraView = MainFrame.get().getCameraViews().getCameraView(camera);
-            if (cameraView == null) {
-                return;
-            }
-            cameraView.removeReticle(PackageVisionPanel.class.getName());
-            Reticle reticle = new FootprintReticle(footprint);
-            cameraView.setReticle(PackageVisionPanel.class.getName(), reticle);
+            // Add the reticle to the top camera
+            showReticleCamera(Configuration.get().getMachine().getDefaultHead().getDefaultCamera());
+            // Add the reticle to the bottom camera
+            for (Camera camera : Configuration.get().getMachine().getCameras()) { showReticleCamera(camera); }
         }
         catch (Exception e) {
             e.printStackTrace();
         }
+    }
+
+    private void showReticleCamera(Camera camera) {
+        CameraView cameraView = MainFrame.get().getCameraViews().getCameraView(camera);
+        if (cameraView == null) {
+            return;
+        }
+        cameraView.removeReticle(PackageVisionPanel.class.getName());
+        Reticle reticle = new FootprintReticle(footprint);
+        cameraView.setReticle(PackageVisionPanel.class.getName(), reticle);
     }
 
     private Pad getSelectedPad() {


### PR DESCRIPTION
# Description & Justification

The yellow package footprint reticle is useful for various purposes. Currently it is only drawn on the top camera view, where it is useful for checking placement alignment and orientation using the top camera to view the board.

This patch adds the same reticle to the bottom camera. This is useful with parts which are distinctive when viewed from below, for checking the feeder rotation-on-tape value.

# Instructions for Use
The bottom camera feature works the same as the existing top camera feature.

# Implementation Details
1. How did you test the change? Be descriptive. Untested code will not be accepted. -- tested on simulated machine only so far. Test on a real machine to follow.
2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)? -- yes
3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing. -- no changes
4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted. -- tests pass
