### PR TITLE
photonfeeder: implement feed options and part take back (recycle)

### DIFF
--- a/src/main/java/org/openpnp/machine/photon/PhotonFeeder.java
+++ b/src/main/java/org/openpnp/machine/photon/PhotonFeeder.java
@@ -264,6 +264,16 @@ public class PhotonFeeder extends ReferenceFeeder {
 
     @Override
     public void feed(Nozzle nozzle) throws Exception {
+        switch (getFeedOptions()) {
+        case Normal:
+            break;
+        case SkipNext:
+            setFeedOptions(FeedOptions.Normal);
+            return;
+        case Disable:
+            return;
+        }
+
         for (int i = 0; i <= photonProperties.getFeederCommunicationMaxRetry(); i++) {
             findSlotAddressIfNeeded();
             initializeIfNeeded();
@@ -565,5 +575,22 @@ public class PhotonFeeder extends ReferenceFeeder {
         for (PhotonFeeder feeder : feedersToAdd) {
             Configuration.get().getMachine().addFeeder(feeder);
         }
+    }
+
+    @Override
+    public boolean canTakeBackPart() {
+        return getFeedOptions() == FeedOptions.Normal;
+    }
+
+    @Override
+    public void takeBackPart(Nozzle nozzle) throws Exception {
+        super.takeBackPart(nozzle);
+        putPartBack(nozzle);
+        setFeedOptions(FeedOptions.SkipNext);
+    }
+
+    @Override
+    public boolean supportsFeedOptions() {
+        return true;
     }
 }


### PR DESCRIPTION
# Description
This follows the advice from Toby by copying his implementation at f66bf15af4933e26343094e2fecb0856f2b27274.

This allows to implement single part recycle with photon feeder by storing a part in the uncovered part of the tape.
I have tried spinning the feeder backward but it doesn't work, backlash is huge and I couldn't get to not move the pick window.

As a side-effect it implements feed options for photon feeder rather than adding a snowflake option doing the same thing but worst.

# Justification
Recycling parts is useful.
I had peoples on the lumenpnp discord ask why recycling is bugged.

# Instructions for Use
Load a photon feeder,
configure the pick window,
Pick a part.
Go to the specials tab and click recycle :sparkle:

Also next to the photon feeder in the feeders tab you can change the feed option.

# Implementation Details
1. How did you test the change? Followed both « Instructions for Use »
2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)? yes
3. ~~If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing.~~
4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted.
  I didn't add tests, I really should but I'm lazy, this is trivial code and the commit I'm copying didn't had them either.