### PR TITLE
photonfeeder: poll using a monotonic clock

### DIFF
--- a/src/main/java/org/openpnp/machine/photon/PhotonFeeder.java
+++ b/src/main/java/org/openpnp/machine/photon/PhotonFeeder.java
@@ -26,7 +26,6 @@ import org.simpleframework.xml.Element;
 import javax.swing.*;
 
 import java.time.Duration;
-import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Matcher;
@@ -280,8 +279,8 @@ public class PhotonFeeder extends ReferenceFeeder {
             // Use expectedTimeToFeed to bound how long we will wait,
             // but use polling to check the status of the feed.
             Duration expectedFeedDuration = Duration.ofMillis(moveFeedForwardResponse.expectedTimeToFeed);
-            Instant endTime = Instant.now().plus(expectedFeedDuration.multipliedBy(3));
-            for (int j = 0; j <= photonProperties.getFeederCommunicationMaxRetry() || Instant.now().isBefore(endTime); j++) {
+            long endTimeNanos = System.nanoTime() + expectedFeedDuration.toNanos() * 3;
+            for (int j = 0; j <= photonProperties.getFeederCommunicationMaxRetry() || System.nanoTime() <= endTimeNanos; j++) {
                 Thread.sleep(50); // MAGIC: this feels like a good number, there is no particular reason it is this way.
 
                 MoveFeedStatus moveFeedStatus = new MoveFeedStatus(slotAddress);

--- a/src/main/java/org/openpnp/machine/photon/PhotonFeeder.java
+++ b/src/main/java/org/openpnp/machine/photon/PhotonFeeder.java
@@ -24,6 +24,9 @@ import org.simpleframework.xml.Attribute;
 import org.simpleframework.xml.Element;
 
 import javax.swing.*;
+
+import java.time.Duration;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Matcher;
@@ -273,11 +276,13 @@ public class PhotonFeeder extends ReferenceFeeder {
                 continue;  // We'll initialize it on a retry
             }
 
-            int timeToWaitMillis = moveFeedForwardResponse.expectedTimeToFeed;
-
-            for (int j = 0; j < 3; j++) {
-                //noinspection BusyWait
-                Thread.sleep(timeToWaitMillis);
+            // The feeder gives us expectedTimeToFeed, but it is way too conservative.
+            // Use expectedTimeToFeed to bound how long we will wait,
+            // but use polling to check the status of the feed.
+            Duration expectedFeedDuration = Duration.ofMillis(moveFeedForwardResponse.expectedTimeToFeed);
+            Instant endTime = Instant.now().plus(expectedFeedDuration.multipliedBy(3));
+            for (int j = 0; j <= photonProperties.getFeederCommunicationMaxRetry() || Instant.now().isBefore(endTime); j++) {
+                Thread.sleep(50); // MAGIC: this feels like a good number, there is no particular reason it is this way.
 
                 MoveFeedStatus moveFeedStatus = new MoveFeedStatus(slotAddress);
                 MoveFeedStatus.Response moveFeedStatusResponse = moveFeedStatus.send(photonBus);

--- a/src/test/java/org/openpnp/machine/photon/protocol/helpers/TestBus.java
+++ b/src/test/java/org/openpnp/machine/photon/protocol/helpers/TestBus.java
@@ -197,5 +197,9 @@ public class TestBus implements PhotonBusInterface {
                 fail(builder.toString());
             }
         }
+
+        public Boolean hasMore() {
+            return currentVerificationIndex < calls.size();
+        }
     }
 }


### PR DESCRIPTION
Avoid a bug if polling the feeder while DST hits.

Using untyped time feels wrong, in Go `Instant`'s equivalent (`time.Time`) is
an hybrid monotonic clock & wall clock and the previous code would just-work™,
but after searching for 5 minutes typesafety in this 2 line case is not worth solving.

I didn't tried running both pieces of code through DST or TZ config change to see what would happen but this feels better.

This PR is stacked on top of #1844 