### PR TITLE
Fix Issues & Solutions auto-focus default on uplooking camera

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/solutions/VisionSolutions.java
+++ b/src/main/java/org/openpnp/machine/reference/solutions/VisionSolutions.java
@@ -44,6 +44,7 @@ import org.openpnp.machine.reference.ReferenceMachine;
 import org.openpnp.machine.reference.ReferenceNozzle;
 import org.openpnp.machine.reference.ReferenceNozzleTip;
 import org.openpnp.machine.reference.camera.AbstractSettlingCamera.SettleMethod;
+import org.openpnp.machine.reference.camera.ReferenceCamera.FocusSensingMethod;
 import org.openpnp.machine.reference.camera.AutoFocusProvider;
 import org.openpnp.machine.reference.camera.ReferenceCamera;
 import org.openpnp.machine.reference.camera.SimulatedUpCamera;
@@ -416,13 +417,14 @@ public class VisionSolutions implements Solutions.Subject {
         @Override
         public Solutions.Issue.Choice[] getChoices() {
             if (camera.getLooking() == Looking.Up) {
+                setChoice(camera.getFocusSensingMethod());
                 return new Solutions.Issue.Choice[]{
-                    new Solutions.Issue.Choice(true,  
+                    new Solutions.Issue.Choice(FocusSensingMethod.AutoFocus,  
                                       "<html><h3>Use Auto-Focus</h3>" 
-                                    + "<p>This is the recommended setting.</p>"
+                                    + "<p>This is the recommended setting, if a focus sensing method is configured.</p>"
                                     + "</html>", 
                                     null), 
-                    new Solutions.Issue.Choice(false,  
+                    new Solutions.Issue.Choice(FocusSensingMethod.None,  
                                       "<html><h3>Use nozzle Z location</h3>" 
                                     + "<p><span style=\"color:red;\">CAUTION:</span> This will invalidate part height auto detection using auto focus.</p>" 
                                     + "</html>", 
@@ -764,7 +766,7 @@ public class VisionSolutions implements Solutions.Subject {
                         }
                         oldVisionDiameter = referenceNozzleTip.getCalibration().getCalibrationTipDiameter();
                         final State oldState = getState();
-                        final boolean autoFocus = (boolean)getChoice();
+                        final boolean autoFocus = getChoice() == FocusSensingMethod.None ? false : true;
                         UiUtils.submitUiMachineTask(
                                 () -> {
                                     // Perform preliminary camera calibration. 


### PR DESCRIPTION
# Description
Make the focus choice on uplooking camera align with the cameras setting. If auto-focus is configured, enable it by default in the solution, otherwise not. 

# Justification
If users don't want to use auto-focus and disable it in the camera settings, Issues & Solutions should respect that and default to whatever the camera setting is. 

# Implementation Details
1. How did you test the change? Be descriptive. Untested code will not be accepted.  
Check if changes in camera setting are reflected in Issues & Solutions, run uplooking camera calibrations on the simulated machine with and without auto-focus.
3. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)?  
Yes
5. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing.  
No
7. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted.  
Done