### PR TITLE
#1885 added some extra log messages, but this one is spurious

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/ReferencePnpJobProcessor.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferencePnpJobProcessor.java
@@ -2328,10 +2328,6 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
                 }
             }
 
-            if(location==null) {
-                Logger.error("error null alignment location for part "+part);
-            }
-
             return convertToHeadLocation(nozzle, location);
         }
 


### PR DESCRIPTION
# Justification

#1885 added some extra log messages to investigate #1884. This removes one spurious log message.

# Implementation Details
1. How did you test the change? Be descriptive. Untested code will not be accepted. -- `mvn test` no longer has spurious error messages; this condition is not an error
2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)? -- yes
3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing. -- no changes
4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted. -- tests pass
