### PR TITLE
Avoid drawing a mask circle of zero radius

### DIFF
--- a/src/main/java/org/openpnp/vision/pipeline/stages/MaskCircle.java
+++ b/src/main/java/org/openpnp/vision/pipeline/stages/MaskCircle.java
@@ -71,8 +71,10 @@ public class MaskCircle extends CvStage {
         center = getPossiblePipelinePropertyOverride(center, pipeline, propertyName+".center", 
                 Point.class, org.openpnp.model.Point.class, Location.class);
 
-        Imgproc.circle(mask, center,  Math.abs(diameter) / 2, 
-                new Scalar(255, 255, 255), -1);
+        if(diameter!=0) {
+            Imgproc.circle(mask, center,  Math.abs(diameter) / 2,
+                    new Scalar(255, 255, 255), -1);
+        }
         if (diameter < 0) {
             Core.bitwise_not(mask,mask);
         }

--- a/src/main/java/org/openpnp/vision/pipeline/stages/MaskRectangle.java
+++ b/src/main/java/org/openpnp/vision/pipeline/stages/MaskRectangle.java
@@ -53,7 +53,9 @@ public class MaskRectangle extends CvStage {
         masked.setTo(color);
         Point low = new Point(mat.cols() / 2 - getWidth() / 2, mat.rows() / 2 - getHeight() / 2);
         Point high = new Point(mat.cols() / 2 + getWidth() / 2, mat.rows() / 2 + getHeight() / 2);
-        Imgproc.rectangle(mask, low, high, new Scalar(255, 255, 255), -1);
+        if(getHeight()!=0 && getWidth()!=0) {
+            Imgproc.rectangle(mask, low, high, new Scalar(255, 255, 255), -1);
+        }
         if (getWidth() * getHeight() < 0) {
             Core.bitwise_not(mask, mask);
         }


### PR DESCRIPTION
# Description

This fixes #1909

The stock bottom vision pipeline uses MaskCircle with a radius of zero, and the intended behaviour is to mask the whole image. But sometimes drawing a circle of zero radius leaves a stray pixel at the center point. Similarly, MaskRectangle with zero width and height can leave a stray pixel.

This change avoids drawing circles of zero radius, and rectangles of zero width or height.

# Justification

In most cases this stray pixel causes no problems, and indeed this has been part of the stock bottom vision pipeline for a long time without causing an issue. However #1909 illustrates one case where the stray pixel can be an issue.

This is a low risk change. There are two new `if` tests which skip calling `ImageProc.drawAShape()` if the shapes dimension is exactly zero.

# Instructions for Use

No change

# Implementation Details
1. How did you test the change? Be descriptive. Untested code will not be accepted.
    a. Manual test in the pipeline editor to see the stray pixel is no longer there.
    b. Code review to confirm this is a low risk change.
3. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)? -- yes
4. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing. -- no changes
5. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted. -- tests pass
