### PR TITLE
Multiple scripts

### DIFF
--- a/src/main/java/org/openpnp/scripting/Scripting.java
+++ b/src/main/java/org/openpnp/scripting/Scripting.java
@@ -3,6 +3,8 @@ package org.openpnp.scripting;
 import java.io.File;
 import java.io.FileReader;
 import java.time.Duration;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -242,12 +244,18 @@ public class Scripting {
             return;
         }
         Boolean foundEventScript = false;
-        for (File script : FileUtils.listFiles(eventsDirectory, getExtensions(), false)) {
+        ArrayList<File> sortedFiles = new ArrayList<File>(FileUtils.listFiles(eventsDirectory, getExtensions(), false));
+        Collections.sort(sortedFiles, new Comparator<File>() {
+            @Override
+            public int compare(File a, File b) {
+                return a.getName().compareTo(b.getName());
+            }});
+        for (File script : sortedFiles) {
             if (!script.isFile()) {
                 continue;
             }
-            if (FilenameUtils.getBaseName(script.getName())
-                             .equals(event)) {
+            String baseName = FilenameUtils.getBaseName(script.getName());
+            if (baseName.equals(event) || baseName.startsWith(event+".")) {
                 Logger.trace("Scripting.on found " + script.getName());
                 foundEventScript = true;
                 execute(script, globals);

--- a/src/test/java/org/openpnp/scripting/ScriptingTest.java
+++ b/src/test/java/org/openpnp/scripting/ScriptingTest.java
@@ -100,7 +100,7 @@ public class ScriptingTest {
         }
 
         // ==== Test 1b ====
-        // Check that it runs all the right script files. In this case two scripts for one event
+        // Check that it runs all the right script files, and in the right order. In this case two scripts for one event
         // ================
         FileUtils.copyURLToFile(
                 ClassLoader.getSystemResource("config/ScriptingTest/Events/testFilename.OtherTextCanBeHere.java"),

--- a/src/test/java/org/openpnp/scripting/ScriptingTest.java
+++ b/src/test/java/org/openpnp/scripting/ScriptingTest.java
@@ -108,6 +108,9 @@ public class ScriptingTest {
         FileUtils.copyURLToFile(
                 ClassLoader.getSystemResource("config/ScriptingTest/Events/testFilename.XYZ.java"),
                 new File(scriptsDirectory, "Events/testFilename.XYZ.java"));
+        FileUtils.copyURLToFile(
+                ClassLoader.getSystemResource("config/ScriptingTest/Events/testFilenameButNotThis.java"),
+                new File(scriptsDirectory, "Events/testFilenameButNotThis.java"));
         scripting.on("testFilename", testGlobals);
         if (!testResults.get("other filenames").equals("first+xyz")) {
             throw new Exception("Script execution for other file names didn't return expected result");

--- a/src/test/java/org/openpnp/scripting/ScriptingTest.java
+++ b/src/test/java/org/openpnp/scripting/ScriptingTest.java
@@ -99,6 +99,20 @@ public class ScriptingTest {
             throw new Exception("Engines in the pool even if pooling is disabled");
         }
 
+        // ==== Test 1b ====
+        // Check that it runs all the right script files. In this case two scripts for one event
+        // ================
+        FileUtils.copyURLToFile(
+                ClassLoader.getSystemResource("config/ScriptingTest/Events/testFilename.OtherTextCanBeHere.java"),
+                new File(scriptsDirectory, "Events/testFilename.OtherTextCanBeHere.java"));
+        FileUtils.copyURLToFile(
+                ClassLoader.getSystemResource("config/ScriptingTest/Events/testFilename.XYZ.java"),
+                new File(scriptsDirectory, "Events/testFilename.XYZ.java"));
+        scripting.on("testFilename", testGlobals);
+        if (!testResults.get("other filenames").equals("first+xyz")) {
+            throw new Exception("Script execution for other file names didn't return expected result");
+        }
+
         // ==== Test 2 ====
         // Check if engines are returned to the pool correctly even when the script throws an
         // exception

--- a/src/test/resources/config/ScriptingTest/Events/testFilename.OtherTextCanBeHere.java
+++ b/src/test/resources/config/ScriptingTest/Events/testFilename.OtherTextCanBeHere.java
@@ -1,0 +1,1 @@
+testResults.put("other filenames", "first");

--- a/src/test/resources/config/ScriptingTest/Events/testFilename.XYZ.java
+++ b/src/test/resources/config/ScriptingTest/Events/testFilename.XYZ.java
@@ -1,0 +1,1 @@
+testResults.put("other filenames", testResults.get("other filenames")+"+xyz");

--- a/src/test/resources/config/ScriptingTest/Events/testFilenameButNotThis.java
+++ b/src/test/resources/config/ScriptingTest/Events/testFilenameButNotThis.java
@@ -1,0 +1,1 @@
+testResults.put("other filenames", testResults.get("other filenames")+"+no");


### PR DESCRIPTION
# Description

Currently event scripts are run if the filename matches `EventName.ext`. With this change openpnp also runs `EventName.YourTextInHere.ext`.

# Justification

## Short Term Justification

I currently run a `Vision.PartAlignment.After.py` script which does two things:
1. It has extra monitoring on part size. I have product certification reasons for extra scrutiny on part sizes.
2. It observes the part/nozzle offset error, performs the calculations to inverts the feeder-to-vision transform, determines the misalignment at the pick location, and applies a correction to the feeder pick location. This is useful on PushPull feeders which have very reliable position on tape advancement, but the tape can wander left and right a little.

The second feature would be useful on other feeders (some Photon feeder users have expressed an interest) and I would like to share the script. It would be helpful if I could refactor my script into `Vision.PartAlignment.After.SizeMonitoring.py` and `Vision.PartAlignment.After.FeederPositionControlLoop.py`.

## Longe Term Justification

"I have a script which does two things" demonstrates poor cohesion. It is inherently better for scripts to only do one thing.

This is actually a tiny change to openpnp. It already iterates through the full directory checking every filename for matches, so there is no extra overhead.

Actually this is not a new feature! It has always been possible for openpnp to run multiple scripts for each event because of how that filename-matching loop works. It can run one python script, plus one javascript using Nashorn engine, plus two java scripts using Beanshell using the filename extensions .java and .bsh.

# Backwards Compatibility and Risks

All existing scripts will continue to be run. The caching introduced in #1744 remains unchanged.

In previous versions a script could be disabled by renaming it to, for example, `Vision.PartAlignment.After.disabled-because-of-a-bug.py`. But this PR would resurrect it. This needs to be noted in CHANGES file.

# Instructions for Use
Needed on the wiki

# Implementation Details
1. How did you test the change? Be descriptive. Untested code will not be accepted. -- new unit test
2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)? -- yes
3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing. -- no changes
4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted. -- tests pass
