### PR TITLE
Jogging into soft limits

### DIFF
--- a/src/main/java/org/openpnp/gui/JogControlsPanel.java
+++ b/src/main/java/org/openpnp/gui/JogControlsPanel.java
@@ -30,6 +30,7 @@ import java.beans.PropertyChangeListener;
 import java.util.HashMap;
 import java.util.Hashtable;
 import java.util.Map;
+import org.pmw.tinylog.Logger;
 
 import javax.swing.AbstractAction;
 import javax.swing.Action;
@@ -166,6 +167,11 @@ public class JogControlsPanel extends JPanel {
     }
 
     private void jog(final int x, final int y, final int z, final int c) {
+        if(UiUtils.isModalDialogBoxOpen()) {
+            Logger.info("jog blocked while modal dialog is open");
+            return;
+        }
+
         UiUtils.submitUiMachineTask(() -> {
             HeadMountable tool = machineControlsPanel.getSelectedTool();
             jogTool(x, y, z, c, tool);

--- a/src/main/java/org/openpnp/util/UiUtils.java
+++ b/src/main/java/org/openpnp/util/UiUtils.java
@@ -3,6 +3,8 @@ package org.openpnp.util;
 import java.awt.Component;
 import java.awt.Desktop;
 import java.awt.Toolkit;
+import java.awt.Dialog;
+import java.awt.Window;
 import java.awt.datatransfer.StringSelection;
 import java.net.URI;
 import java.util.concurrent.Callable;
@@ -366,5 +368,14 @@ public class UiUtils {
                 }
             }
         });
+    }
+
+    public static boolean isModalDialogBoxOpen() {
+        for( Window w : Window.getWindows() ) {
+            if( w.isShowing() && w instanceof Dialog && ((Dialog)w).isModal() ) {
+                return true;
+            }
+        }
+        return false;
     }
 }


### PR DESCRIPTION
# Description
This change blocks manual jogging actions when the gui has a modal dialog box open.

# Justification
If manual jogging hits a soft limit then openpnp shows an error message. However in this condition the jog keys are still active, and it is possible to get many nested error message windows stacked up.

![image](https://github.com/user-attachments/assets/00195ee3-4aaf-4858-85b9-52c09b5bd827)


This patch prevents this scenario. On jogging into a soft limit, all further jogging is prevented until the first error message is acknowledged.

This patch also prevents manual jogging when any other error message is open. This is probably a good thing.

This patch also prevents manual jogging in another modal dialog box is open, like a File/Save box. I hope this is harmless.

Java swing experts - can you suggest a better implementation of `isModalDialogBoxOpen`?

# Instructions for Use
n/a

# Implementation Details
1. How did you test the change? on simulated machine.
2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)? -- yes
3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing. -- no changes
4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted. -- tests pass
