### PR TITLE
Fix Neoden 4 Linux support

### DIFF
--- a/src/main/java/org/openpnp/machine/neoden4/NeoDen4Driver.java
+++ b/src/main/java/org/openpnp/machine/neoden4/NeoDen4Driver.java
@@ -3,6 +3,7 @@ package org.openpnp.machine.neoden4;
 import java.awt.geom.Point2D;
 import java.io.IOException;
 import java.util.concurrent.TimeoutException;
+import java.util.Arrays;
 
 import org.openpnp.gui.support.PropertySheetWizardAdapter;
 // import org.openpnp.logging.CalibrationLogger;
@@ -289,17 +290,22 @@ public class NeoDen4Driver extends AbstractReferenceDriver {
         getCommunications().write(d);
     }
 
+    void writeBytes(byte[] b, boolean log) throws Exception {
+        if (log) {
+            StringBuffer sb = new StringBuffer();
+            for (int i = 0; i < b.length; i++) {
+                sb.append(String.format("%02x", b[i] & 0xff));
+            }
+            Logger.trace("> " + sb.toString());
+        }
+
+        getCommunications().writeBytes(b);
+    }
+
     void writeWithChecksum(byte[] b) throws Exception {
-        StringBuffer sb = new StringBuffer();
-        for (int i = 0; i < b.length; i++) {
-            sb.append(String.format("%02x", b[i] & 0xff));
-        }
-        sb.append(String.format("%02x", checksum(b) & 0xff));
-        Logger.trace("> " + sb.toString());
-        for (int i = 0; i < b.length; i++) {
-            write(b[i], false);
-        }
-        getCommunications().write(checksum(b) & 0xff);
+        byte target[] = Arrays.copyOf(b, b.length+1);
+        target[b.length] = (byte)(checksum(b) & 0xff);
+        writeBytes(target, true);
     }
 
     byte[] readWithChecksum(int length) throws Exception {

--- a/src/main/java/org/openpnp/machine/neoden4/Neoden4CameraHandler.java
+++ b/src/main/java/org/openpnp/machine/neoden4/Neoden4CameraHandler.java
@@ -10,7 +10,7 @@ public final class Neoden4CameraHandler implements Neoden4CameraDriver {
 	private static Neoden4CameraDriver driver;
 
 	public Neoden4CameraHandler() {
-		String sharedLib = "libneodencam";
+		String sharedLib = "neodencam"; // translates to libneodencam.so
 		if (SystemUtils.IS_OS_WINDOWS) {
 			sharedLib = "NeodenCamera.dll";
 		}

--- a/src/main/java/org/openpnp/machine/reference/driver/ReferenceDriverCommunications.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/ReferenceDriverCommunications.java
@@ -70,7 +70,7 @@ public abstract class ReferenceDriverCommunications {
     }
     abstract public String getConnectionName();
 
-    abstract protected void writeBytes(byte[] data) throws IOException;
+    abstract public void writeBytes(byte[] data) throws IOException;
 
     abstract public int read() throws TimeoutException, IOException;
 


### PR DESCRIPTION
# Description
The [PR adding Neoden4 camera support for Linux](https://github.com/openpnp/openpnp/pull/1604) contains a mistake that prevents the shared library from being loaded, due to the addition of the `lib` prefix.

I also noticed that the RS-232 communication with the Neoden 4 driver board is very sensitive to timing and I could only get it to work reliably by sending out the entire buffer in one go. Hence the other change I'm trying to sneak in with this PR.

If there is any reason not to make `ReferenceDriverCommunications::writeBytes()` public, please let me know.

# Justification
Improve support for Neoden 4 under Linux.

## Implementation Details
(copied from the commit message)

Previously, write() was called in a loop over all bytes. This seems unnecessary because that method will in turn call writeBytes() with a length-1 array for each byte.

Now we're exporting writeBytes() as a public method so the machine drivers can use it directly.

Neoden4Driver was adapted to use writeBytes(). Without this change, serial communication would be too slow on the original hardware and the machine controller would not recognize command sequences.