### PR TITLE
GUI tidy up

### DIFF
--- a/src/main/java/org/openpnp/gui/PackagesPanel.java
+++ b/src/main/java/org/openpnp/gui/PackagesPanel.java
@@ -29,6 +29,7 @@ import java.awt.datatransfer.StringSelection;
 import java.awt.event.ActionEvent;
 import java.awt.event.ComponentAdapter;
 import java.awt.event.ComponentEvent;
+import java.awt.event.MouseEvent;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.io.StringReader;
@@ -175,7 +176,14 @@ public class PackagesPanel extends JPanel implements WizardContainer {
 
         tabbedPane = new JTabbedPane(JTabbedPane.TOP);
 
-        table = new AutoSelectTextTable(tableModel);
+        table = new AutoSelectTextTable(tableModel) {
+            @Override
+            public String getToolTipText(MouseEvent evt) {
+                int column = convertColumnIndexToModel(columnAtPoint(evt.getPoint()));
+                if(column==2) { return Translations.getString("PackagesTableModel.Column.TapeSpecification.toolTip"); } //$NON-NLS-1$
+                return null;
+            }
+        };
         table.setSelectionMode(ListSelectionModel.MULTIPLE_INTERVAL_SELECTION);
 
         JComboBox<BottomVisionSettings> bottomVisionCombo = new JComboBox<>(

--- a/src/main/java/org/openpnp/machine/reference/feeder/ReferenceStripFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/ReferenceStripFeeder.java
@@ -75,6 +75,7 @@ import org.simpleframework.xml.core.Persist;
  * hole to part lateral is tape width / 2 - 0.5mm
  */
 public class ReferenceStripFeeder extends ReferenceFeeder {
+    // This is not used
     public enum TapeType {
         WhitePaper("White Paper"),
         BlackPlastic("Black Plastic"),

--- a/src/main/java/org/openpnp/machine/reference/feeder/wizards/ReferenceStripFeederConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/wizards/ReferenceStripFeederConfigurationWizard.java
@@ -63,7 +63,6 @@ import org.openpnp.gui.support.MutableLocationProxy;
 import org.openpnp.gui.support.PartsComboBoxModel;
 import org.openpnp.machine.reference.camera.BufferedImageCamera;
 import org.openpnp.machine.reference.feeder.ReferenceStripFeeder;
-import org.openpnp.machine.reference.feeder.ReferenceStripFeeder.TapeType;
 import org.openpnp.model.Board;
 import org.openpnp.model.Configuration;
 import org.openpnp.model.Length;
@@ -120,8 +119,6 @@ public class ReferenceStripFeederConfigurationWizard extends AbstractConfigurati
     private JLabel lblMaxFeedCount;
     private JButton btnMaxFeedCount;
     private JTextField textFieldMaxFeedCount;
-    private JLabel lblTapeType;
-    private JComboBox comboBoxTapeType;
     private JLabel lblRotationInTape;
     private JTextField textFieldLocationRotation;
     private JButton btnAutoSetup;
@@ -244,13 +241,6 @@ public class ReferenceStripFeederConfigurationWizard extends AbstractConfigurati
         btnAutoSetup = new JButton(autoSetup);
         panelTapeSettings.add(btnAutoSetup, "2, 2, 11, 1");
 
-        lblTapeType = new JLabel(Translations.getString(
-                "ReferenceStripFeederConfigurationWizard.TapeTypeLabel.text")); //$NON-NLS-1$
-        panelTapeSettings.add(lblTapeType, "2, 4, right, default");
-
-        comboBoxTapeType = new JComboBox(TapeType.values());
-        panelTapeSettings.add(comboBoxTapeType, "4, 4, fill, default");
-
         JLabel lblTapeWidth = new JLabel(Translations.getString(
                 "ReferenceStripFeederConfigurationWizard.TapeWidthLabel.text")); //$NON-NLS-1$
         panelTapeSettings.add(lblTapeWidth, "8, 4, right, default");
@@ -261,10 +251,10 @@ public class ReferenceStripFeederConfigurationWizard extends AbstractConfigurati
 
         lblPartPitch = new JLabel(Translations.getString(
                 "ReferenceStripFeederConfigurationWizard.PartPitchLabel.text")); //$NON-NLS-1$
-        panelTapeSettings.add(lblPartPitch, "2, 6, right, default");
+        panelTapeSettings.add(lblPartPitch, "2, 4, right, default");
 
         textFieldPartPitch = new JTextField();
-        panelTapeSettings.add(textFieldPartPitch, "4, 6");
+        panelTapeSettings.add(textFieldPartPitch, "4, 4");
         textFieldPartPitch.setColumns(5);
 
         lblFeedCount = new JLabel(Translations.getString(
@@ -473,7 +463,6 @@ public class ReferenceStripFeederConfigurationWizard extends AbstractConfigurati
         addWrappedBinding(feeder, "part", comboBoxPart, "selectedItem");
         addWrappedBinding(feeder, "feedRetryCount", retryCountTf, "text", intConverter);
         addWrappedBinding(feeder, "pickRetryCount", pickRetryCount, "text", intConverter);
-        addWrappedBinding(feeder, "tapeType", comboBoxTapeType, "selectedItem");
 
         addWrappedBinding(feeder, "tapeWidth", textFieldTapeWidth, "text", lengthConverter);
         addWrappedBinding(feeder, "partPitch", textFieldPartPitch, "text", lengthConverter);

--- a/src/main/resources/org/openpnp/translations.properties
+++ b/src/main/resources/org/openpnp/translations.properties
@@ -1011,6 +1011,7 @@ PackagesPanel.SearchLabel.text=Search
 PackagesPanel.SettingsTab.title=Settings
 PackagesPanel.VisionCompositingTab.title=Vision Compositing
 PackagesPanel.VisionTab.title=Footprint
+PackagesTableModel.Column.TapeSpecification.toolTip=This is a text field used by some feeder implementations. Check your feeder documentation for more details.
 PackagesTableModel.ColumnName.BottomVision=BottomVision
 PackagesTableModel.ColumnName.Description=Description
 PackagesTableModel.ColumnName.FiducialVision=FiducialVision


### PR DESCRIPTION
# Description
Fixes #1882 
This makes two changes to tidy the GUI
1. ReferenceStripFeeder has a "tape type" field, default "white paper". This field has no effect. This change removes the gui field, but leaves the attribute in the object for xml compatibility.
2. I had thought the "tape specification" field was unused, but Martin pointed out one use. This change adds a tooltip.

# Justification
GUI tidy.

These are both fields where a colleague has asked its purpose, and it feels silly to have to explain there is none.

# Implementation Details
1. How did you test the change? Be descriptive. Untested code will not be accepted. -- manual test of gui change
3. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)? -- yes
4. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing. -- no changes
5. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted. -- tests pass
