### PR TITLE
CvPipeline always needs a "camera" property

### DIFF
--- a/src/main/java/org/openpnp/gui/components/PipelineControls.java
+++ b/src/main/java/org/openpnp/gui/components/PipelineControls.java
@@ -164,6 +164,8 @@ public abstract class PipelineControls extends JPanel {
      */
     public abstract void configurePipeline(CvPipeline pipeline, Map<String, Object> pipelineParameterAssignments, boolean edit) throws Exception;
 
+    public abstract Camera getCamera() throws Exception;
+
     /**
      * Override this method to reset the pipeline to the default.
      * 
@@ -433,8 +435,10 @@ public abstract class PipelineControls extends JPanel {
         @Override
         public void actionPerformed(ActionEvent arg0) {
             try {
+                CvPipeline pipeline = getPipeline();
+                pipeline.setProperty("camera",getCamera());
                 StringSelection stringSelection =
-                        new StringSelection(getPipeline().toXmlString());
+                        new StringSelection(pipeline.toXmlString());
                 Clipboard clipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
                 clipboard.setContents(stringSelection, null);
             }

--- a/src/main/java/org/openpnp/machine/reference/vision/wizards/BottomVisionSettingsConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/vision/wizards/BottomVisionSettingsConfigurationWizard.java
@@ -284,6 +284,9 @@ public class BottomVisionSettingsConfigurationWizard extends AbstractConfigurati
             }
 
             @Override
+            public Camera getCamera() throws Exception { return VisionUtils.getBottomVisionCamera(); }
+
+            @Override
             public void resetPipeline() throws Exception {
                 int result = JOptionPane.showConfirmDialog(getTopLevelAncestor(),
                         "This will replace the Pipeline with the default. Are you sure??", null,

--- a/src/main/java/org/openpnp/machine/reference/vision/wizards/FiducialVisionSettingsConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/vision/wizards/FiducialVisionSettingsConfigurationWizard.java
@@ -228,6 +228,9 @@ public class FiducialVisionSettingsConfigurationWizard extends AbstractConfigura
             }
 
             @Override
+            public Camera getCamera() throws Exception { return fiducialLocator.getVisionCamera(); }
+
+            @Override
             public void resetPipeline() throws Exception {
                 int result = JOptionPane.showConfirmDialog(getTopLevelAncestor(),
                         "This will replace the Pipeline with the default. Are you sure??", null,


### PR DESCRIPTION
# Description
A bug was reported [on google groups](https://groups.google.com/d/msgid/openpnp/68004a08-08f1-45b4-b57b-3bc42599c357n%40googlegroups.com?utm_medium=email&utm_source=footer).

This is a consequence of #1717, merged as part of #1719.

Pipeline `ParameterNumeric` stages hold their properties in engineering units, for example the 'Minimum Detail Size' property uses mm². `ParameterNumeric` then needs to perform a units conversion when updating other vision stages which might not use engineering units, for example the `FilterContours` `minArea` property uses pixel count. On my system the default 0.01mm² minimum detail size corresponds to 55 pixels.

#1717 fixed a bug where this conversion did not occur in some cases, and `FilterContours` was incorrectly using a size limit of 0.01 pixels.

This bug is the inverse problem. `ParameterNumeric` is in a pipeline which has not been configured with a camera property, and an exception is raised when it attempts to perform the conversion.

This fix involves adding a new method to the `PipelineControls` base class, to allow the two derived classes to provide a camera object.

In other contexts the camera object gets provided by the the `configurePipeline` method. But that enforces some other constraints that are relevant to running a pipeline. This bug occurs in the `resetToDefault` method where those constraints are not relevant.

# Implementation Details
1. How did you test the change? Be descriptive. Untested code will not be accepted.
      * Reported error message when copying a pipline is no longer seen
      * Pipeline copy and paste works as expected. Tested with stock pipelines, and several custom pipelines.
3. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)? -- yes
4. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing. -- no changes
5. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted. -- test pass
