### PR TITLE
photonfeeder: Press Play Walk Away

### DIFF
--- a/src/main/java/org/openpnp/machine/photon/PhotonFeeder.java
+++ b/src/main/java/org/openpnp/machine/photon/PhotonFeeder.java
@@ -62,9 +62,9 @@ public class PhotonFeeder extends ReferenceFeeder {
     final private double correctionLimit = 5.0; // millimeters
     final private double correctionGain = 0.5; // portion of error to correct each bottom vision
 
-    private Location pickCorrectionOffset = new Location(LengthUnit.Millimeters);
+    private Location pickCorrectionIntegral = new Location(LengthUnit.Millimeters);
 
-    private Location pickCorrectionOffsetAccumulatorSinceLastFeed = new Location(LengthUnit.Millimeters);
+    private Location pickCorrectionAveragingAccumulatorSinceLastFeed = new Location(LengthUnit.Millimeters);
     private int visionsSinceLastFeed = 0;
 
     private static PhotonBusInterface photonBus;
@@ -103,7 +103,7 @@ public class PhotonFeeder extends ReferenceFeeder {
     }
 
     private Location getPickCorrectionOffset() throws Exception {
-        return pickCorrectionOffset;
+        return pickCorrectionIntegral;
     }
 
     private Location getPickLocationWithoutError() throws Exception {
@@ -364,7 +364,7 @@ public class PhotonFeeder extends ReferenceFeeder {
         int partPitchNudgeTicks = 0;
         final double feedTickMm = 0.1;
 
-        double yPlaneErrorMm = pickCorrectionOffset.getLengthY().convertToUnits(LengthUnit.Millimeters).getValue();
+        double yPlaneErrorMm = pickCorrectionIntegral.getLengthY().convertToUnits(LengthUnit.Millimeters).getValue();
 
         if (yPlaneErrorMm <= -feedTickMm || feedTickMm <= yPlaneErrorMm) {
             // far enough to nudge the part pitch
@@ -377,13 +377,13 @@ public class PhotonFeeder extends ReferenceFeeder {
             Logger.debug("{}: Nudging tape by {} ticks", getSlotAddress(), partPitchNudgeTicks);
         }
 
-        pickCorrectionOffset = pickCorrectionOffset.add(nudgeOffset);
+        pickCorrectionIntegral = pickCorrectionIntegral.add(nudgeOffset);
 
         try {
             feed(nozzle, getPartPitch() * 10 + partPitchNudgeTicks);
         } catch (Exception e) {
             // Didn't feed, revert correction offset.
-            pickCorrectionOffset = pickCorrectionOffset.subtract(nudgeOffset);
+            pickCorrectionIntegral = pickCorrectionIntegral.subtract(nudgeOffset);
             throw e;
         }
     }
@@ -682,29 +682,29 @@ public class PhotonFeeder extends ReferenceFeeder {
         }
 
         visionsSinceLastFeed++;
-        pickCorrectionOffsetAccumulatorSinceLastFeed = pickCorrectionOffsetAccumulatorSinceLastFeed.add(offset.rotateXy(pickLocation.getRotation()));
+        pickCorrectionAveragingAccumulatorSinceLastFeed = pickCorrectionAveragingAccumulatorSinceLastFeed.add(offset.rotateXy(pickLocation.getRotation()));
     }
 
     private void emptyPickCorrectionAccumulatorIntoCorrection() {
         if (visionsSinceLastFeed <= 0)
             return;
 
-        Location averageOffset = pickCorrectionOffsetAccumulatorSinceLastFeed.multiply(1.0 / (double)visionsSinceLastFeed);
-        pickCorrectionOffset = pickCorrectionOffset.add(averageOffset.multiply(correctionGain));
+        Location averageOffset = pickCorrectionAveragingAccumulatorSinceLastFeed.multiply(1.0 / (double)visionsSinceLastFeed);
+        pickCorrectionIntegral = pickCorrectionIntegral.add(averageOffset.multiply(correctionGain));
 
         visionsSinceLastFeed = 0;
-        pickCorrectionOffsetAccumulatorSinceLastFeed = new Location(pickCorrectionOffsetAccumulatorSinceLastFeed.getUnits());
+        pickCorrectionAveragingAccumulatorSinceLastFeed = new Location(pickCorrectionAveragingAccumulatorSinceLastFeed.getUnits());
 
-        double distance = pickCorrectionOffset.convertToUnits(LengthUnit.Millimeters).getLinearDistanceTo(0, 0);
+        double distance = pickCorrectionIntegral.convertToUnits(LengthUnit.Millimeters).getLinearDistanceTo(0, 0);
         if (distance > correctionLimit) {
             // Avoid physical damage, saturate it back to limit.
-            pickCorrectionOffset = pickCorrectionOffset.multiply(correctionLimit / distance);
+            pickCorrectionIntegral = pickCorrectionIntegral.multiply(correctionLimit / distance);
         }
     }
 
     public void resetPickCorrection() {
-        pickCorrectionOffset = new Location(LengthUnit.Millimeters);
+        pickCorrectionIntegral = new Location(LengthUnit.Millimeters);
         visionsSinceLastFeed = 0;
-        pickCorrectionOffsetAccumulatorSinceLastFeed = new Location(LengthUnit.Millimeters);
+        pickCorrectionAveragingAccumulatorSinceLastFeed = new Location(LengthUnit.Millimeters);
     }
 }

--- a/src/main/java/org/openpnp/machine/photon/PhotonFeeder.java
+++ b/src/main/java/org/openpnp/machine/photon/PhotonFeeder.java
@@ -1,5 +1,13 @@
 package org.openpnp.machine.photon;
 
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import javax.swing.Action;
+
 import org.openpnp.ConfigurationListener;
 import org.openpnp.gui.support.Wizard;
 import org.openpnp.machine.photon.exceptions.FeedFailureException;
@@ -9,28 +17,30 @@ import org.openpnp.machine.photon.exceptions.UnconfiguredSlotException;
 import org.openpnp.machine.photon.protocol.ErrorTypes;
 import org.openpnp.machine.photon.protocol.PhotonBus;
 import org.openpnp.machine.photon.protocol.PhotonBusInterface;
-import org.openpnp.machine.photon.protocol.commands.*;
+import org.openpnp.machine.photon.protocol.commands.GetFeederAddress;
+import org.openpnp.machine.photon.protocol.commands.GetFeederId;
+import org.openpnp.machine.photon.protocol.commands.InitializeFeeder;
+import org.openpnp.machine.photon.protocol.commands.MoveFeedForward;
+import org.openpnp.machine.photon.protocol.commands.MoveFeedStatus;
 import org.openpnp.machine.photon.sheets.FeederPropertySheet;
 import org.openpnp.machine.photon.sheets.GlobalConfigPropertySheet;
 import org.openpnp.machine.reference.ReferenceActuator;
 import org.openpnp.machine.reference.ReferenceFeeder;
 import org.openpnp.machine.reference.driver.GcodeDriver;
 import org.openpnp.model.Configuration;
+import org.openpnp.model.LengthUnit;
 import org.openpnp.model.Location;
 import org.openpnp.model.Solutions;
-import org.openpnp.spi.*;
+import org.openpnp.spi.Actuator;
+import org.openpnp.spi.Driver;
+import org.openpnp.spi.Feeder;
+import org.openpnp.spi.Machine;
+import org.openpnp.spi.Nozzle;
+import org.openpnp.spi.PropertySheetHolder;
 import org.openpnp.util.MovableUtils;
 import org.pmw.tinylog.Logger;
 import org.simpleframework.xml.Attribute;
 import org.simpleframework.xml.Element;
-
-import javax.swing.*;
-
-import java.time.Duration;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 public class PhotonFeeder extends ReferenceFeeder {
     public static final String ACTUATOR_DATA_NAME = "PhotonFeederData";
@@ -48,6 +58,9 @@ public class PhotonFeeder extends ReferenceFeeder {
 
     @Element(required = false)
     private Location offset;
+
+    final private double correctionLimit = 5.0; // millimeters
+    private Location pickCorrectionOffset = new Location(LengthUnit.Millimeters);
 
     private static PhotonBusInterface photonBus;
 
@@ -84,11 +97,19 @@ public class PhotonFeeder extends ReferenceFeeder {
         photonBus = new PhotonBus(0, getDataActuator());
     }
 
-    @Override
-    public Location getPickLocation() throws Exception {
+    private Location getPickCorrectionOffset() throws Exception {
+        return pickCorrectionOffset;
+    }
+
+    private Location getPickLocationWithoutError() throws Exception {
         verifyFeederLocationIsFullyConfigured();
 
         return offset.offsetWithRotationFrom(getSlot().getLocation());
+    }
+
+    @Override
+    public Location getPickLocation() throws Exception {
+        return getPickLocationWithoutError().add(getPickCorrectionOffset());
     }
 
     private void verifyFeederLocationIsFullyConfigured() throws NoSlotAddressException,
@@ -115,6 +136,7 @@ public class PhotonFeeder extends ReferenceFeeder {
     public void setOffset(Location offsets) {
         Object oldValue = this.offset;
         this.offset = offsets;
+        pickCorrectionOffset = new Location(LengthUnit.Millimeters);
         firePropertyChange("offsets", oldValue, offsets);
     }
 
@@ -262,7 +284,7 @@ public class PhotonFeeder extends ReferenceFeeder {
         return actuator;
     }
 
-    private void feed(Nozzle nozzle, int distance_mm) throws Exception {
+    private void feed(Nozzle nozzle, int distance_HundredMicrons) throws Exception {
         for (int i = 0; i <= photonProperties.getFeederCommunicationMaxRetry(); i++) {
             findSlotAddressIfNeeded();
             initializeIfNeeded();
@@ -273,7 +295,7 @@ public class PhotonFeeder extends ReferenceFeeder {
 
             verifyFeederLocationIsFullyConfigured();
 
-            MoveFeedForward moveFeedForward = new MoveFeedForward(slotAddress, distance_mm * 10);
+            MoveFeedForward moveFeedForward = new MoveFeedForward(slotAddress, distance_HundredMicrons);
             MoveFeedForward.Response moveFeedForwardResponse = moveFeedForward.send(photonBus);
 
             if (moveFeedForwardResponse == null) {
@@ -330,11 +352,38 @@ public class PhotonFeeder extends ReferenceFeeder {
             return;
         }
 
-        feed(nozzle, partPitch);
+        // To solve long term drift. Nudge the part pitch sent to the feeder if the correction offset is big enough.
+        Location nudgeOffset = new Location(LengthUnit.Millimeters);
+        int partPitchNudgeTicks = 0;
+        final double feedTickMm = 0.1;
+
+        double yPlaneErrorMm = pickCorrectionOffset.getLengthY().convertToUnits(LengthUnit.Millimeters).getValue();
+
+        if (yPlaneErrorMm <= -feedTickMm || feedTickMm <= yPlaneErrorMm) {
+            // far enough to nudge the part pitch
+            partPitchNudgeTicks = -(int)(yPlaneErrorMm / feedTickMm);
+            nudgeOffset = new Location(LengthUnit.Millimeters, 0, (double)partPitchNudgeTicks * feedTickMm, 0, 0);
+            if (getSlotAddress() > 25) {
+                // back row of feeders; tape flows oposite direction as our commands so invert the nudge
+                partPitchNudgeTicks = -partPitchNudgeTicks;
+            }
+            Logger.debug("{}: Nudging tape by {} ticks", getSlotAddress(), partPitchNudgeTicks);
+        }
+
+        pickCorrectionOffset = pickCorrectionOffset.add(nudgeOffset);
+
+        try {
+            feed(nozzle, getPartPitch() * 10 + partPitchNudgeTicks);
+        } catch (Exception e) {
+            // Didn't feed, revert correction offset.
+            pickCorrectionOffset = pickCorrectionOffset.subtract(nudgeOffset);
+            throw e;
+        }
     }
 
     public void feedOneMm() throws Exception {
-        feed(null, 1);
+        feed(null, 10);
+        pickCorrectionOffset = new Location(LengthUnit.Millimeters);
     }
 
     @Override
@@ -443,6 +492,8 @@ public class PhotonFeeder extends ReferenceFeeder {
 
         this.slotAddress = slotAddress;
 
+        pickCorrectionOffset = new Location(LengthUnit.Millimeters);
+
         firePropertyChange("slotAddress", oldValue, slotAddress);
         firePropertyChange("slot", oldSlot, getSlot());
         firePropertyChange("name", oldName, getName());
@@ -459,6 +510,8 @@ public class PhotonFeeder extends ReferenceFeeder {
         if (getClass().getSimpleName().equals(name)) {
             name = hardwareId;
         }
+
+        pickCorrectionOffset = new Location(LengthUnit.Millimeters);
 
         firePropertyChange("hardwareId", oldValue, hardwareId);
     }
@@ -479,6 +532,7 @@ public class PhotonFeeder extends ReferenceFeeder {
 
     public void setPartPitch(int partPitch) {
         this.partPitch = partPitch;
+        pickCorrectionOffset = new Location(LengthUnit.Millimeters);
     }
 
     public int getPartPitch() {
@@ -600,5 +654,26 @@ public class PhotonFeeder extends ReferenceFeeder {
     @Override
     public boolean supportsFeedOptions() {
         return true;
+    }
+
+    @Override
+    public void bottomVisionCorrectionCallback(Location offset) {
+        Location pickLocation;
+        try {
+            pickLocation = getPickLocationWithoutError();
+        } catch (Exception e) {
+            Logger.error("{}: Could not get pick location without error for bottom vision callback: {}", getSlotAddress(), e);
+            return;
+        }
+        // Add half of the error to the running total to avoid over-correction
+        Location before = pickCorrectionOffset;
+        pickCorrectionOffset = pickCorrectionOffset.add(offset.rotateXy(pickLocation.getRotation()).multiply(0.5));
+        Logger.debug("{}: bottom vision reports pick error of: {}; old pick correction: {} new {}", getSlotAddress(), offset, before, pickCorrectionOffset);
+
+        double distance = pickCorrectionOffset.convertToUnits(LengthUnit.Millimeters).getLinearDistanceTo(0, 0);
+        if (distance > correctionLimit) {
+            // Avoid physical damage, saturate it back to limit.
+            pickCorrectionOffset = pickCorrectionOffset.multiply(correctionLimit / distance);
+        }
     }
 }

--- a/src/main/java/org/openpnp/machine/photon/PhotonFeeder.java
+++ b/src/main/java/org/openpnp/machine/photon/PhotonFeeder.java
@@ -499,6 +499,14 @@ public class PhotonFeeder extends ReferenceFeeder {
 
         this.slotAddress = slotAddress;
 
+        if (oldSlot.getFeeder() == this) {
+            oldSlot.setFeeder(null);
+        }
+
+        if (getSlot() != null) {
+            getSlot().setFeeder(this);
+        }
+
         resetPickCorrection();
 
         firePropertyChange("slotAddress", oldValue, slotAddress);

--- a/src/main/java/org/openpnp/machine/photon/PhotonFeeder.java
+++ b/src/main/java/org/openpnp/machine/photon/PhotonFeeder.java
@@ -60,7 +60,11 @@ public class PhotonFeeder extends ReferenceFeeder {
     private Location offset;
 
     final private double correctionLimit = 5.0; // millimeters
+    final private double correctionGain = 0.5; // portion of error to correct each bottom vision
+
     private Location pickCorrectionOffset = new Location(LengthUnit.Millimeters);
+
+    private Location pickCorrectionOffsetAccumulatorSinceLastFeed = new Location(LengthUnit.Millimeters);
     private int visionsSinceLastFeed = 0;
 
     private static PhotonBusInterface photonBus;
@@ -137,7 +141,7 @@ public class PhotonFeeder extends ReferenceFeeder {
     public void setOffset(Location offsets) {
         Object oldValue = this.offset;
         this.offset = offsets;
-        pickCorrectionOffset = new Location(LengthUnit.Millimeters);
+        resetPickCorrection();
         firePropertyChange("offsets", oldValue, offsets);
     }
 
@@ -353,7 +357,7 @@ public class PhotonFeeder extends ReferenceFeeder {
             return;
         }
 
-        visionsSinceLastFeed = 0;
+        emptyPickCorrectionAccumulatorIntoCorrection();
 
         // To solve long term drift. Nudge the part pitch sent to the feeder if the correction offset is big enough.
         Location nudgeOffset = new Location(LengthUnit.Millimeters);
@@ -386,7 +390,7 @@ public class PhotonFeeder extends ReferenceFeeder {
 
     public void feedOneMm() throws Exception {
         feed(null, 10);
-        pickCorrectionOffset = new Location(LengthUnit.Millimeters);
+        resetPickCorrection();
     }
 
     @Override
@@ -495,7 +499,7 @@ public class PhotonFeeder extends ReferenceFeeder {
 
         this.slotAddress = slotAddress;
 
-        pickCorrectionOffset = new Location(LengthUnit.Millimeters);
+        resetPickCorrection();
 
         firePropertyChange("slotAddress", oldValue, slotAddress);
         firePropertyChange("slot", oldSlot, getSlot());
@@ -514,7 +518,7 @@ public class PhotonFeeder extends ReferenceFeeder {
             name = hardwareId;
         }
 
-        pickCorrectionOffset = new Location(LengthUnit.Millimeters);
+        resetPickCorrection();
 
         firePropertyChange("hardwareId", oldValue, hardwareId);
     }
@@ -535,7 +539,7 @@ public class PhotonFeeder extends ReferenceFeeder {
 
     public void setPartPitch(int partPitch) {
         this.partPitch = partPitch;
-        pickCorrectionOffset = new Location(LengthUnit.Millimeters);
+        resetPickCorrection();
     }
 
     public int getPartPitch() {
@@ -669,19 +673,30 @@ public class PhotonFeeder extends ReferenceFeeder {
             return;
         }
 
-        // Add half of the error to the running total to avoid over-correction
-        Location before = pickCorrectionOffset;
-
-        double factor = 1 / (double)(2 << visionsSinceLastFeed); // Start at 0.5 then have each new vision half.
         visionsSinceLastFeed++;
+        pickCorrectionOffsetAccumulatorSinceLastFeed = pickCorrectionOffsetAccumulatorSinceLastFeed.add(offset.rotateXy(pickLocation.getRotation()));
+    }
 
-        pickCorrectionOffset = pickCorrectionOffset.add(offset.rotateXy(pickLocation.getRotation()).multiply(factor));
-        Logger.debug("{}: bottom vision reports pick error of: {}; old pick correction: {} new {}", getSlotAddress(), offset, before, pickCorrectionOffset);
+    private void emptyPickCorrectionAccumulatorIntoCorrection() {
+        if (visionsSinceLastFeed <= 0)
+            return;
+
+        Location averageOffset = pickCorrectionOffsetAccumulatorSinceLastFeed.multiply(1.0 / (double)visionsSinceLastFeed);
+        pickCorrectionOffset = pickCorrectionOffset.add(averageOffset.multiply(correctionGain));
+
+        visionsSinceLastFeed = 0;
+        pickCorrectionOffsetAccumulatorSinceLastFeed = new Location(pickCorrectionOffsetAccumulatorSinceLastFeed.getUnits());
 
         double distance = pickCorrectionOffset.convertToUnits(LengthUnit.Millimeters).getLinearDistanceTo(0, 0);
         if (distance > correctionLimit) {
             // Avoid physical damage, saturate it back to limit.
             pickCorrectionOffset = pickCorrectionOffset.multiply(correctionLimit / distance);
         }
+    }
+
+    public void resetPickCorrection() {
+        pickCorrectionOffset = new Location(LengthUnit.Millimeters);
+        visionsSinceLastFeed = 0;
+        pickCorrectionOffsetAccumulatorSinceLastFeed = new Location(LengthUnit.Millimeters);
     }
 }

--- a/src/main/java/org/openpnp/machine/photon/PhotonFeederSlots.java
+++ b/src/main/java/org/openpnp/machine/photon/PhotonFeederSlots.java
@@ -30,7 +30,7 @@ public class PhotonFeederSlots {
         @Element(required = false)
         private Location location;
 
-        private Slot() {}
+        private PhotonFeeder feeder;
 
         public Slot(int address) {
             this.address = address;
@@ -55,6 +55,17 @@ public class PhotonFeederSlots {
 
         public void setLocation(Location location) {
             this.location = location;
+            if (feeder != null) {
+                feeder.resetPickCorrection();
+            }
+        }
+
+        public PhotonFeeder getFeeder() {
+            return feeder;
+        }
+
+        public void setFeeder(PhotonFeeder feeder) {
+            this.feeder = feeder;
         }
     }
 }

--- a/src/main/java/org/openpnp/spi/Feeder.java
+++ b/src/main/java/org/openpnp/spi/Feeder.java
@@ -24,6 +24,7 @@ import org.openpnp.model.Location;
 import org.openpnp.model.Named;
 import org.openpnp.model.Part;
 import org.openpnp.model.Solutions;
+import org.openpnp.spi.PartAlignment.PartAlignmentOffset;
 
 
 
@@ -154,4 +155,7 @@ public interface Feeder extends Identifiable, Named, WizardConfigurable, Propert
             super(s);
         }
     }
+
+    // bottomVisionCorrectionCallback is called after vision and gives part pick error offset in the machine's reference frame.
+    public void bottomVisionCorrectionCallback(Location partAlignement);
 }

--- a/src/main/java/org/openpnp/spi/base/AbstractFeeder.java
+++ b/src/main/java/org/openpnp/spi/base/AbstractFeeder.java
@@ -8,9 +8,11 @@ import org.openpnp.gui.support.Icons;
 import org.openpnp.gui.support.PropertySheetWizardAdapter;
 import org.openpnp.model.AbstractModelObject;
 import org.openpnp.model.Configuration;
+import org.openpnp.model.Location;
 import org.openpnp.model.Part;
 import org.openpnp.spi.Feeder;
 import org.openpnp.spi.Nozzle;
+import org.openpnp.spi.PartAlignment.PartAlignmentOffset;
 import org.simpleframework.xml.Attribute;
 
 public abstract class AbstractFeeder extends AbstractModelObject implements Feeder {
@@ -181,4 +183,5 @@ public abstract class AbstractFeeder extends AbstractModelObject implements Feed
     @Attribute(required=false)
     protected Priority priority = Priority.Normal;
 
+    public void bottomVisionCorrectionCallback(Location partAlignement) {}
 }

--- a/src/main/java/org/openpnp/util/VisionUtils.java
+++ b/src/main/java/org/openpnp/util/VisionUtils.java
@@ -289,7 +289,7 @@ public class VisionUtils {
             Configuration.get().getScripting().on("Vision.PartAlignment.After", globals);
 
             Feeder f = nozzle.getPartsFeeder();
-            if (f != null && offsets != null) {
+            if (f != null && offsets != null && boardLocation != null && placement != null) {
                 Location realError = offsets.getLocation();
                 if (offsets.getPreRotated()) {
                     realError = realError.rotateXy(

--- a/src/main/java/org/openpnp/util/VisionUtils.java
+++ b/src/main/java/org/openpnp/util/VisionUtils.java
@@ -27,6 +27,7 @@ import org.openpnp.model.Point;
 import org.openpnp.model.Footprint.Pad;
 import org.openpnp.spi.Camera;
 import org.openpnp.spi.CameraBatchOperation;
+import org.openpnp.spi.Feeder;
 import org.openpnp.spi.HeadMountable;
 import org.openpnp.spi.Nozzle;
 import org.openpnp.spi.PartAlignment;
@@ -286,6 +287,17 @@ public class VisionUtils {
             }
             globals.put("offsets", offsets);
             Configuration.get().getScripting().on("Vision.PartAlignment.After", globals);
+
+            Feeder f = nozzle.getPartsFeeder();
+            if (f != null && offsets != null) {
+                Location realError = offsets.getLocation();
+                if (offsets.getPreRotated()) {
+                    realError = realError.rotateXy(
+                        -Utils2D.calculateBoardPlacementLocation(boardLocation, placement.getLocation()).getRotation()
+                    );
+                }
+                f.bottomVisionCorrectionCallback(realError);
+            }
         }
     }
 


### PR DESCRIPTION
# TODO for Ready-For-Merge:
- [ ] ~~split into 3 commits (spi, pick location nudging, tape nudging)~~
- [ ] ~~remove accidental formater diff lines~~ reordering imports is not the best but it's fine
- [ ] ~~extract feature to be usable by other feeders~~ gonna be done in 2.7
- [ ] add some configuration knobs ?
- [ ] add tests
- [x] merge #1913 (stacked PR)
- [x] rename `pickCorrectionOffset` to `pickCorrectionIntegral` to reflect we are implementing an `I`-controler
- [x] **known bugs**:
  - [x] setting the slot offset does not the reset the correction offset
  - [x] having multiple nozzles pick from the same feeder is metastable
  - [x] using test alignment does a null deref in the vision utils code trying to undo rotation 

# Description

Implements #1896 for photon feeder (generic implementation will be implemented in 2.7)

Implements Backtransformed bottom vision → pick location closed loop control.
After doing a bottom vision the VisionUtils code will callback into the feeder it were picked from.

PhotonFeeder uses this to implement two things:
1. Nudge the pick location to aim for perfectly picked components on the first try.
2. Nudge the feed pitch to remove long term drift in pick location nudging.

# Justification
I have ran a couple of before and after jobs.
Feeders are literally >20x more reliable.
On average an operator used to have to manually fix the the pick location alignment every 30 pick.
With this PR I can run a 650 placement job without any manual intervention.

# Instructions for Use
None just enjoy >20x more reliable feeders.

# Implementation Details
1. How did you test the change?
  I've ran multiple jobs with it, also created tests jobs making sure the coordinate transformations are bullet proof.
2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)?
  probably not, maybe
3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing.
  I did, I am not 100% sure on the final signature form (mainly thinking if we should pass `x` & `y` components individually since `z` & `rotation` are always 0 by definition of the coordinate frame used)
4. Be sure to run `mvn test` before submitting the Pull Request. **TODO** meaningless to do before I add my own tests.
