### PR TITLE
Fix rotation mode Minimal Rotation

### DIFF
--- a/src/main/java/org/openpnp/spi/base/AbstractNozzle.java
+++ b/src/main/java/org/openpnp/spi/base/AbstractNozzle.java
@@ -190,7 +190,7 @@ public abstract class AbstractNozzle extends AbstractHeadMountable implements No
                 newRotationModeOffset = placementLocation.getRotation();
                 break;
             case MinimalRotation:
-                newRotationModeOffset = Utils2D.angleNorm(getLocation().getRotation() - pickLocation.getRotation(), 180);
+                newRotationModeOffset = Utils2D.angleNorm(pickLocation.getRotation() - getLocation().getRotation(), 180);
                 break;
             case LimitedArticulation:
                 double [] rotationLimits = getRotationModeLimits();


### PR DESCRIPTION
# Description
This PR fixes the nozzle rotation mode "Minimal Rotation" setting by calculating a rotationModeOffset that results in no rotation when moving to the next pick location. The issue was reported at https://groups.google.com/g/openpnp/c/lZgjIsqylVc.

This is documentation for a user, not for a developer.

# Implementation Details
1. How did you test the change? **using a specially tuned job and dedicated logfile filter tools to monitor nozzle rotation only**
2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)? **NA/yes**
3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing. **yes: rotation mode calculation is in AbstractNozzle, but the change is safe, because it only affect this particular rotation mode setting.**
4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted. **yes**
