### PR TITLE
Fix null pointer errors with Photon feeder wizards on the Machine Setup tab

### DIFF
--- a/src/main/java/org/openpnp/gui/MachineSetupPanel.java
+++ b/src/main/java/org/openpnp/gui/MachineSetupPanel.java
@@ -241,6 +241,12 @@ public class MachineSetupPanel extends JPanel implements WizardContainer {
                     for (PropertySheet propertySheet : propertySheets) {
                         String title = propertySheet.getPropertySheetTitle();
                         JPanel panel = propertySheet.getPropertySheetPanel();
+                        if(panel instanceof AbstractConfigurationWizard) {
+                            AbstractConfigurationWizard wizard = (AbstractConfigurationWizard) panel;
+                            if (wizard.getWizardContainer() == null) {
+                                wizard.setWizardContainer(MachineSetupPanel.this);
+                            }
+                        }
                         if (title == null) {
                             title = Translations.getString("MachineSetupPanel.RightComponent.tabs.configuration.title"); //$NON-NLS-1$
                         }


### PR DESCRIPTION
# Description
This is a bug fix for issue #1846. This change ensures the wizard container is setup for all subclasses of AbstractConfigurationWizard when they are added to the Machine Setup tab.

# Justification
Bug fix.

# Instructions for Use
No special instructions - selecting Photon feeders on the Machine Setup tab should now work correctly

# Implementation Details
1. How did you test the change? **Loaded a Photon machine.xml file and verified that feeders could not be selected and updated on the Machine Setup tab.**
2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)? **Yes.**
3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing. **No changes.**
4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted. **All maven tests ran and passed.**
