### PR TITLE
change ReferenceStripFeeder to do sprocket hole detection using DetectCircularSymmetry

### DIFF
--- a/src/main/resources/org/openpnp/machine/reference/feeder/ReferenceStripFeeder-DefaultPipeline.xml
+++ b/src/main/resources/org/openpnp/machine/reference/feeder/ReferenceStripFeeder-DefaultPipeline.xml
@@ -1,15 +1,13 @@
 <cv-pipeline>
    <stages>
-      <cv-stage class="org.openpnp.vision.pipeline.stages.ImageCapture" name="original" enabled="true" settle-first="true"/>
-      <cv-stage class="org.openpnp.vision.pipeline.stages.BlurMedian" name="cleanup-original" enabled="true" kernel-size="5"/>
-      <cv-stage class="org.openpnp.vision.pipeline.stages.ConvertColor" name="gray" enabled="true" conversion="Bgr2Gray"/>
-      <cv-stage class="org.openpnp.vision.pipeline.stages.DetectEdgesCanny" name="find-edges" enabled="true" threshold-1="5.0" threshold-2="15.0"/>
-      <cv-stage class="org.openpnp.vision.pipeline.stages.BlurGaussian" name="predetect-1" enabled="true" kernel-size="5"/>
-      <cv-stage class="org.openpnp.vision.pipeline.stages.BlurMedian" name="predetect-2" enabled="false" kernel-size="7"/>
-      <cv-stage class="org.openpnp.vision.pipeline.stages.DetectFixedCirclesHough" name="results" enabled="true" dp="1.0" param-1="25.0" param-2="20.0"/>
-      <cv-stage class="org.openpnp.vision.pipeline.stages.ImageRecall" name="recalled" enabled="true" image-stage-name="original"/>
-      <cv-stage class="org.openpnp.vision.pipeline.stages.DrawCircles" name="display" enabled="true" circles-stage-name="results" thickness="1">
+      <cv-stage class="org.openpnp.vision.pipeline.stages.ImageCapture" name="0" enabled="true" default-light="true" settle-first="true" count="1"/>
+      <cv-stage class="org.openpnp.vision.pipeline.stages.ImageWriteDebug" name="deb0" enabled="false" prefix="strip_" suffix=".png"/>
+      <cv-stage class="org.openpnp.vision.pipeline.stages.BlurGaussian" name="1" enabled="true" kernel-size="5"/>
+      <cv-stage class="org.openpnp.vision.pipeline.stages.DetectCircularSymmetry" name="results" enabled="true" min-diameter="10" max-diameter="100" max-distance="100" max-target-count="10" min-symmetry="1.2" corr-symmetry="0.2" property-name="sprocketHole" outer-margin="0.3" inner-margin="0.1" sub-sampling="8" super-sampling="1" symmetry-score="RingMedianVarianceVsRingVarianceSum" diagnostics="false"/>
+      <cv-stage class="org.openpnp.vision.pipeline.stages.ImageRecall" name="7" enabled="false" image-stage-name="0"/>
+      <cv-stage class="org.openpnp.vision.pipeline.stages.DrawCircles" name="8" enabled="false" circles-stage-name="results" thickness="1">
          <color r="255" g="0" b="0" a="255"/>
       </cv-stage>
+      <cv-stage class="org.openpnp.vision.pipeline.stages.ImageWriteDebug" name="deb1" enabled="false" prefix="strip_result_" suffix=".png"/>
    </stages>
 </cv-pipeline>


### PR DESCRIPTION
# Description

Change the ReferenceStripFeeder sprocket-hole detection pipeline to be the same as ReferencePushPullFeeder (etc)

# Justification
This justification was originally posted on [google groups](https://groups.google.com/d/msgid/openpnp/b27d3235-b639-4680-94c7-05eb58eb2389%40mcguirescientificservices.com)

* There have been long-standing [reports](https://groups.google.com/g/openpnp/c/TRK5Q4vZUbc) of this not working right. It certainly doesnt work for me.
* The ReferenceStripFeeder [wiki](https://github.com/openpnp/openpnp/wiki/ReferenceStripFeeder#cvpipeline) is anticipating problems. It has a "If your pipeline is not working" section, with a reference to a DetectCircularSymmetry alternative pipeline. This pipeline is what works for me.
* PushPullFeeder uses DetectCircularSymmetry pipeline for the same purpose.
* DetectCircularSymmetry was introduced in PR [1179](https://github.com/openpnp/openpnp/pull/1179) and a comment from Mark there says "The idea is to make these default pipelines someday use the DetectCircularSymmetry, if practice shows it works across many machine". I think this is now due.

# Instructions for Use
Wiki pages linked above need to be updated after merge. The "If your pipeline is not working" section will be updated to refer to the `symmetry-score` attribute of DetectCircularSymmetry.

# Implementation Details
1. How did you test the change? -- I have been using something very similar to this pipeline for many months now
2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)? -- yes
3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing. -- no changes
4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted. -- tests pass

This feels like a change that should be merged early in the release cycle, so I propose not merging this until after version 2.4

# Concerns

Are there users who have no problem with `DetectFixedCirclesHough` who would be disadvantaged by this change? No one replied when I raised that question on google groups, so I hope not.