### PR TITLE
An empty delay command should be treated the same as a missing delay command

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/driver/GcodeDriver.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/GcodeDriver.java
@@ -685,7 +685,7 @@ public class GcodeDriver extends AbstractReferenceDriver implements Named {
     @Override
     public boolean delay(int milliseconds) throws Exception {
             String command = getCommand(null, CommandType.DELAY_COMMAND);
-        if (command == null) {
+        if (command == null || command.isEmpty()) {
             // return false to signal that delaying in driver is not supported
             return false;
         }


### PR DESCRIPTION
# Description
PR #1699 added driver-side-delaying. This includes a new configurable gcode command, and fallback logic for the upgrade scenario when that gcode has not been configured.

This PR extends the fallback logic if the DELAY_COMMAND an empty string. Previously the fallback logic was only enabled if DELAY_COMMAND was null.

# Justification
I&S guides the user to set some appropriate gcode DELAY_COMMAND. The I&S solution shows that the gcode is initially blank, and shows the new recommended gcode.

After performing this upgrade, a curious user might want to revert back to java-side-delaying. Maybe to perform a comparison, or maybe because the effect was not quite what he expected. However this does not work. This fallback logic is triggered only if the gcode variable is null, but the gui gcode editor can only set it to an empty string.

# Implementation Details
1. How did you test the change? Be descriptive. Untested code will not be accepted.
    * I was that "curious user".
    * Tested on real machine: After the first upgrade to 2.3, I&S upgrade path, and the gcode editing "downgrade" path.
3. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)? -- yes
4. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing. -- no changes
5. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted. -- tests pass
