### PR TITLE
sot-23 vision pipeline

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/vision/ReferenceBottomVision.java
+++ b/src/main/java/org/openpnp/machine/reference/vision/ReferenceBottomVision.java
@@ -852,6 +852,7 @@ public class ReferenceBottomVision extends AbstractPartAlignment {
                 // Create other stock pipelines.
                 createStockVisionSettings(configuration, AbstractVisionSettings.STOCK_BOTTOM_RECTLINEAR_ID, "Rectlinear", "- Rectlinear Symmetry Bottom Vision Settings -");
                 createStockVisionSettings(configuration, AbstractVisionSettings.STOCK_BOTTOM_BODY_ID, "Body", "- Whole Part Body Bottom Vision Settings -");
+                createStockVisionSettings(configuration, AbstractVisionSettings.STOCK_BOTTOM_SOT23_ID, "sot23", "- SOT-23 20° Bottom Vision Settings -");
                 return;
             }
         }
@@ -862,6 +863,8 @@ public class ReferenceBottomVision extends AbstractPartAlignment {
         configuration.addVisionSettings(stockBottomVisionSettings);
         BottomVisionSettings rectlinearBottomVisionSettings = createRectlinearBottomVisionSettings();
         configuration.addVisionSettings(rectlinearBottomVisionSettings);
+        BottomVisionSettings sot23BottomVisionSettings = createSot23BottomVisionSettings();
+        configuration.addVisionSettings(sot23BottomVisionSettings);
         PartSettings equivalentPartSettings = new PartSettings();
         equivalentPartSettings.setPipeline(stockBottomVisionSettings.getPipeline());
         bottomVisionSettingsHashMap.put(AbstractVisionSettings.createSettingsFingerprint(equivalentPartSettings), stockBottomVisionSettings);
@@ -936,6 +939,11 @@ public class ReferenceBottomVision extends AbstractPartAlignment {
     protected BottomVisionSettings createRectlinearBottomVisionSettings() {
         return createBottomVisionSettings(AbstractVisionSettings.STOCK_BOTTOM_RECTLINEAR_ID, 
                 "- Rectlinear Symmetry Bottom Vision Settings -", createStockPipeline("Rectlinear"));
+    }
+
+    protected BottomVisionSettings createSot23BottomVisionSettings() {
+        return createBottomVisionSettings(AbstractVisionSettings.STOCK_BOTTOM_SOT23_ID,
+                "- sot-23 20° Bottom Vision Settings -", createStockPipeline("sot23"));
     }
 
     protected BottomVisionSettings createStockBottomVisionSettings() {

--- a/src/main/java/org/openpnp/model/AbstractVisionSettings.java
+++ b/src/main/java/org/openpnp/model/AbstractVisionSettings.java
@@ -23,6 +23,7 @@ import org.simpleframework.xml.Serializer;
 public abstract class AbstractVisionSettings extends AbstractModelObject implements VisionSettings {
     public static final String STOCK_BOTTOM_ID = "BVS_Stock";
     public static final String STOCK_BOTTOM_RECTLINEAR_ID = "BVS_Stock_R";
+    public static final String STOCK_BOTTOM_SOT23_ID = "BVS_Stock_S";
     public static final String STOCK_BOTTOM_BODY_ID = "BVS_Stock_B";
     public static final String STOCK_FIDUCIAL_ID = "FVS_Stock";
     public static final String STOCK_FIDUCIAL_TEMPLATE_ID = "FVS_Stock_T";

--- a/src/main/resources/org/openpnp/machine/reference/vision/ReferenceBottomVision-sot23Pipeline.xml
+++ b/src/main/resources/org/openpnp/machine/reference/vision/ReferenceBottomVision-sot23Pipeline.xml
@@ -1,0 +1,27 @@
+<cv-pipeline>
+    <stages>
+      <cv-stage class="org.openpnp.vision.pipeline.stages.ParameterNumeric" name="pThreshold" enabled="true" parameter-label="Threshold" 
+          parameter-description="Set the brightness threshold that isolates the shiny contacts of a part." stage-name="threshold" property-name="threshold" effect-stage-name="threshold" preview-result="true" minimum-value="1.0" maximum-value="254.0" default-value="100.0" numeric-type="Integer"/>
+      <cv-stage class="org.openpnp.vision.pipeline.stages.ParameterNumeric" name="pDetail" enabled="true" parameter-label="Min. Detail Size" parameter-description="Minimal size of a detail that should be included in the detected shape." stage-name="filterContours" property-name="minArea" effect-stage-name="contours" preview-result="true" minimum-value="0.0" maximum-value="0.25" default-value="0.01" numeric-type="SquareMillimetersToPixels"/>
+      <cv-stage class="org.openpnp.vision.pipeline.stages.ImageCapture" name="0" enabled="true" default-light="true" settle-first="true" count="1"/>
+      <cv-stage class="org.openpnp.vision.pipeline.stages.ImageWriteDebug" name="deb0" enabled="true" prefix="bv_source_" suffix=".png"/>
+      <cv-stage class="org.openpnp.vision.pipeline.stages.BlurGaussian" name="3" enabled="true" kernel-size="9" property-name="BlurGaussian"/>
+      <cv-stage class="org.openpnp.vision.pipeline.stages.MaskCircle" name="4" enabled="true" diameter="525" property-name="MaskCircle"/>
+      <cv-stage class="org.openpnp.vision.pipeline.stages.MaskCircle" name="4b" enabled="true" diameter="100000" property-name="partmask"/>
+      <cv-stage class="org.openpnp.vision.pipeline.stages.ConvertColor" name="5" enabled="true" conversion="Bgr2HsvFull"/>
+      <cv-stage class="org.openpnp.vision.pipeline.stages.MaskHsv" name="6" enabled="true" auto="false" fraction-to-mask="0.0" hue-min="60" hue-max="130" saturation-min="32" saturation-max="255" value-min="64" value-max="255" invert="false" binary-mask="false" property-name="MaskHsv"/>
+      <cv-stage class="org.openpnp.vision.pipeline.stages.ConvertColor" name="7" enabled="true" conversion="Hsv2BgrFull"/>
+      <cv-stage class="org.openpnp.vision.pipeline.stages.ConvertColor" name="8" enabled="true" conversion="Bgr2Gray"/>
+      <cv-stage class="org.openpnp.vision.pipeline.stages.Threshold" name="threshold" enabled="true" threshold="100" auto="false" invert="false"/>
+      <cv-stage class="org.openpnp.vision.pipeline.stages.FindContours" name="findCountours" enabled="true" retrieval-mode="List" approximation-method="None"/>
+      <cv-stage class="org.openpnp.vision.pipeline.stages.FilterContours" name="filterContours" enabled="true" contours-stage-name="findCountours" min-area="0.01" max-area="900000.0" property-name="FilterContours"/>
+      <cv-stage class="org.openpnp.vision.pipeline.stages.MaskCircle" name="11" enabled="true" diameter="0" property-name=""/>
+      <cv-stage class="org.openpnp.vision.pipeline.stages.DrawContours" name="contours" enabled="true" contours-stage-name="filterContours" thickness="1" index="-1">
+         <color r="255" g="255" b="255" a="255"/>
+      </cv-stage>
+      <cv-stage class="org.openpnp.vision.pipeline.stages.MinAreaRect" name="results" enabled="true" threshold-min="100" threshold-max="255" search-angle="20"/>
+      <cv-stage class="org.openpnp.vision.pipeline.stages.ImageRecall" name="14" enabled="true" image-stage-name="0"/>
+      <cv-stage class="org.openpnp.vision.pipeline.stages.DrawRotatedRects" name="15" enabled="true" rotated-rects-stage-name="results" thickness="2" draw-rect-center="false" rect-center-radius="20" show-orientation="false"/>
+      <cv-stage class="org.openpnp.vision.pipeline.stages.ImageWriteDebug" name="deb1" enabled="true" prefix="bv_result_" suffix=".png"/>
+   </stages>
+</cv-pipeline>


### PR DESCRIPTION
# Description
As discussed on google groups, some parts with 3 legs such as sot-23 footprint can appear triangular to bottom vision. This is not a great match for the vision pipeline which is oriented around finding rectangles.

Generally `MinAreaRect` will do the right thing, but sometimes it can do this:

<img width="708" height="629" alt="image" src="https://github.com/user-attachments/assets/6062dcb2-0188-42e6-931b-940b4c1f156e" />

This problem can be avoided by restricting the search angle to less than 20°.

This works because the false solution shown above is actually 360/3 = 120° out. Openpnp sees this as 30° pick alignment error (and openpn is ignorant of having the wrong major axis). Restricting the search angle to 20° allows a margin of safety of 10°. That is, the part would have to be picked with a misalignment of more than 10° before openpnp would select the false solution shown above.

# Justification

This is a common problem and there is a stock solution, so it makes sense to include this in openpnp default install.

# Instructions for Use

Needed on the wiki somewhere.

# FAQ

Should the same restriction be applied to other pipelines?

I dont think so. In the case of SOT-23 and other triangular parts, the `MinAreaRect` minimum shown above is a false minimum.  Other square parts do not have a false minimum solution in the same way.

It might make sense to add an _Alignment tolerance_ field that works like size checking: it raises an error and reject the part if was found to be picked at a funny angle. But that would be a different feature; this feature never raises an error.

# Timeline

I have been using a pipeline like this for sot-23 parts since #1667 fixed the search-angle code.

But this PR is untested, and I definitely wont have time to test before the next release.

# Implementation Details

1. How did you test the change? Be descriptive. Untested code will not be accepted. -- not yet tested
2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)? -- yes
3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing. -- no
4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted. -- tests pass
