### PR TITLE
fix the longer-than-typical dwell time on the last placement of a job

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/ReferencePnpJobProcessor.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferencePnpJobProcessor.java
@@ -63,6 +63,7 @@ import org.openpnp.spi.PnpJobPlanner.PlannedPlacement;
 import org.openpnp.spi.PnpJobProcessor.JobPlacement.Status;
 import org.openpnp.spi.base.AbstractJobProcessor;
 import org.openpnp.spi.base.AbstractPnpJobProcessor;
+import org.openpnp.spi.MotionPlanner.CompletionType;
 import org.openpnp.util.MovableUtils;
 import org.openpnp.util.TravelCost;
 import org.openpnp.util.TravellingSalesman;
@@ -1839,7 +1840,15 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
             catch (Exception e) {
                 throw new JobProcessorException(head, e);
             }
-            
+
+
+            try {// Wait until those actions are complete
+                machine.getMotionPlanner().waitForCompletion(null,CompletionType.WaitForStillstand);
+            }
+            catch (Exception e) {
+                throw new JobProcessorException(head, e);
+            }
+
             return null;
         }
     }


### PR DESCRIPTION
# Description
This change adds waitForCompletion after the final machine activities in a job, and before doing all the other processes that do not involve moving the machine.

# Justification
I sometimes see what appears to be an extra-long dwell time on the final placement of the job, or a delay before homing the machine at the end of a job. The async driver has received those movements but there is a delay somewhere. It makes sense to ensure make sure that all machine processes are complete at this point.

# Instructions for Use
no changes

# Implementation Details
1. How did you test the change? Be descriptive. Untested code will not be accepted. -- tested on a real machine
2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)? -- yes
3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing. -- no changes
4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted. -- tests pass
