### PR TITLE
change various length columns to be right aligned, and not use space padding

### DIFF
--- a/src/main/java/org/openpnp/gui/tablemodel/PlacementsHolderLocationsTableModel.java
+++ b/src/main/java/org/openpnp/gui/tablemodel/PlacementsHolderLocationsTableModel.java
@@ -75,8 +75,8 @@ public class PlacementsHolderLocationsTableModel extends AbstractObjectTableMode
             LengthCellValue.class, Side.class, LengthCellValue.class, LengthCellValue.class,
             LengthCellValue.class, RotationCellValue.class, Boolean.class, Boolean.class};
 
-    private int[] columnAlignments = new int[] {LEFT, LEFT, CENTER, CENTER, CENTER, CENTER, 
-            CENTER, CENTER, CENTER, CENTER, CENTER};
+    private int[] columnAlignments = new int[] {LEFT, LEFT, RIGHT, RIGHT, CENTER, RIGHT,
+            RIGHT, RIGHT, RIGHT, CENTER, CENTER};
     
     private int[] columnWidthTypes = new int[] {FIXED, PROPORTIONAL, FIXED, FIXED, FIXED, 
             FIXED, FIXED, FIXED, FIXED, FIXED, FIXED};
@@ -384,19 +384,19 @@ public class PlacementsHolderLocationsTableModel extends AbstractObjectTableMode
             case 1:
                 return placementsHolderLocation.getPlacementsHolder().getName();
             case 2:
-                return new LengthCellValue(dim.getLengthX(), true, true);
+                return new LengthCellValue(dim.getLengthX(), true, false);
             case 3:
-                return new LengthCellValue(dim.getLengthY(), true, true);
+                return new LengthCellValue(dim.getLengthY(), true, false);
             case 4:
                 return placementsHolderLocation.getGlobalSide();
             case 5:
-                return new LengthCellValue(loc.getLengthX(), true, true);
+                return new LengthCellValue(loc.getLengthX(), true, false);
             case 6:
-                return new LengthCellValue(loc.getLengthY(), true, true);
+                return new LengthCellValue(loc.getLengthY(), true, false);
             case 7:
-                return new LengthCellValue(loc.getLengthZ(), true, true);
+                return new LengthCellValue(loc.getLengthZ(), true, false);
             case 8:
-                return new RotationCellValue(loc.getRotation(), true, true);
+                return new RotationCellValue(loc.getRotation(), true, false);
             case 9:
                 return placementsHolderLocation.isEnabled();
             case 10:

--- a/src/main/java/org/openpnp/gui/tablemodel/PlacementsHolderPlacementsTableModel.java
+++ b/src/main/java/org/openpnp/gui/tablemodel/PlacementsHolderPlacementsTableModel.java
@@ -90,8 +90,9 @@ public class PlacementsHolderPlacementsTableModel extends AbstractObjectTableMod
             Side.class, LengthCellValue.class, LengthCellValue.class, RotationCellValue.class, 
             Type.class, Boolean.class, Status.class, ErrorHandling.class, Integer.class, String.class};
     
-    private int[] columnAlignments = new int[] {CENTER, LEFT, LEFT, CENTER, CENTER, CENTER, 
-            CENTER, CENTER, CENTER, CENTER, CENTER, CENTER, LEFT};
+    private int[] columnAlignments = new int[] {CENTER, LEFT, LEFT, CENTER,
+            RIGHT, RIGHT, RIGHT,
+            CENTER, CENTER, CENTER, CENTER, CENTER, LEFT};
 
     private int[] columnWidthTypes = new int[] {FIXED, FIXED, PROPORTIONAL, FIXED, FIXED, 
             FIXED, FIXED, FIXED, FIXED, FIXED, FIXED, FIXED, PROPORTIONAL};
@@ -396,11 +397,11 @@ public class PlacementsHolderPlacementsTableModel extends AbstractObjectTableMod
             case 3:
                 return side;
             case 4:
-                return new LengthCellValue(loc.getLengthX(), true, true);
+                return new LengthCellValue(loc.getLengthX(), true, false);
             case 5:
-                return new LengthCellValue(loc.getLengthY(), true, true);
+                return new LengthCellValue(loc.getLengthY(), true, false);
             case 6:
-                return new RotationCellValue(loc.getRotation(), true, true);
+                return new RotationCellValue(loc.getRotation(), true, false);
             case 7:
                 return placement.getType();
             case 8:


### PR DESCRIPTION
# Description

This changes the `displayAligned` parameter of `LengthCellValue` to avoid using space character padding for alignment. There is a corresponding change to make those columns right aligned, so that the decimal points all line up. 

This leads to a much more compact column presentation. Previously numeric cells were padded with 5 characters to the left of the decimal point, and 5 characters to the right. Such cells can not be made particularly narrow, which is a problem when working with large tables on small screens.

@tonyluken originally wrote this so hopefully he can review.

# Justification
This was discussed on [google groups](https://groups.google.com/d/msgid/openpnp/9e1b21aa-461a-433a-89d5-476b3d4bb525n%40googlegroups.com?utm_medium=email&utm_source=footer)

**Before:** This screenshot show some wasted space in the placement X and Y columns. The board X, Y and Z columns have used ellipses to obliterate the useful data, while preserving space for all the padding spaces.
<img width="1010" height="667" alt="image" src="https://github.com/user-attachments/assets/a7e53498-540e-4346-9f60-1af136efdf8a" />

**After:** A compact layout with no wasted padding
<img width="664" height="664" alt="image" src="https://github.com/user-attachments/assets/425d397b-09e7-46dc-9fe3-be0dc9c051b0" />


# Instructions for Use
There is no change to usage.


# Implementation Details
1. How did you test the change? Be descriptive. Untested code will not be accepted.
    * viewed my production board data to confirm everything looks ok
    * edited some x/y/z/rotation data in some boards
    * edited some other field on a board.
3. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)? -- yes
5. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing. -- no changes
6. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted. -- tests pass
