### PR TITLE
Defensive changes to various table wizards when finding an object fro…

### DIFF
--- a/src/main/java/org/openpnp/gui/PackagesPanel.java
+++ b/src/main/java/org/openpnp/gui/PackagesPanel.java
@@ -271,7 +271,14 @@ public class PackagesPanel extends JPanel implements WizardContainer {
         List<Package> selections = new ArrayList<>();
         for (int selectedRow : table.getSelectedRows()) {
             selectedRow = table.convertRowIndexToModel(selectedRow);
-            selections.add(tableModel.getRowObjectAt(selectedRow));
+            try {
+                selections.add(tableModel.getRowObjectAt(selectedRow));
+            }
+            catch (IndexOutOfBoundsException e) {
+                // sometimes this happens when deleting a row, if the gui state
+                // updates after the model state
+                Logger.warn("package selection index {} out of bounds", selectedRow);
+            }
         }
         return selections;
     }

--- a/src/main/java/org/openpnp/gui/PartsPanel.java
+++ b/src/main/java/org/openpnp/gui/PartsPanel.java
@@ -273,7 +273,14 @@ public class PartsPanel extends JPanel implements WizardContainer {
         List<Part> selections = new ArrayList<>();
         for (int selectedRow : table.getSelectedRows()) {
             selectedRow = table.convertRowIndexToModel(selectedRow);
-            selections.add(tableModel.getRowObjectAt(selectedRow));
+            try {
+                selections.add(tableModel.getRowObjectAt(selectedRow));
+            }
+            catch (IndexOutOfBoundsException e) {
+                // sometimes this happens when deleting a row, if the gui state
+                // updates after the model state
+                Logger.warn("part selection index {} out of bounds", selectedRow);
+            }
         }
         return selections;
     }

--- a/src/main/java/org/openpnp/gui/VisionSettingsPanel.java
+++ b/src/main/java/org/openpnp/gui/VisionSettingsPanel.java
@@ -16,6 +16,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.prefs.Preferences;
 import java.util.stream.Collectors;
+import org.pmw.tinylog.Logger;
 
 import javax.swing.AbstractAction;
 import javax.swing.Action;
@@ -186,7 +187,14 @@ public class VisionSettingsPanel extends JPanel implements WizardContainer {
         List<AbstractVisionSettings> selections = new ArrayList<>();
         for (int selectedRow : table.getSelectedRows()) {
             selectedRow = table.convertRowIndexToModel(selectedRow);
-            selections.add(tableModel.getRowObjectAt(selectedRow));
+            try {
+                selections.add(tableModel.getRowObjectAt(selectedRow));
+            }
+            catch (IndexOutOfBoundsException e) {
+                // sometimes this happens when deleting a row, if the gui state
+                // updates after the model state
+                Logger.warn("vision settings selection index {} out of bounds", selectedRow);
+            }
         }
         return selections;
     }


### PR DESCRIPTION
# Description

#1904 reports a problem where an exception is raised when deleting a part. The table wizard getSelections method uses JTable to determine the selected row index, and then the table model to determine the object at that row index. However this method gets called in the middle of an update, when the JTable still thinks the last row is selected and the model knows it no longer exists.

The now code catches the exception, and simply omits that row from its `List<>` return value.

Several other wizards have similar code. I have not been able to reproduce the same problem, but made the same change defensively.

# Justification

fixes #1904

# Instructions for Use

no changes

# Implementation Details
1. How did you test the change? Be descriptive. Untested code will not be accepted. -- manually deleting various table rows
2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)? -- yes
3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing. -- no changes
4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted. -- test pass
