### PR TITLE
non-portable solutions

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/solutions/CalibrationSolutions.java
+++ b/src/main/java/org/openpnp/machine/reference/solutions/CalibrationSolutions.java
@@ -206,7 +206,8 @@ public class CalibrationSolutions implements Solutions.Subject {
                                 "Calibrate backlash compensation for axis "+axis.getName()+".", 
                                 "Automatically calibrates the backlash compensation for "+axis.getName()+" using the primary calibration fiducial.", 
                                 Solutions.Severity.Fundamental,
-                                "https://github.com/openpnp/openpnp/wiki/Calibration-Solutions#calibrating-backlash-compensation") {
+                                "https://github.com/openpnp/openpnp/wiki/Calibration-Solutions#calibrating-backlash-compensation",
+                                true) {
 
                             {
                                 tolerance = oldAcceptableTolerance;
@@ -318,7 +319,8 @@ public class CalibrationSolutions implements Solutions.Subject {
                         "Advanced camera "+camera.getName()+" calibration.", 
                         "Automatically calibrates the camera "+camera.getName()+" using the primary and secondary calibration fiducials.", 
                         Solutions.Severity.Suggestion,
-                        "https://github.com/openpnp/openpnp/wiki/Calibration-Solutions#advanced-camera-calibration") {
+                        "https://github.com/openpnp/openpnp/wiki/Calibration-Solutions#advanced-camera-calibration",
+                        true) {
 
                     @Override 
                     public void activate() throws Exception {
@@ -376,7 +378,8 @@ public class CalibrationSolutions implements Solutions.Subject {
                     "Calibrate precise camera ↔ nozzle "+nozzle.getName()+" offsets.", 
                     "Use a test object to perform the precision camera ↔ nozzle "+nozzle.getName()+" offsets calibration.", 
                     Solutions.Severity.Fundamental,
-                    "https://github.com/openpnp/openpnp/wiki/Calibration-Solutions#calibrating-precision-camera-to-nozzle-offsets") {
+                    "https://github.com/openpnp/openpnp/wiki/Calibration-Solutions#calibrating-precision-camera-to-nozzle-offsets",
+                    true) {
 
                 private Location oldNozzleOffsets = null;
 
@@ -476,7 +479,8 @@ public class CalibrationSolutions implements Solutions.Subject {
                     "Advanced camera "+camera.getName()+" calibration.", 
                     "Automatically calibrates the camera "+camera.getName()+" using the nozzle "+defaultNozzle.getName()+".", 
                     Solutions.Severity.Suggestion,
-                    "https://github.com/openpnp/openpnp/wiki/Calibration-Solutions#advanced-camera-calibration") {
+                    "https://github.com/openpnp/openpnp/wiki/Calibration-Solutions#advanced-camera-calibration",
+                    true) {
 
                 @Override 
                 public void activate() throws Exception {

--- a/src/main/java/org/openpnp/machine/reference/solutions/VisionSolutions.java
+++ b/src/main/java/org/openpnp/machine/reference/solutions/VisionSolutions.java
@@ -290,8 +290,8 @@ public class VisionSolutions implements Solutions.Subject {
 
     public class VisionFeatureIssue extends Solutions.Issue {
 
-        public VisionFeatureIssue(Subject subject, ReferenceCamera camera, Length featureDiameterIfKnown, String issue, String solution, Severity severity, String uri) {
-            super(subject, issue, solution, severity, uri);
+        public VisionFeatureIssue(Subject subject, ReferenceCamera camera, Length featureDiameterIfKnown, String issue, String solution, Severity severity, String uri, boolean isNonPortable) {
+            super(subject, issue, solution, severity, uri, isNonPortable);
             this.camera = camera;
             featureDiameter = 20;
             if (camera.getUnitsPerPixelPrimary().getX() != 0
@@ -300,6 +300,9 @@ public class VisionSolutions implements Solutions.Subject {
                 // Existing diameter setting.
                 featureDiameter = (int) Math.round(featureDiameterIfKnown.divide(camera.getUnitsPerPixel().getLengthX()));
             }
+        }
+        public VisionFeatureIssue(Subject subject, ReferenceCamera camera, Length featureDiameterIfKnown, String issue, String solution, Severity severity, String uri) {
+            this(subject, camera, featureDiameterIfKnown, issue, solution, severity, uri, false);
         }
 
         private ReferenceCamera camera; 
@@ -708,7 +711,8 @@ public class VisionSolutions implements Solutions.Subject {
                     "Determine the up-looking camera "+camera.getName()+" position and initial calibration.", 
                     "Move the nozzle "+defaultNozzle.getName()+" over the up-looking camera "+camera.getName()+" and capture the position.", 
                     Solutions.Severity.Fundamental,
-                    "https://github.com/openpnp/openpnp/wiki/Vision-Solutions#up-looking-camera-offsets") {
+                    "https://github.com/openpnp/openpnp/wiki/Vision-Solutions#up-looking-camera-offsets",
+                    true) {
 
                 @Override 
                 public void activate() throws Exception {


### PR DESCRIPTION
# Description
This PR contains a proposal to extend Issues & Solutions with non-portable solutions. Solutions can now be marked as non-portable. If a solutions is marked as such, its hash value (that identifies it internally) is appended by some local data (currently the mainboard's serial number) which makes it considered unsolved if evaluated on a different computer (mainboard).

# Justification
In the past a lot of support issues where raised because a machine.xml was shared and the user was not aware of which issues he still has to solve and which are still ok as they have been solved by the provide. With this PR some Issues will automatically open up if a machine.xml is shared.

# Instructions for Use
Existing setup will be handled as if the machine.xml has just been copied over. To prevent this, the flag "disableNonPortableSolutions" may be set to true which considers all solutions a portable again as is the current state.

This is documentation for a user, not for a developer.

# Implementation Details
1. How did you test the change? Be descriptive. Untested code will not be accepted. **using simulation and physical machine making sure the solutions I currently would expect to open up are open**
2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)? **yes**
3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing. **yes: Solutions() has been extended**
4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted. **yes**
