### PR TITLE
Add scriptState, a public Map attribute of the configuration object, …

### DIFF
--- a/src/main/java/org/openpnp/model/Configuration.java
+++ b/src/main/java/org/openpnp/model/Configuration.java
@@ -36,6 +36,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
+import java.util.TreeMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -57,6 +58,7 @@ import org.openpnp.util.NanosecondTime;
 import org.pmw.tinylog.Logger;
 import org.simpleframework.xml.Element;
 import org.simpleframework.xml.ElementList;
+import org.simpleframework.xml.ElementMap;
 import org.simpleframework.xml.Root;
 import org.simpleframework.xml.Serializer;
 import org.simpleframework.xml.convert.AnnotationStrategy;
@@ -124,6 +126,7 @@ public class Configuration extends AbstractModelObject {
     private Preferences prefs;
     private Scripting scripting;
     private EventBus bus = new EventBus();
+    public TreeMap<String, String> scriptState = new TreeMap<>();
 
     public static boolean isInstanceInitialized() {
         return (instance != null);
@@ -519,6 +522,24 @@ public class Configuration extends AbstractModelObject {
             throw new Exception("Error while reading machine.xml (" + message + ")", e);
         }
 
+        try {
+            File file = new File(configurationDirectory, "script-state.xml");
+            if (overrideUserConfig || !file.exists()) {
+                Logger.info("No script-state.xml found in configuration directory, loading defaults.");
+                file = File.createTempFile("script-state", "xml");
+                FileUtils.copyURLToFile(ClassLoader.getSystemResource("config/script-state.xml"), file);
+                forceSave = true;
+            }
+            loadScriptState(file);
+        }
+        catch (Exception e) {
+            String message = e.getMessage();
+            if (e.getCause() != null && e.getCause().getMessage() != null) {
+                message = e.getCause().getMessage();
+            }
+            throw new Exception("Error while reading script-state.xml (" + message + ")", e);
+        }
+
         loaded = true;
 
         // Tell all listeners the configuration is loaded. Use a snapshot of the list in order to tolerate new
@@ -575,6 +596,12 @@ public class Configuration extends AbstractModelObject {
         }
         catch (Exception e) {
             throw new Exception("Error while saving vision-settings.xml (" + e.getMessage() + ")", e);
+        }
+        try {
+            saveScriptState(createBackedUpFile("script-state.xml", now));
+        }
+        catch (Exception e) {
+            throw new Exception("Error while saving script-state.xml (" + e.getMessage() + ")", e);
         }
     }
 
@@ -996,6 +1023,18 @@ public class Configuration extends AbstractModelObject {
     private void saveVisionSettings(File file) throws Exception {
         VisionSettingsConfigurationHolder holder = new VisionSettingsConfigurationHolder();
         holder.visionSettings = new ArrayList<>(visionSettings.values());
+        serializeObject(holder, file);
+    }
+
+    private void loadScriptState(File file) throws Exception {
+        Serializer serializer = createSerializer();
+        ScriptStateConfigurationHolder holder = serializer.read(ScriptStateConfigurationHolder.class, file);
+        scriptState = holder.scriptState;
+    }
+
+    private void saveScriptState(File file) throws Exception {
+        ScriptStateConfigurationHolder holder = new ScriptStateConfigurationHolder();
+        holder.scriptState = scriptState;
         serializeObject(holder, file);
     }
 
@@ -1548,6 +1587,12 @@ public class Configuration extends AbstractModelObject {
     public static class VisionSettingsConfigurationHolder {
         @ElementList(inline = true, entry = "visionSettings", required = false)
         public ArrayList<AbstractVisionSettings> visionSettings = new ArrayList<>();
+    }
+
+    @Root(name = "openpnp-script-state")
+    public static class ScriptStateConfigurationHolder {
+        @ElementMap(keyType = String.class,valueType = String.class,required = false, key="key", value="value", inline = true)
+        private TreeMap<String, String> scriptState = new TreeMap<>();
     }
 
 }

--- a/src/main/resources/config/script-state.xml
+++ b/src/main/resources/config/script-state.xml
@@ -1,0 +1,2 @@
+<openpnp-script-state>
+</openpnp-script-state>


### PR DESCRIPTION
This is a provisional PR. I plan to test this over the next few weeks.

# Description & Justification

This feature was discussed on [google groups](https://groups.google.com/d/msgid/openpnp/b9f87478-4464-4a4b-b6af-b79cce6db157%40googlemail.com)

Openpnp has a wonderful scripting feature. Scripts can manipulate openpnp state, but sometimes scripts have state of their own. This can easily be stored inside the scripting engine library, but this has problems. The state gets lost if the scripting engine is reset, or if two scripts run concurrently and openpnp starts a second instance of the scripting engine. The state would also be inaccessible to scripts using a different scripting language. This PR provides somewhere to store that state. 

The scriptState object is a public Map attribute of the configuration object. It is public because we expect scripts to use the Java Map interface to access this namespace.

This Map is parameterised as `<String,String>`. Keys are Strings because we expect state to be identified by a string name. Values are Strings too. We require scripts to marshal its state into string format.

This map is stored in `script-state.xml` in the normal configuration directory. We use a TreeMap so that values are written sorted by key name.

# Instructions for Use

Instructions to be added [here](https://github.com/openpnp/openpnp/wiki/Scripting#global-variables)

### Script Global Variables

Any variables that need to be shared between scripts can be stored in the `config.scriptState` object. This object is a [Map<String,String>](https://docs.oracle.com/javase/8/docs/api/java/util/Map.html) so variable names and values need to be strings. For example:
```
run_counter = config.scriptState.getOrDefault("script-run-counter","0")  # fetch the variable
run_counter = int(run_counter)  # it is stored as a string, so convert it to an integer now
run_counter += 1 # increment the counter
config.scriptState.put("script-run-counter",str(run_counter)) # update the stored variable
print "This script has been run", run_counter, "times"
```

# Implementation Details
1. How did you test the change? Be descriptive. Untested code will not be accepted. -- not yet tested 
2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)? -- yes
3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing. -- no changes
4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted. -- existing tests pass
