### PR TITLE
Nozzle tracks which feeder provided the part

### DIFF
--- a/src/main/java/org/openpnp/gui/FeedersPanel.java
+++ b/src/main/java/org/openpnp/gui/FeedersPanel.java
@@ -704,7 +704,7 @@ public class FeedersPanel extends JPanel implements WizardContainer {
 
         // Go to the pick location and pick.
         nozzle.moveToPickLocation(feeder);
-        nozzle.pick(feeder.getPart());
+        nozzle.pick(feeder.getPart(),feeder);
         nozzle.moveToSafeZ();
 
         // After the pick. 

--- a/src/main/java/org/openpnp/machine/reference/ReferenceNozzle.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceNozzle.java
@@ -349,7 +349,7 @@ public class ReferenceNozzle extends AbstractNozzle implements HeadMountable {
     }
 
     @Override
-    public void pick(Part part) throws Exception {
+    public void pick(Part part,Feeder feeder) throws Exception {
         Logger.debug("{}.pick()", getName());
         if (part == null) {
             throw new Exception("Can't pick null part");
@@ -364,6 +364,7 @@ public class ReferenceNozzle extends AbstractNozzle implements HeadMountable {
         Configuration.get().getScripting().on("Nozzle.BeforePick", globals);
 
         setPart(part);
+        setPartsFeeder(feeder);
 
         // if the method needs it, store one measurement up front
         storeBeforePickVacuumLevel();
@@ -428,6 +429,7 @@ public class ReferenceNozzle extends AbstractNozzle implements HeadMountable {
         establishPlaceVacuumLevel(this.getPlaceDwellMilliseconds() + nozzleTip.getPlaceDwellMilliseconds());
 
         setPart(null);
+        setPartsFeeder(null);
         getMachine().fireMachineHeadActivity(head);
 
         Configuration.get().getScripting().on("Nozzle.AfterPlace", globals);

--- a/src/main/java/org/openpnp/machine/reference/ReferencePnpJobProcessor.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferencePnpJobProcessor.java
@@ -1448,7 +1448,7 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
                 nozzle.moveToPickLocation(feeder);
 
                 // Pick
-                nozzle.pick(part);
+                nozzle.pick(part,feeder);
 
                 // Retract
                 nozzle.moveToSafeZ();

--- a/src/main/java/org/openpnp/machine/reference/feeder/ReferenceHeapFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/ReferenceHeapFeeder.java
@@ -353,7 +353,7 @@ public class ReferenceHeapFeeder extends ReferenceFeeder {
             lastFeedDepth = stirParts(nozzle, vacuumLevel);
         } 
             
-        nozzle.pick(getPart()); // so the nozzle knows what it is carring. introduces some additional delay
+        nozzle.pick(getPart(),null); // so the nozzle knows what it is carring. introduces some additional delay
         // but rewrite of pick/place without calling nozzle doesn't seem worth, slow anyway
         nozzle.moveToSafeZ();
         moveFromHeap(nozzle); // safe way away from the other heaps
@@ -834,7 +834,7 @@ public class ReferenceHeapFeeder extends ReferenceFeeder {
             // Move to pick location.
             MovableUtils.moveToLocationAtSafeZ(nozzle, location);
             // Pick
-            nozzle.pick(part);
+            nozzle.pick(part,null);
             // Retract
             nozzle.moveToSafeZ();
         }

--- a/src/main/java/org/openpnp/machine/reference/solutions/CalibrationSolutions.java
+++ b/src/main/java/org/openpnp/machine/reference/solutions/CalibrationSolutions.java
@@ -1141,7 +1141,7 @@ public class CalibrationSolutions implements Solutions.Subject {
                 Location placementLocation = location.derive(null, null, null, angle + 180.0);
                 nozzle.prepareForPickAndPlaceArticulation(pickLocation, placementLocation);
                 nozzle.moveToPickLocation(feeder);
-                nozzle.pick(testPart);
+                nozzle.pick(testPart,null);
                 // Extra wait time.
                 Thread.sleep(extraVacuumDwellMs);
                 nozzle.moveToPlacementLocation(placementLocation, testPart);

--- a/src/main/java/org/openpnp/spi/Nozzle.java
+++ b/src/main/java/org/openpnp/spi/Nozzle.java
@@ -5,6 +5,7 @@ import java.util.Set;
 import org.openpnp.model.Length;
 import org.openpnp.model.Location;
 import org.openpnp.model.Part;
+import org.openpnp.spi.Feeder;
 
 /**
  * A Nozzle is a tool capable of picking up parts and releasing them. It is attached to a Head and
@@ -98,7 +99,7 @@ public interface Nozzle
      * 
      * @throws Exception
      */
-    public void pick(Part part) throws Exception;
+    public void pick(Part part,Feeder feeder) throws Exception;
 
     /**
      * Move the Nozzle to the given placementLocation. This will move at safe Z and position the Nozzle
@@ -155,9 +156,14 @@ public interface Nozzle
      * Should typically be non-null after a pick operation and before a place operation and null
      * after a pick operation. Of note, it should be non-null after a failed pick operation
      * so that the system can determine which part it may need to discard. It may also be null
-     * if a user initiated, manual, pick is performed with no Part to reference. 
+     * if a user initiated, manual, pick is performed with no Part to reference.
      */
     public Part getPart();
+
+    /**
+     * Get the feeder that provided the part that is currently picked on the Nozzle, or null if none is picked.
+     */
+    public Feeder getPartsFeeder();
 
     public enum PartOnStep {
         AfterPick,

--- a/src/main/java/org/openpnp/spi/base/AbstractNozzle.java
+++ b/src/main/java/org/openpnp/spi/base/AbstractNozzle.java
@@ -21,6 +21,7 @@ import org.openpnp.spi.CoordinateAxis;
 import org.openpnp.spi.Head;
 import org.openpnp.spi.Nozzle;
 import org.openpnp.spi.NozzleTip;
+import org.openpnp.spi.Feeder;
 import org.openpnp.util.Utils2D;
 import org.pmw.tinylog.Logger;
 import org.simpleframework.xml.Attribute;
@@ -63,6 +64,8 @@ public abstract class AbstractNozzle extends AbstractHeadMountable implements No
     protected Head head;
 
     protected Part part;
+
+    protected Feeder partsFeeder;
 
     protected Double rotationModeOffset;
 
@@ -116,6 +119,17 @@ public abstract class AbstractNozzle extends AbstractHeadMountable implements No
     @Override
     public Part getPart() {
         return part;
+    }
+
+    protected void setPartsFeeder(Feeder feeder) {
+        Object oldValue = this.partsFeeder;
+        this.partsFeeder = feeder;
+        firePropertyChange("partsFeeder", oldValue, feeder);
+    }
+
+    @Override
+    public Feeder getPartsFeeder() {
+        return partsFeeder;
     }
 
     @Override

--- a/src/test/java/ReferenceBottomVisionOffsetTest.java
+++ b/src/test/java/ReferenceBottomVisionOffsetTest.java
@@ -101,7 +101,7 @@ public class ReferenceBottomVisionOffsetTest {
         Location maxError = new Location(LengthUnit.Millimeters, 0.1, 0.1, 0, 0.07);
         for (Location[] testPair: testData) {
             machine.execute(() -> {
-                nozzle.pick(part);
+                nozzle.pick(part,null);
                 Placement placement = new Placement("Dummy");
                 placement.setLocation(testPair[0]);
                 PartAlignmentOffset offset = bottomVision.findOffsets(part, boardLocation, placement, nozzle);
@@ -147,7 +147,7 @@ public class ReferenceBottomVisionOffsetTest {
         Location maxError = new Location(LengthUnit.Millimeters, 0.1, 0.1, 0, 0.07);
         for (Location[] testPair: testData) {
             machine.execute(() -> {
-                nozzle.pick(part);
+                nozzle.pick(part,null);
                 Placement placement = new Placement("Dummy");
                 placement.setLocation(testPair[0]);
                 PartAlignmentOffset offset = bottomVision.findOffsets(part, boardLocation, placement, nozzle);
@@ -194,7 +194,7 @@ public class ReferenceBottomVisionOffsetTest {
         Location maxError = new Location(LengthUnit.Millimeters, 0.1, 0.1, 0, 0.07);
         for (Location[] testPair: testData) {
             machine.execute(() -> {
-                nozzle.pick(part);
+                nozzle.pick(part,null);
                 Placement placement = new Placement("Dummy");
                 placement.setLocation(testPair[0]);
                 PartAlignmentOffset offset = bottomVision.findOffsets(part, boardLocation, placement, nozzle);
@@ -243,7 +243,7 @@ public class ReferenceBottomVisionOffsetTest {
         Location maxError = new Location(LengthUnit.Millimeters, 0.1, 0.1, 0, 0.07);
         for (Location[] testPair: testData) {
             machine.execute(() -> {
-                nozzle.pick(part);
+                nozzle.pick(part,null);
                 Placement placement = new Placement("Dummy");
                 placement.setLocation(testPair[0]);
                 PartAlignmentOffset offset = bottomVision.findOffsets(part, boardLocation, placement, nozzle);
@@ -291,7 +291,7 @@ public class ReferenceBottomVisionOffsetTest {
         Location maxError = new Location(LengthUnit.Millimeters, 0.1, 0.1, 0, 0.07);
         for (Location[] testPair: testData) {
             machine.execute(() -> {
-                nozzle.pick(part);
+                nozzle.pick(part,null);
                 Placement placement = new Placement("Dummy");
                 placement.setLocation(testPair[0]);
                 PartAlignmentOffset offset = bottomVision.findOffsets(part, boardLocation, placement, nozzle);
@@ -338,7 +338,7 @@ public class ReferenceBottomVisionOffsetTest {
         Location maxError = new Location(LengthUnit.Millimeters, 0.1, 0.1, 0, 0.07);
         for (Location[] testPair: testData) {
             machine.execute(() -> {
-                nozzle.pick(part);
+                nozzle.pick(part,null);
                 Placement placement = new Placement("Dummy");
                 placement.setLocation(testPair[0]);
                 PartAlignmentOffset offset = bottomVision.findOffsets(part, boardLocation, placement, nozzle);
@@ -385,7 +385,7 @@ public class ReferenceBottomVisionOffsetTest {
         Location maxError = new Location(LengthUnit.Millimeters, 0.1, 0.1, 0, 0.07);
         for (Location[] testPair: testData) {
             machine.execute(() -> {
-                nozzle.pick(part);
+                nozzle.pick(part,null);
                 Placement placement = new Placement("Dummy");
                 placement.setLocation(testPair[0]);
                 PartAlignmentOffset offset = bottomVision.findOffsets(part, boardLocation, placement, nozzle);
@@ -436,7 +436,7 @@ public class ReferenceBottomVisionOffsetTest {
         Location maxError = new Location(LengthUnit.Millimeters, 0.1, 0.1, 0, 0.07);
         for (Location[] testPair: testData) {
             machine.execute(() -> {
-                nozzle.pick(part);
+                nozzle.pick(part,null);
                 Placement placement = new Placement("Dummy");
                 placement.setLocation(testPair[0]);
                 PartAlignmentOffset offset = bottomVision.findOffsets(part, boardLocation, placement, nozzle);
@@ -490,7 +490,7 @@ public class ReferenceBottomVisionOffsetTest {
         Location maxError = new Location(LengthUnit.Millimeters, 0.1, 0.1, 0, 0.07);
         for (Location[] testPair: testData) {
             machine.execute(() -> {
-                nozzle.pick(part);
+                nozzle.pick(part,null);
                 Placement placement = new Placement("Dummy");
                 placement.setLocation(testPair[0]);
                 PartAlignmentOffset offset = bottomVision.findOffsets(part, boardLocation, placement, nozzle);

--- a/src/test/java/ReferenceBottomVisionTest.java
+++ b/src/test/java/ReferenceBottomVisionTest.java
@@ -57,7 +57,7 @@ public class ReferenceBottomVisionTest {
         machine.setEnabled(true);
         machine.home();
         machine.execute(() -> {
-            nozzle.pick(part);
+            nozzle.pick(part,null);
             PartAlignmentOffset offset = bottomVision.findOffsets(part, null, null, nozzle);
             Location offsets = offset.getLocation();
             assertMaxDelta(offsets.getX(), error.getX(), maxError.getX());

--- a/src/test/java/ReferenceJobProcessorRetryTests.java
+++ b/src/test/java/ReferenceJobProcessorRetryTests.java
@@ -28,6 +28,7 @@ import org.openpnp.model.Part;
 import org.openpnp.model.Placement;
 import org.openpnp.spi.Axis.Type;
 import org.openpnp.spi.Camera.Looking;
+import org.openpnp.spi.Feeder;
 import org.openpnp.spi.Machine;
 import org.openpnp.spi.Nozzle;
 import org.openpnp.spi.NozzleTip;
@@ -277,8 +278,8 @@ public class ReferenceJobProcessorRetryTests {
         int pickCount = 0;
         
         @Override
-        public void pick(Part part) throws Exception {
-            super.pick(part);
+        public void pick(Part part,Feeder feeder) throws Exception {
+            super.pick(part,feeder);
             pickCount++;
         }
         

--- a/src/test/java/VisionCompositingTest.java
+++ b/src/test/java/VisionCompositingTest.java
@@ -111,7 +111,7 @@ public class VisionCompositingTest {
                         maxError = new Location(LengthUnit.Millimeters, 0.05, 0.05, 0, 0.07);
                     }
                     camera.setErrorOffsets(error);
-                    nozzle.pick(part);
+                    nozzle.pick(part,null);
                     Placement placement = new Placement("Dummy");
                     placement.setLocation(Location.origin);
                     PartAlignmentOffset offset = bottomVision.findOffsets(part, null, placement, nozzle);


### PR DESCRIPTION
# Description & Justification
This is one part of #1891 PR #1898 which would be useful to have merged sooner. It will be coincidentally be useful for #1896.

This is a change to the `Nozzle` `pick()` api which optionally allows the `Nozzle` to track which feeder provided the part. The two uses for this API are:
 * Getting the feeder disabled if it is causing errors later identified by the job processor
 * Adjusting a feeder's pick location based on precise error measured during vision
The common factor here is that these features need to be sure about which feeder the part came from. 

# Instructions for Use
This is a new API, with no user-visible elements.

# Implementation Details
1. How did you test the change? Be descriptive. Untested code will not be accepted. -- unit tests are on #1898
2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)? -- yes
3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing. -- **yes!!** `Nozzle` and `AbstractNozzle` have changes that allow it to keep track of the feeder which provided the part it is carrying.
4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted. -- tests pass
