### PR TITLE
fix sub-ordinate motion merging

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/driver/AbstractMotionPlanner.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/AbstractMotionPlanner.java
@@ -172,7 +172,7 @@ public abstract class AbstractMotionPlanner extends AbstractModelObject implemen
         }
         
         /**
-         * collect all axes that are ok to move (all head mountable of all heads are in SafeZ)
+         * collect all axes that are ok to move (all head mountables of all heads are in SafeZ)
          * @return
          */
         private LinkedHashSet<ControllerAxis> getOkToMoveAxes(AxesLocation targetLocation) throws Exception {
@@ -186,7 +186,7 @@ public abstract class AbstractMotionPlanner extends AbstractModelObject implemen
                 // loop over all its head mountables
                 for (HeadMountable hm : h.getHeadMountables()) {
                     // take the raw axes location of the current hm location
-                    AxesLocation rawCurrentLocation = hm.toRaw(hm.getLocation());
+                    AxesLocation rawCurrentLocation = hm.toRaw(hm.toHeadLocation(hm.getLocation(), LocationOption.Quiet), LocationOption.Quiet);
                     // get only controller axes (Note, we don't care if virtual axes are not safe)
                     LinkedHashSet<ControllerAxis> headAxes = rawCurrentLocation.getControllerAxes();
                     // optimistically add them to the ok to move head axes


### PR DESCRIPTION
# Description
This PR fixes sub-ordinate motion merging in situations where a head mountable has a Z offset and the safe z zone is thin. The code does not correctly respect the head mountables offset which makes it look as if its outside the safe z zone. With this PR the missing toHeadLocation() transformation is added.

This is documentation for a user, not for a developer.

# Implementation Details
1. How did you test the change? Be descriptive. Untested code will not be accepted. **using simulation machine tuned to reproduce the reported issue, applied the fix and the issue is solved**
2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)? **yes**
3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing. **no**
4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted. **yes**
