### PR TITLE
Job Planner TravelCost optimisations

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/ReferencePnpJobProcessor.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferencePnpJobProcessor.java
@@ -2922,16 +2922,23 @@ public class ReferencePnpJobProcessor extends AbstractPnpJobProcessor {
                     travelCost = null;
                 }
                 if (travelCost != null) {
-                    // find the placement with the least cost for motion to averagePlickLocation and averagePlaceLocation
+                    // find the placement with the least cost for motion to averagePickLocation and averagePlaceLocation
                     double leastCost = Double.MAX_VALUE;
+                    HashMap<Part, Double> travelCostForPickingPart = new HashMap<>(); // cache travel cost for picking each part
                     for (JobPlacement p : compatibleJobPlacements) {
-                        double cost = travelCost.getCost(pickLocator.getLocation(p, nozzle), averagePickLocation) 
-                                    + travelCost.getCost(placeLocator.getLocation(p, nozzle), averagePlaceLocation);
-    
-                        // if this placement is closes with respect to its pick and place 
+                        Part part = p.getPlacement().getPart();
+                        Double cost = travelCostForPickingPart.get(part);
+                        if (cost == null) { // calculate the travel cost for picking this part and cache it, so we only do this once per part
+                            cost = travelCost.getCost(pickLocator.getLocation(p, nozzle), averagePickLocation);
+                            travelCostForPickingPart.put(part,cost);
+                        }
                         if (leastCost > cost) {
-                            planningCost = leastCost = cost;
-                            bestPlacement = p;
+                            cost += travelCost.getCost(placeLocator.getLocation(p, nozzle), averagePlaceLocation);
+                            // if this placement is closes with respect to its pick and place
+                            if (leastCost > cost) {
+                                planningCost = leastCost = cost;
+                                bestPlacement = p;
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
# Description

On a big job yesterday I noticed some behaviour that suggests the system was cpu-bound during the job planning stage. So I looked at the inner loops, and spotted a couple of easy optimisation opportunities.

This is purely a saving in cpu cycles. Job planner and machine behaviour should be unchanged. Details are in the commit comments.

Unit test still pass.

I have not yet proven this helps in practice, so this is a provisional PR for now.

# Justification

Less cpu for the same behaviour

# Instructions for Use

No changes

# Implementation Details
1. How did you test the change? Be descriptive. Untested code will not be accepted. -- this is still outstanding
2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)? -- yes
3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing. -- no changes
4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted. -- tests still pass
