### PR TITLE
prevent TrayFeeder divide by zero

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/feeder/ReferenceTrayFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/ReferenceTrayFeeder.java
@@ -19,8 +19,6 @@
 
 package org.openpnp.machine.reference.feeder;
 
-
-
 import javax.swing.Action;
 
 import org.openpnp.gui.support.Wizard;
@@ -51,6 +49,7 @@ public class ReferenceTrayFeeder extends ReferenceFeeder {
     @Attribute
     private int feedCount = 0;  // UI is base 1, 0 is ok because a pick operation always preceded by a feed, which increments feedCount to 1
 
+
     @Override
     public Location getPickLocation() {
         int partX, partY;
@@ -63,20 +62,20 @@ public class ReferenceTrayFeeder extends ReferenceFeeder {
             feedCountBase0 = 0;
         }
         // limit feed count to tray size
-        else if (feedCount > (trayCountX * trayCountY)) {
-            feedCountBase0 = trayCountX * trayCountY -1;
+        else if (feedCount > (getEffectiveTrayCountX() * getEffectiveTrayCountY())) {
+            feedCountBase0 = getEffectiveTrayCountX() * getEffectiveTrayCountY() -1;
             Logger.warn("{}.getPickLocation: feedCount larger then tray, limiting to maximum.", getName());
         }
 
-        if (trayCountX >= trayCountY) {
+        if (getEffectiveTrayCountX() >= getEffectiveTrayCountY()) {
             // X major axis.
-            partX = feedCountBase0 / trayCountY;
-            partY = feedCountBase0 % trayCountY;
+            partX = feedCountBase0 / getEffectiveTrayCountY();
+            partY = feedCountBase0 % getEffectiveTrayCountY();
         }
         else {
             // Y major axis.
-            partX = feedCountBase0 % trayCountX;
-            partY = feedCountBase0 / trayCountX;
+            partX = feedCountBase0 % getEffectiveTrayCountX();
+            partY = feedCountBase0 / getEffectiveTrayCountX();
         }
 
         // Multiply the offsets by the X/Y part indexes to get the total offsets
@@ -88,7 +87,7 @@ public class ReferenceTrayFeeder extends ReferenceFeeder {
     public void feed(Nozzle nozzle) throws Exception {
         Logger.debug("{}.feed({})", getName(), nozzle);
 
-        if (feedCount >= (trayCountX * trayCountY)) {
+        if (feedCount >= (getEffectiveTrayCountX() * getEffectiveTrayCountY())) {
             throw new FeederEmptyException("Feeder: " + getName() + " (" + getPart().getId() + ") - tray empty.");
         }
 
@@ -135,6 +134,14 @@ public class ReferenceTrayFeeder extends ReferenceFeeder {
 
     public void setTrayCountY(int trayCountY) {
         this.trayCountY = trayCountY;
+    }
+
+    public int getEffectiveTrayCountX() {
+        return Math.max(trayCountX,1);
+    }
+
+    public int getEffectiveTrayCountY() {
+        return Math.max(trayCountY,1);
     }
 
     public Location getOffsets() {


### PR DESCRIPTION
# Description
When a tray feeder is using its `trayRows` or `trayColumns` attribute, use a new `getEffectiveTrayRows` accessor that ensures the number is no smaller than 1.

A tray cant have zero rows. It cant have a negative number of rows.

# Justification

Fixes #1918.



# Instructions for Use
no changes

# Implementation Details
1. How did you test the change? Be descriptive. Untested code will not be accepted. -- simulated machine manual test.
2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)? -- yes
3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing. -- no changes
4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted. -- yes, because TrayFeeder classes currently have no unit tests :-(
