### PR TITLE
Better metric for motion optimization

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/solutions/VisionSolutions.java
+++ b/src/main/java/org/openpnp/machine/reference/solutions/VisionSolutions.java
@@ -1198,7 +1198,7 @@ public class VisionSolutions implements Solutions.Subject {
 
             // Perform zero knowledge calibration motion pattern.
             double displacementAbsMm = zeroKnowledgeDisplacementMm;
-            Location unitsPerPixel = new Location(null);
+            Location unitsPerPixel = new Location();
             Length featureDiameter = null;
             for (int pass = 0; pass < 3; pass++) {
                 double displacementMm = displacementAbsMm;

--- a/src/main/java/org/openpnp/model/Location.java
+++ b/src/main/java/org/openpnp/model/Location.java
@@ -44,12 +44,8 @@ public class Location {
     @Attribute(required = false)
     private double rotation;
 
-    /**
-     * Only used by XML serialization.
-     */
-    @SuppressWarnings("unused")
-    private Location() {
-        this(null);
+    public Location() {
+        this((LengthUnit)null);
     }
 
     public Location(LengthUnit units) {
@@ -62,6 +58,10 @@ public class Location {
         this.y = y;
         this.z = z;
         this.rotation = rotation;
+    }
+
+    public Location(Location l) {
+        this(l.getUnits(), l.getX(), l.getY(), l.getZ(), l.getRotation());
     }
 
     static final public Location origin = new Location(LengthUnit.Millimeters);
@@ -87,10 +87,21 @@ public class Location {
     }
 
     public Location convertToUnits(LengthUnit units) {
-        Location location =
-                new Location(units, new Length(x, this.units).convertToUnits(units).getValue(),
-                        new Length(y, this.units).convertToUnits(units).getValue(),
-                        new Length(z, this.units).convertToUnits(units).getValue(), rotation);
+        Location location;
+
+        // If the units do not change, take the shortcut to return this.
+        // This is safe because all members are guaranteed to not change
+        // after creation. This has been verified defining them final.
+        // Unfortunately this compiler assisted test can not stay in place
+        // because the serializer requires elements to be writeable.
+        if (this.units == units) {
+            location = this;
+        }
+        else {
+            location = new Location(units, new Length(x, this.units).convertToUnits(units).getValue(),
+                            new Length(y, this.units).convertToUnits(units).getValue(),
+                            new Length(z, this.units).convertToUnits(units).getValue(), rotation);
+        }
         return location;
     }
 

--- a/src/main/java/org/openpnp/util/TravelCost.java
+++ b/src/main/java/org/openpnp/util/TravelCost.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright (C) 2025 <janm012012@googlemail.com>
+ * 
+ * This file is part of OpenPnP.
+ * 
+ * OpenPnP is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * OpenPnP is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License along with OpenPnP. If not, see
+ * <http://www.gnu.org/licenses/>.
+ * 
+ * For more information about OpenPnP visit http://openpnp.org
+ */
+
+package org.openpnp.util;
+
+import org.openpnp.machine.reference.axis.ReferenceControllerAxis;
+import org.openpnp.machine.reference.solutions.HeadSolutions;
+import org.openpnp.model.Configuration;
+import org.openpnp.model.LengthUnit;
+import org.openpnp.model.Location;
+import org.openpnp.spi.CoordinateAxis;
+import org.openpnp.spi.HeadMountable;
+import org.openpnp.spi.Machine;
+import org.pmw.tinylog.Logger;
+
+/**
+ * Methods to estimate the cost of motion between two locations.
+ * 
+ * The basic principle is to estimate the cost using three point motion with
+ * two constant acceleration segments and one optional feedrate limited segment.
+ * The estimation assumes, that motion starts and ends at standstill.
+ */
+public class TravelCost {
+    
+    /**
+     * @param movable head mountable's axis to use for cost estimation, if null
+     * the default camera on the default head is used
+     * @param units the units to calculate the in. static data is prepared in this
+     * units and Length input is convert to this units for the estimation
+     * @throws if no default camera is define or if the movable has no mapped XY axis
+     */
+    public TravelCost(HeadMountable movable, LengthUnit units) throws Exception {
+        super();
+
+        // use default units if not specified
+        if (units == null) {
+            units = defaultUnits;
+        }
+        this.units = units;
+        
+        // collect axis parameter
+        Machine machine = Configuration.get().getMachine();
+        // if no movable is specified, use the default camera of the default head
+        if (movable == null) {
+            movable = machine.getDefaultHead().getDefaultCamera();
+        }
+        CoordinateAxis rawAxisX = HeadSolutions.getRawAxis(machine, movable.getAxisX());
+        CoordinateAxis rawAxisY = HeadSolutions.getRawAxis(machine, movable.getAxisY());
+        if (! (rawAxisX instanceof ReferenceControllerAxis
+                && rawAxisY instanceof ReferenceControllerAxis)) {
+            throw new Exception("HeadMountable "+ movable + "has no XY axis assigned");
+        }
+        ReferenceControllerAxis referenceControllerAxisX = (ReferenceControllerAxis)rawAxisX;
+        ReferenceControllerAxis referenceControllerAxisY = (ReferenceControllerAxis)rawAxisY;
+
+        this.xAxis = new AxisParameter(referenceControllerAxisX, units);
+        this.yAxis = new AxisParameter(referenceControllerAxisY, units);
+        
+        // try to collect information about Z axis
+        CoordinateAxis rawAxisZ = HeadSolutions.getRawAxis(machine, movable.getAxisZ());
+        if (!(rawAxisZ instanceof ReferenceControllerAxis)) {
+            Logger.trace("Travel cost estimation for headmountable " + movable + " not avaiable on Z axis");
+            this.zAxis = null;
+        }
+        else {
+            ReferenceControllerAxis referenceControllerAxisZ = (ReferenceControllerAxis)rawAxisZ;
+    
+            this.zAxis = new AxisParameter(referenceControllerAxisZ, units);
+        }
+        
+        // try to collect information about rotational axis
+        CoordinateAxis rawAxisC = HeadSolutions.getRawAxis(machine, movable.getAxisRotation());
+        if (!(rawAxisC instanceof ReferenceControllerAxis)) {
+            Logger.trace("Travel cost estimation for headmountable " + movable + " not avaiable on rotational axis");
+            this.cAxis = null;
+        }
+        else {
+            ReferenceControllerAxis referenceControllerAxisC = (ReferenceControllerAxis)rawAxisC;
+    
+            this.cAxis = new AxisParameter(referenceControllerAxisC, units);
+        }
+    }
+    public TravelCost(HeadMountable movable) throws Exception {
+        this(movable, null);
+    }
+    public TravelCost() throws Exception {
+        this(null);
+    }
+    
+    //* define default units to use for calculations
+    private static final LengthUnit defaultUnits = LengthUnit.Millimeters;
+
+    /**
+     * Collect and group axis parameter for later use for cost estimation
+     */
+    private static class AxisParameter {
+        private double acceleration;        // in [units]/s^2
+        private double feedrate;            // in [units]/s
+        private double shortDistanceLimit;  // in [units] - the distance at which motion is feedrate limited
+        
+        private AxisParameter(ReferenceControllerAxis axis, LengthUnit units) {
+            this.acceleration = axis.getAccelerationPerSecond2().convertToUnits(units).getValue();
+            this.feedrate     = axis.getFeedratePerSecond().convertToUnits(units).getValue();
+            this.shortDistanceLimit = feedrate * feedrate / acceleration;
+        }
+    }
+
+    private final LengthUnit units;
+    private final AxisParameter xAxis;
+    private final AxisParameter yAxis;
+    private final AxisParameter zAxis;
+    private final AxisParameter cAxis;
+
+    /**
+     * @param a
+     * @param b
+     * @return cost to travel from a to b using mapped axes parameters
+     */
+    public double getCost(Location a, Location b) {
+        a = a.convertToUnits(units);
+        b = b.convertToUnits(units);
+        double costX = estimateCost(a.getX() - b.getX(), xAxis);
+        double costY = estimateCost(a.getY() - b.getY(), yAxis);
+        
+        return Math.max(costX, costY);
+    }
+
+    public double getXyzCost(Location a, Location b) {
+        a = a.convertToUnits(units);
+        b = b.convertToUnits(units);
+        double cost = getCost(a, b);
+        // if zAxis parameters are not available, assume 0 and return cost on XY only
+        if (zAxis != null) {
+            cost = Math.max(cost, estimateCost(a.getZ() - b.getZ(), zAxis));
+        }
+        
+        return cost;
+    }
+
+    public double getXyzcCost(Location a, Location b) {
+        a = a.convertToUnits(units);
+        b = b.convertToUnits(units);
+        double cost = getXyzCost(a, b);
+        // if cAxis parameters are not available, assume 0 and return cost on XYZ only
+        if (cAxis != null) {
+            cost = Math.max(cost, estimateCost((a.getRotation() - b.getRotation()) % 360, cAxis));
+        }
+        
+        return cost;
+    }
+
+    /**
+     * Return a cost estimation to travel <distance> using <axis>.
+     * The feedrate and acceleration limits are used to estimate 
+     * the cost assuming the motion is at stand still before and
+     * after <distance>.
+     *
+     * @param distance distance to travel
+     * @param axis axis to take acceleration and feedrate from
+     * @return
+     */
+    private double estimateCost(double distance, AxisParameter axis) {
+        double acceleration = axis.acceleration;
+        double feedrate     = axis.feedrate;
+        double cost;
+        
+        // make distance a positive number
+        distance = Math.abs(distance);
+        
+        // on short distances, only acceleration has to be taken into account
+        if (distance < axis.shortDistanceLimit) {
+            cost = 2 * Math.sqrt(distance / acceleration);
+        }
+        else {
+            cost = feedrate / acceleration + distance / feedrate;
+        }
+        
+        return cost;
+    }
+}

--- a/src/main/java/org/openpnp/util/TravellingSalesman.java
+++ b/src/main/java/org/openpnp/util/TravellingSalesman.java
@@ -151,20 +151,15 @@ public class TravellingSalesman<T> {
      * Plain old data TravelLocation for faster processing. Improved solving by a factor of 6 from using
      * OpenPNP Locations directly. These are always in Millimeters, no conversions needed.  
      */
-    private class TravelLocation {
-        private  double x, y, z;
-        private  int index;
+    private class TravelLocation extends Location {
+        private int index;
 
         private  TravelLocation(int index, Location l) {
-            super();
+            super(l.convertToUnits(LengthUnit.Millimeters));
             this.index = index;
-            l = l.convertToUnits(LengthUnit.Millimeters);
-            this.x = l.getX();
-            this.y = l.getY();
-            this.z = l.getZ();
         }
         private double getLinearDistanceTo(TravelLocation other) {
-            return Math.sqrt(Math.pow(this.x-other.x, 2.0) + Math.pow(this.y-other.y, 2.0) + Math.pow(this.z-other.z, 2.0));
+            return getXyzDistanceTo(other);
         }
 
         /**
@@ -175,8 +170,8 @@ public class TravellingSalesman<T> {
          */
         private double getCostTo(TravelLocation other) {
 
-            double costX = estimateCost(this.x - other.x, xAxis);
-            double costY = estimateCost(this.y - other.y, yAxis);
+            double costX = estimateCost(this.getX() - other.getX(), xAxis);
+            double costY = estimateCost(this.getY() - other.getY(), yAxis);
             
             return Math.max(costX, costY);
         }
@@ -436,11 +431,11 @@ public class TravellingSalesman<T> {
     }
 
     public Location getStartLocation() {
-        return new Location(LengthUnit.Millimeters, startLocation.x, startLocation.y, startLocation.z, 0.);
+        return startLocation;
     }
 
     public Location getEndLocation() {
-        return new Location(LengthUnit.Millimeters, endLocation.x, endLocation.y, endLocation.z, 0.);
+        return endLocation;
     }
 
     public long getSolverDuration() {
@@ -453,17 +448,17 @@ public class TravellingSalesman<T> {
         for (int i = -1; i <= this.travelSize; i++) {
             TravelLocation l = this.getLocation(i);
             if (l != null) {
-                if (Double.isNaN(minX) || minX > l.x) {
-                    minX = l.x;
+                if (Double.isNaN(minX) || minX > l.getX()) {
+                    minX = l.getX();
                 }
-                if (Double.isNaN(minY) || minY > l.y) {
-                    minY = l.y;
+                if (Double.isNaN(minY) || minY > l.getY()) {
+                    minY = l.getY();
                 }
-                if (Double.isNaN(maxX) || maxX < l.x + l.z) {
-                    maxX = l.x + l.z;
+                if (Double.isNaN(maxX) || maxX < l.getX() + l.getZ()) {
+                    maxX = l.getX() + l.getZ();
                 }
-                if (Double.isNaN(maxY) || maxY < l.y + l.z) {
-                    maxY = l.y + l.z;
+                if (Double.isNaN(maxY) || maxY < l.getY() + l.getZ()) {
+                    maxY = l.getY() + l.getZ();
                 }
             }
         }
@@ -486,8 +481,8 @@ public class TravellingSalesman<T> {
             TravelLocation la = this.getLocation(i);
             TravelLocation lb = this.getLocation(i+1);
             if (la != null && lb != null) {
-                svg.append("<line x1=\""+(la.x+la.z)+"\" y1=\""+(la.y+la.z)+"\" x2=\""+(lb.x+lb.z)+"\" y2=\""+(lb.y+lb.z)+"\" style=\"stroke:lightgrey;\"/>");
-                svg.append("<circle cx=\""+(lb.x+lb.z)+"\" cy=\""+(lb.y+lb.z)+"\" r=\"2\" style=\"fill:lightgrey;\"/>\n");
+                svg.append("<line x1=\""+(la.getX()+la.getZ())+"\" y1=\""+(la.getY()+la.getZ())+"\" x2=\""+(lb.getX()+lb.getZ())+"\" y2=\""+(lb.getY()+lb.getZ())+"\" style=\"stroke:lightgrey;\"/>");
+                svg.append("<circle cx=\""+(lb.getX()+lb.getZ())+"\" cy=\""+(lb.getY()+lb.getZ())+"\" r=\"2\" style=\"fill:lightgrey;\"/>\n");
             }
         }
         // lines
@@ -495,14 +490,14 @@ public class TravellingSalesman<T> {
             TravelLocation la = this.getLocation(i);
             TravelLocation lb = this.getLocation(i+1);
             if (la != null && lb != null) {
-                svg.append("<line x1=\""+la.x+"\" y1=\""+la.y+"\" x2=\""+lb.x+"\" y2=\""+lb.y+"\" style=\"stroke:black;\"/>");
+                svg.append("<line x1=\""+la.getX()+"\" y1=\""+la.getY()+"\" x2=\""+lb.getX()+"\" y2=\""+lb.getY()+"\" style=\"stroke:black;\"/>");
             }
         }
         // nodes
         for (int i = -1; i <= this.travelSize; i++) {
             TravelLocation la = this.getLocation(i);
             if (la != null) {
-                svg.append("<circle cx=\""+la.x+"\" cy=\""+la.y+"\" r=\"2\" style=\"");
+                svg.append("<circle cx=\""+la.getX()+"\" cy=\""+la.getY()+"\" r=\"2\" style=\"");
                 if (la == this.startLocation) { 
                     svg.append("stroke:blue; fill:white;");
                 } 

--- a/src/main/java/org/openpnp/util/TravellingSalesman.java
+++ b/src/main/java/org/openpnp/util/TravellingSalesman.java
@@ -246,7 +246,12 @@ public class TravellingSalesman<T> {
         int swaps = 0, twists = 0, copies = 0;
         double bestDistance = getTravellingDistance();
         double temperature = startingTemperature;
-        double endTemperature = startingTemperature/10000;
+        // The endTemperature defines the point until which small variations are tried. With a value to large
+        // the result is not good enough (as can be seen in the .svg the TavelingSalesmanTest generates).
+        // With a value to small the number of iterations increases without notable benefit to the end result.
+        // 10000 is a conservative setting. With 1000 only about 75% of the iterations are needed for the 610 
+        // cities test case with only a very little bit worth results.
+        double endTemperature = startingTemperature/1000;
         if (debugLevel > 0) {
             System.out.println("Initial distance of travel: " + bestDistance);
         }
@@ -255,6 +260,10 @@ public class TravellingSalesman<T> {
             double globalBestDistance = globalBestDistanceScalingFactor * bestDistance; // cost of global best route
 
             // make this repeatable by seeding the random generator
+            // It has been discussed, that the solver shall generate repeatable results.
+            // (https://github.com/openpnp/openpnp/pull/1715#issuecomment-2549791916)
+            // The overall stability can be verified by using the random number generator
+            // without a seed. (remove the "0")
             Random rnd = new java.util.Random(0);
             for (; i > 0; i--) {
                 if (temperature > endTemperature) {

--- a/src/main/java/org/openpnp/util/TravellingSalesman.java
+++ b/src/main/java/org/openpnp/util/TravellingSalesman.java
@@ -130,9 +130,13 @@ public class TravellingSalesman<T> {
     private final TravelLocation startLocation;
     private final TravelLocation endLocation;
     private final List<TravelLocation> travel;
-    private final TravelCost travelCost;
+    private TravelCost travelCost;
     
     private long solverDuration = 0; 
+
+    public void setTravelCost (TravelCost t) {
+        travelCost = t;
+    }
 
     private TravelLocation getLocation(int i) {
         if (i < 0) {
@@ -241,7 +245,8 @@ public class TravellingSalesman<T> {
         int i = maxIterations;
         int swaps = 0, twists = 0, copies = 0;
         double bestDistance = getTravellingDistance();
-        double t = startingTemperature;
+        double temperature = startingTemperature;
+        double endTemperature = startingTemperature/10000;
         if (debugLevel > 0) {
             System.out.println("Initial distance of travel: " + bestDistance);
         }
@@ -252,7 +257,7 @@ public class TravellingSalesman<T> {
             // make this repeatable by seeding the random generator
             Random rnd = new java.util.Random(0);
             for (; i > 0; i--) {
-                if (t > 0.1) {
+                if (temperature > endTemperature) {
                     int a = rnd.nextInt(this.travelSize);
                     int b;
                     do {
@@ -286,7 +291,7 @@ public class TravellingSalesman<T> {
                         }
                     }
 
-                    if (swapDistance < 0.0 || (Math.exp(-swapDistance / t) >= rnd.nextDouble())) {
+                    if (swapDistance < 0.0 || (Math.exp(-swapDistance / temperature) >= rnd.nextDouble())) {
                         // better or within annealing probability
                         this.swapLocations(a, b, twist);
                         bestDistance += swapDistance;   // keep bestDistance up-to-date
@@ -303,14 +308,14 @@ public class TravellingSalesman<T> {
                             swaps++;
                         }
                     }
-                    t *= coolingRate;
+                    temperature *= coolingRate;
                 } else {
                     break;
                 }
                 if (debugLevel > 0) {
                     if (i % 100000 == 0) {
                         double distance = getTravellingDistance();
-                        System.out.println("Iterations #" + i +", temperature: "+t+", distance of travel: " + distance + ", best distance to travel: " + globalBestDistance + ", swaps: "+swaps+", twists: "+twists+", copies: "+copies);
+                        System.out.println("Iterations #" + i +", temperature: "+temperature+", distance of travel: " + distance + ", best distance to travel: " + globalBestDistance + ", swaps: "+swaps+", twists: "+twists+", copies: "+copies);
                         //System.out.println(this.asSvg());
                     }
                 }
@@ -325,7 +330,7 @@ public class TravellingSalesman<T> {
         }
         bestDistance = getTravellingDistance();
         if (debugLevel > 0) {
-            System.out.println("Iterations #" + i +", temperature: "+t+",  distance of travel: " + bestDistance+", swaps: "+swaps+", twists: "+twists+", copies: "+copies);
+            System.out.println("Iterations #" + i +", temperature: "+temperature+",  distance of travel: " + bestDistance+", swaps: "+swaps+", twists: "+twists+", copies: "+copies);
         }
         long endTime = System.currentTimeMillis();
         this.solverDuration = endTime - startTime;

--- a/src/test/java/TavellingSalesmanTest.java
+++ b/src/test/java/TavellingSalesmanTest.java
@@ -23,10 +23,14 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 
+import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.Test;
+import org.openpnp.model.Configuration;
 import org.openpnp.model.LengthUnit;
 import org.openpnp.model.Location;
 import org.openpnp.util.TravellingSalesman;
+
+import com.google.common.io.Files;
 
 public class TavellingSalesmanTest {
     /**
@@ -43,6 +47,22 @@ public class TavellingSalesmanTest {
      */
     @Test
     public void testTravellingSalesman() throws Exception {
+        File workingDirectory = Files.createTempDir();
+        workingDirectory = new File(workingDirectory, ".openpnp");
+        System.out.println("Configuration directory: " + workingDirectory);
+
+        // Copy the required configuration files over to the new configuration
+        // directory.
+        FileUtils.copyURLToFile(ClassLoader.getSystemResource("config/BasicJobTest/machine.xml"),
+                new File(workingDirectory, "machine.xml"));
+        FileUtils.copyURLToFile(ClassLoader.getSystemResource("config/BasicJobTest/packages.xml"),
+                new File(workingDirectory, "packages.xml"));
+        FileUtils.copyURLToFile(ClassLoader.getSystemResource("config/BasicJobTest/parts.xml"),
+                new File(workingDirectory, "parts.xml"));
+
+        Configuration.initialize(workingDirectory);
+        Configuration.get().load();
+
         for (int t = 2, scale = 100; scale > 0; t--, scale /= 10) {
             // make this test repeatable, by seeding the random generator.
             Random rnd = new java.util.Random(42);
@@ -77,8 +97,8 @@ public class TavellingSalesmanTest {
             // now solve the bugger
             double bestDistance = tsm.solve();
             // for the unit test, roughly check expected solution distance   
-            double target = new double [] { 3000.0, 5100.0, 12000.0 } [t];
-            System.out.println("TavellingSalesmanTest.testTravellingSalesman() solved "+list.size()+" locations, distance: "+Math.round(bestDistance)+"mm, target: "+target+"mm, time: "+tsm.getSolverDuration()+"ms");
+            double target = new double [] { 20.0, 50.0, 260.0 } [t];
+            System.out.println("TavellingSalesmanTest.testTravellingSalesman() solved "+list.size()+" locations, cost: "+Math.round(bestDistance)+"sec, target: "+target+"sec, time: "+tsm.getSolverDuration()+"ms");
             // save the solution, so we can have a look
             File file = File.createTempFile("travelling-salesman", ".svg");
             try (PrintWriter out = new PrintWriter(file.getAbsolutePath())) {

--- a/src/test/java/TavellingSalesmanTest.java
+++ b/src/test/java/TavellingSalesmanTest.java
@@ -139,7 +139,7 @@ public class TavellingSalesmanTest {
             //
             // for the unit test, roughly check expected solution distance   
             double target = new double [] { 3000, 5000, 13000 } [t];
-            System.out.println("TavellingSalesmanTest.testTravellingSalesman() test "+name+t+" solved "+list.size()+" locations, cost: "+bestDistance+"sec, distance: "+linearDistance+" mm, target: "+target+"sec, time: "+tsm.getSolverDuration()+"ms");
+            System.out.println("TavellingSalesmanTest.testTravellingSalesman() test "+name+t+" solved "+list.size()+" locations, cost: "+bestDistance+"sec, distance: "+linearDistance+" mm, target: "+target+"mm, time: "+tsm.getSolverDuration()+"ms");
             // save the solution, so we can have a look
             File file = File.createTempFile("travelling-salesman", ".svg");
             try (PrintWriter out = new PrintWriter(file.getAbsolutePath())) {


### PR DESCRIPTION
# Description
This PR adds a new metric for travel cost estimation based on axes acceleration and feed rate parameters named TravelCost. This new metric is then used by the traveling salesman and in the job processor for n+1 placement selection. For efficient use, the traveling salesman class has got a new constructor that allows to specify the effected head mountable. This head mountable is then used for travel cost estimation by the traveling salesman algorithm. The implementation defaults to the default camera on the default head and is therefore automatically available everywhere where the traveling salesman is used. The new TravelCost class is also available separately for use eg. within sorting loops.

# Justification
At present travel cost is not actually taken into account. All optimization is based on geometrical distance, which provides a high significance for optimization, but does not reflect how controller today work. They either operate all axes independently or delay axes such that all reach the target at once. With the new metric this behavior is now taken into account and different axes parameter are respected as well.

This is documentation for a user, not for a developer.

# Implementation Details
1. How did you test the change? Be descriptive. Untested code will not be accepted. **using simulation machine**
2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)? **yes**
3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing. **yes: Length extended with a copy constructor**
4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted. **yes**
