### PR TITLE
If the main window is offscreen at launch, move it to the default location.

### DIFF
--- a/src/main/java/org/openpnp/gui/MainFrame.java
+++ b/src/main/java/org/openpnp/gui/MainFrame.java
@@ -27,6 +27,9 @@ import java.awt.Dimension;
 import java.awt.EventQueue;
 import java.awt.FlowLayout;
 import java.awt.Font;
+import java.awt.GraphicsDevice;
+import java.awt.GraphicsEnvironment;
+import java.awt.Rectangle;
 import java.awt.Toolkit;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
@@ -321,6 +324,21 @@ public class MainFrame extends JFrame {
                 prefs.getInt(PREF_WINDOW_Y, PREF_WINDOW_Y_DEF),
                 prefs.getInt(PREF_WINDOW_WIDTH, PREF_WINDOW_WIDTH_DEF),
                 prefs.getInt(PREF_WINDOW_HEIGHT, PREF_WINDOW_HEIGHT_DEF));
+
+        // Ensure the window is within the bounds of a screen.
+        Rectangle windowBounds = getBounds();
+        boolean isWithinScreen = false;
+        for (GraphicsDevice gd : GraphicsEnvironment.getLocalGraphicsEnvironment().getScreenDevices()) {
+            Rectangle screenBounds = gd.getDefaultConfiguration().getBounds();
+            if (windowBounds.intersects(screenBounds)) {
+                isWithinScreen = true;
+                break;
+            }
+        }
+        if (!isWithinScreen) {
+        	// If the window is not within any screen, reset it to the default position.
+            setBounds(PREF_WINDOW_X_DEF, PREF_WINDOW_Y_DEF, PREF_WINDOW_WIDTH_DEF, PREF_WINDOW_HEIGHT_DEF);
+        }
         jobPanel = new JobPanel(configuration, this);
         panelsPanel = new PanelsPanel(configuration, this);
         boardsPanel = new BoardsPanel(configuration, this);


### PR DESCRIPTION
# Description
On launch, check if the window is off screen and, if it is, move it to the system default position.

# Justification
I lost my window off the screen when I unplugged a monitor and couldn't get it back without doing a hot-plug dance. This is a quality-of-life fix for users.

# Instructions for Use
OpenPNP will move itself onto the main screen if it was previously positioned on a screen that no longer exists.

# Implementation Details
1. How did you test the change?
    - Tested on Windows. Should have the same behaviour on Linux/MacOS although they may be smart enough to refuse off-screen windows in the first place.
    - Launch OpenPNP and position it on a monitor.
    - Close OpenPNP and either reconfigure or remove monitors to make the previous position offscreen.
    - Open OpenPNP and it'll be in the default new-window position (top-left of first monitor).
3. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)? _Yes_
4. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing. _N/A_
5. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted. _Tests are green._