### PR TITLE
fix for bug where tooltips are shown for wrong columns when table is …

### DIFF
--- a/src/main/java/org/openpnp/gui/PartsPanel.java
+++ b/src/main/java/org/openpnp/gui/PartsPanel.java
@@ -183,7 +183,7 @@ public class PartsPanel extends JPanel implements WizardContainer {
         table = new AutoSelectTextTable(tableModel) {
             @Override
             public String getToolTipText(MouseEvent evt) {
-                int column = columnAtPoint(evt.getPoint());
+                int column = convertColumnIndexToModel(columnAtPoint(evt.getPoint()));
                 if(column==2) { return Translations.getString("PartsTableModel.Column.Height.toolTip"); } //$NON-NLS-1$
                 if(column==3) { return Translations.getString("PartsTableModel.Column.ThroughBoardDepth.toolTip"); } //$NON-NLS-1$
                 return null;


### PR DESCRIPTION
# Description

This is a fix for a GUI bug where the table tooltips can be presented against the wrong columns, when the table columns are reordered.

# Instructions for Use
This is just a gui fix

# Implementation Details
1. How did you test the change? Be descriptive. Untested code will not be accepted. -- tested interactively my moving those columns
2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)? -- yes
3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing. -- no changes
4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted. -- tests pass
