### PR TITLE
Use advanced camera calibration to populate the 3D Calibration data.

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/camera/calibration/AdvancedCalibration.java
+++ b/src/main/java/org/openpnp/machine/reference/camera/calibration/AdvancedCalibration.java
@@ -1473,4 +1473,79 @@ public class AdvancedCalibration extends LensCalibrationParams {
         camera.clearCalibrationCache();
         camera.captureTransformed();
     }
+    
+    /**
+     * Enables 3D calibration on the camera and sets the Units Per Pixel values from the  
+     * advanced calibration data. This should be called after successful advanced calibration
+     * completion to automatically configure the basic 3D calibration settings.
+     * 
+     * @param camera - the ReferenceCamera to configure
+     */
+    public void enable3DCalibration(ReferenceCamera camera) {
+        if (savedTestPattern3dPointsList == null || savedTestPattern3dPointsList.length < 2) {
+            // Need at least 2 Z heights for 3D calibration
+            Logger.debug("Advanced calibration does not have data at multiple Z heights, skipping 3D calibration auto-enable");
+            return;
+        }
+        
+        // Get the Z coordinates from the first and last test patterns
+        // These represent the measurements at different Z heights
+        double z1 = savedTestPattern3dPointsList[0][0][2]; // Primary Z (first calibration point)
+        double z2 = savedTestPattern3dPointsList[savedTestPattern3dPointsList.length - 1][0][2]; // Secondary Z (last calibration point)
+        
+        if (Math.abs(z1 - z2) < 0.1) {
+            // Z heights are too similar, not suitable for 3D calibration
+            Logger.debug("Advanced calibration Z heights are too similar ({} vs {}), skipping 3D calibration auto-enable", z1, z2);
+            return;
+        }
+        
+        if (virtualCameraMatrix == null) {
+            Logger.debug("Virtual camera matrix not available, skipping 3D calibration auto-enable");
+            return;
+        }
+        
+        // Use the virtual camera matrix focal lengths (which account for distortion and rectification)
+        // The virtual camera represents the corrected view after undistortion/rectification
+        double virtualFx = virtualCameraMatrix.get(0, 0)[0];
+        double virtualFy = virtualCameraMatrix.get(1, 1)[0];
+        
+        Length z1Length = new Length(z1, LengthUnit.Millimeters);
+        Length z2Length = new Length(z2, LengthUnit.Millimeters);
+        
+        // Get camera Z coordinate at time of each measurement
+        // For down-looking cameras, this is typically the same as the camera location
+        Location cameraPhysicalLocation = camera.getCameraPhysicalLocation();
+        Length cameraPrimaryZ = cameraPhysicalLocation.getLengthZ();
+        Length cameraSecondaryZ = cameraPrimaryZ; // Both measurements use the same camera position
+        
+        // Calculate Units Per Pixel using the exact same formula as advanced calibration
+        // Use getDistanceToCameraAtZ which accounts for camera tilt/orientation
+        double cameraToPrimaryPlane = getDistanceToCameraAtZ(z1Length).convertToUnits(LengthUnit.Millimeters).getValue();
+        double cameraToSecondaryPlane = getDistanceToCameraAtZ(z2Length).convertToUnits(LengthUnit.Millimeters).getValue();
+        
+        double uppPrimaryX = cameraToPrimaryPlane / virtualFx;
+        double uppPrimaryY = cameraToPrimaryPlane / virtualFy;
+        double uppSecondaryX = cameraToSecondaryPlane / virtualFx;
+        double uppSecondaryY = cameraToSecondaryPlane / virtualFy;
+        
+        // Set the Units Per Pixel values on the camera
+        Location primaryUPP = new Location(LengthUnit.Millimeters, uppPrimaryX, uppPrimaryY, z1, 0);
+        Location secondaryUPP = new Location(LengthUnit.Millimeters, uppSecondaryX, uppSecondaryY, z2, 0);
+        
+        camera.setUnitsPerPixelPrimary(primaryUPP);
+        camera.setUnitsPerPixelSecondary(secondaryUPP);
+        camera.setCameraPrimaryZ(cameraPrimaryZ);
+        camera.setCameraSecondaryZ(cameraSecondaryZ);
+        
+        // Set default working plane Z to the primary Z (typically the PCB surface)
+        if (camera.getDefaultZ() == null) {
+            camera.setDefaultZ(z1Length);
+        }
+        
+        // Enable 3D calibration
+        camera.setEnableUnitsPerPixel3D(true);
+        
+        Logger.info("Auto-enabled 3D calibration on camera {} with primary UPP: {}, secondary UPP: {}", 
+                camera.getName(), primaryUPP, secondaryUPP);
+    }
 }

--- a/src/main/java/org/openpnp/machine/reference/wizards/ReferenceCameraCalibrationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/wizards/ReferenceCameraCalibrationWizard.java
@@ -1026,6 +1026,9 @@ public class ReferenceCameraCalibrationWizard extends AbstractConfigurationWizar
                                             testPattern3dPointsList, testPatternImagePointsList, 
                                             size, mirrored, apparentMotionDirection);
                                     
+                                    // Auto-enable 3D calibration now that we have calibration data
+                                    advCal.enable3DCalibration(referenceCamera);
+                                    
                                     postCalibrationProcessing();
                                 }
                                 catch (Exception e) {
@@ -1065,6 +1068,9 @@ public class ReferenceCameraCalibrationWizard extends AbstractConfigurationWizar
                         referenceCamera.getAdvancedCalibration().processRawCalibrationData(
                                 new Size(advCal.getRawCroppedImageWidth(), advCal.getRawCroppedImageHeight()));
                     
+                        // Auto-enable 3D calibration now that we have calibration data  
+                        advCal.enable3DCalibration(referenceCamera);
+                        
                         postCalibrationProcessing();
                     }
                     catch (Exception ex) {


### PR DESCRIPTION
# Description
automatic enablement of 3D calibration when advanced calibration completes. The feature automatically:

 - Enables the "3D Calibration?" checkbox
 - Populates Units Per Pixel values at two Z heights
 - Sets the Default Working Plane Z value
 - Handles edge cases gracefully

# Justification
As a new user, I didn't realize I was operating without 3D Calibration and then couldn't figure out how why it was disabled; the Advanced Camera Calibration path is a more user friendly and automated approach to capturing the 3D calibration data.

I implemented this by populating 3D Calibration, maybe the right solution is to patch all users of 3D calibration data but I wasn't as confident I'd find all of them.

# Instructions for Use
1. Perform Advanced Calibration. Notice that the 3D Calibration data is prepopulated for you and 3D Calibration is enabled. You can now use features like "Estimate Z Height".
2. If you don't want to repeat 3D Calibration, you can check "Skip New Collection And Reprocess Prior Collection" and your previously captured calibration data will be used to populate the 3D Calibration data.
3. If you disable Advanced Calibration, the 3D calibration settings remain enabled even if advanced calibration is later disabled, allowing for independent manual adjustment if desired.

# Implementation Details
1. How did you test the change? _Tested by repeatedly running Advanced Calibration both in full and by re-applying prior collection. Values match the Advanced Calibration results and are proximate (but I suspect more accurate) than those captured with the 3D Calibration method._
4. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)? _Yes_
5. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing. _No changes_
6. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted. _tests green_.
