### PR TITLE
add the Job.Error script

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/ReferencePnpJobProcessor.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferencePnpJobProcessor.java
@@ -176,12 +176,26 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
         }
         catch (Exception e) {
             this.fireJobState(Configuration.get().getMachine().getSignalers(), AbstractJobProcessor.State.ERROR);
+            scriptJobError(e);
             throw e;
         }
         if (currentStep == null) {
             this.fireJobState(Configuration.get().getMachine().getSignalers(), AbstractJobProcessor.State.FINISHED);
         }
         return currentStep != null;
+    }
+
+    private void scriptJobError(Exception e1) throws JobProcessorException {
+        HashMap<String, Object> params = new HashMap<>();
+        params.put("job", job);
+        params.put("jobProcessor", this);
+        params.put("exception", e1);
+        try {
+            Configuration.get().getScripting().on("Job.Error", params);
+        }
+        catch (Exception e) {
+            throw new JobProcessorException(null, e);
+        }
     }
 
     public synchronized void abort() throws JobProcessorException {
@@ -350,7 +364,7 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
                 throw new JobProcessorException(null, e);
             }
         }
-        
+
         private void prepMachine() throws JobProcessorException {
             // Everything looks good, so prepare the machine.
             fireTextStatus("Preparing machine.");


### PR DESCRIPTION
# Description
This adds a script event for job error.

# Justification
This is a relatively common user request.

There is currently a workaround that involves creating a signaler to run a script on job error, but that is cumbersome. I currently use this method to get a message on google chat when the machine in stopped on error.

# Instructions for Use
Instructions need to be added to the [scripting wiki page](https://github.com/openpnp/openpnp/wiki/Scripting)

# Implementation Details
1. How did you test the change? Be descriptive. Untested code will not be accepted.
     Manual tests for the following cases:
       - running a job
       - single step a job
       - triggering a job error my disabling a required feeder
3. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)? -- yes
4. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing. -- no changes
5. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted. -- tests pass
