### PR TITLE
Fully display all options in the JobOrder's ComboBox.

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/wizards/ReferencePnpJobProcessorConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/wizards/ReferencePnpJobProcessorConfigurationWizard.java
@@ -55,7 +55,7 @@ public class ReferencePnpJobProcessorConfigurationWizard extends AbstractConfigu
         contentPanel.setLayout(new BoxLayout(contentPanel, BoxLayout.Y_AXIS));
 
         JPanel panelGeneral = new JPanel();
-        panelGeneral.setBorder(new TitledBorder(null, "General", TitledBorder.LEADING,
+        panelGeneral.setBorder(new TitledBorder(null, Translations.getString("MachineSetup.JobProcessors.ReferencePnpJobProcessor.GeneralPanel.Border.title"), TitledBorder.LEADING, //$NON-NLS-1$
                 TitledBorder.TOP, null, null));
         contentPanel.add(panelGeneral);
         panelGeneral.setLayout(new FormLayout(new ColumnSpec[] {
@@ -84,6 +84,7 @@ public class ReferencePnpJobProcessorConfigurationWizard extends AbstractConfigu
         panelGeneral.add(lblJobOrder, "2, 2, right, default");
 
         comboBoxJobOrder = new JComboBox<JobOrderHint>(JobOrderHint.values());
+        comboBoxJobOrder.setMaximumRowCount(10);
         panelGeneral.add(comboBoxJobOrder, "4, 2");
 
         JLabel lblPlannerStrategy = new JLabel(Translations.getString("MachineSetup.JobProcessors.ReferencePnpJobProcessor.lblPlannerStrategy.text")); //$NON-NLS-1$

--- a/src/main/resources/org/openpnp/translations.properties
+++ b/src/main/resources/org/openpnp/translations.properties
@@ -810,6 +810,7 @@ MachineControls.Action.Home=Home
 MachineControls.Action.Start=Start
 MachineControls.Action.Stop=Stop
 MachineControls.Label=Machine Controls
+MachineSetup.JobProcessors.ReferencePnpJobProcessor.GeneralPanel.Border.title=General
 MachineSetup.JobProcessors.ReferencePnpJobProcessor.JobOrder.BoardPart=Board\:Part
 MachineSetup.JobProcessors.ReferencePnpJobProcessor.JobOrder.HeightPartBoard=Height\:Part\:Board
 MachineSetup.JobProcessors.ReferencePnpJobProcessor.JobOrder.NozzleTips=Nozzle Tips


### PR DESCRIPTION
# Description

- Currently([after PR#1799](https://github.com/openpnp/openpnp/pull/1799)), the ComboBoxJobOrder has 10 options, but by default, only 8 options can be displayed. 
- I'm concerned that users may overlook the scrollbar, resulting in them missing out on the last 2 available functional options. 
- I believe this is more of a usage habit issue, as the ComboBoxes in OpenPnP are typically displayed in their entirety.
- By the way, extracted 'GeneralPanel.Border.title'.



# Justification

- Add the code of `comboBoxJobOrder.setMaximumRowCount(10);`
- The number is set to 10, which just meets the current requirements. Of course, if new options are added to the joborder later, this number should be adjusted accordingly.

![JobOrder](https://github.com/user-attachments/assets/e9acb546-5e1d-4f13-9a2f-c1f37542ab4b)


# Instructions for Use

Optimize the display to show all options fully in the JobOrder's ComboBox.

# Implementation Details
1. How did you test the change? Be descriptive. Untested code will not be accepted. **Test in my Eclipse.**
2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)? **Yes.**
3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing. **No Change.**
4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted. **Yes. Build Success.**
