### PR TITLE
the discard button always performs the discard movement, even if ther…

### DIFF
--- a/src/main/java/org/openpnp/gui/JogControlsPanel.java
+++ b/src/main/java/org/openpnp/gui/JogControlsPanel.java
@@ -643,7 +643,7 @@ public class JogControlsPanel extends JPanel {
         public void actionPerformed(ActionEvent arg0) {
             UiUtils.submitUiMachineTask(() -> {
                 Nozzle nozzle = machineControlsPanel.getSelectedNozzle();
-                Cycles.discard(nozzle);
+                Cycles.discardAlways(nozzle);
             });
         }
     };

--- a/src/main/java/org/openpnp/util/Cycles.java
+++ b/src/main/java/org/openpnp/util/Cycles.java
@@ -66,6 +66,17 @@ public class Cycles {
             return;
         }
 
+        discardAlways(nozzle);
+    }
+
+    /**
+     * Discard the Part on the given Nozzle. Perform the discard action whether there is a part on the nozzle or not.
+     * The Nozzle is returned to Safe Z at the end of the operation.
+     *
+     * @param nozzle
+     * @throws Exception
+     */
+    public static void discardAlways(Nozzle nozzle) throws Exception {
         Map<String, Object> globals = new HashMap<>();
         globals.put("nozzle", nozzle);
         Configuration.get().getScripting().on("Job.BeforeDiscard", globals);


### PR DESCRIPTION
# Description

The discard GUI button only performs the discard action if openpnp believes there is a part on the nozzle. If openpnp believes the nozzle is empty then the discard button has no effect.

This PR changes the GUI button to always perform the discard action.

# Justification

This was suggested and discussed on [google groups](https://groups.google.com/d/msgid/openpnp/6cb49c50-4700-4590-a771-aa34567cef39n%40googlegroups.com?utm_medium=email&utm_source=footer)

Sometimes the operator can see that the openpnp state is out of sync with the machine state. He can see that there is a part on the nozzle, but openpnp believes there is not. Maybe this was due to an opnpnp error, or maybe the part was sticky and did not drop off the nozzle when previously discarded. The discard operation is the best way to get state back in sync.

# Instructions for Use
The discard button usage is unchanged.

`CHANGES.md` and scripting wiki should note that the part parameter to `Job.BeforeDiscard` script may now be null.

# Implementation Details
1. How did you test the change? Be descriptive. Untested code will not be accepted. -- testing on the simulated machine only so far. I want to test this on a real machine before merge.
2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)? -- yes
3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing. -- no changes
4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted. -- tests pass
