### PR TITLE
a possible fix for issue #1804. feeders empty list

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/ReferencePnpJobProcessor.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferencePnpJobProcessor.java
@@ -780,6 +780,12 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
                 catch (Exception e) {
                 }
             }
+
+            if (feeders.size()==0) {
+                // We were unable to find any feeders, so there is no need for TSM.
+                // We end where we started.
+                return startLocation;
+            }
             
             // route pick locations of all feeders through travelling salesman
             TravellingSalesman<Feeder> tsm = new TravellingSalesman<>(


### PR DESCRIPTION
# Description
This is a proposed fix for issue #1804. The exception stack trace recorded in that issue occurs when `updateFeederIndex` returns its finishing location, using the location of the last feeder visited by the TSM, but that list is empty. This patch detects this case, skips the TSM operation, and simply returns the `startLocation`.

This change conclusively avoids the exception recorded in issue #1804. It has been tested for 2 days of production usage with no further problems observed.

An outstanding task before merging is to prove that this wont leave some other problems. Previously the return value from `updateFeederIndex` could never have been `null`, because it returns a feeder location and feeders always have a location. However sometimes the provided `startLocation` is `null`. I have not fully proven that this can not cause a problem. This is a provisional PR for now.

# Implementation Details
1. How did you test the change? Be descriptive. Untested code will not be accepted. 
    * tests pass
    * code review confirms that the reported exception is no longer possible
    * test in production shows no further problems
3. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)? -- yes
4. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing. -- no changes
5. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted. -- tests pass.
