### PR TITLE
Angular Calibration for ReferenceTrayFeeders

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/feeder/ReferenceTrayFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/ReferenceTrayFeeder.java
@@ -80,9 +80,9 @@ public class ReferenceTrayFeeder extends ReferenceFeeder {
         }
 
         // Multiply the offsets by the X/Y part indexes to get the total offsets
+        // Rotate according to the rotation part of the offset
         // and then add the pickLocation to offset the final value.
-        // and then add them to the location to get the final pickLocation.
-        return location.add(offsets.multiply(partX, partY, 0.0, 0.0));
+        return location.addWithRotation(offsets.multiply(partX, partY, 0.0, 0.0).rotateXy(offsets.getRotation()));
     }
 
     public void feed(Nozzle nozzle) throws Exception {


### PR DESCRIPTION
# Description
This pull request adds the functionality of compensating misaligned tray feeders by calibrating the angular offset of parts. This is done by first setting the pick location to the first part. By moving along the feeder to another part and pressing: Calculate Rotation, the angular offset is calculated. When calculating the next pick location this offset is factored in.

# Justification
When using tray feeders mounted on a pick and place machine running OpenPnP they must be perfectly aligned. In cases where they are even slightly rotated, picking of parts becomes difficult. By integration of this change the rotation can be simply calibrated in the wizard of the feeder.

# Instructions for Use
1. Have a pick and place machine running OpenPnP ;)
2. Equip the machine with a tray feeder (which contains parts).
3. Add a ReferenceTrayFeeder to your feeders in OpenPnP.
4. Perform setup of the feeder as usual (setting Part, Counts and Offsets etc.).
5. Set the "Pick Location" to the location of the first part. 
6. Move the selected tool / camera over another part on the strip (to achieve the best precision, move to the last part)
7. Press "Calculate Rotation" 

Calculate Rotation will fill out the new field "Rotation" in the Offsets. It may also be provided manually. The rotational offset will be applied when picking such that parts are picked accordingly, even in misaligned tray feeders.

# Implementation Details
Testing was done by running OpenPnP through the IntelliJ IDEA with according debug logging, running the maven tests (which passed) and on a physical LumenPnP.  
