### PR TITLE
Through-Hole Parts and Dynamic Safe Z

### DIFF
--- a/src/main/java/org/openpnp/gui/PartsPanel.java
+++ b/src/main/java/org/openpnp/gui/PartsPanel.java
@@ -26,6 +26,7 @@ import java.awt.datatransfer.Clipboard;
 import java.awt.datatransfer.DataFlavor;
 import java.awt.datatransfer.StringSelection;
 import java.awt.event.ActionEvent;
+import java.awt.event.MouseEvent;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.io.StringReader;
@@ -171,7 +172,15 @@ public class PartsPanel extends JPanel implements WizardContainer {
 
         tabbedPane = new JTabbedPane(JTabbedPane.TOP);
 
-        table = new AutoSelectTextTable(tableModel);
+        table = new AutoSelectTextTable(tableModel) {
+            @Override
+            public String getToolTipText(MouseEvent evt) {
+                int column = columnAtPoint(evt.getPoint());
+                if(column==2) { return Translations.getString("PartsTableModel.Column.Height.toolTip"); } //$NON-NLS-1$
+                if(column==3) { return Translations.getString("PartsTableModel.Column.ThroughHoleDepth.toolTip"); } //$NON-NLS-1$
+                return null;
+            }
+        };
         table.setSelectionMode(ListSelectionModel.MULTIPLE_INTERVAL_SELECTION);
         table.setDefaultEditor(org.openpnp.model.Package.class,
                 new DefaultCellEditor(packagesCombo));

--- a/src/main/java/org/openpnp/gui/PartsPanel.java
+++ b/src/main/java/org/openpnp/gui/PartsPanel.java
@@ -177,7 +177,7 @@ public class PartsPanel extends JPanel implements WizardContainer {
             public String getToolTipText(MouseEvent evt) {
                 int column = columnAtPoint(evt.getPoint());
                 if(column==2) { return Translations.getString("PartsTableModel.Column.Height.toolTip"); } //$NON-NLS-1$
-                if(column==3) { return Translations.getString("PartsTableModel.Column.ThroughHoleDepth.toolTip"); } //$NON-NLS-1$
+                if(column==3) { return Translations.getString("PartsTableModel.Column.ThroughBoardDepth.toolTip"); } //$NON-NLS-1$
                 return null;
             }
         };

--- a/src/main/java/org/openpnp/gui/tablemodel/PartsTableModel.java
+++ b/src/main/java/org/openpnp/gui/tablemodel/PartsTableModel.java
@@ -78,7 +78,7 @@ public class PartsTableModel extends AbstractObjectTableModel implements Propert
 
     @Override
     public boolean isCellEditable(int rowIndex, int columnIndex) {
-        return columnIndex >= 1 && columnIndex <= 6;
+        return columnIndex >= 1 && columnIndex <= 7;
     }
 
     @Override

--- a/src/main/java/org/openpnp/gui/tablemodel/PartsTableModel.java
+++ b/src/main/java/org/openpnp/gui/tablemodel/PartsTableModel.java
@@ -40,7 +40,7 @@ public class PartsTableModel extends AbstractObjectTableModel implements Propert
             new String[] {Translations.getString("PartsTableModel.ColumnName.ID"), //$NON-NLS-1$
                     Translations.getString("PartsTableModel.ColumnName.Description"), //$NON-NLS-1$
                     Translations.getString("PartsTableModel.ColumnName.Height"), //$NON-NLS-1$
-                    Translations.getString("PartsTableModel.ColumnName.ThroughHoleDepth"), //$NON-NLS-1$
+                    Translations.getString("PartsTableModel.ColumnName.ThroughBoardDepth"), //$NON-NLS-1$
                     Translations.getString("PartsTableModel.ColumnName.Package"), //$NON-NLS-1$
                     Translations.getString("PartsTableModel.ColumnName.SpeedPercent"), //$NON-NLS-1$
                     Translations.getString("PartsTableModel.ColumnName.BottomVision"), //$NON-NLS-1$
@@ -113,12 +113,12 @@ public class PartsTableModel extends AbstractObjectTableModel implements Propert
                 LengthCellValue value = (LengthCellValue) aValue;
                 value.setDisplayNativeUnits(true);
                 Length length = value.getLength();
-                Length oldDepth = part.getThroughHoleDepth();
+                Length oldDepth = part.getThroughBoardDepth();
                 if (oldDepth != null) {
                     length = length.changeUnitsIfUnspecified(oldDepth.getUnits());
                 }
                 length = length.changeUnitsIfUnspecified(Configuration.get().getSystemUnits());
-                part.setThroughHoleDepth(length);
+                part.setThroughBoardDepth(length);
             }
             else if (columnIndex == 4) {
                 part.setPackage((Package) aValue);
@@ -148,7 +148,7 @@ public class PartsTableModel extends AbstractObjectTableModel implements Propert
             case 2:
                 return new LengthCellValue(part.getHeight(), true);
             case 3:
-                return new LengthCellValue(part.getThroughHoleDepth(), true);
+                return new LengthCellValue(part.getThroughBoardDepth(), true);
             case 4:
                 return part.getPackage();
             case 5:

--- a/src/main/java/org/openpnp/gui/tablemodel/PartsTableModel.java
+++ b/src/main/java/org/openpnp/gui/tablemodel/PartsTableModel.java
@@ -40,6 +40,7 @@ public class PartsTableModel extends AbstractObjectTableModel implements Propert
             new String[] {Translations.getString("PartsTableModel.ColumnName.ID"), //$NON-NLS-1$
                     Translations.getString("PartsTableModel.ColumnName.Description"), //$NON-NLS-1$
                     Translations.getString("PartsTableModel.ColumnName.Height"), //$NON-NLS-1$
+                    Translations.getString("PartsTableModel.ColumnName.ThroughHoleDepth"), //$NON-NLS-1$
                     Translations.getString("PartsTableModel.ColumnName.Package"), //$NON-NLS-1$
                     Translations.getString("PartsTableModel.ColumnName.SpeedPercent"), //$NON-NLS-1$
                     Translations.getString("PartsTableModel.ColumnName.BottomVision"), //$NON-NLS-1$
@@ -47,7 +48,7 @@ public class PartsTableModel extends AbstractObjectTableModel implements Propert
                     Translations.getString("PartsTableModel.ColumnName.Placements"), //$NON-NLS-1$
                     Translations.getString("PartsTableModel.ColumnName.Feeders") //$NON-NLS-1$
     };
-    private Class[] columnTypes = new Class[] {String.class, String.class, LengthCellValue.class,
+    private Class[] columnTypes = new Class[] {String.class, String.class, LengthCellValue.class, LengthCellValue.class,
             Package.class, String.class, BottomVisionSettings.class, FiducialVisionSettings.class, Integer.class, Integer.class};
     private List<Part> parts;
     private PercentConverter percentConverter = new PercentConverter();
@@ -109,15 +110,26 @@ public class PartsTableModel extends AbstractObjectTableModel implements Propert
                 part.setHeight(length);
             }
             else if (columnIndex == 3) {
-                part.setPackage((Package) aValue);
+                LengthCellValue value = (LengthCellValue) aValue;
+                value.setDisplayNativeUnits(true);
+                Length length = value.getLength();
+                Length oldDepth = part.getThroughHoleDepth();
+                if (oldDepth != null) {
+                    length = length.changeUnitsIfUnspecified(oldDepth.getUnits());
+                }
+                length = length.changeUnitsIfUnspecified(Configuration.get().getSystemUnits());
+                part.setThroughHoleDepth(length);
             }
             else if (columnIndex == 4) {
-                part.setSpeed(percentConverter.convertReverse(aValue.toString()));
+                part.setPackage((Package) aValue);
             }
             else if (columnIndex == 5) {
-                part.setBottomVisionSettings((BottomVisionSettings) aValue);
+                part.setSpeed(percentConverter.convertReverse(aValue.toString()));
             }
             else if (columnIndex == 6) {
+                part.setBottomVisionSettings((BottomVisionSettings) aValue);
+            }
+            else if (columnIndex == 7) {
                 part.setFiducialVisionSettings((FiducialVisionSettings) aValue);
             }
         }
@@ -136,16 +148,18 @@ public class PartsTableModel extends AbstractObjectTableModel implements Propert
             case 2:
                 return new LengthCellValue(part.getHeight(), true);
             case 3:
-                return part.getPackage();
+                return new LengthCellValue(part.getThroughHoleDepth(), true);
             case 4:
-                return percentConverter.convertForward(part.getSpeed());
+                return part.getPackage();
             case 5:
-                return part.getBottomVisionSettings();
+                return percentConverter.convertForward(part.getSpeed());
             case 6:
-                return part.getFiducialVisionSettings();
+                return part.getBottomVisionSettings();
             case 7:
-                return part.getPlacementCount();
+                return part.getFiducialVisionSettings();
             case 8:
+                return part.getPlacementCount();
+            case 9:
                 return part.getAssignedFeeders();
             default:
                 return null;

--- a/src/main/java/org/openpnp/machine/reference/ReferenceNozzle.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceNozzle.java
@@ -542,7 +542,7 @@ public class ReferenceNozzle extends AbstractNozzle implements HeadMountable {
                 return nozzleTip.getMaxPartHeight();
             }
             else {
-                return part.getHeight();
+                return part.getHeightForSafeZ();
             }
         }
         return new Length(0, LengthUnit.Millimeters);

--- a/src/main/java/org/openpnp/model/Part.java
+++ b/src/main/java/org/openpnp/model/Part.java
@@ -42,9 +42,9 @@ public class Part extends AbstractPartSettingsHolder {
     private double height;
 
     @Attribute(required = false)
-    private LengthUnit throughHoleDepthUnits = LengthUnit.Millimeters;
+    private LengthUnit throughBoardDepthUnits = LengthUnit.Millimeters;
     @Attribute(required = false)
-    private double throughHoleDepth;
+    private double throughBoardDepth;
 
     private Package packag;
 
@@ -129,26 +129,26 @@ public class Part extends AbstractPartSettingsHolder {
         firePropertyChange("height", oldValue, getHeight());
     }
 
-    public Length getThroughHoleDepth() {
-        return new Length(throughHoleDepth, throughHoleDepthUnits);
+    public Length getThroughBoardDepth() {
+        return new Length(throughBoardDepth, throughBoardDepthUnits);
     }
 
-    public void setThroughHoleDepth(Length depth) {
-        Length oldValue = getThroughHoleDepth();
+    public void setThroughBoardDepth(Length depth) {
+        Length oldValue = getThroughBoardDepth();
         if (depth == null) {
-            this.throughHoleDepth = 0;
-            this.throughHoleDepthUnits = null;
+            this.throughBoardDepth = 0;
+            this.throughBoardDepthUnits = null;
         }
         else {
-            this.throughHoleDepth = depth.getValue();
-            this.throughHoleDepthUnits = depth.getUnits();
+            this.throughBoardDepth = depth.getValue();
+            this.throughBoardDepthUnits = depth.getUnits();
         }
-        firePropertyChange("throughHoleDepth", oldValue, getThroughHoleDepth());
+        firePropertyChange("throughBoardDepth", oldValue, getThroughBoardDepth());
     }
 
     public Length getHeightForSafeZ() {
         // The length that dangles under a nozzle when carried
-        return getHeight().add(getThroughHoleDepth());
+        return getHeight().add(getThroughBoardDepth());
     }
 
     public Package getPackage() {

--- a/src/main/java/org/openpnp/model/Part.java
+++ b/src/main/java/org/openpnp/model/Part.java
@@ -41,6 +41,11 @@ public class Part extends AbstractPartSettingsHolder {
     @Attribute
     private double height;
 
+    @Attribute(required = false)
+    private LengthUnit throughHoleDepthUnits = LengthUnit.Millimeters;
+    @Attribute(required = false)
+    private double throughHoleDepth;
+
     private Package packag;
 
     @Attribute
@@ -122,6 +127,28 @@ public class Part extends AbstractPartSettingsHolder {
             this.heightUnits = height.getUnits();
         }
         firePropertyChange("height", oldValue, getHeight());
+    }
+
+    public Length getThroughHoleDepth() {
+        return new Length(throughHoleDepth, throughHoleDepthUnits);
+    }
+
+    public void setThroughHoleDepth(Length depth) {
+        Length oldValue = getThroughHoleDepth();
+        if (depth == null) {
+            this.throughHoleDepth = 0;
+            this.throughHoleDepthUnits = null;
+        }
+        else {
+            this.throughHoleDepth = depth.getValue();
+            this.throughHoleDepthUnits = depth.getUnits();
+        }
+        firePropertyChange("throughHoleDepth", oldValue, getThroughHoleDepth());
+    }
+
+    public Length getHeightForSafeZ() {
+        // The length that dangles under a nozzle when carried
+        return getHeight().add(getThroughHoleDepth());
     }
 
     public Package getPackage() {

--- a/src/main/resources/org/openpnp/translations.properties
+++ b/src/main/resources/org/openpnp/translations.properties
@@ -1045,13 +1045,13 @@ PartsTableModel.ColumnName.Description=Description
 PartsTableModel.ColumnName.Feeders=Feeders
 PartsTableModel.ColumnName.FiducialVision=FiducialVision
 PartsTableModel.ColumnName.Height=Height
-PartsTableModel.ColumnName.ThroughHoleDepth=Through-Hole Depth
+PartsTableModel.ColumnName.ThroughBoardDepth=Through-Board Depth
 PartsTableModel.ColumnName.ID=ID
 PartsTableModel.ColumnName.Package=Package
 PartsTableModel.ColumnName.Placements=Placements
 PartsTableModel.ColumnName.SpeedPercent=Speed %
 PartsTableModel.Column.Height.toolTip=Part height; the distance between board surface and pick position.
-PartsTableModel.Column.ThroughHoleDepth.toolTip=<html><p width\="500">The length of any through-hole features on the part. That is, the size any feature which is sunken below the board surface when placed. This is added to the Part Height to determine how high the nozzle needs to be lifted when processing Dynamic Safe Z.<br>This should be zero for purely surface-mount parts.</p></html>
+PartsTableModel.Column.ThroughBoardDepth.toolTip=<html><p width\="500">The length of any through-board features on the part. That is, the size any feature which is below the board surface when placed. This is added to the Part Height to determine how high the nozzle needs to be lifted when processing Dynamic Safe Z.<br>This should be zero for purely surface-mount parts.</p></html>
 PipelineEditor.FiducialVisionPipeline.title=Fiducial Vision Pipeline
 PipelinePanel.Action.CopyPipeline.Description=Copy the pipeline to the clipboard in text format.
 PipelinePanel.Action.CopyPipeline.errorMessage=Copy failed

--- a/src/main/resources/org/openpnp/translations.properties
+++ b/src/main/resources/org/openpnp/translations.properties
@@ -1045,10 +1045,13 @@ PartsTableModel.ColumnName.Description=Description
 PartsTableModel.ColumnName.Feeders=Feeders
 PartsTableModel.ColumnName.FiducialVision=FiducialVision
 PartsTableModel.ColumnName.Height=Height
+PartsTableModel.ColumnName.ThroughHoleDepth=Through-Hole Depth
 PartsTableModel.ColumnName.ID=ID
 PartsTableModel.ColumnName.Package=Package
 PartsTableModel.ColumnName.Placements=Placements
 PartsTableModel.ColumnName.SpeedPercent=Speed %
+PartsTableModel.Column.Height.toolTip=Part height; the distance between board surface and pick position.
+PartsTableModel.Column.ThroughHoleDepth.toolTip=<html><p width\="500">The length of any through-hole features on the part. That is, the size any feature which is sunken below the board surface when placed. This is added to the Part Height to determine how high the nozzle needs to be lifted when processing Dynamic Safe Z.<br>This should be zero for purely surface-mount parts.</p></html>
 PipelineEditor.FiducialVisionPipeline.title=Fiducial Vision Pipeline
 PipelinePanel.Action.CopyPipeline.Description=Copy the pipeline to the clipboard in text format.
 PipelinePanel.Action.CopyPipeline.errorMessage=Copy failed


### PR DESCRIPTION

# Justification

Dynamic Safe Z lifts a part just enough to clear the obstacles. This height to which it is lifted is based on part height.

But this goes wrong for parts with through-hole features. For example, mechanical alignment pips, through-hole electrical pins, lenses on down-firing leds, and connectors with features that overhang the side of the board.

This was discussed [on google groups](https://groups.google.com/d/msgid/openpnp/8b21ded0-d044-4cc0-a117-31ff3e6a0498n%40googlegroups.com?utm_medium=email&utm_source=footer)

# Description

This PR adds a "Through-Hole Depth" property to Parts. Default zero for backwards compatibility.

There is an extra column on the Parts tab for this new property. There are tooltip messages for the two height fields.

Parts have a new method `getHeightForSafeZ` which is now used in safe z calculations. This method returns the sum of `getPartHeight()` and `getThroughHoleDepth()`.


# Wiki Update
[This section](https://github.com/openpnp/openpnp/wiki/User-Manual#parts) needs an updated screenshot. Also add:
 * **Height:** The physical height of the part as measured with calipers, or found in a data sheet. This is the distance between the board surface, and the point where the nozzle will pick it up. Part height is important because it determines how high above the board OpenPnP will stop when placing the part. You should only need to measure the part height for a specific part once, and then you can refer to the part in as many boards as you like.
 * **Through-Hole Depth:** The size of any through-hole feature which is sunken below the board surface when placed. This is added to the Part Height when determining how high the nozzle needs to be lifted to avoid obstacles when carrying the part. This should be zero for purely surface-mount SMT parts.

# Testing

On the simulated machine:
1. set the Z for the "Upper Strips 1" 0805 simulated strip feeder to -20
2. set the simulated zN1 axis Safe Zone Low to -10
3. perform a simulated pick. Note the DRO moves to -20 for pick, then -10 for safe Z
4. enable Dynamic Safe Z on simulated Nozzle N1
5. perform another simulated pick. Note the DRO moves to -20 for pick, then -9 for safe Z because the part height is 1mm
6. set the TH Depth for the simulated part to 0.5mm
7. perform another simulated pick. Note the DRO moves to -20 for pick, then -8.5 for safe Z.

This has also been tested in a production run placing connectors with a TH mechanical alignment pip.

# Implementation Details
1. How did you test the change? Be descriptive. Untested code will not be accepted. -- as above
5. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)? -- yes
6. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing. -- **YES** `openpnp.model.Part` has a new property, and a new method.
7. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted. -- tests pass
