### PR TITLE
Fix error when dismissing secondary fiducial position solution

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/solutions/VisionSolutions.java
+++ b/src/main/java/org/openpnp/machine/reference/solutions/VisionSolutions.java
@@ -595,8 +595,7 @@ public class VisionSolutions implements Solutions.Subject {
                         head.setCalibrationSecondaryFiducialLocation(head.getCalibrationSecondaryFiducialLocation()
                                 .derive(oldSecondaryFiducialLocation, true, true, false, false));
                         head.setCalibrationSecondaryFiducialDiameter(oldSecondaryFiducialDiameter);
-                        camera.setUnitsPerPixelSecondary(camera.getUnitsPerPixelSecondary()
-                                .derive(oldUnitsPerPixelSecondary, true, true, false, false));
+                        camera.setUnitsPerPixelSecondary(oldUnitsPerPixelSecondary);
                         // Persist this unsolved state.
                         solutions.setSolutionsIssueSolved(this, false);
                         super.setState(state);


### PR DESCRIPTION
# Description
Dismissing the secondary calibration fiducial position solution throws an error. This is due to the secondary units per pixel being initialized to `null` to indicate a missing 3D calibration. The solution calls `.derive()` on this to restore the old value, which causes a null pointer exception. This fix restores the old value without calling it's methods.

# Justification
Dismissing solutions should not cause errors.

# Instructions for Use
Same as before.

# Implementation Details
1. How did you test the change? Be descriptive. Untested code will not be accepted.
Tested on the simulated machine if the solution can be accepted, dismissed and reopened without errors.
2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)?
Yes
3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing.
No
4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted.
Done
