### PR TITLE
Marlin-specific I&S logic.

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/solutions/GcodeDriverSolutions.java
+++ b/src/main/java/org/openpnp/machine/reference/solutions/GcodeDriverSolutions.java
@@ -415,7 +415,7 @@ public class GcodeDriverSolutions implements Solutions.Subject {
                 if (gcodeDriver instanceof GcodeAsyncDriver) {
                     boolean locationConfirmation = ((GcodeAsyncDriver)gcodeDriver).isReportedLocationConfirmation();
                     boolean confirmationFlowControl = ((GcodeAsyncDriver)gcodeDriver).isConfirmationFlowControl();
-                    boolean locationConfirmationRecommended = hasAxes;
+                    boolean locationConfirmationRecommended = hasAxes && firmware!=FirmwareType.Marlin;
                     if (locationConfirmationRecommended != locationConfirmation) {
                         solutions.add(new Solutions.Issue(
                                 gcodeDriver, 
@@ -424,7 +424,8 @@ public class GcodeDriverSolutions implements Solutions.Subject {
                                                 ? "Location Confirmation recommended for extra features in homing, contact probing, etc."
                                                         : "Location Confirmation required when Confirmation Flow Control is off. "
                                                                 + "Supports extra features in homing, contact probing, etc.")
-                                                : "Location Confirmation usually not available when no axes present."),
+                                                : ( !hasAxes ? "Location Confirmation usually not available when no axes present."
+                                                             : "Marlin sends location-like responses to other commands so Location Confirmation is not reliable")),
                                 (locationConfirmationRecommended ? "Enable Location Confirmation" : "Disable Location Confirmation"),
                                 (confirmationFlowControl ? Severity.Suggestion : Severity.Error),
                                 "https://github.com/openpnp/openpnp/wiki/GcodeAsyncDriver#advanced-settings") {
@@ -440,7 +441,8 @@ public class GcodeDriverSolutions implements Solutions.Subject {
                     boolean serialFlowControlOff = (gcodeDriver.getCommunicationsType() == CommunicationsType.serial 
                         && gcodeDriver.getSerial() != null 
                         && gcodeDriver.getSerial().getFlowControl() == FlowControl.Off) || firmware.getFlowControl(gcodeDriver) == FlowControl.Off;
-                    boolean confirmationFlowControlRecommended = serialFlowControlOff || ! hasAxes;
+                    boolean confirmationFlowControlRecommended = serialFlowControlOff || ! hasAxes ||
+                                                                 firmware==FirmwareType.Marlin; // Marlin require application-level flow control
                     if (confirmationFlowControlRecommended != confirmationFlowControl) {
                         solutions.add(new Solutions.Issue(
                                 gcodeDriver,


### PR DESCRIPTION
This is a draft PR. Not for action yet.

# Description

This PR adds some Marlin-specific logic to I&S

I&S normally recommends that *Location Confirmation* is enabled and *Confirmation Flow Control* is disabled. Openpnp needs at least one of these options enabled for isWaitingForDrivers completion with async gcode processing. This PR changes I&S to recommend the opposite combination for Marlin.

## Confirmation Flow Control

Confirmation Flow Control needs to be enabled because Marlin needs application-level flow control. RtsCts flow control is insufficient. This seems unlikely, but:
 a. With Confirmation Flow Control disabled I have observed Marlin reporting that commands were corrupt towards the end of a long block of gcode commands, as might be expected from an input buffer overrun.
 b. Marlin has optional [XON/XOFF](https://github.com/MarlinFirmware/Marlin/blob/dda42fb599d17fd049ee38a95b4e80dc95c9cbd2/Marlin/Configuration_adv.h#L2653) support which only makes sense if RtsCts flow control is unreliable. And no, I dont want to be implementing XON/XOFF in openpnp and recompiling my marlin to support it.
 c. [Here](https://github.com/MarlinFirmware/Marlin/blob/dda42fb599d17fd049ee38a95b4e80dc95c9cbd2/Marlin/src/HAL/STM32/MarlinSerial.cpp#L117) is where Marlin drops random bytes in the middle of a gcode line if the buffer overruns.

This is fine. Confirmation Flow Control method is fine.

## Location Confirmation

Location Confirmation mode is problematic because Marlin sends location-like responses to other commands, so getReportedLocation() doesnt have any 'uniquely recognisable confirmation'. Those responses might be limited to homing commands, so there might be a way to work around this. But we dont need to. Location Confirmation is marginal benefit given we have to enable Confirmation Flow Control anyway.

# Justification
Currently I&S guidance leaves Marlin users with a dangerous machine after enabling async gcode processing. When first trying this I quickly saw unpredictable dangerous machine movement and hit the emergency stop button

# Implementation Details
1. How did you test the change? Be descriptive. Untested code will not be accepted. -- tested on a real machine. An outstanding test is to redo the I&S guided upgrade from synchronous gcode.
2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)? -- yes
3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing. -- no changes
4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted. -- tests pass
