### PR TITLE
"git blame" ignore some commits

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,3 @@
+14d3f5675e6da7c40e7dcc20cc0e125f9d1e3059 # Corrected line endings found by Maven tests
+
+


### PR DESCRIPTION
# Description
This PR adds the .git-blame-ignore-revs file.

# Justification
This file lists revisions which should be excluded from "git blame". This is useful for revisions like 14d3f5675e6da7c40e7dcc20cc0e125f9d1e3059 which was a mass update to correct line endings in lots of files. This revision is not semantically interesting, so it is useful to exclude it from "git blame" when investigating the code history.

Github supports this automatically, and the git client can be configured to do so.

https://docs.github.com/en/repositories/working-with-files/using-files/viewing-and-understanding-files#ignore-commits-in-the-blame-view

# Implementation Details
1. How did you test the change? Be descriptive. Untested code will not be accepted. -- no code changes
2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)? -- no code changes
3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing. -- no changes
4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted. -- tests pass
