### PR TITLE
photonfeeder: add Feed 1mm button

### DIFF
--- a/src/main/java/org/openpnp/machine/photon/PhotonFeeder.java
+++ b/src/main/java/org/openpnp/machine/photon/PhotonFeeder.java
@@ -262,18 +262,7 @@ public class PhotonFeeder extends ReferenceFeeder {
         return actuator;
     }
 
-    @Override
-    public void feed(Nozzle nozzle) throws Exception {
-        switch (getFeedOptions()) {
-        case Normal:
-            break;
-        case SkipNext:
-            setFeedOptions(FeedOptions.Normal);
-            return;
-        case Disable:
-            return;
-        }
-
+    private void feed(Nozzle nozzle, int distance_mm) throws Exception {
         for (int i = 0; i <= photonProperties.getFeederCommunicationMaxRetry(); i++) {
             findSlotAddressIfNeeded();
             initializeIfNeeded();
@@ -284,7 +273,7 @@ public class PhotonFeeder extends ReferenceFeeder {
 
             verifyFeederLocationIsFullyConfigured();
 
-            MoveFeedForward moveFeedForward = new MoveFeedForward(slotAddress, partPitch * 10);
+            MoveFeedForward moveFeedForward = new MoveFeedForward(slotAddress, distance_mm * 10);
             MoveFeedForward.Response moveFeedForwardResponse = moveFeedForward.send(photonBus);
 
             if (moveFeedForwardResponse == null) {
@@ -327,6 +316,25 @@ public class PhotonFeeder extends ReferenceFeeder {
         }
 
         throw new FeedFailureException("Failed to feed for an unknown reason. Is the feeder inserted?");
+    }
+
+    @Override
+    public void feed(Nozzle nozzle) throws Exception {
+        switch (getFeedOptions()) {
+        case Normal:
+            break;
+        case SkipNext:
+            setFeedOptions(FeedOptions.Normal);
+            return;
+        case Disable:
+            return;
+        }
+
+        feed(nozzle, partPitch);
+    }
+
+    public void feedOneMm() throws Exception {
+        feed(null, 1);
     }
 
     @Override

--- a/src/main/java/org/openpnp/machine/photon/sheets/gui/FeederConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/photon/sheets/gui/FeederConfigurationWizard.java
@@ -138,6 +138,9 @@ public class FeederConfigurationWizard extends AbstractConfigurationWizard {
 		
 		JButton feedButton = new JButton(feedAction);
 		partPanel.add(feedButton, "6, 4"); //$NON-NLS-1$
+
+		JButton feedOneMmButton = new JButton(feedOneMmAction);
+		partPanel.add(feedOneMmButton, "8, 4"); //$NON-NLS-1$
 		
 		JLabel feedRetryLabel = new JLabel(Translations.getString("FeederConfigurationWizard.PartPanel.feedRetryLabel.text")); //$NON-NLS-1$
 		partPanel.add(feedRetryLabel, "2, 6, right, default"); //$NON-NLS-1$
@@ -278,6 +281,7 @@ public class FeederConfigurationWizard extends AbstractConfigurationWizard {
 		addWrappedBinding(feeder, "pickRetryCount", pickRetryCountTf, "text", intConverter); //$NON-NLS-1$ //$NON-NLS-2$
 
 		bind(UpdateStrategy.READ, slotProxy, "enabled", feedAction, "enabled"); //$NON-NLS-1$ //$NON-NLS-2$
+		bind(UpdateStrategy.READ, slotProxy, "enabled", feedOneMmAction, "enabled"); //$NON-NLS-1$ //$NON-NLS-2$
 
 		bind(UpdateStrategy.READ, slotProxy, "enabled", xSlotTf, "enabled"); //$NON-NLS-1$ //$NON-NLS-2$
 		bind(UpdateStrategy.READ, slotProxy, "enabled", ySlotTf, "enabled"); //$NON-NLS-1$ //$NON-NLS-2$
@@ -321,6 +325,15 @@ public class FeederConfigurationWizard extends AbstractConfigurationWizard {
 		public void actionPerformed(ActionEvent e) {
 			UiUtils.submitUiMachineTask(() -> {
 				feeder.feed(null); // TODO This probably shouldn't be null
+			});
+		}
+	};
+
+	private final Action feedOneMmAction = new AbstractAction(Translations.getString("FeederConfigurationWizard.FeedOneMmAction.Name")) { //$NON-NLS-1$
+		@Override
+		public void actionPerformed(ActionEvent e) {
+			UiUtils.submitUiMachineTask(() -> {
+				feeder.feedOneMm();
 			});
 		}
 	};

--- a/src/main/resources/org/openpnp/translations.properties
+++ b/src/main/resources/org/openpnp/translations.properties
@@ -379,6 +379,7 @@ ExistingBoardOrPanelDialog.Label.SelectOneFile.Trailer=\ from the list below or 
 ExistingBoardOrPanelDialog.boardOrPanel.Board=board
 ExistingBoardOrPanelDialog.boardOrPanel.Panel=panel
 FeederConfigurationWizard.FeedAction.Name=Feed
+FeederConfigurationWizard.FeedOneMmAction.Name=Feed 1mm
 FeederConfigurationWizard.FindSlotAddressAction.Name=Find
 FeederConfigurationWizard.InfoPanel.Border.title=Info
 FeederConfigurationWizard.InfoPanel.hardwareIdLabel.text=Hardware ID\: 


### PR DESCRIPTION
# Description
For photon feeders, add `Feed 1mm` button right next to the `Feed` button.

# Justification
While using the photon feeder I found myself doing this on a regular basis to fine tune the tape position in the pick window:
- change part pitch to 1mm
- apply
- feed
- change part pitch to what it was
- apply

Because the physical buttons on the photon feeder are 2mm feed and just inconveniently located for the half on the other side of the machine.

# Instructions for Use
Go to a photon feeder.
Go to global config, search all slots.
Go back to a photon feeder.
Press `Feed 1mm` button.

# Implementation Details
1. How did you test the change? I tested it on my machine, pressed the button it feeds 1mm.
2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)? y
3. ~~If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing.~~
4. Be sure to run `mvn test` before submitting the Pull Request. I love CI :heart:
