### PR TITLE
photonfeeder: while doing moveWhileFeeding move to safeZ rather than 0

### DIFF
--- a/src/main/java/org/openpnp/machine/photon/PhotonFeeder.java
+++ b/src/main/java/org/openpnp/machine/photon/PhotonFeeder.java
@@ -296,7 +296,7 @@ public class PhotonFeeder extends ReferenceFeeder {
                 Thread.sleep(50); // MAGIC: this feels like a good number, there is no particular reason it is this way.
 
                 if (j == 0 && nozzle != null && getMoveWhileFeeding()) {
-                    MovableUtils.moveToLocationAtSafeZ(nozzle, getPickLocation().derive(null, null, Double.NaN, null));
+                    MovableUtils.moveToLocationAtSafeZ(nozzle, getPickLocation().deriveLengths(null, null, nozzle.getEffectiveSafeZ(), null));
                 }
 
                 MoveFeedStatus moveFeedStatus = new MoveFeedStatus(slotAddress);


### PR DESCRIPTION
# Description
While doing moveWhileFeeding move to safeZ rather than 0.

# Justification
This fixes an interesting case where my nozzles go above safeZ while doing a moveWhileFeeding action.

# Instructions for Use
None just profit (it makes an other option `moveWhileFeeding` slightly faster).

# Implementation Details
1. How did you test the change? **TODO**
2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)?
3. ~~If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing.~~
4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted. **TODO**
