### PR TITLE
AsyncGcodeDriver: Fix Marlin position synchronization issues causing machine crashes

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/driver/GcodeAsyncDriver.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/GcodeAsyncDriver.java
@@ -381,9 +381,20 @@ public class GcodeAsyncDriver extends GcodeDriver {
             if (reportedLocationConfirmation) {
                 // Then make sure we get a uniquely recognizable confirmation. 
                 // Confirmation is signaled with a position report.
+
+                // NOTICE: This routine `reportedLocationConfirmation` CANNOT be used for Marlin firmware. 
+                // Marlin may report its position before the motion actually completes, 
+                // prematurely terminating the wait and causing synchronization issues.
                 getReportedLocation(timeout);
             }
             else {
+                // For Marlin firmware, we MUST re-verify the reported position. 
+                // This works around Marlin's unexpected position reports (e.g., after G92) that can cause synchronization issues.
+                if (getFirmwareProperty("FIRMWARE_NAME", "").contains("Marlin")) {
+                    Logger.trace("{} re-verifying position for Marlin firmware.", getName());
+                    getReportedLocation(timeout);
+                }
+
                 drainCommandQueue(timeout);
             }
             Logger.trace("{} confirmation complete.", getName());


### PR DESCRIPTION
# Description
Marlin firmware occasionally prints unexpected or unsolicited position reports (for example, after executing a `G92` command).  
In `GcodeAsyncDriver`, this behavior causes the driver to synchronize with outdated position data, leading to severe synchronization errors and potential physical crashes.  

This PR introduces a targeted fix by explicitly forcing a position re-verification (`getReportedLocation`) if the firmware is identified as Marlin,  
ensuring the driver catches the correct, final position before draining the command queue.

# Justification
The existing OpenPnP Solutions suggest disabling `reportedLocationConfirmation` for Marlin to avoid issues.  
However, this does not address the root cause.  

Even with `reportedLocationConfirmation` set to `false`, the Reader Thread logic ([GcodeDriver:L1561](https://github.com/openpnp/openpnp/blob/main/src/main/java/org/openpnp/machine/reference/driver/GcodeDriver.java#L1561)) unconditionally calls `processPositionReport(line);`, processing any unsolicited position report sent by Marlin.  
Because the existing `GcodeAsyncDriver` logic does not explicitly force a new `M114` to fetch the *true* final position at the end of the wait, Marlin's premature position reports are erroneously accepted as the final state.  

Consequently, Marlin users are effectively unable to use `GcodeAsyncDriver` safely, 
as machine crashes will almost inevitably occur at random moments.  

Additionally, the `reportedLocationConfirmation` routine is fundamentally unreliable for Marlin and must be avoided.  
Marlin tends to trigger position reports *before* the physical motion actually completes, which prematurely terminates the driver's wait.  
While existing Solutions already suggest disabling this, I have added explicit in-line comments in the code to clarify exactly why this routine is dangerous for Marlin.  

# Instructions for Use
Users do not need to perform any manual configuration or extra steps.  
This fix works automatically out-of-the-box for all `GcodeAsyncDriver` users.  
As long as the `FIRMWARE_NAME` property is correctly set and contains "Marlin", the driver will automatically enforce the position re-verification mechanism to ensure safety.  

# Implementation Details
1. **How did you test the change?** 
   - I initially experienced multiple severe head crashes on my OpenPnP machine when migrating to `GcodeAsyncDriver`. By analyzing the logs, I found that Marlin's position reports were breaking the command completion wait, causing the machine to execute subsequent commands at the wrong physical locations.
   - Following existing Solutions and historical issues/PRs, I disabled `reportedLocationConfirmation`. However, the crashes persisted. Log analysis revealed that Marlin's unsolicited position reports were still being accepted by the Reader Thread and erroneously used as the final position, breaking synchronization.
   - I investigated the `GcodeAsyncDriver` implementation and identified the root cause. As a temporary workaround, I appended an `M114` command to my `MOVE_TO_COMPLETE_COMMAND` to force a position refresh.
   - After extensive long-term testing on my physical machine, this workaround completely resolved the synchronization issues, and the random crashes entirely ceased.
   - Finally, I translated this proven workaround into a formal fix within the `GcodeAsyncDriver` source code, adding the targeted position re-verification step for Marlin and explanatory comments.
2. **Did you follow the coding style?** Yes.
3. **If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages...** N/A (No changes made to these packages).
4. **Be sure to run `mvn test` before submitting...** Yes, tests passed locally.