### PR TITLE
Change camera view zoom behaviour from linear to log

### DIFF
--- a/src/main/java/org/openpnp/gui/components/CameraView.java
+++ b/src/main/java/org/openpnp/gui/components/CameraView.java
@@ -307,10 +307,10 @@ public class CameraView extends JComponent implements CameraListener {
 
         // load the zoom increment pref, if any
         zoomIncPerMouseWheelTick = prefs.getDouble(getZoomIncrementPrefKey(), DEFAULT_ZOOM_INCREMENT);
-// reset invalid value from before v2.3
+        // reset invalid value from before v2.3
         if (zoomIncPerMouseWheelTick <= 1) {
             setZoomIncPerMouseWheelTick(DEFAULT_ZOOM_INCREMENT);
-}
+        }
 
         // load sub.pixel rendering prefs, if any.
         try {
@@ -1783,7 +1783,7 @@ public class CameraView extends JComponent implements CameraListener {
         }
         @Override
         public void mouseReleased(MouseEvent e) {
-            if (e.isPopupTrigger()) {
+            if (e.isPopupTrigger() && !isDragJogging()) {
                 new CameraViewPopupMenu(CameraView.this).show(e.getComponent(), e.getX(), e.getY());
                 return;
             }

--- a/src/main/java/org/openpnp/gui/components/CameraView.java
+++ b/src/main/java/org/openpnp/gui/components/CameraView.java
@@ -49,9 +49,11 @@ import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
+import java.util.EnumMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Map.Entry;
 import java.util.TreeMap;
 import java.util.concurrent.Executors;
@@ -89,11 +91,22 @@ import org.pmw.tinylog.Logger;
 @SuppressWarnings("serial")
 public class CameraView extends JComponent implements CameraListener {
     private static final String PREF_RETICLE = "CamerView.reticle";
+    private static final String DEFAULT_RETICLE_KEY = "DEFAULT_RETICLE_KEY";
     private static final String PREF_ZOOM_INCREMENT = "CamerView.zoomIncrement";
     private static final String PREF_RENDERING_QUALITY = "CamerView.renderingQuality";
-    private static final double DEFAULT_ZOOM_INCREMENT = 1.4142;
 
-    private static final String DEFAULT_RETICLE_KEY = "DEFAULT_RETICLE_KEY";
+    public enum ZoomSensitivity {
+        High,
+        Medium,
+        Low
+    };
+
+    public static final EnumMap<ZoomSensitivity, Double> zoomIncrements = new EnumMap<>(Map.of(
+            ZoomSensitivity.High, 2.0,
+            ZoomSensitivity.Medium, Math.pow(2, 1.0 / 2),
+            ZoomSensitivity.Low, Math.pow(2, 1.0 / 4)));
+
+    private static final double DEFAULT_ZOOM_INCREMENT = zoomIncrements.get(ZoomSensitivity.Medium);
 
     private final static int HANDLE_DIAMETER = 8;
 
@@ -308,7 +321,7 @@ public class CameraView extends JComponent implements CameraListener {
         // load the zoom increment pref, if any
         zoomIncPerMouseWheelTick = prefs.getDouble(getZoomIncrementPrefKey(), DEFAULT_ZOOM_INCREMENT);
         // reset invalid value from before v2.3
-        if (zoomIncPerMouseWheelTick <= 1) {
+        if (!CameraView.zoomIncrements.containsValue(Double.valueOf(zoomIncPerMouseWheelTick))) {
             setZoomIncPerMouseWheelTick(DEFAULT_ZOOM_INCREMENT);
         }
 

--- a/src/main/java/org/openpnp/gui/components/CameraView.java
+++ b/src/main/java/org/openpnp/gui/components/CameraView.java
@@ -91,7 +91,7 @@ public class CameraView extends JComponent implements CameraListener {
     private static final String PREF_RETICLE = "CamerView.reticle";
     private static final String PREF_ZOOM_INCREMENT = "CamerView.zoomIncrement";
     private static final String PREF_RENDERING_QUALITY = "CamerView.renderingQuality";
-    private static final double DEFAULT_ZOOM_INCREMENT = 0.1;
+    private static final double DEFAULT_ZOOM_INCREMENT = 1.1;
 
     private static final String DEFAULT_RETICLE_KEY = "DEFAULT_RETICLE_KEY";
 
@@ -307,6 +307,11 @@ public class CameraView extends JComponent implements CameraListener {
 
         // load the zoom increment pref, if any
         zoomIncPerMouseWheelTick = prefs.getDouble(getZoomIncrementPrefKey(), DEFAULT_ZOOM_INCREMENT);
+// reset invalid value from before v2.3
+        if (zoomIncPerMouseWheelTick <= 1) {
+            setZoomIncPerMouseWheelTick(DEFAULT_ZOOM_INCREMENT);
+}
+
         // load sub.pixel rendering prefs, if any.
         try {
             renderingQuality = RenderingQuality.valueOf(prefs.get(getQualityRenderingPrefKey(), RenderingQuality.Low.toString()));
@@ -1829,11 +1834,11 @@ public class CameraView extends JComponent implements CameraListener {
             boolean ctrlDown = (modifiers & InputEvent.CTRL_DOWN_MASK) != 0;
             if (!ctrlDown) { // Scroll wheel without Ctrl changes the zoom factor
                 double zoomInc = Math.max(zoomIncPerMouseWheelTick,
-                        // When best-scale is selected, we can only zoom by 1.0 or faster.
-                        renderingQuality == RenderingQuality.BestScale ? 1.0 : 0);
-                zoom = (Math.round(zoom/zoomInc) - e.getPreciseWheelRotation()) * zoomInc; 
+                        // When best-scale is selected, we can only zoom by integers
+                        renderingQuality == RenderingQuality.BestScale ? 2.0 : 0);
+                zoom = zoom * Math.pow(zoomInc, - e.getPreciseWheelRotation());
                 zoom = Math.max(zoom, 1.0d);
-                zoom = Math.min(zoom, 100d);
+                zoom = Math.min(zoom, 64d);
             }
             calculateScalingData();
             repaint();

--- a/src/main/java/org/openpnp/gui/components/CameraView.java
+++ b/src/main/java/org/openpnp/gui/components/CameraView.java
@@ -91,7 +91,7 @@ public class CameraView extends JComponent implements CameraListener {
     private static final String PREF_RETICLE = "CamerView.reticle";
     private static final String PREF_ZOOM_INCREMENT = "CamerView.zoomIncrement";
     private static final String PREF_RENDERING_QUALITY = "CamerView.renderingQuality";
-    private static final double DEFAULT_ZOOM_INCREMENT = 1.1;
+    private static final double DEFAULT_ZOOM_INCREMENT = 1.4142;
 
     private static final String DEFAULT_RETICLE_KEY = "DEFAULT_RETICLE_KEY";
 

--- a/src/main/java/org/openpnp/gui/components/CameraViewPopupMenu.java
+++ b/src/main/java/org/openpnp/gui/components/CameraViewPopupMenu.java
@@ -115,63 +115,39 @@ public class CameraViewPopupMenu extends JPopupMenu {
     private JMenu createZoomIncMenu() {
         JMenu subMenu = new JMenu("Zoom Increment Per Mouse Wheel Tick");
         ButtonGroup buttonGroup = new ButtonGroup();
-        JRadioButtonMenuItem menuItem = new JRadioButtonMenuItem("10.0");
+        JRadioButtonMenuItem menuItem = new JRadioButtonMenuItem("Large");
         buttonGroup.add(menuItem);
-        if (cameraView.getZoomIncPerMouseWheelTick() == 10.0) {
+        if (cameraView.getZoomIncPerMouseWheelTick() == 2.0) {
             menuItem.setSelected(true);
         }
         menuItem.addActionListener(new ActionListener() {
             @Override
             public void actionPerformed(ActionEvent e) {
-                cameraView.setZoomIncPerMouseWheelTick(10.0);
+                cameraView.setZoomIncPerMouseWheelTick(2.0);
             }
         });
         subMenu.add(menuItem);
-        menuItem = new JRadioButtonMenuItem("1.0");
+        menuItem = new JRadioButtonMenuItem("Default");
         buttonGroup.add(menuItem);
-        if (cameraView.getZoomIncPerMouseWheelTick() == 1.0) {
+        if (cameraView.getZoomIncPerMouseWheelTick() == 1.1) {
             menuItem.setSelected(true);
         }
         menuItem.addActionListener(new ActionListener() {
             @Override
             public void actionPerformed(ActionEvent e) {
-                cameraView.setZoomIncPerMouseWheelTick(1.0);
+                cameraView.setZoomIncPerMouseWheelTick(1.1);
             }
         });
         subMenu.add(menuItem);
-        menuItem = new JRadioButtonMenuItem("0.1");
+        menuItem = new JRadioButtonMenuItem("Small");
         buttonGroup.add(menuItem);
-        if (cameraView.getZoomIncPerMouseWheelTick() == 0.1) {
+        if (cameraView.getZoomIncPerMouseWheelTick() == 1.01) {
             menuItem.setSelected(true);
         }
         menuItem.addActionListener(new ActionListener() {
             @Override
             public void actionPerformed(ActionEvent e) {
-                cameraView.setZoomIncPerMouseWheelTick(0.1);
-            }
-        });
-        subMenu.add(menuItem);
-        menuItem = new JRadioButtonMenuItem("0.01");
-        buttonGroup.add(menuItem);
-        if (cameraView.getZoomIncPerMouseWheelTick() == 0.01) {
-            menuItem.setSelected(true);
-        }
-        menuItem.addActionListener(new ActionListener() {
-            @Override
-            public void actionPerformed(ActionEvent e) {
-                cameraView.setZoomIncPerMouseWheelTick(0.01);
-            }
-        });
-        subMenu.add(menuItem);
-        menuItem = new JRadioButtonMenuItem("0.001");
-        buttonGroup.add(menuItem);
-        if (cameraView.getZoomIncPerMouseWheelTick() == 0.001) {
-            menuItem.setSelected(true);
-        }
-        menuItem.addActionListener(new ActionListener() {
-            @Override
-            public void actionPerformed(ActionEvent e) {
-                cameraView.setZoomIncPerMouseWheelTick(0.001);
+                cameraView.setZoomIncPerMouseWheelTick(1.01);
             }
         });
         subMenu.add(menuItem);

--- a/src/main/java/org/openpnp/gui/components/CameraViewPopupMenu.java
+++ b/src/main/java/org/openpnp/gui/components/CameraViewPopupMenu.java
@@ -35,6 +35,7 @@ import javax.swing.JRadioButtonMenuItem;
 
 import org.openpnp.gui.MainFrame;
 import org.openpnp.gui.components.CameraView.RenderingQuality;
+import org.openpnp.gui.components.CameraView.ZoomSensitivity;
 import org.openpnp.gui.components.reticle.CrosshairReticle;
 import org.openpnp.gui.components.reticle.FiducialReticle;
 import org.openpnp.gui.components.reticle.GridReticle;
@@ -117,40 +118,46 @@ public class CameraViewPopupMenu extends JPopupMenu {
         ButtonGroup buttonGroup = new ButtonGroup();
         JRadioButtonMenuItem menuItem = new JRadioButtonMenuItem("High");
         buttonGroup.add(menuItem);
-        if (cameraView.getZoomIncPerMouseWheelTick() == 2.0000) {
+        if (cameraView.getZoomIncPerMouseWheelTick()
+                == CameraView.zoomIncrements.get(ZoomSensitivity.High)) {
             menuItem.setSelected(true);
         }
         menuItem.setToolTipText("One mouse wheel tick changes the zoom by 2x.");
         menuItem.addActionListener(new ActionListener() {
             @Override
             public void actionPerformed(ActionEvent e) {
-                cameraView.setZoomIncPerMouseWheelTick(2.0000);
+                cameraView.setZoomIncPerMouseWheelTick(
+                        CameraView.zoomIncrements.get(ZoomSensitivity.High));
             }
         });
         subMenu.add(menuItem);
         menuItem = new JRadioButtonMenuItem("Medium");
         buttonGroup.add(menuItem);
-        if (cameraView.getZoomIncPerMouseWheelTick() == 1.4142) {
+        if (cameraView.getZoomIncPerMouseWheelTick()
+                == CameraView.zoomIncrements.get(ZoomSensitivity.Medium)) {
             menuItem.setSelected(true);
         }
         menuItem.setToolTipText("Two mouse wheel ticks change the zoom by 2x.");
         menuItem.addActionListener(new ActionListener() {
             @Override
             public void actionPerformed(ActionEvent e) {
-                cameraView.setZoomIncPerMouseWheelTick(1.4142);
+                cameraView.setZoomIncPerMouseWheelTick(
+                        CameraView.zoomIncrements.get(ZoomSensitivity.Medium));
             }
         });
         subMenu.add(menuItem);
         menuItem = new JRadioButtonMenuItem("Low");
         buttonGroup.add(menuItem);
-        if (cameraView.getZoomIncPerMouseWheelTick() == 1.1892) {
+        if (cameraView.getZoomIncPerMouseWheelTick()
+                == CameraView.zoomIncrements.get(ZoomSensitivity.Low)) {
             menuItem.setSelected(true);
         }
         menuItem.setToolTipText("Four mouse wheel ticks change the zoom by 2x.");
         menuItem.addActionListener(new ActionListener() {
             @Override
             public void actionPerformed(ActionEvent e) {
-                cameraView.setZoomIncPerMouseWheelTick(1.1892);
+                cameraView.setZoomIncPerMouseWheelTick(
+                        CameraView.zoomIncrements.get(ZoomSensitivity.Low));
             }
         });
         subMenu.add(menuItem);

--- a/src/main/java/org/openpnp/gui/components/CameraViewPopupMenu.java
+++ b/src/main/java/org/openpnp/gui/components/CameraViewPopupMenu.java
@@ -113,41 +113,44 @@ public class CameraViewPopupMenu extends JPopupMenu {
     }
 
     private JMenu createZoomIncMenu() {
-        JMenu subMenu = new JMenu("Zoom Increment Per Mouse Wheel Tick");
+        JMenu subMenu = new JMenu("Zoom Sensitivity");
         ButtonGroup buttonGroup = new ButtonGroup();
-        JRadioButtonMenuItem menuItem = new JRadioButtonMenuItem("Large");
+        JRadioButtonMenuItem menuItem = new JRadioButtonMenuItem("High");
         buttonGroup.add(menuItem);
-        if (cameraView.getZoomIncPerMouseWheelTick() == 2.0) {
+        if (cameraView.getZoomIncPerMouseWheelTick() == 2.0000) {
             menuItem.setSelected(true);
         }
+        menuItem.setToolTipText("One mouse wheel tick changes the zoom by 2x.");
         menuItem.addActionListener(new ActionListener() {
             @Override
             public void actionPerformed(ActionEvent e) {
-                cameraView.setZoomIncPerMouseWheelTick(2.0);
+                cameraView.setZoomIncPerMouseWheelTick(2.0000);
             }
         });
         subMenu.add(menuItem);
-        menuItem = new JRadioButtonMenuItem("Default");
+        menuItem = new JRadioButtonMenuItem("Medium");
         buttonGroup.add(menuItem);
-        if (cameraView.getZoomIncPerMouseWheelTick() == 1.1) {
+        if (cameraView.getZoomIncPerMouseWheelTick() == 1.4142) {
             menuItem.setSelected(true);
         }
+        menuItem.setToolTipText("Two mouse wheel ticks change the zoom by 2x.");
         menuItem.addActionListener(new ActionListener() {
             @Override
             public void actionPerformed(ActionEvent e) {
-                cameraView.setZoomIncPerMouseWheelTick(1.1);
+                cameraView.setZoomIncPerMouseWheelTick(1.4142);
             }
         });
         subMenu.add(menuItem);
-        menuItem = new JRadioButtonMenuItem("Small");
+        menuItem = new JRadioButtonMenuItem("Low");
         buttonGroup.add(menuItem);
-        if (cameraView.getZoomIncPerMouseWheelTick() == 1.01) {
+        if (cameraView.getZoomIncPerMouseWheelTick() == 1.1892) {
             menuItem.setSelected(true);
         }
+        menuItem.setToolTipText("Four mouse wheel ticks change the zoom by 2x.");
         menuItem.addActionListener(new ActionListener() {
             @Override
             public void actionPerformed(ActionEvent e) {
-                cameraView.setZoomIncPerMouseWheelTick(1.01);
+                cameraView.setZoomIncPerMouseWheelTick(1.1892);
             }
         });
         subMenu.add(menuItem);


### PR DESCRIPTION
# Description
This pull request changes how the zoom level is calculated, when a `MouseWheelEvent` is received. The calculation is now multiplicative instead of additive as before. The increments are adapted and reduced from 5 to 3 in number. Additionally, the numbers in the the context menu are replaced with text and a tooltip explanation because without any indication of the current zoom level, these numbers are meaningless.

During testing two issues emerged:
- The new increments need to be larger than 1, while previous increments could also be 1 or smaller. Because these settings are stored using the Preferences API, they prevail and cannot easily be reset. If the previous increment was 1, zooming is effectively disabled. If the previous increment was smaller than 1, zooming is inverted. This is likely to confuse users und must therefore be avoided. For this, the value is checked inside setCamera() after being loaded from the preferences and reset to default if it isn't one of the allowed values. The downgrade path doesn't lead to such confusing behaviour and will only result in the current setting not being marked in the popup, as none of the new values are match the previous values.
- When doing a careless right mouse click inside the camera view, dragging is registered and drag jogging starts. At the same time, the popup appears and drag jogging stays active, if the next click happens inside the popup and not inside the camera view. This detaches the drag cursor from the mouse pointer and the former remains hanging in the camera view. This is mitigated by blocking the appearance of the popup, if drag jogging has been started. I would prefer to block right mouse button drag jogging altogether but I'm not sure how to implement this in a way that it works with all platforms and mice.

Inside `createZoomIncMenu()` the increments are hardcoded as magic numbers although the are effectively stored inside `CameraView`. Additionally each number occurs twice and they need to match in order for the logic to work. ~~I wanted to replace them with a HashMap (as in Python dictionary), but failed to achieve it.~~ I got around to implement this using an EnumMap, which additionally allows to easily check if the loaded value is valid or not.

# Justification
Zooming the camera view is a handy feature, especially on cameras with an extreme FOV as the LumenPnP's bottom camera. The previous linear zoom behaviour steadily decreases it's effectiveness the further zoomed in the image is. This change introduces a logarithmic zoom behaviour with a constant effectiveness over the total zoomable range.

Adresses #1747.

# Instructions for Use
As before.

# Implementation Details
1. How did you test the change?  
Manually by clicking and scrolling around the camera view while observing changes in the current values of `zoom` and `zoomInc`.
2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)?  
Yes
3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing.  
No
4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted.  
Done
