### PR TITLE
Actuator API without method overloading

### DIFF
--- a/src/main/java/org/openpnp/spi/base/AbstractActuator.java
+++ b/src/main/java/org/openpnp/spi/base/AbstractActuator.java
@@ -373,6 +373,11 @@ public abstract class AbstractActuator extends AbstractHeadMountable implements 
         }
     }
 
+    public final void actuateBoolean(boolean value) throws Exception { actuate(value); }
+    public final void actuateDouble(double value) throws Exception { actuate(value); }
+    public final void actuateString(String value) throws Exception { actuate(value); }
+    public final void actuateObject(Object value) throws Exception { actuate(value); }
+
     public void assertOnOffDefined() throws Exception {
         if (getDefaultOnValue() == null 
                 || getDefaultOffValue() == null 


### PR DESCRIPTION
# Description
`Actuator.actuate()` has several overloaded methods with different parameter types.

This is fine in java, but can be problematic when using actuators from scripting languages with different type systems. A specific problem is that Python's `True` and `False` objects can also be used as numeric 1 and 0, and therefore `actuator.actuate(True)` in a Jython script ends up calling `actuate(Double value)`.

This patch adds some forwarding methods with explicit names.

```
Python 2.7.17 (default, Mar  8 2023, 18:40:28) 
[GCC 7.5.0] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> float(True)
1.0
>>> int(False)
0
```

# Justification
It should be possible to turn on my vacuum pump from a Python script.

# Concerns
Is there a better java language solution for this problem?

# Implementation Details
1. How did you test the change? Be descriptive. Untested code will not be accepted.
     a. Tests pass
     b. My script that needs to control the vacuum pump now works.
3. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)? -- review would be appreciated
4. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing. -- no changes
5. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted. -- tests pass
