### PR TITLE
The jog motion safety checks need to account for through-hole depth t…

### DIFF
--- a/src/main/java/org/openpnp/gui/MachineControlsPanel.java
+++ b/src/main/java/org/openpnp/gui/MachineControlsPanel.java
@@ -248,8 +248,9 @@ public class MachineControlsPanel extends JPanel {
                     }
                     if (part != null) {
                         // Subtract the part height for clearance.
+                        Length partHeight = part.getHeightForSafeZ();
                         hmLocation = hmLocation
-                                .subtract(new Location(part.getHeight().getUnits(), 0, 0, part.getHeight().getValue(), 0));
+                                .subtract(new Location(partHeight.getUnits(), 0, 0, partHeight.getValue(), 0));
                         subject += " holding "+part.getId();
                     }
                 }


### PR DESCRIPTION
# Description

Fix for an omission spotted by @jbussmann in PR #1749 

The jog motion safety mechanism needs to account for through-hole height too.

# Implementation Details
1. How did you test the change? Be descriptive. Untested code will not be accepted.  -- code review only
2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)?  -- yes
3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing. -- no changes
4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted. -- tests pass
