### PR TITLE
photonfeeder: while doing move-while-feeding target SafeZ

### DIFF
--- a/src/main/java/org/openpnp/machine/photon/PhotonFeeder.java
+++ b/src/main/java/org/openpnp/machine/photon/PhotonFeeder.java
@@ -295,7 +295,7 @@ public class PhotonFeeder extends ReferenceFeeder {
                 Thread.sleep(50); // MAGIC: this feels like a good number, there is no particular reason it is this way.
 
                 if (j == 0 && nozzle != null && Configuration.get().getMachine().isHomed() && getMoveWhileFeeding()) {
-                    MovableUtils.moveToLocationAtSafeZ(nozzle, getPickLocation().derive(null, null, Double.NaN, null));
+                    MovableUtils.moveToLocationAtSafeZ(nozzle, getPickLocation().deriveLengths(null, null, nozzle.getEffectiveSafeZ(), null));
                 }
 
                 MoveFeedStatus moveFeedStatus = new MoveFeedStatus(slotAddress);


### PR DESCRIPTION
# Description
NaN clamps 0 to SafeZ's bounds, but if SafeZ encompass 0 like in openpnp's recomanded setting, we move to 0 when we actually want the nozzle to move as close as reasonably possible to the feeder, since it makes the non-masked Z move during the pick shorter.

# Justification
It makes the machine faster by masking more of the Z move with the XY moves & the photon feed.
A faster machine is good.

# Instructions for Use
None, just profit.

(you need safe z configured but I don't believe you can run openpnp without safe z anyway)

# Implementation Details
1. How did you test the change?
  I've ran it on my machine, it works.
2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)?
  I hope so.
3. ~~If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing.~~
4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted.
  I love CI.
