### PR TITLE
Fix Advanced Camera Calibration GUI problems

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/wizards/ReferenceCameraCalibrationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/wizards/ReferenceCameraCalibrationWizard.java
@@ -307,6 +307,8 @@ public class ReferenceCameraCalibrationWizard extends AbstractConfigurationWizar
                 FormSpecs.DEFAULT_ROWSPEC,
                 FormSpecs.RELATED_GAP_ROWSPEC,
                 FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
                 FormSpecs.UNRELATED_GAP_ROWSPEC,
                 FormSpecs.DEFAULT_ROWSPEC,
                 FormSpecs.UNRELATED_GAP_ROWSPEC,
@@ -518,35 +520,37 @@ public class ReferenceCameraCalibrationWizard extends AbstractConfigurationWizar
         sliderAlpha.setPaintLabels(true);
         sliderAlpha.addChangeListener(sliderAlphaChanged);
         
+        lblNewLabel_3 = new JLabel(Translations.getString(
+                "ReferenceCameraCalibrationWizard.CameraCalibrationPanel.SliderLabel.text")); //$NON-NLS-1$
+        panelCameraCalibration.add(lblNewLabel_3, "4, 36, 7, 1");
+        
         lblNewLabel = new JLabel(Translations.getString(
                 "ReferenceCameraCalibrationWizard.CameraCalibrationPanel.CropInvalidPixelsLabel.text")); //$NON-NLS-1$
         lblNewLabel.setHorizontalAlignment(SwingConstants.TRAILING);
-        panelCameraCalibration.add(lblNewLabel, "2, 36");
-        sliderAlpha.setToolTipText(Translations.getString(
-                "ReferenceCameraCalibrationWizard.CameraCalibrationPanel.AlfaSlider.toolTipText")); //$NON-NLS-1$
-        panelCameraCalibration.add(sliderAlpha, "4, 36, 5, 1");
+        panelCameraCalibration.add(lblNewLabel, "2, 38");
+        panelCameraCalibration.add(sliderAlpha, "4, 38, 5, 1");
         
-        lblNewLabel_3 = new JLabel(Translations.getString(
+        lblNewLabel_38 = new JLabel(Translations.getString(
                 "ReferenceCameraCalibrationWizard.CameraCalibrationPanel.ShowValidPixelsLabel.text")); //$NON-NLS-1$
-        panelCameraCalibration.add(lblNewLabel_3, "10, 36");
+        panelCameraCalibration.add(lblNewLabel_38, "10, 38");
         
         separator_1 = new JSeparator();
-        panelCameraCalibration.add(separator_1, "2, 38, 13, 1");
+        panelCameraCalibration.add(separator_1, "2, 40, 13, 1");
         
         lblNewLabel_33 = new JLabel(Translations.getString(
                 "ReferenceCameraCalibrationWizard.CameraCalibrationPanel.CalibrationResults.text")); //$NON-NLS-1$
         lblNewLabel_33.setHorizontalAlignment(SwingConstants.CENTER);
         lblNewLabel_33.setFont(new Font("Tahoma", Font.BOLD, 14));
-        panelCameraCalibration.add(lblNewLabel_33, "2, 40, 7, 1");
+        panelCameraCalibration.add(lblNewLabel_33, "2, 42, 7, 1");
         
         lblNewLabel_25 = new JLabel("X");
-        panelCameraCalibration.add(lblNewLabel_25, "4, 42");
+        panelCameraCalibration.add(lblNewLabel_25, "4, 44");
         
         lblNewLabel_26 = new JLabel("Y");
-        panelCameraCalibration.add(lblNewLabel_26, "6, 42");
+        panelCameraCalibration.add(lblNewLabel_26, "6, 44");
         
         lblNewLabel_27 = new JLabel("Z");
-        panelCameraCalibration.add(lblNewLabel_27, "8, 42");
+        panelCameraCalibration.add(lblNewLabel_27, "8, 44");
         
         String offsetOrPositionLabel;
         if (isMovable) {
@@ -559,134 +563,134 @@ public class ReferenceCameraCalibrationWizard extends AbstractConfigurationWizar
         }
         lblHeadOffsetOrPosition = new JLabel(offsetOrPositionLabel);
         lblHeadOffsetOrPosition.setHorizontalAlignment(SwingConstants.TRAILING);
-        panelCameraCalibration.add(lblHeadOffsetOrPosition, "2, 44, right, default");
+        panelCameraCalibration.add(lblHeadOffsetOrPosition, "2, 46, right, default");
         
         textFieldXOffset = new JTextField();
         textFieldXOffset.setEditable(false);
-        panelCameraCalibration.add(textFieldXOffset, "4, 44, fill, default");
+        panelCameraCalibration.add(textFieldXOffset, "4, 46, fill, default");
         textFieldXOffset.setColumns(10);
         
         textFieldYOffset = new JTextField();
         textFieldYOffset.setEditable(false);
-        panelCameraCalibration.add(textFieldYOffset, "6, 44, fill, default");
+        panelCameraCalibration.add(textFieldYOffset, "6, 46, fill, default");
         textFieldYOffset.setColumns(10);
         
         textFieldZOffset = new JTextField();
         textFieldZOffset.setEditable(false);
-        panelCameraCalibration.add(textFieldZOffset, "8, 44, fill, default");
+        panelCameraCalibration.add(textFieldZOffset, "8, 46, fill, default");
         textFieldZOffset.setColumns(10);
         
         lblNewLabel_24 = new JLabel(Translations.getString(
                 "ReferenceCameraCalibrationWizard.CameraCalibrationPanel.UnitsPerPixelLabel.text")); //$NON-NLS-1$
         lblNewLabel_24.setHorizontalAlignment(SwingConstants.TRAILING);
-        panelCameraCalibration.add(lblNewLabel_24, "2, 46, right, default");
+        panelCameraCalibration.add(lblNewLabel_24, "2, 48, right, default");
         
         textFieldUnitsPerPixel = new JTextField();
         textFieldUnitsPerPixel.setToolTipText(Translations.getString(
                 "ReferenceCameraCalibrationWizard.CameraCalibrationPanel.UnitsPerPixelTextField.toolTipText")); //$NON-NLS-1$
         textFieldUnitsPerPixel.setEditable(false);
-        panelCameraCalibration.add(textFieldUnitsPerPixel, "4, 46, fill, default");
+        panelCameraCalibration.add(textFieldUnitsPerPixel, "4, 48, fill, default");
         textFieldUnitsPerPixel.setColumns(10);
         
         lblNewLabel_30 = new JLabel(Translations.getString(
                 "ReferenceCameraCalibrationWizard.CameraCalibrationPanel.AtDefaultWorkingPlaneZLabel.text")); //$NON-NLS-1$
-        panelCameraCalibration.add(lblNewLabel_30, "6, 46");
+        panelCameraCalibration.add(lblNewLabel_30, "6, 48");
         
         lblNewLabel_4 = new JLabel(Translations.getString(
                 "ReferenceCameraCalibrationWizard.CameraCalibrationPanel.EstimatedLocatingAccuracyLabel.text")); //$NON-NLS-1$
         lblNewLabel_4.setHorizontalAlignment(SwingConstants.TRAILING);
-        panelCameraCalibration.add(lblNewLabel_4, "2, 48, right, default");
+        panelCameraCalibration.add(lblNewLabel_4, "2, 50, right, default");
         
         textFieldRmsError = new JTextField();
         textFieldRmsError.setToolTipText(Translations.getString(
                 "ReferenceCameraCalibrationWizard.CameraCalibrationPanel.RmsErrorTextField.toolTipText")); //$NON-NLS-1$
         textFieldRmsError.setEditable(false);
-        panelCameraCalibration.add(textFieldRmsError, "4, 48, fill, default");
+        panelCameraCalibration.add(textFieldRmsError, "4, 50, fill, default");
         textFieldRmsError.setColumns(10);
         
         lblNewLabel_29 = new JLabel(Translations.getString(
                 "ReferenceCameraCalibrationWizard.CameraCalibrationPanel.AtDefaultWorkingPlaneZLabel.text")); //$NON-NLS-1$
-        panelCameraCalibration.add(lblNewLabel_29, "6, 48");
+        panelCameraCalibration.add(lblNewLabel_29, "6, 50");
         
         lblNewLabel_40 = new JLabel(Translations.getString(
                 "ReferenceCameraCalibrationWizard.CameraCalibrationPanel.WidthLabel.text")); //$NON-NLS-1$
-        panelCameraCalibration.add(lblNewLabel_40, "4, 50, default, top");
+        panelCameraCalibration.add(lblNewLabel_40, "4, 52, default, top");
         
         lblNewLabel_41 = new JLabel(Translations.getString(
                 "ReferenceCameraCalibrationWizard.CameraCalibrationPanel.HeightLabel.text")); //$NON-NLS-1$
-        panelCameraCalibration.add(lblNewLabel_41, "6, 50");
+        panelCameraCalibration.add(lblNewLabel_41, "6, 52");
         
         lblNewLabel_39 = new JLabel(Translations.getString(
                 "ReferenceCameraCalibrationWizard.CameraCalibrationPanel.PhysicalFieldOfViewLabel.text")); //$NON-NLS-1$
         lblNewLabel_39.setHorizontalAlignment(SwingConstants.TRAILING);
-        panelCameraCalibration.add(lblNewLabel_39, "2, 52, right, default");
+        panelCameraCalibration.add(lblNewLabel_39, "2, 54, right, default");
         
         textFieldWidthFov = new JTextField();
         textFieldWidthFov.setEditable(false);
-        panelCameraCalibration.add(textFieldWidthFov, "4, 52, fill, default");
+        panelCameraCalibration.add(textFieldWidthFov, "4, 54, fill, default");
         textFieldWidthFov.setColumns(10);
         
         textFieldHeightFov = new JTextField();
         textFieldHeightFov.setEditable(false);
-        panelCameraCalibration.add(textFieldHeightFov, "6, 52, fill, default");
+        panelCameraCalibration.add(textFieldHeightFov, "6, 54, fill, default");
         textFieldHeightFov.setColumns(10);
         
         lblNewLabel_42 = new JLabel(Translations.getString(
                 "ReferenceCameraCalibrationWizard.CameraCalibrationPanel.EffectiveFieldOfViewLabel.text")); //$NON-NLS-1$
         lblNewLabel_42.setHorizontalAlignment(SwingConstants.TRAILING);
-        panelCameraCalibration.add(lblNewLabel_42, "2, 54, right, default");
+        panelCameraCalibration.add(lblNewLabel_42, "2, 56, right, default");
         
         textFieldVirtualWidthFov = new JTextField();
         textFieldVirtualWidthFov.setEditable(false);
-        panelCameraCalibration.add(textFieldVirtualWidthFov, "4, 54, fill, default");
+        panelCameraCalibration.add(textFieldVirtualWidthFov, "4, 56, fill, default");
         textFieldVirtualWidthFov.setColumns(10);
         
         textFieldVirtualHeightFov = new JTextField();
         textFieldVirtualHeightFov.setEditable(false);
-        panelCameraCalibration.add(textFieldVirtualHeightFov, "6, 54, fill, default");
+        panelCameraCalibration.add(textFieldVirtualHeightFov, "6, 56, fill, default");
         textFieldVirtualHeightFov.setColumns(10);
         
         lblNewLabel_5 = new JLabel(Translations.getString(
                 "ReferenceCameraCalibrationWizard.CameraCalibrationPanel.XAxisLabel.text")); //$NON-NLS-1$
-        panelCameraCalibration.add(lblNewLabel_5, "4, 56");
+        panelCameraCalibration.add(lblNewLabel_5, "4, 58");
         
         lblNewLabel_6 = new JLabel(Translations.getString(
                 "ReferenceCameraCalibrationWizard.CameraCalibrationPanel.YAxisLabel.text")); //$NON-NLS-1$
-        panelCameraCalibration.add(lblNewLabel_6, "6, 56");
+        panelCameraCalibration.add(lblNewLabel_6, "6, 58");
         
         lblNewLabel_7 = new JLabel(Translations.getString(
                 "ReferenceCameraCalibrationWizard.CameraCalibrationPanel.ZAxisLabel.text")); //$NON-NLS-1$
-        panelCameraCalibration.add(lblNewLabel_7, "8, 56");
+        panelCameraCalibration.add(lblNewLabel_7, "8, 58");
         
         lblNewLabel_2 = new JLabel(Translations.getString(
                 "ReferenceCameraCalibrationWizard.CameraCalibrationPanel.CameraMountingErrorLabel.text")); //$NON-NLS-1$
-        panelCameraCalibration.add(lblNewLabel_2, "2, 58, right, default");
+        panelCameraCalibration.add(lblNewLabel_2, "2, 60, right, default");
         
         textFieldXRotationError = new JTextField();
         textFieldXRotationError.setToolTipText(Translations.getString(
                 "ReferenceCameraCalibrationWizard.CameraCalibrationPanel.XRotationErrorTextField.toolTipText")); //$NON-NLS-1$
         textFieldXRotationError.setEditable(false);
-        panelCameraCalibration.add(textFieldXRotationError, "4, 58, fill, default");
+        panelCameraCalibration.add(textFieldXRotationError, "4, 60, fill, default");
         textFieldXRotationError.setColumns(10);
         
         textFieldYRotationError = new JTextField();
         textFieldYRotationError.setToolTipText(Translations.getString(
                 "ReferenceCameraCalibrationWizard.CameraCalibrationPanel.YRotationErrorTextField.toolTipText")); //$NON-NLS-1$
         textFieldYRotationError.setEditable(false);
-        panelCameraCalibration.add(textFieldYRotationError, "6, 58, fill, default");
+        panelCameraCalibration.add(textFieldYRotationError, "6, 60, fill, default");
         textFieldYRotationError.setColumns(10);
         
         textFieldZRotationError = new JTextField();
         textFieldZRotationError.setToolTipText(Translations.getString(
                 "ReferenceCameraCalibrationWizard.CameraCalibrationPanel.ZRotationErrorTextField.toolTipText")); //$NON-NLS-1$
         textFieldZRotationError.setEditable(false);
-        panelCameraCalibration.add(textFieldZRotationError, "8, 58, fill, default");
+        panelCameraCalibration.add(textFieldZRotationError, "8, 60, fill, default");
         textFieldZRotationError.setColumns(10);
         
         lblNewLabel_8 = new JLabel(Translations.getString(
                 "ReferenceCameraCalibrationWizard.CameraCalibrationPanel.SelectedCalZForPlottingLabel.text")); //$NON-NLS-1$
         lblNewLabel_8.setHorizontalAlignment(SwingConstants.TRAILING);
-        panelCameraCalibration.add(lblNewLabel_8, "2, 60");
+        panelCameraCalibration.add(lblNewLabel_8, "2, 62");
         
         spinnerModel = new SpinnerListModel(calibrationHeightSelections);
         spinnerIndex = new JSpinner(spinnerModel);
@@ -702,12 +706,12 @@ public class ReferenceCameraCalibrationWizard extends AbstractConfigurationWizar
             }
             
         });
-        panelCameraCalibration.add(spinnerIndex, "4, 60");
+        panelCameraCalibration.add(spinnerIndex, "4, 62");
         
         chckbxShowOutliers = new JCheckBox(Translations.getString(
                 "ReferenceCameraCalibrationWizard.CameraCalibrationPanel.ShowOutliersChkBox.text")); //$NON-NLS-1$
         chckbxShowOutliers.addActionListener(showOutliersActionListener);
-        panelCameraCalibration.add(chckbxShowOutliers, "6, 60");
+        panelCameraCalibration.add(chckbxShowOutliers, "6, 62");
 
         
         lblNewLabel_14 = new JLabel(Translations.getString(
@@ -715,18 +719,18 @@ public class ReferenceCameraCalibrationWizard extends AbstractConfigurationWizar
         ));
         lblNewLabel_14.setFont(new Font("Tahoma", Font.BOLD, 13));
         lblNewLabel_14.setHorizontalAlignment(SwingConstants.CENTER);
-        panelCameraCalibration.add(lblNewLabel_14, "4, 62, 3, 1");
+        panelCameraCalibration.add(lblNewLabel_14, "4, 64, 3, 1");
 
         lblNewLabel_9 = new VerticalLabel(String.format(Translations.getString(
                 "ReferenceCameraCalibrationWizard.CameraCalibrationPanel.ResidualError.text") //$NON-NLS-1$
                 + " [%s]", smallDisplayUnits.getShortName()));
         lblNewLabel_9.setVerticalAlignment(SwingConstants.BOTTOM);
         lblNewLabel_9.setRotation(VerticalLabel.ROTATE_LEFT);
-        panelCameraCalibration.add(lblNewLabel_9, "2, 64");
+        panelCameraCalibration.add(lblNewLabel_9, "2, 66");
         
         modelErrorsTimeSequenceView = new SimpleGraphView();
         modelErrorsTimeSequenceView.setFont(new Font("Dialog", Font.PLAIN, 11));
-        panelCameraCalibration.add(modelErrorsTimeSequenceView, "4, 64, 3, 1, fill, fill");
+        panelCameraCalibration.add(modelErrorsTimeSequenceView, "4, 66, 3, 1, fill, fill");
 
         String legend = Translations.getString(
                 "ReferenceCameraCalibrationWizard.CameraCalibrationPanel.Legend.text"); //$NON-NLS-1$
@@ -734,65 +738,65 @@ public class ReferenceCameraCalibrationWizard extends AbstractConfigurationWizar
         lblNewLabel_17 = new JLabel(String.format(Translations.getString(
                 "ReferenceCameraCalibrationWizard.CameraCalibrationPanel.ResidualErrorsLegendDescriptionLabel.text" //$NON-NLS-1$
         ), legend));
-        panelCameraCalibration.add(lblNewLabel_17, "8, 64, 3, 1, left, default");
+        panelCameraCalibration.add(lblNewLabel_17, "8, 66, 3, 1, left, default");
         
         lblNewLabel_10 = new JLabel(Translations.getString(
                 "ReferenceCameraCalibrationWizard.CameraCalibrationPanel.CollectionSequenceNumberLabel.text" //$NON-NLS-1$
         ));
         lblNewLabel_10.setHorizontalAlignment(SwingConstants.CENTER);
-        panelCameraCalibration.add(lblNewLabel_10, "4, 66, 3, 1");
+        panelCameraCalibration.add(lblNewLabel_10, "4, 68, 3, 1");
 
         lblNewLabel_15 = new JLabel(Translations.getString(
                 "ReferenceCameraCalibrationWizard.CameraCalibrationPanel.ResidualErrorXYScatterPlotLabel.text")); //$NON-NLS-1$
         lblNewLabel_15.setFont(new Font("Tahoma", Font.BOLD, 13));
         lblNewLabel_15.setHorizontalAlignment(SwingConstants.CENTER);
-        panelCameraCalibration.add(lblNewLabel_15, "4, 68, 3, 1");
+        panelCameraCalibration.add(lblNewLabel_15, "4, 70, 3, 1");
 
         lblNewLabel_11 = new VerticalLabel(String.format("Y %s [%s]", Translations.getString(
                 "ReferenceCameraCalibrationWizard.CameraCalibrationPanel.ResidualError.text"), //$NON-NLS-1$
                 smallDisplayUnits.getShortName()));
         lblNewLabel_11.setVerticalAlignment(SwingConstants.BOTTOM);
         lblNewLabel_11.setRotation(VerticalLabel.ROTATE_LEFT);
-        panelCameraCalibration.add(lblNewLabel_11, "2, 70");
+        panelCameraCalibration.add(lblNewLabel_11, "2, 72");
 
         modelErrorsScatterPlotView = new SimpleGraphView();
         modelErrorsScatterPlotView.setFont(new Font("Dialog", Font.PLAIN, 11));
-        panelCameraCalibration.add(modelErrorsScatterPlotView, "4, 70, 3, 1, fill, fill");
+        panelCameraCalibration.add(modelErrorsScatterPlotView, "4, 72, 3, 1, fill, fill");
         
         lblNewLabel_18 = new JLabel(Translations.getString(
                 "ReferenceCameraCalibrationWizard.CameraCalibrationPanel.ResidualErrorsXYDescriptionLabel.text")); //$NON-NLS-1$
-        panelCameraCalibration.add(lblNewLabel_18, "8, 70, 3, 1, left, default");
+        panelCameraCalibration.add(lblNewLabel_18, "8, 72, 3, 1, left, default");
 
         lblNewLabel_12 = new JLabel(String.format("X %s [%s]", Translations.getString(
                 "ReferenceCameraCalibrationWizard.CameraCalibrationPanel.ResidualError.text"), //$NON-NLS-1$
                 smallDisplayUnits.getShortName()));
         lblNewLabel_12.setHorizontalAlignment(SwingConstants.CENTER);
-        panelCameraCalibration.add(lblNewLabel_12, "4, 72, 3, 1");
+        panelCameraCalibration.add(lblNewLabel_12, "4, 74, 3, 1");
         
 
         lblNewLabel_16 = new JLabel(Translations.getString(
                 "ReferenceCameraCalibrationWizard.CameraCalibrationPanel.ResidualErrorMapLabel.text")); //$NON-NLS-1$
         lblNewLabel_16.setFont(new Font("Tahoma", Font.BOLD, 13));
         lblNewLabel_16.setHorizontalAlignment(SwingConstants.CENTER);
-        panelCameraCalibration.add(lblNewLabel_16, "4, 74, 3, 1");
+        panelCameraCalibration.add(lblNewLabel_16, "4, 76, 3, 1");
 
         lblNewLabel_13 = new VerticalLabel(Translations.getString(
                 "ReferenceCameraCalibrationWizard.CameraCalibrationPanel.ImageYLocationLabel.text")); //$NON-NLS-1$
         lblNewLabel_13.setVerticalAlignment(SwingConstants.BOTTOM);
         lblNewLabel_13.setRotation(VerticalLabel.ROTATE_LEFT);
-        panelCameraCalibration.add(lblNewLabel_13, "2, 76");
+        panelCameraCalibration.add(lblNewLabel_13, "2, 78");
 
         modelErrorsView = new MatView();
-        panelCameraCalibration.add(modelErrorsView, "4, 76, 3, 1, fill, fill");
+        panelCameraCalibration.add(modelErrorsView, "4, 78, 3, 1, fill, fill");
         
         lblNewLabel_19 = new JLabel(Translations.getString(
                 "ReferenceCameraCalibrationWizard.CameraCalibrationPanel.ResidualErrorMapDescriptionLabel.text")); //$NON-NLS-1$
-        panelCameraCalibration.add(lblNewLabel_19, "8, 76, 5, 1, left, default");
+        panelCameraCalibration.add(lblNewLabel_19, "8, 78, 5, 1, left, default");
         
         lblNewLabel_12 = new JLabel(Translations.getString(
                 "ReferenceCameraCalibrationWizard.CameraCalibrationPanel.ImageXLocationLabel.text")); //$NON-NLS-1$
         lblNewLabel_12.setHorizontalAlignment(SwingConstants.CENTER);
-        panelCameraCalibration.add(lblNewLabel_12, "4, 78, 3, 1");
+        panelCameraCalibration.add(lblNewLabel_12, "4, 80, 3, 1");
         
     }
 
@@ -1347,5 +1351,6 @@ public class ReferenceCameraCalibrationWizard extends AbstractConfigurationWizar
     private JLabel lblNewLabel_42;
     private JTextField textFieldVirtualWidthFov;
     private JTextField textFieldVirtualHeightFov;
+    private JLabel lblNewLabel_38;
 
 }

--- a/src/main/resources/org/openpnp/translations.properties
+++ b/src/main/resources/org/openpnp/translations.properties
@@ -1183,7 +1183,6 @@ ReferenceCameraCalibrationConfigurationWizard.LensCalibrationPanel.ApplyCalibrat
 ReferenceCameraCalibrationConfigurationWizard.LensCalibrationPanel.Border.title=Lens Calibration
 ReferenceCameraCalibrationWizard.CameraCalibrationPanel.AdvancedCalOverrideChkbox.text=Enable the advanced calibration to override old  style image transforms and distortion correction settings
 ReferenceCameraCalibrationWizard.CameraCalibrationPanel.AdvancedCalOverrideChkbox.toolTipText=Enable the advanced calibration to override old  style image transforms and distortion correction settings
-ReferenceCameraCalibrationWizard.CameraCalibrationPanel.AlfaSlider.toolTipText=<html><p width\="500">Значение 0 обрезает все недопустимые пиксели с края изображения, но с риском потери некоторых допустимых пикселей на краю изображения. Значение 100 заставляет отображать все допустимые пиксели, но существует риск того, что некоторые недопустимые (обычно черные) пиксели будут отображаться по краям изображения.</p></html>
 ReferenceCameraCalibrationWizard.CameraCalibrationPanel.ApplyCalibrationChkBox.text=Apply Calibration
 ReferenceCameraCalibrationWizard.CameraCalibrationPanel.ApplyCalibrationChkBox.toolTipText=Enable this to apply the new image transform and distortion correction settings.  Disable this and no calibration will be applied (raw images will be displayed).
 ReferenceCameraCalibrationWizard.CameraCalibrationPanel.AtDefaultWorkingPlaneZLabel.text=(at Default Working Plane Z)
@@ -1235,7 +1234,8 @@ ReferenceCameraCalibrationWizard.CameraCalibrationPanel.SelectedCalZForPlottingL
 ReferenceCameraCalibrationWizard.CameraCalibrationPanel.SetZeroForNoCropped1Label.text=(Set to zero for no cropping)
 ReferenceCameraCalibrationWizard.CameraCalibrationPanel.SetZeroForNoCropped2Label.text=(Set to zero for no cropping)
 ReferenceCameraCalibrationWizard.CameraCalibrationPanel.ShowOutliersChkBox.text=Show Outliers
-ReferenceCameraCalibrationWizard.CameraCalibrationPanel.ShowValidPixelsLabel.text=<html><p width\="500">A value of 0 crops all invalid pixels from the edge of the image but at the risk of losing some valid pixels at the edge of the image. A value of 100 forces all valid pixels to be displayed but at the risk of some invalid (usually black) pixels being displayed around the edges of the image.</p></html>
+ReferenceCameraCalibrationWizard.CameraCalibrationPanel.ShowValidPixelsLabel.text=Show All Valid Pixels
+ReferenceCameraCalibrationWizard.CameraCalibrationPanel.SliderLabel.text=<html><p width\="500">The slider below controls how the edges of the image are handled. A value of 0 crops all invalid pixels from the edge of the image but at the risk of losing some valid pixels at the edge of the image. A value of 100 forces all valid pixels to be visible in the image but at the risk of some invalid (usually black) pixels being visible around the edges of the image. For best computer vision processing, it is recommended that all invalid pixels be cropped (slider set to zero) after calibration is completed.</p></html>
 ReferenceCameraCalibrationWizard.CameraCalibrationPanel.StartCameraCalibrationButton.text=Start Calibration
 ReferenceCameraCalibrationWizard.CameraCalibrationPanel.UnitsPerPixelLabel.text=Units Per Pixel
 ReferenceCameraCalibrationWizard.CameraCalibrationPanel.UnitsPerPixelTextField.toolTipText=<html><p width\="500">This is the calculated units per pixel at this camera's default Z. Note that the units per pixel is the same in both the X and Y directions.</p></html>


### PR DESCRIPTION
# Description
Removed probable Russian text that accidently was entered in the English translation file and fixed GUI formatting to correctly display verbiage associated with the Crop All Invalid Pixels/Show All Valid Pixels slider.

# Justification
Bug fix to remove confusing Russian language tool tip being displayed to English operators. 

# Instructions for Use
No special instructions needed.

# Implementation Details
1. How did you test the change? Be descriptive. Untested code will not be accepted. **Observed the camera Advanced Calibration tab and verified that the verbiage is now displayed in English and in the correct location.**
2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)? **Yes.**
3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing. **No changes.**
4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted. **All tests ran and all passed.**
