### PR TITLE
fix for null PlannedPlacement bug

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/ReferencePnpJobProcessor.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferencePnpJobProcessor.java
@@ -2739,12 +2739,19 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
                     nozzleCount += 1;
                     if (nozzleCount==2 && plannerState.plannedPlacements.size()==2 && plannerState.plannedPlacements.get(1).planningCost!=null) {
                         PlannerState plannerStateAlt = new PlannerState(jobPlacements,head.getNozzles(),nozzleTips);
-                        plannerStateAlt.addPlannedPlacement(planWithoutNozzleTipChange(plannerState.plannedPlacements.get(1).nozzle,plannerStateAlt));
-                        plannerStateAlt.addPlannedPlacement(planWithoutNozzleTipChange(plannerState.plannedPlacements.get(0).nozzle,plannerStateAlt));
-                        if(plannerStateAlt.plannedPlacements.get(1).planningCost != null &&
-                           plannerStateAlt.plannedPlacements.get(1).planningCost<plannerState.plannedPlacements.get(1).planningCost) {
-                            Logger.debug("Alternate plan accepted {} better than {}",plannerStateAlt.plannedPlacements, plannerState.plannedPlacements);
-                            plannerState = plannerStateAlt;
+                        PlannedPlacement pp;
+                        pp = planWithoutNozzleTipChange(plannerState.plannedPlacements.get(1).nozzle,plannerStateAlt);
+                        if (pp != null) {
+                            plannerStateAlt.addPlannedPlacement(pp);
+                            pp = planWithoutNozzleTipChange(plannerState.plannedPlacements.get(0).nozzle,plannerStateAlt);
+                            if (pp != null) {
+                                plannerStateAlt.addPlannedPlacement(pp);
+                                if(plannerStateAlt.plannedPlacements.get(1).planningCost != null &&
+                                plannerStateAlt.plannedPlacements.get(1).planningCost<plannerState.plannedPlacements.get(1).planningCost) {
+                                    Logger.debug("Alternate plan accepted {} better than {}",plannerStateAlt.plannedPlacements, plannerState.plannedPlacements);
+                                    plannerState = plannerStateAlt;
+                                }
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
# Description

This adds some null object checking.

# Justification
This bug was reported by Khammed Guseynov on [google groups](https://groups.google.com/d/msgid/openpnp/7da6c179-172e-4aff-abdf-12dccb8bf4c0n%40googlegroups.com?utm_medium=email&utm_source=footer)

The bug occurs because `planWithoutNozzleTipChange` can return null, `addPlannedPlacement` requires its argument to not be null, and there was previously no null checking.

The bug occurs rarely because this logic occurs inside the optimisation where the planner has already selected a placement for nozzle A using the high level planner, then found another nearby placement for nozzle B using travelCost optimisation. The optimisation is considering what would happen if it processed nozzle B first, and the null object error occurs if it cant find any placement.

# Instructions for Use
no changes

# Implementation Details
1. How did you test the change? Be descriptive. Untested code will not be accepted. -- unit tests still pass
2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)? -- yes
3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing. -- no changes
4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted. -- tests pass

# Outstanding Tasks
A regression test will follow in a subsequent pull request.
