### PR TITLE
Delay fix

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/driver/AbstractMotionPlanner.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/AbstractMotionPlanner.java
@@ -289,22 +289,29 @@ public abstract class AbstractMotionPlanner extends AbstractModelObject implemen
                     }
                 }
             }
-            
-            // now execute the delay on all effected drivers
-            for (Driver driver : drivers) {
-                delayNotExecuted |= driver.delay(milliseconds);
-            }
+            delayAllDrivers(drivers,milliseconds);
         }
         else {
-            for (Driver driver : machine.getDrivers()) {
-                delayNotExecuted |= driver.delay(milliseconds);
-            }
+            delayAllDrivers(machine.getDrivers(),milliseconds);
         }
-        
-        // if any driver was not able to execute the delay, fabllback using Thread.sleep()
-        if (delayNotExecuted) {
+    }
+
+    // Execute a delay on all drivers in the list.
+    // If any driver can not execute the delay then we fallback to using Thread.sleep()
+    private void delayAllDrivers(final List<Driver> drivers, int milliseconds) throws Exception
+    {
+        boolean delayExecutedInAllDrivers = true;   // set to false if any driver requested to delay does not support delaying
+
+        for (Driver driver : drivers) {
+            // delay() returns false if the delay was not executed
+            delayExecutedInAllDrivers &= driver.delay(milliseconds);
+        }
+
+        if(!delayExecutedInAllDrivers) {
             // time delay using OS
+            Logger.trace("delay sleep before");
             Thread.sleep(milliseconds);
+            Logger.trace("delay sleep after");
         }
     }
 

--- a/src/main/java/org/openpnp/machine/reference/driver/AbstractMotionPlanner.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/AbstractMotionPlanner.java
@@ -260,7 +260,6 @@ public abstract class AbstractMotionPlanner extends AbstractModelObject implemen
 
     @Override
     public void delay(int milliseconds, HeadMountable... hms) throws Exception {
-        boolean delayNotExecuted = false;   // set to true if any driver requested to delay does not support delaying
         // Plan and execute any queued motion commands. 
         executeMotionPlan(CompletionType.CommandStillstand);
         ReferenceMachine machine = getMachine();

--- a/src/main/java/org/openpnp/machine/reference/driver/AbstractMotionPlanner.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/AbstractMotionPlanner.java
@@ -308,9 +308,8 @@ public abstract class AbstractMotionPlanner extends AbstractModelObject implemen
 
         if(!delayExecutedInAllDrivers) {
             // time delay using OS
-            Logger.trace("delay sleep before");
+            Logger.trace("delay Thread.sleep");
             Thread.sleep(milliseconds);
-            Logger.trace("delay sleep after");
         }
     }
 

--- a/src/main/java/org/openpnp/machine/reference/driver/GcodeDriver.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/GcodeDriver.java
@@ -686,7 +686,7 @@ public class GcodeDriver extends AbstractReferenceDriver implements Named {
     public boolean delay(int milliseconds) throws Exception {
             String command = getCommand(null, CommandType.DELAY_COMMAND);
         if (command == null || command.isEmpty()) {
-            // return false to signal that delaying in driver is not supported
+            Logger.trace("delaying in gcode driver is not supported");
             return false;
         }
         else if (milliseconds > 0) {
@@ -697,6 +697,9 @@ public class GcodeDriver extends AbstractReferenceDriver implements Named {
             // consider this delay a pending motion for subsequent WaitForCompletion to actually
             // wait which might otherwise be optimized away.
             motionPending = true;
+            Logger.trace("gcode delay sent");
+        } else {
+            Logger.trace("gcode delay not sent for zero duration");
         }
         
         return true;


### PR DESCRIPTION
# Description

I believe this is a fix for #1867. A different fix for this issue was proposed in #1868.

I think the bug is very simple and silly. @janm012012 review please.

GcodeDriver returns **FALSE** if we need a java sleep

https://github.com/openpnp/openpnp/blob/c56e1dd5661a5028a1f3011172dcb14c7278fc38/src/main/java/org/openpnp/machine/reference/driver/GcodeDriver.java#L686-L690

but the motion planner expects drivers to return **TRUE** if we need a java sleep

https://github.com/openpnp/openpnp/blob/c56e1dd5661a5028a1f3011172dcb14c7278fc38/src/main/java/org/openpnp/machine/reference/driver/AbstractMotionPlanner.java#L293-L296

# Testing & Risks

I have reproduced #1867 by removing the delay gcode from my configuration and seen the delay getting skipped during vacuum pick. I have confirmed that this PR restores the expected behaviour.

I have confirmed with a brief test that my machine still works with this change and the delay gcode restored. This definitely needs wider testing. If we agree this is the right fix then we should notify beta testers to update.

But I dont really understand why the #1868 fix worked. What am I missing?


# Instructions for Use

no changes 

# Implementation Details
1. How did you test the change? Be descriptive. Untested code will not be accepted. - described above
2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)? - yes
3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing. - **YES** to fix a comment
4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted. - tests pass
