### PR TITLE
Fix error on pressing test alignment

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/vision/wizards/BottomVisionSettingsConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/vision/wizards/BottomVisionSettingsConfigurationWizard.java
@@ -15,10 +15,7 @@ import javax.swing.JTextField;
 import javax.swing.UIManager;
 import javax.swing.border.TitledBorder;
 
-import org.jdesktop.beansbinding.AutoBinding;
 import org.jdesktop.beansbinding.AutoBinding.UpdateStrategy;
-import org.jdesktop.beansbinding.BeanProperty;
-import org.jdesktop.beansbinding.Bindings;
 import org.openpnp.Translations;
 import org.openpnp.gui.MainFrame;
 import org.openpnp.gui.components.ComponentDecorators;
@@ -338,9 +335,9 @@ public class BottomVisionSettingsConfigurationWizard extends AbstractConfigurati
         panelAlign.add(testAlignmentAngle, "4, 2");
         testAlignmentAngle.setColumns(10);
 
-        JButton btnTestAlighment = new JButton(Translations.getString(
+        JButton btnTestAlignment = new JButton(Translations.getString(
                 "BottomVisionSettingsConfigurationWizard.PanelAlign.TestAlignmentButton.text")); //$NON-NLS-1$
-        panelAlign.add(btnTestAlighment, "6, 2");
+        panelAlign.add(btnTestAlignment, "6, 2");
 
         chckbxCenterAfterTest = new JCheckBox(Translations.getString(
                 "BottomVisionSettingsConfigurationWizard.PanelAlign.CenterAfterTestChkbox.text")); //$NON-NLS-1$
@@ -348,9 +345,9 @@ public class BottomVisionSettingsConfigurationWizard extends AbstractConfigurati
         chckbxCenterAfterTest.setToolTipText(Translations.getString(
                 "BottomVisionSettingsConfigurationWizard.PanelAlign.CenterAfterTestChkbox.toolTipText")); //$NON-NLS-1$
         chckbxCenterAfterTest.setSelected(true);
-        btnTestAlighment.addActionListener((e) -> {
+        btnTestAlignment.addActionListener((e) -> {
+            applyAction.actionPerformed(null);
             UiUtils.submitUiMachineTask(() -> {
-                applyAction .actionPerformed(null);
                 testAlignment(chckbxCenterAfterTest.isSelected());
             });
         });
@@ -412,8 +409,8 @@ public class BottomVisionSettingsConfigurationWizard extends AbstractConfigurati
         btnAutoVisionCenterOffset.setToolTipText(Translations.getString(
                 "BottomVisionSettingsConfigurationWizard.PanelDetectOffset.AutoVisionCenterOffsetButton.toolTipText")); //$NON-NLS-1$
         btnAutoVisionCenterOffset.addActionListener((e) -> {
+            applyAction.actionPerformed(null);
             UiUtils.submitUiMachineTask(() -> {
-                applyAction.actionPerformed(null);
                 determineVisionOffset();
             });
         });


### PR DESCRIPTION
# Description
This change fixes intermittent null pointer errors that occur when pressing the Test Alignment button on the Packages Bottom Vision tab. It moves saving the wizard's changes out of the machine task and puts it on the Event Dispatch thread where it belongs.

# Justification
Bug fix for everyone.

# Instructions for Use
No special instructions for the user.

# Implementation Details
1. How did you test the change? Be descriptive. Untested code will not be accepted. **Using the simulated machine, I verified I could duplicate the problem (although only intermittently) and then verified that after this change, with many attempts, the NPEs no longer occurred.**
2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)? **Yes.**
3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing. **No changes.**
4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted. **All maven tests ran and passed.**
