### PR TITLE
Job Optimisation nozzle order

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/ReferencePnpJobProcessor.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferencePnpJobProcessor.java
@@ -977,7 +977,7 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
             
             // sort lists per nozzleTips by their size such that the nozzle tip that can handle
             // the most jobPlacments is first. As second sorting criteria the nozzleTip's name is used.
-            // For mulit-nozzle machines with different nozzleTips for each nozzle that are compatible
+            // For multi-nozzle machines with different nozzleTips for each nozzle that are compatible
             // with the same jobPlacments this always results in groups of identical amounts of
             // jobPlacments. Taking the name into account makes the sorting unique again.
             perNozzleTipJobPlacements.sort(Comparator.comparing(JobPlacementNozzleTip::size).reversed()
@@ -992,7 +992,9 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
             // the other nozzles. Keeping all possible tips sorted by amount of placements they can
             // handle will likely provide a good starting point in selecting the next best one.
             List<NozzleTip> plannedNozzleTips = perNozzleTipJobPlacements.stream().map(j -> j.getNozzleTip()).collect(Collectors.toList());
-            
+
+            HashMap <NozzleTip,Integer> perNozzlePlacementOptions = new HashMap<NozzleTip,Integer>();
+
             // Remove duplicate placements keeping only the first occurrence
             // Skip this step if there is only one nozzle tip left.
             if (perNozzleTipJobPlacements.size() > 1) {
@@ -1004,15 +1006,30 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
                     for (int j = i + 1; j < perNozzleTipJobPlacements.size(); ++j) {
                         // remove all placements that are in the dominant group
                         JobPlacementNozzleTip recessivePlacements = perNozzleTipJobPlacements.get(j);
+                        int n = recessivePlacements.size();
                         recessivePlacements.removeAll(dominantPlacements);
                         perNozzleTipJobPlacements.set(j, recessivePlacements);
+                        n -= recessivePlacements.size(); // calculate the number of recessive placements removed
+                        if(n>0) {
+                            perNozzlePlacementOptions.put(nozzleTips.get(i), perNozzlePlacementOptions.getOrDefault(nozzleTips.get(i),0) + n);
+                            perNozzlePlacementOptions.put(nozzleTips.get(j), perNozzlePlacementOptions.getOrDefault(nozzleTips.get(j),0) + n);
+                        }
                     }
                 }
                 
                 // remove empty nozzle groups
                 perNozzleTipJobPlacements = perNozzleTipJobPlacements.stream().filter(i -> !i.isEmpty()).collect(Collectors.toList());
             }
-            
+
+            // It is a bad outcome for a multi-nozzle machine to get stuck running on only a single nozzle.
+            // We do not track enough information to optimise multi-nozzle scenarios, but we have this heuristic to minimise the chance of this occurring.
+            // Inflexible nozzle tips are run first, and the flexible nozzle tips (i.e. those that can handle parts which can also be handled
+            // by other tips) are kept for the end of the job.
+            Logger.trace("perNozzlePlacementOptions {}",perNozzlePlacementOptions);
+            perNozzleTipJobPlacements.sort(Comparator.comparing( (JobPlacementNozzleTip j) -> perNozzlePlacementOptions.getOrDefault(j.getNozzleTip(),0))
+                                                    .thenComparing(Comparator.comparing(JobPlacementNozzleTip::size).reversed())
+                                                    .thenComparing(j -> j.getNozzleTip().getName()));
+
             // optimize each nozzle tip group using PickPlaceLocation
             output = new ArrayList<JobPlacement>();
             // This variable is the return value of planJobPlacmentsByPickPlaceLocation

--- a/src/main/resources/org/openpnp/translations.properties
+++ b/src/main/resources/org/openpnp/translations.properties
@@ -813,6 +813,7 @@ MachineControls.Label=Machine Controls
 MachineSetup.JobProcessors.ReferencePnpJobProcessor.JobOrder.BoardPart=Board\:Part
 MachineSetup.JobProcessors.ReferencePnpJobProcessor.JobOrder.HeightPartBoard=Height\:Part\:Board
 MachineSetup.JobProcessors.ReferencePnpJobProcessor.JobOrder.NozzleTips=Nozzle Tips
+MachineSetup.JobProcessors.ReferencePnpJobProcessor.JobOrder.NozzleTipsByFlexibility=Nozzle Tips (Inflexible Tips First)
 MachineSetup.JobProcessors.ReferencePnpJobProcessor.JobOrder.Part=Part
 MachineSetup.JobProcessors.ReferencePnpJobProcessor.JobOrder.PartBoard=Part\:Board
 MachineSetup.JobProcessors.ReferencePnpJobProcessor.JobOrder.PartHeight=Height\:Part


### PR DESCRIPTION
# Description

It is a bad outcome for a multi-nozzle machine to get stuck using only a single nozzle, while another nozzle is left idle. This occurs if the job reaches a point where the idle nozzle can not find a tip which can handle any of the outstanding parts.

This PR changes the "Nozzle Tips" Job Ordering method with a heuristic to reduce the likelihood of this occuring.

The "Nozzle Tips" method operates by grouping parts according to the nozzle tip, then optimising the order of feeders then placements within each group.

The description in [the wiki](https://github.com/openpnp/openpnp/wiki/Job-Processing#configuration) is that it uses "most efficient order of nozzle tips". A code comment says "keeping all possible tips sorted by amount of placements they can handle will likely provide a good starting point in selecting the next best one". Maybe I am missing something, but I do not have an intuitive understanding of why that is a desirable order to run the job.

This PR uses a different sort order. For each tip, it counts the number of placements that can also be handled by an alternative tip, then this count is the primary sort key. A high count indicates that the nozzle is handling parts which can be placed by more than one nozzle. On a multi-nozzle machine it is desirable to schedule these at the end of the job.

# Concerns

I changed the "Nozzle Tips" policy sort order, but I am open to the suggestion that adding a new policy to the `JobOrderHint` enum would be better:

1. Am I overlooking some advantage to the original "Nozzle Tips" sort order? On a single nozzle machine maybe?
2. Are there users who would be better served by the original sort order?
3. Are there users who have got used to the original sort order and would not appreciate it changing?

# Justification
I have been testing this on my lumenpnp which has 2 nozzles, and 7 tips which can be used on any nozzle.

Having tested the original "Nozzle Tips" on several different jobs, more than half of those got stuck finishing the job with a single nozzle. Typically this occurs when there is a module or connector which needs a larger tip, and only one tip is suitable. Sorting by number of placements means that this tip is scheduled last, because there is a small number of placements using this tip, and the job reaches a point where only this tip is active.

I have tested two of those problem jobs with this PR. It schedules the tip to place those inflexible parts first. The job finishes using the tips with the greatest flexibility, with both nozzles remaining busy until the end of the job.

# Implementation Details
1. How did you test the change? Be descriptive. Untested code will not be accepted. -- tested on two real jobs. 
5. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)? -- yes
6. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing. -- no changes
7. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted. -- tests pass
