### PR TITLE
Fiducial pipeline Hug feedback

### DIFF
--- a/src/main/resources/org/openpnp/machine/reference/vision/ReferenceFiducialLocator-DefaultPipeline.xml
+++ b/src/main/resources/org/openpnp/machine/reference/vision/ReferenceFiducialLocator-DefaultPipeline.xml
@@ -7,7 +7,7 @@
       <cv-stage class="org.openpnp.vision.pipeline.stages.DetectCircularSymmetry" name="circular" enabled="true" min-diameter="10" max-diameter="100" max-distance="4" search-width="0" search-height="0" max-target-count="1" min-symmetry="1.2" corr-symmetry="0.0" outer-margin="0.2" inner-margin="0.4" sub-sampling="8" super-sampling="8" symmetry-score="OverallVarianceVsRingVarianceSum" property-name="fiducial" diagnostics="true" heat-map="true"/>
       <cv-stage class="org.openpnp.vision.pipeline.stages.ImageRecall" name="0" enabled="true" image-stage-name="image"/>
       <cv-stage class="org.openpnp.vision.pipeline.stages.ConvertModelToKeyPoints" name="results" enabled="true" model-stage-name="circular"/>
-      <cv-stage class="org.openpnp.vision.pipeline.stages.DrawCircles" name="draw" enabled="false" circles-stage-name="circular" thickness="1">
+      <cv-stage class="org.openpnp.vision.pipeline.stages.DrawCircles" name="draw" enabled="true" circles-stage-name="circular" thickness="1">
          <color r="255" g="255" b="0" a="255"/>
          <center-color r="255" g="153" b="0" a="255"/>
       </cv-stage>


### PR DESCRIPTION
# Description
Previously the fiducial vision pipeline would draw circles to highlight the fiducial that had been detected. Several changes were introduced in PR #1719, with the overall result that highlight circles were removed.

This was reported by Tao Qu on [google groups](https://groups.google.com/d/msgid/openpnp/a7aaef82-df39-46bb-b2fb-8aa2221cf8c5n%40googlegroups.com?utm_medium=email&utm_source=footer) -- thank you for the feedback.

# Implementation Details
1. How did you test the change? Be descriptive. Untested code will not be accepted. 
    1. tested in simulated machine
    2. code review - this changes one attribute in an xml file.
3. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)? -- yes
4. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing. -- no changes
5. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted. -- tests pass
