### PR TITLE
Block keyboard shortcuts if a TextInput is focused

### DIFF
--- a/src/main/java/org/openpnp/gui/MainFrame.java
+++ b/src/main/java/org/openpnp/gui/MainFrame.java
@@ -574,11 +574,16 @@ public class MainFrame extends JFrame {
             @Override
             protected void dispatchEvent(AWTEvent event) {
                 if (event instanceof KeyEvent) {
-                    KeyStroke ks = KeyStroke.getKeyStrokeForEvent((KeyEvent) event);
-                    Action action = hotkeyActionMap.get(ks);
-                    if (action != null && action.isEnabled()) {
-                        action.actionPerformed(null);
-                        return;
+                    // Skip hotkey processing if a text input component has focus.
+                    // This prevents accidental machine motion when editing text
+                    // (e.g., using Ctrl+Shift+Arrow to select words).
+                    if (!UiUtils.isTextInputFocused()) {
+                        KeyStroke ks = KeyStroke.getKeyStrokeForEvent((KeyEvent) event);
+                        Action action = hotkeyActionMap.get(ks);
+                        if (action != null && action.isEnabled()) {
+                            action.actionPerformed(null);
+                            return;
+                        }
                     }
                 }
                 super.dispatchEvent(event);

--- a/src/main/java/org/openpnp/util/UiUtils.java
+++ b/src/main/java/org/openpnp/util/UiUtils.java
@@ -2,6 +2,7 @@ package org.openpnp.util;
 
 import java.awt.Component;
 import java.awt.Desktop;
+import java.awt.KeyboardFocusManager;
 import java.awt.Toolkit;
 import java.awt.Dialog;
 import java.awt.Window;
@@ -12,7 +13,9 @@ import java.util.concurrent.Future;
 import java.util.function.Consumer;
 
 import javax.swing.JOptionPane;
+import javax.swing.JSpinner;
 import javax.swing.SwingUtilities;
+import javax.swing.text.JTextComponent;
 
 import org.apache.commons.lang3.SystemUtils;
 import org.openpnp.gui.MainFrame;
@@ -375,6 +378,38 @@ public class UiUtils {
             if( w.isShowing() && w instanceof Dialog && ((Dialog)w).isModal() ) {
                 return true;
             }
+        }
+        return false;
+    }
+
+    /**
+     * Check if the currently focused component is a text input component.
+     * This is used to prevent global hotkeys (like jog commands) from being
+     * triggered when the user is editing text.
+     *
+     * @return true if a text input component has focus
+     */
+    public static boolean isTextInputFocused() {
+        Component focusOwner = KeyboardFocusManager.getCurrentKeyboardFocusManager()
+                .getFocusOwner();
+        if (focusOwner == null) {
+            return false;
+        }
+        // Check for text components (JTextField, JTextArea, JEditorPane, etc.)
+        if (focusOwner instanceof JTextComponent) {
+            return true;
+        }
+        // Check for spinner editors which contain text fields
+        if (focusOwner instanceof JSpinner.DefaultEditor) {
+            return true;
+        }
+        // Check if focused component is inside a JSpinner
+        Component parent = focusOwner.getParent();
+        while (parent != null) {
+            if (parent instanceof JSpinner) {
+                return true;
+            }
+            parent = parent.getParent();
         }
         return false;
     }


### PR DESCRIPTION
When editing a text input (i.e., setting height, or constructing a vision pipeline), it's common to press CTRL+SHIFT+ARROW or CTRL+ARROW to select a word to the left or right. Unfortunately, these commands also trigger unexpected keyboard shortcuts which risk damaging machines and parts.

This change will block keyboard shortcuts if a text input has focus.

I tested the change by triggering the issue in the main build of openpnp and then verifying that it is not present this build. 

I ran `mvn test` and everything passed.