### PR TITLE
gcodeasyncdriver: bubble up errors through machine coordination

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/driver/GcodeAsyncDriver.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/GcodeAsyncDriver.java
@@ -390,7 +390,7 @@ public class GcodeAsyncDriver extends GcodeDriver {
     }
 
     @Override
-    protected void drainCommandQueue(long timeout) throws InterruptedException {
+    protected void drainCommandQueue(long timeout) throws Exception {
         // Normal confirmation report wanted. We queue a null command to drain the queue and confirm 
         // the last real command. 
         confirmationComplete = false;
@@ -406,6 +406,7 @@ public class GcodeAsyncDriver extends GcodeDriver {
             catch (InterruptedException e) {
                 Logger.warn(e, getName() +" was interrupted while waiting for completion.");
             }
+            bailOnError();
         }
         long dt = System.currentTimeMillis() - t0;
         if (dt > 1) {

--- a/src/main/java/org/openpnp/machine/reference/driver/GcodeDriver.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/GcodeDriver.java
@@ -1023,7 +1023,7 @@ public class GcodeDriver extends AbstractReferenceDriver implements Named {
         return motionPending;
     }
 
-    protected void drainCommandQueue(long timeout) throws InterruptedException {
+    protected void drainCommandQueue(long timeout) throws Exception {
         // This does nothing in the plain GcodeDriver. It will be overridden in the GcodeAsyncDriver.
     }
 


### PR DESCRIPTION
# Description

Previous to this patch, a timeout during M400 would softlock openpnp.
Fixes #1848

# Justification

This bug stole hours of my life I will never get back just because I didn't knew I had wrong configuration that made M400 timeout.

# Instructions for Use

None, this is a bug fix.

# Implementation Details
1. How did you test the change?
  On my lumen right after tool changing it goes for bottom vision or Z focus, and the combined tool change plus move always timeout the M400 sent by the bottom camera or vacuum actuator, previous to this patch openpnp softlocks, now it raises an error along the line of « M400 timeout » and continues to be usable.
2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)?
  yes.
3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing.
  I did not.
4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted.
  This is running.
