### PR TITLE
Fix PartsComboBoxModel and board import problem.

### DIFF
--- a/src/main/java/org/openpnp/gui/BoardPlacementsPanel.java
+++ b/src/main/java/org/openpnp/gui/BoardPlacementsPanel.java
@@ -602,6 +602,8 @@ public class BoardPlacementsPanel extends JPanel {
                 
                 importedBoard.dispose();
                 
+                tableModel.fireTableDataChanged();
+                
                 configuration.getBus()
                     .post(new DefinitionStructureChangedEvent(board, "placements", BoardPlacementsPanel.this)); //$NON-NLS-1$
             }

--- a/src/main/java/org/openpnp/gui/BoardsPanel.java
+++ b/src/main/java/org/openpnp/gui/BoardsPanel.java
@@ -273,7 +273,7 @@ public class BoardsPanel extends JPanel {
         });
     }
 
-    private void selectBoard(Board board) {
+    public void selectBoard(Board board) {
         if (board == null) {
             boardsTable.getSelectionModel().clearSelection();
             return;

--- a/src/main/java/org/openpnp/gui/FeedersPanel.java
+++ b/src/main/java/org/openpnp/gui/FeedersPanel.java
@@ -288,6 +288,11 @@ public class FeedersPanel extends JPanel implements WizardContainer {
 
                     Feeder feeder = getSelection();
 
+                    for (Component comp : configurationPanel.getComponents()) {
+                        if (comp instanceof AbstractConfigurationWizard) {
+                            ((AbstractConfigurationWizard) comp).dispose();
+                        }
+                    }
                     configurationPanel.removeAll();
                     if (feeder != null) {
                         priorFeederId = feeder.getId();

--- a/src/main/java/org/openpnp/gui/MainFrame.java
+++ b/src/main/java/org/openpnp/gui/MainFrame.java
@@ -91,6 +91,7 @@ import org.openpnp.gui.support.MessageBoxes;
 import org.openpnp.gui.support.OSXAdapter;
 import org.openpnp.gui.support.PropertySheetWizardAdapter;
 import org.openpnp.gui.support.RotationCellValue;
+import org.openpnp.model.Board;
 import org.openpnp.model.BoardLocation;
 import org.openpnp.model.Configuration;
 import org.openpnp.model.Configuration.TablesLinked;
@@ -914,6 +915,7 @@ public class MainFrame extends JFrame {
 
                 @Override
                 public void actionPerformed(ActionEvent e) {
+                    boardsPanel.selectBoard((Board) jobPanel.getSelection().getPlacementsHolder().getDefinition());
                     boardsPanel.getBoardPlacementsPanel().importBoard(boardImporter.getClass());
                 }
             });

--- a/src/main/java/org/openpnp/gui/support/AbstractConfigurationWizard.java
+++ b/src/main/java/org/openpnp/gui/support/AbstractConfigurationWizard.java
@@ -122,6 +122,14 @@ public abstract class AbstractConfigurationWizard extends JPanel implements Wiza
         applyAction.setEnabled(false);
         resetAction.setEnabled(false);
     }
+    
+    /**
+     * Override this method if the wizard needs to do any cleanup like removing property change 
+     * listeners that may have been added during the wizard's construction
+     */
+    public void dispose() {
+        
+    }
 
     public WrappedBinding addWrappedBinding(Object source, String sourceProperty,
             Object target, String targetProperty, Converter converter) {

--- a/src/main/java/org/openpnp/machine/reference/feeder/wizards/AbstractReferenceFeederConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/wizards/AbstractReferenceFeederConfigurationWizard.java
@@ -70,6 +70,7 @@ public abstract class AbstractReferenceFeederConfigurationWizard
     private JTextField feedRetryCount;
     private JLabel lblPickRetryCount;
     private JTextField pickRetryCount;
+    private PartsComboBoxModel partsComboBoxModel;
 
     /**
      * @wbp.parser.constructor
@@ -105,7 +106,8 @@ public abstract class AbstractReferenceFeederConfigurationWizard
         comboBoxPart = new JComboBox();
         comboBoxPart.setMaximumRowCount(20);
         try {
-            comboBoxPart.setModel(new PartsComboBoxModel());
+            partsComboBoxModel = new PartsComboBoxModel();
+            comboBoxPart.setModel(partsComboBoxModel);
         }
         catch (Throwable t) {
             // Swallow this error. This happens during parsing in
@@ -214,5 +216,12 @@ public abstract class AbstractReferenceFeederConfigurationWizard
 
         ComponentDecorators.decorateWithAutoSelect(feedRetryCount);
         ComponentDecorators.decorateWithAutoSelect(pickRetryCount);
+    }
+    
+    @Override
+    public void dispose() {
+        if (partsComboBoxModel != null) {
+            partsComboBoxModel.dispose();
+        }
     }
 }


### PR DESCRIPTION
# Description
Fixes the PartsComboBoxModel so that the current selection is not disturbed when the configuration parts list is updated. Also removes the associated propertyChangeListener from the configuration parts list when the comboBox is no longer needed - this was in effect a memory leak.

Fixes a problem with using the File->Import menu option that could potentially import into the wrong board if tables were unlinked.

# Justification
Bug fixes.

# Instructions for Use
No special instructions for the operator.

# Implementation Details
1. How did you test the change? **Tested with scenarios that were previously causing feeders to erroneously have their part selection changed. Now they no longer change when the parts list is changed.**
2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)? **Yes.**
3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing. **No changes**.
4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted. **All tests ran and passed.**
