### PR TITLE
Check that the nozzle is empty before the job processor does a pick

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/ReferencePnpJobProcessor.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferencePnpJobProcessor.java
@@ -1233,6 +1233,22 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
              */
             JobProcessorException lastException = null;
             for (int partPickTry = 0; partPickTry < 1 + part.getPickRetryCount(); partPickTry++) {
+
+                if (nozzle.getPart() == null) {
+                    // We expect the nozzle to be empty before a pick.
+                } else {
+                    // Unexpected!
+                    if (nozzle.getPart() == part) {
+                        // The part on the nozzle matches the placement.
+                        // How did this happen? The operator must have manually picked the part for us.
+                        // We do not need to pick again.
+                        return this;
+                    } else {
+                        throw new JobProcessorException(part, nozzle, "Part mismatch with part on nozzle before pick. Found "+nozzle.getPart().getId()+" but expected the nozzle to be empty.");
+                    }
+                }
+
+
                 /**
                  * Find an available feeder. If one cannot be found this will throw. There's nothing
                  * else we can do with this part.


### PR DESCRIPTION
NB this PR is intended for the next release.

# Justification
Lets compare the operator-led recovery scenarios for two common job problems. Assume we are using the "Alert" error handling policy.

If a pick problem is detected by **bottom vision** then an error message is shown and the job is paused. Immediately resuming the job will cause the alignment step to be repeated and it will fail again for the same reason. This cycle can be repeated many times. An operator can fix this problem by correcting the feeder, performing a manual pick operation which loads a part onto the nozze, and resuming the job. The job resumes at the bottom vision step again, and this time it will succeed and the job continues.

If a pick problem is detected by **pick vacuum test** then an error message is shown and the job is paused. From the operators point of view this looks very similar to the previous scenario, so it is reasonable to perform the same recovery scenario. He fixes the problem with the feeder, performs a manual pick, and resumes the job. But in this case openpnp behaves differently and things go wrong. The job resumes at the pick step and it attempts to perform another pick while the part is already on the nozzle.

This is bad. It might cause a nozzle collision if the part is tall. It might damage the part which is already on the nozzle. It might cause openpnp to misunderstand the part rotation, causing it to be placed at the wrong orientation.

We had some rework with QFN misaligned by 90° due to this.

# Description

This PR implements the following logic:
 * When the Job processor is about to feed and pick it expects the nozzle to be empty. If it is not empty then:
    *  If the part on the nozzle matches the part we are about to feed and pick, then it can skip that feed and pick cycle. This is the scenario described above.
    * If the part does not match then it reports an error.

# Other PRs
This fix is similar to #1712 in that it can show an error message during picking if there is a part on the nozzle. That PR added the check to manual feeding, and Jan [objected](https://github.com/openpnp/openpnp/pull/1712#issuecomment-2717483839) to #1712 because it interfered with some other legitimate workflows.

This PR adds the check to JobProcessor's automated feed and pick cycle. I dont think this affects any legitimate workflows.

# Instructions for Use
no changes - this just adds an error message to an error scenario.

# Testing
I have tested the following cases on a real machine:
1. Force a vision error on the first nozzle, manually pick the right part, and resume the job. Observe that the job proceeds using the manually picked part.
2. As 1. but for the second nozzle. 
3. As 1. but pick the wrong part. Observe that is shows a suitable error message. Discard the part then the job can be resumed.
4. As 3. but manually pick the right part after discarding the wrong part.

# Implementation Details
1. How did you test the change? Be descriptive. Untested code will not be accepted. -- described above
2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)? -- yes
4. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing. -- no changes
5. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted. -- tests pass
