### PR TITLE
calculate travel time using backlash calibration data

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/ReferencePnpJobProcessor.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferencePnpJobProcessor.java
@@ -68,6 +68,7 @@ import org.openpnp.util.TravellingSalesman;
 import org.openpnp.util.UiUtils;
 import org.openpnp.util.Utils2D;
 import org.openpnp.util.VisionUtils;
+import org.openpnp.util.MotionUtils;
 import org.pmw.tinylog.Logger;
 import org.simpleframework.xml.Attribute;
 import org.simpleframework.xml.Element;
@@ -2540,15 +2541,15 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
                 Location averagePickLocation  = calcCenterLocation(plannedPlacements, pickLocator);
                 Location averagePlaceLocation = calcCenterLocation(plannedPlacements, placeLocator);
                 
-                // find the placement with the shortest distance to averagePlickLocation and averagePlaceLocation
-                double bestDistance = Double.MAX_VALUE;
+                // find the placement with the lowest cost to averagePickLocation and averagePlaceLocation.
+                double bestCost = Double.MAX_VALUE;
                 for (JobPlacement p : compatibleJobPlacements) {
-                    double distance = pickLocator.getLocation(p, nozzle).getLinearDistanceTo(averagePickLocation) 
-                                    + placeLocator.getLocation(p, nozzle).getLinearDistanceTo(averagePlaceLocation);
+                    double cost = MotionUtils.getMotionCost(pickLocator.getLocation(p, nozzle).subtract(averagePickLocation))
+                                + MotionUtils.getMotionCost(placeLocator.getLocation(p, nozzle).subtract(averagePlaceLocation));
 
-                    // if this placement is closes with respect to its pick and place 
-                    if (bestDistance > distance) {
-                        bestDistance = distance;
+                    // if this placement is closest with respect to its pick and place
+                    if (bestCost > cost) {
+                        bestCost = cost;
                         bestPlacement = p;
                     }
                 }

--- a/src/main/java/org/openpnp/util/MotionUtils.java
+++ b/src/main/java/org/openpnp/util/MotionUtils.java
@@ -1,0 +1,89 @@
+package org.openpnp.util;
+
+import java.awt.geom.Point2D;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.Collections;
+import org.pmw.tinylog.Logger;
+import org.openpnp.model.Configuration;
+import org.openpnp.model.Location;
+import org.openpnp.machine.reference.ReferenceMachine;
+import org.openpnp.spi.base.AbstractAxis;
+import org.openpnp.machine.reference.axis.ReferenceControllerAxis;
+import org.openpnp.util.SimpleGraph;
+import org.openpnp.util.SimpleGraph.DataScale;
+import org.openpnp.util.SimpleGraph.DataRow;
+
+public class MotionUtils {
+
+    // Given a x/y movement vector, return a measurement of the cost of performing that movement.
+    // This return value is suitable for use in optimising a movement plan.
+    //
+    // It might be either:
+    // 1. A time value, if the x and y axes have performed backlash calibration
+    //    which records a profile of single-axis movement times over a range of distances.
+    // 2. The linear distance, as a fallback if there is no way to estimate movement time.
+    //
+    public static double getMotionCost(Location l) {
+        Double xt = getSingleAxisMotionCost(AbstractAxis.Type.X,l.getX());
+        Double yt = getSingleAxisMotionCost(AbstractAxis.Type.Y,l.getY());
+        if (xt==null || yt==null) {
+            // Fallback to just returning the distance
+            return l.getLinearDistanceTo(Location.origin);
+        } else {
+            // Assume that each axis movement is independent of the other,
+            // and return the maximum of the duration of the axis movement.
+            double t=Math.max(xt,yt);
+            return t;
+        }
+    }
+
+    public static Double getSingleAxisMotionCost(AbstractAxis.Type axisType,double d) {
+        // Find the axis. Find the graph recorded by axis backlash calibration.
+        // Find the timing data rows. Check that row has enough data. Interpolate.
+        ReferenceMachine machine = (ReferenceMachine)Configuration.get().getMachine();
+        AbstractAxis axis = machine.getDefaultAxis(axisType);
+        if(axis instanceof ReferenceControllerAxis) {
+            SimpleGraph graph = ((ReferenceControllerAxis)axis).getBacklashDistanceTestGraph();
+            if (graph != null) {
+                for(DataScale scale : graph.getScales()) {
+                    if(scale.getLabel().equals("T")) {
+                        for (DataRow dataRow : scale.getDataRows()) {
+                            if (dataRow.getLabel().equals("T0")) {
+                                if (dataRow.size()>5) {
+                                    d = Math.abs(d);
+                                    Double t = dataRow.getInterpolated(d);
+                                    if (t!=null) {
+                                        return t;
+                                    } else {
+                                        // This distance is outside the range which was tested during
+                                        // backlash calibration. We therefore need to extrapolate
+                                        if(d< (dataRow.getMinimum().x+dataRow.getMaximum().x)/2) {
+                                            // This movement is smaller than the smallest calibrated movement.
+                                            // Interpolate between that smallest, and zero time for zero distance.
+                                            Set<Double> xaxis = dataRow.getXAxis();
+                                            double sd = Collections.min(xaxis);
+                                            double st = dataRow.getDataPoint(sd);
+                                            return d * st/sd;
+                                        } else {
+                                            // This movement is further than the largest. Linear extrapolation through the two largest points
+                                            TreeSet<Double> xaxis = new TreeSet<Double>(dataRow.getXAxis()); // make a copy
+                                            double sd = Collections.max(xaxis);
+                                            double st = dataRow.getDataPoint(sd);
+                                            xaxis.remove(sd); // find the second-largest; this is why we made a copy above
+                                            double rd = Collections.max(xaxis);
+                                            double rt = dataRow.getDataPoint(rd);
+                                            return st + (d-sd) * (rt-st) / (rd-sd);
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        return null;
+    }
+}
+


### PR DESCRIPTION
**This is a Proof Of Concept PR, shared for feedback and ideas. I do not plan to merge this in its current form**

# Description

This loop in the job processor optimises the combination of placements which will be handled simultaneously on a multi-nozzle machine. It optimises based on the total **travel distance**: from one pick location to the next, plus the distance from one placement to the next.

https://github.com/openpnp/openpnp/blob/535678fe6a554a8bf4ab2b0bb3a8f78565f64a3a/src/main/java/org/openpnp/machine/reference/ReferencePnpJobProcessor.java#L2534-L2555

Optimising based on travel distance is ok, but it ignores:
* Differences between axes. One axis might be stronger and faster
* Acceleration profiles

Anecdotally, I had noticed that the job processor was sometimes picking pairs of placements that were less optimal than they could be. My lumenpnp machine is distinctly limited by acceleration, so it is not a surprise that optimising based on travel distance was picking some poor combinations.

This PR changes that loop to optimise **travel time**, using some of the data collected during backlash calibration to convert movement vectors into travel time. Specifically it uses the data which is plotted on this chart (image copied from the [wiki](https://github.com/openpnp/openpnp/wiki/Calibration-Solutions#backlash-calibration-on-the-axis--diagnostics) ):

![image](https://github.com/user-attachments/assets/4e676b12-bba5-4573-a8c7-559fa3b0c42c)

I have used this on a few jobs, and it looks to be an improvement. A higher proportion of the moves between pick locations and between placement locations are desirable, efficient moves. I do not yet have a quantitative analysis.

# Disadvantages

1. The standard backlash compensation does not record quite enough data. It records timing data for a range of movements up to 10mm. For my testing I increased this to 100mm. That significantly increases the duration of the backlash compensation process, so this is definitely not an approach that I can generally recommend.
https://github.com/openpnp/openpnp/blob/535678fe6a554a8bf4ab2b0bb3a8f78565f64a3a/src/main/java/org/openpnp/machine/reference/solutions/CalibrationSolutions.java#L82-L82
2. The backlash data is specific to each axis. It provides data about movements parallel to an axis, but we have no information about diagonal movements.
3. The backlash data is stored in a `SimpleGraph` object; ideal for plotting as a graph, but not a great format for further calculations.

# Outstanding Questions

A. Does this general approach sound useful?
B. Feedback would be appreciated on the new `MotionUtils` api
C. I think it makes sense to create a new I&S solution to collect motion timing data over a range of steps sizes, at 0° 90° and 45° movements. Maybe 22.5° too. Does that approach make sense?
