### PR TITLE
Add a fixed vision offset to BambooFeeders for improved contrast on clear tape

### DIFF
--- a/src/main/java/org/openpnp/machine/pandaplacer/AbstractPandaplacerVisionFeeder.java
+++ b/src/main/java/org/openpnp/machine/pandaplacer/AbstractPandaplacerVisionFeeder.java
@@ -77,6 +77,9 @@ public abstract class AbstractPandaplacerVisionFeeder extends ReferenceFeeder {
     protected PipelineType pipelineType = PipelineType.CircularSymmetry;
 
     @Element(required = false)
+    protected Location visionLocationOffset = new Location(LengthUnit.Millimeters);
+
+    @Element(required = false)
     private Length precisionWanted = new Length(0.1, LengthUnit.Millimeters);
     @Attribute(required = false)
     private int calibrationCount = 0;
@@ -160,7 +163,7 @@ public abstract class AbstractPandaplacerVisionFeeder extends ReferenceFeeder {
             , normalizePickLocation, snapToAxis
             , partPitch, feedPitch, 1 //multiplier is fixed to 1, not used in Pandaplacer feeders
             , location, hole1Location, hole2Location
-            , calibrationToleranceMm, sprocketHoleToleranceMm);
+            , calibrationToleranceMm, sprocketHoleToleranceMm, visionLocationOffset);
     }
 
     public Camera getCamera() throws Exception {
@@ -276,6 +279,16 @@ public abstract class AbstractPandaplacerVisionFeeder extends ReferenceFeeder {
         Object oldValue = this.snapToAxis;
         this.snapToAxis = snapToAxis;
         firePropertyChange("snapToAxis", oldValue, snapToAxis);
+    }
+
+    public Location getVisionLocationOffset() {
+        return visionLocationOffset;
+    }
+
+    public void setVisionLocationOffset(Location visionLocationOffset) {
+        Object oldValue = this.visionLocationOffset;
+        this.visionLocationOffset = visionLocationOffset;
+        firePropertyChange("visionLocationOffset", oldValue, visionLocationOffset);
     }
 
     public Location getHole1Location() {
@@ -475,6 +488,7 @@ public abstract class AbstractPandaplacerVisionFeeder extends ReferenceFeeder {
         else {
             ensureCameraZ(getCamera(), false);
             return getHole1Location().add(getHole2Location()).multiply(0.5)
+                    .add(getVisionLocationOffset().derive(null, null, 0.0, 0.0))
                     .deriveLengths(null, null, getLocation().getLengthZ(),
                             getLocation().getRotation()+getRotationInFeeder());
         }
@@ -506,6 +520,12 @@ public abstract class AbstractPandaplacerVisionFeeder extends ReferenceFeeder {
                         .add(new Length(sprocketHolePitchMm, LengthUnit.Millimeters));
             }
             pipeline.setProperty("sprocketHole.maxDistance", range);
+            // Set the search center to the holes midpoint so the search area is
+            // centered on the holes rather than the (potentially offset) camera position.
+            if (hole1Location.isInitialized() && hole2Location.isInitialized()) {
+                pipeline.setProperty("sprocketHole.center",
+                        hole1Location.add(hole2Location).multiply(0.5));
+            }
 
             return pipeline;
         }
@@ -517,7 +537,7 @@ public abstract class AbstractPandaplacerVisionFeeder extends ReferenceFeeder {
     public void showFeatures() throws Exception {
         Camera camera = getCamera();
         ensureCameraZ(camera, true);
-        camera.moveTo(this.getLocation()); //make sure the camera is pointing to the currently selected pick location
+        MovableUtils.moveToLocationAtSafeZ(camera, getNominalVisionLocation());
         try (CvPipeline pipeline = getCvPipeline(camera, true, true)) {
 
             // Process vision and show feature without applying anything
@@ -545,11 +565,20 @@ public abstract class AbstractPandaplacerVisionFeeder extends ReferenceFeeder {
 
     protected Exception autoSetupPipeline(Camera camera, PipelineType type) {
         try (CvPipeline pipeline = getCvPipeline(camera, true, true)) {
+            Location initialPickLocation = camera.getLocation()
+                    .derive(getLocation(), false, false, true, false);
+            if (hole1Location.isInitialized() && hole2Location.isInitialized()) {
+                Location midPoint = hole1Location.add(hole2Location).multiply(0.5)
+                        .add(getVisionLocationOffset().derive(null, null, 0.0, 0.0))
+                        .derive(camera.getLocation(), false, false, true, false);
+                MovableUtils.moveToLocationAtSafeZ(camera, midPoint);
+            }
             // Process vision and get some features
             FeederVisionHelper feature = new FeederVisionHelper(getVisionHelperParams(camera, pipeline))
                     .findFeatures(FindFeaturesMode.FromPickLocationGetHoles);
             // Store the initial vision based results
-            setLocation(feature.getCalibratedPickLocation());
+            setLocation(initialPickLocation.derive(feature.getCalibratedPickLocation(),
+                    false, false, false, true));
             setHole1Location(feature.getCalibratedHole1Location());
             setHole2Location(feature.getCalibratedHole2Location());
             // As we've changed all this -> reset any stats
@@ -621,6 +650,7 @@ public abstract class AbstractPandaplacerVisionFeeder extends ReferenceFeeder {
             for (int i = 0; i < calibrateMaxPasses; i++) {
                 // move the camera to the mid-point
                 Location midPoint = runningHole1Location.add(runningHole2Location).multiply(0.5, 0.5, 0, 0)
+                        .add(getVisionLocationOffset().derive(null, null, 0.0, 0.0))
                         .derive(camera.getLocation(), false, false, true, false)
                         .derive(null, null, null, runningPickLocation.getRotation()+getRotationInFeeder());
                 Logger.debug("calibrating sprocket holes pass "+ i+ " midPoint is "+midPoint);

--- a/src/main/java/org/openpnp/machine/pandaplacer/BambooFeederAutoVisionConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/pandaplacer/BambooFeederAutoVisionConfigurationWizard.java
@@ -53,9 +53,11 @@ import org.openpnp.machine.reference.feeder.wizards.AbstractReferenceFeederConfi
 import org.openpnp.machine.pandaplacer.BambooFeederAutoVision;
 import org.openpnp.machine.pandaplacer.AbstractPandaplacerVisionFeeder.CalibrationTrigger;
 import org.openpnp.model.Configuration;
+import org.openpnp.model.Location;
 import org.openpnp.spi.Actuator;
 import org.openpnp.spi.Camera;
 import org.openpnp.util.FeederVisionHelper.PipelineType;
+import org.openpnp.util.MovableUtils;
 import org.openpnp.util.UiUtils;
 import org.openpnp.vision.pipeline.CvPipeline;
 import org.openpnp.vision.pipeline.ui.CvPipelineEditor;
@@ -303,6 +305,8 @@ extends AbstractReferenceFeederConfigurationWizard {
                 FormSpecs.RELATED_GAP_ROWSPEC,
                 FormSpecs.DEFAULT_ROWSPEC,
                 FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
                 FormSpecs.DEFAULT_ROWSPEC,}));
 
         lblVisionType = new JLabel("Vision Type");
@@ -367,6 +371,42 @@ extends AbstractReferenceFeederConfigurationWizard {
 
         btnResetStatistics = new JButton(resetStatisticsAction);
         panelVisionEnabled.add(btnResetStatistics, "12, 6, 3, 1");
+
+        lblVisionOffsetX = new JLabel("X");
+        panelVisionEnabled.add(lblVisionOffsetX, "4, 8, center, default");
+
+        lblVisionOffsetY = new JLabel("Y");
+        panelVisionEnabled.add(lblVisionOffsetY, "6, 8, center, default");
+
+        lblVisionLocationOffset = new JLabel("Vision Offset");
+        lblVisionLocationOffset.setToolTipText("<html>X/Y offset applied to the camera position during sprocket hole vision operations.<br/>"
+                + "Use this to shift the camera away from component pockets when using clear carrier tape,<br/>"
+                + "so the camera sees a better background for hole detection. Leave at (0,0) for normal use.</html>");
+        panelVisionEnabled.add(lblVisionLocationOffset, "2, 10, right, default");
+
+        textFieldVisionOffsetX = new JTextField();
+        textFieldVisionOffsetX.setToolTipText("<html>X offset added to the camera position for vision calibration.<br/>"
+                + "Positive moves the camera right relative to the sprocket hole midpoint.</html>");
+        panelVisionEnabled.add(textFieldVisionOffsetX, "4, 10");
+        textFieldVisionOffsetX.setColumns(10);
+
+        textFieldVisionOffsetY = new JTextField();
+        textFieldVisionOffsetY.setToolTipText("<html>Y offset added to the camera position for vision calibration.<br/>"
+                + "Positive moves the camera upward relative to the sprocket hole midpoint.</html>");
+        panelVisionEnabled.add(textFieldVisionOffsetY, "6, 10");
+        textFieldVisionOffsetY.setColumns(10);
+
+        btnMoveCameraToVisionOffset = new JButton(moveCameraToVisionOffsetAction);
+        btnMoveCameraToVisionOffset.setToolTipText("<html>Move the camera to the position used for vision calibration<br/>"
+                + "(sprocket hole midpoint plus the offset above). Use this to verify<br/>"
+                + "the offset gives a good view of the tape without component pockets.</html>");
+        panelVisionEnabled.add(btnMoveCameraToVisionOffset, "8, 10");
+
+        btnCaptureVisionOffset = new JButton(captureVisionOffsetAction);
+        btnCaptureVisionOffset.setToolTipText("<html>Capture the current camera position as the vision offset.<br/>"
+                + "Move the camera to a good viewing position for the sprocket holes,<br/>"
+                + "then press this button. The offset is stored relative to the hole midpoint.</html>");
+        panelVisionEnabled.add(btnCaptureVisionOffset, "10, 10");
 
 
 // Panel End: Vision
@@ -513,6 +553,13 @@ extends AbstractReferenceFeederConfigurationWizard {
 
         addWrappedBinding(feeder, "pipelineType", pipelineType, "selectedItem");
 
+        MutableLocationProxy visionLocationOffset = new MutableLocationProxy();
+        bind(UpdateStrategy.READ_WRITE, feeder, "visionLocationOffset", visionLocationOffset, "location");
+        addWrappedBinding(visionLocationOffset, "lengthX", textFieldVisionOffsetX, "text",
+                lengthConverter);
+        addWrappedBinding(visionLocationOffset, "lengthY", textFieldVisionOffsetY, "text",
+                lengthConverter);
+
         addWrappedBinding(feeder, "feedActuator", comboBoxFeedActuator, "selectedItem", actuatorConverter);
         addWrappedBinding(feeder, "feedActuatorValue", feedActuatorValue, "text", doubleConverter);
 
@@ -530,6 +577,8 @@ extends AbstractReferenceFeederConfigurationWizard {
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldHole1LocationY);
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldHole2LocationX);
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldHole2LocationY);
+        ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldVisionOffsetX);
+        ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldVisionOffsetY);
 
         ComponentDecorators.decorateWithAutoSelect(feedActuatorValue);
         ComponentDecorators.decorateWithAutoSelect(postPickActuatorValue);
@@ -648,6 +697,49 @@ extends AbstractReferenceFeederConfigurationWizard {
             });
         }
     };
+
+    private Action moveCameraToVisionOffsetAction =
+            new AbstractAction("", Icons.centerCamera) {
+        {
+            putValue(Action.SHORT_DESCRIPTION,
+                    "Move the camera to the vision offset position (midpoint + offset).");
+        }
+
+        @Override
+        public void actionPerformed(ActionEvent e) {
+            UiUtils.submitUiMachineTask(() -> {
+                Camera camera = feeder.getCamera();
+                feeder.ensureCameraZ(camera, true);
+                Location target = feeder.getNominalVisionLocation();
+                MovableUtils.moveToLocationAtSafeZ(camera, target);
+                MovableUtils.fireTargetedUserAction(camera);
+            });
+        }
+    };
+
+    private Action captureVisionOffsetAction =
+            new AbstractAction("", Icons.captureCamera) {
+        {
+            putValue(Action.SHORT_DESCRIPTION,
+                    "Capture the current camera position as the vision offset (relative to the sprocket hole midpoint).");
+        }
+
+        @Override
+        public void actionPerformed(ActionEvent e) {
+            UiUtils.messageBoxOnException(() -> {
+                applyAction.actionPerformed(e);
+                UiUtils.submitUiMachineTask(() -> {
+                    Camera camera = feeder.getCamera();
+                    Location cameraLocation = camera.getLocation();
+                    Location midPoint = feeder.getHole1Location().add(feeder.getHole2Location()).multiply(0.5);
+                    Location offset = cameraLocation.subtract(midPoint)
+                            .derive(null, null, 0.0, 0.0);
+                    feeder.setVisionLocationOffset(offset);
+                });
+            });
+        }
+    };
+
     private Action autoSetupAction =
             new AbstractAction("Auto-Setup with Camera at Pick Location", Icons.captureCamera) {
         {
@@ -774,6 +866,13 @@ extends AbstractReferenceFeederConfigurationWizard {
     private JButton btnResetStatistics;
     private JLabel lblPrecisionConfidenceLimit;
     private JTextField textFieldPrecisionConfidenceLimit;
+    private JLabel lblVisionLocationOffset;
+    private JLabel lblVisionOffsetX;
+    private JLabel lblVisionOffsetY;
+    private JTextField textFieldVisionOffsetX;
+    private JTextField textFieldVisionOffsetY;
+    private JButton btnMoveCameraToVisionOffset;
+    private JButton btnCaptureVisionOffset;
     private JLabel lblNormalizePickLocation;
     private JCheckBox checkBoxNormalizePickLocation;
     private JLabel lblSnapToAxis;

--- a/src/main/java/org/openpnp/machine/reference/feeder/ReferencePushPullFeeder.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/ReferencePushPullFeeder.java
@@ -88,6 +88,9 @@ public class ReferencePushPullFeeder extends ReferenceFeeder {
     @Element(required = false)
     protected Location hole2Location = new Location(LengthUnit.Millimeters);
 
+    @Element(required = false)
+    protected Location visionLocationOffset = new Location(LengthUnit.Millimeters);
+
     @Attribute(required = false)
     protected boolean usedAsTemplate = false; 
 
@@ -330,7 +333,8 @@ public class ReferencePushPullFeeder extends ReferenceFeeder {
             , this.normalizePickLocation, this.snapToAxis
             , this.partPitch, this.feedPitch, this.feedMultiplier
             , this.location, this.hole1Location, this.hole2Location
-            , this.calibrationToleranceMm, this.sprocketHoleToleranceMm);
+            , this.calibrationToleranceMm, this.sprocketHoleToleranceMm
+            , this.visionLocationOffset);
     }
 
     public void assertCalibrated(boolean tapeFeed) throws Exception {
@@ -645,6 +649,16 @@ public class ReferencePushPullFeeder extends ReferenceFeeder {
         this.hole2Location = hole2Location;
         firePropertyChange("hole2Location", oldValue, hole2Location);
         resetCalibration();
+    }
+
+    public Location getVisionLocationOffset() {
+        return visionLocationOffset;
+    }
+
+    public void setVisionLocationOffset(Location visionLocationOffset) {
+        Object oldValue = this.visionLocationOffset;
+        this.visionLocationOffset = visionLocationOffset;
+        firePropertyChange("visionLocationOffset", oldValue, visionLocationOffset);
     }
 
     public boolean isUsedAsTemplate() {
@@ -1265,7 +1279,8 @@ public class ReferencePushPullFeeder extends ReferenceFeeder {
         else {
             ensureCameraZ(getCamera(), false);
             return getHole1Location().add(getHole2Location()).multiply(0.5)
-                    .deriveLengths(null, null, getLocation().getLengthZ(), 
+                    .add(getVisionLocationOffset().derive(null, null, 0.0, 0.0))
+                    .deriveLengths(null, null, getLocation().getLengthZ(),
                             getLocation().getRotation()+getRotationInFeeder());
         }
     }
@@ -1317,12 +1332,18 @@ public class ReferencePushPullFeeder extends ReferenceFeeder {
                         : upp.getLengthY().multiply(camera.getWidth());
             }
             else {
-                // Normal mode: search range is half the distance between the holes plus one pitch. 
+                // Normal mode: search range is half the distance between the holes plus one pitch.
                 range = getHole1Location().getLinearLengthTo(getHole2Location())
                         .multiply(0.5)
                         .add(new Length(sprocketHolePitchMm, LengthUnit.Millimeters));
             }
             pipeline.setProperty("sprocketHole.maxDistance", range);
+            // Set the search center to the holes midpoint so the search area is
+            // centered on the holes rather than the (potentially offset) camera position.
+            if (hole1Location.isInitialized() && hole2Location.isInitialized()) {
+                pipeline.setProperty("sprocketHole.center",
+                        hole1Location.add(hole2Location).multiply(0.5));
+            }
             if (performOcr && getOcrRegion() != null) {
                 setupOcr(camera, pipeline);
             }
@@ -1340,6 +1361,7 @@ public class ReferencePushPullFeeder extends ReferenceFeeder {
     public void showFeatures() throws Exception {
         Camera camera = getCamera();
         ensureCameraZ(camera, true);
+        MovableUtils.moveToLocationAtSafeZ(camera, getNominalVisionLocation());
         try (CvPipeline pipeline = getCvPipeline(camera, true, true, true)) {
 
             // Process vision and show feature without applying anything
@@ -1390,12 +1412,26 @@ public class ReferencePushPullFeeder extends ReferenceFeeder {
             resetPipeline(type);
         }
         try (CvPipeline pipeline = getCvPipeline(camera, true, true, true)) {
-            // Process vision and get some features 
+            // Save the initial pick location before potentially moving the camera.
+            // We only want the rotation from vision; X/Y/Z stay as the user set them.
+            Location initialPickLocation = camera.getLocation()
+                    .derive(getLocation(), false, false, true, false);
+            // Move the camera to apply the vision offset before detecting sprocket holes.
+            // If hole locations are already known, use the midpoint + offset. Otherwise
+            // stay at the current camera position (pick location) for first-time setup.
+            if (hole1Location.isInitialized() && hole2Location.isInitialized()) {
+                Location midPoint = hole1Location.add(hole2Location).multiply(0.5)
+                        .add(getVisionLocationOffset().derive(null, null, 0.0, 0.0))
+                        .derive(camera.getLocation(), false, false, true, false);
+                MovableUtils.moveToLocationAtSafeZ(camera, midPoint);
+            }
+            // Process vision and get some features
             FeederVisionHelper feature = new FeederVisionHelper(getVisionHelperParams(camera, pipeline));
             feature.findFeatures(FindFeaturesMode.FromPickLocationGetHoles);
 
             // Store the initial vision based results
-            setLocation(feature.getCalibratedPickLocation());
+            setLocation(initialPickLocation.derive(feature.getCalibratedPickLocation(),
+                    false, false, false, true));
             setHole1Location(feature.getCalibratedHole1Location());
             setHole2Location(feature.getCalibratedHole2Location());
             // Second preliminary smart clone to get pipeline, OCR region etc. from a template,
@@ -2073,6 +2109,7 @@ public class ReferencePushPullFeeder extends ReferenceFeeder {
             for (int i = 0; i < calibrateMaxPasses; i++) {
                 // move the camera to the mid-point 
                 Location midPoint = runningHole1Location.add(runningHole2Location).multiply(0.5, 0.5, 0, 0)
+                        .add(getVisionLocationOffset().derive(null, null, 0.0, 0.0))
                         .derive(camera.getLocation(), false, false, true, false)
                         .derive(null, null, null, runningPickLocation.getRotation()+getRotationInFeeder());
                 Logger.debug("calibrating sprocket holes pass "+ i+ " midPoint is "+midPoint);

--- a/src/main/java/org/openpnp/machine/reference/feeder/wizards/ReferencePushPullFeederConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/wizards/ReferencePushPullFeederConfigurationWizard.java
@@ -58,6 +58,7 @@ import org.openpnp.gui.support.MutableLocationProxy;
 import org.openpnp.machine.reference.feeder.ReferencePushPullFeeder;
 import org.openpnp.machine.reference.feeder.ReferencePushPullFeeder.OcrWrongPartAction;
 import org.openpnp.model.Configuration;
+import org.openpnp.model.Location;
 import org.openpnp.model.RegionOfInterest;
 import org.openpnp.spi.Camera;
 import org.openpnp.spi.Head;
@@ -328,6 +329,10 @@ extends AbstractReferenceFeederConfigurationWizard {
                 FormSpecs.RELATED_GAP_ROWSPEC,
                 FormSpecs.DEFAULT_ROWSPEC,
                 FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
                 FormSpecs.DEFAULT_ROWSPEC,}));
 
         lblCalibrationTrigger = new JLabel("Calibration Trigger");
@@ -437,6 +442,42 @@ extends AbstractReferenceFeederConfigurationWizard {
 
         btnResetPipeline = new JButton(resetPipelineAction);
         panelVisionEnabled.add(btnResetPipeline, "12, 16, 3, 1");
+
+        lblVisionOffsetX = new JLabel("X");
+        panelVisionEnabled.add(lblVisionOffsetX, "4, 18, center, default");
+
+        lblVisionOffsetY = new JLabel("Y");
+        panelVisionEnabled.add(lblVisionOffsetY, "6, 18, center, default");
+
+        lblVisionLocationOffset = new JLabel("Vision Offset");
+        lblVisionLocationOffset.setToolTipText("<html>X/Y offset applied to the camera position during sprocket hole vision operations.<br/>"
+                + "Use this to shift the camera away from component pockets when using clear carrier tape,<br/>"
+                + "so the camera sees a better background for hole detection. Leave at (0,0) for normal use.</html>");
+        panelVisionEnabled.add(lblVisionLocationOffset, "2, 20, right, default");
+
+        textFieldVisionOffsetX = new JTextField();
+        textFieldVisionOffsetX.setToolTipText("<html>X offset added to the camera position for vision calibration.<br/>"
+                + "Positive moves the camera right relative to the sprocket hole midpoint.</html>");
+        panelVisionEnabled.add(textFieldVisionOffsetX, "4, 20");
+        textFieldVisionOffsetX.setColumns(10);
+
+        textFieldVisionOffsetY = new JTextField();
+        textFieldVisionOffsetY.setToolTipText("<html>Y offset added to the camera position for vision calibration.<br/>"
+                + "Positive moves the camera upward relative to the sprocket hole midpoint.</html>");
+        panelVisionEnabled.add(textFieldVisionOffsetY, "6, 20");
+        textFieldVisionOffsetY.setColumns(10);
+
+        btnMoveCameraToVisionOffset = new JButton(moveCameraToVisionOffsetAction);
+        btnMoveCameraToVisionOffset.setToolTipText("<html>Move the camera to the position used for vision calibration<br/>"
+                + "(sprocket hole midpoint plus the offset above). Use this to verify<br/>"
+                + "the offset gives a good view of the tape without component pockets.</html>");
+        panelVisionEnabled.add(btnMoveCameraToVisionOffset, "8, 20");
+
+        btnCaptureVisionOffset = new JButton(captureVisionOffsetAction);
+        btnCaptureVisionOffset.setToolTipText("<html>Capture the current camera position as the vision offset.<br/>"
+                + "Move the camera to a good viewing position for the sprocket holes,<br/>"
+                + "then press this button. The offset is stored relative to the hole midpoint.</html>");
+        panelVisionEnabled.add(btnCaptureVisionOffset, "10, 20");
 
         panelCloning = new JPanel();
         panelCloning.setBorder(new TitledBorder(null, "Clone Settings", TitledBorder.LEADING, TitledBorder.TOP, null, null));
@@ -595,6 +636,13 @@ extends AbstractReferenceFeederConfigurationWizard {
         addWrappedBinding(feeder, "ocrFontSizePt", textFieldFontSizePt, "text", doubleConverter);
         addWrappedBinding(feeder, "pipelineType", pipelineType, "selectedItem");
 
+        MutableLocationProxy visionLocationOffset = new MutableLocationProxy();
+        bind(UpdateStrategy.READ_WRITE, feeder, "visionLocationOffset", visionLocationOffset, "location");
+        addWrappedBinding(visionLocationOffset, "lengthX", textFieldVisionOffsetX, "text",
+                lengthConverter);
+        addWrappedBinding(visionLocationOffset, "lengthY", textFieldVisionOffsetY, "text",
+                lengthConverter);
+
         addWrappedBinding(feeder, "cloneTemplateStatus", textPaneCloneTemplateStatus, "text");
 
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldPickLocationX);
@@ -605,6 +653,8 @@ extends AbstractReferenceFeederConfigurationWizard {
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldHole1LocationY);
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldHole2LocationX);
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldHole2LocationY);
+        ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldVisionOffsetX);
+        ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldVisionOffsetY);
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldPartPitch);
         ComponentDecorators.decorateWithAutoSelectAndLengthConversion(textFieldFeedPitch);
         ComponentDecorators.decorateWithAutoSelect(textFieldFontSizePt);
@@ -721,6 +771,49 @@ extends AbstractReferenceFeederConfigurationWizard {
             });
         }
     };
+
+    private Action moveCameraToVisionOffsetAction =
+            new AbstractAction("", Icons.centerCamera) {
+        {
+            putValue(Action.SHORT_DESCRIPTION,
+                    "Move the camera to the vision offset position (midpoint + offset).");
+        }
+
+        @Override
+        public void actionPerformed(ActionEvent e) {
+            UiUtils.submitUiMachineTask(() -> {
+                Camera camera = feeder.getCamera();
+                feeder.ensureCameraZ(camera, true);
+                Location target = feeder.getNominalVisionLocation();
+                MovableUtils.moveToLocationAtSafeZ(camera, target);
+                MovableUtils.fireTargetedUserAction(camera);
+            });
+        }
+    };
+
+    private Action captureVisionOffsetAction =
+            new AbstractAction("", Icons.captureCamera) {
+        {
+            putValue(Action.SHORT_DESCRIPTION,
+                    "Capture the current camera position as the vision offset (relative to the sprocket hole midpoint).");
+        }
+
+        @Override
+        public void actionPerformed(ActionEvent e) {
+            UiUtils.messageBoxOnException(() -> {
+                applyAction.actionPerformed(e);
+                UiUtils.submitUiMachineTask(() -> {
+                    Camera camera = feeder.getCamera();
+                    Location cameraLocation = camera.getLocation();
+                    Location midPoint = feeder.getHole1Location().add(feeder.getHole2Location()).multiply(0.5);
+                    Location offset = cameraLocation.subtract(midPoint)
+                            .derive(null, null, 0.0, 0.0);
+                    feeder.setVisionLocationOffset(offset);
+                });
+            });
+        }
+    };
+
     private Action autoSetupAction =
             new AbstractAction("Auto-Setup with Camera at Pick Location", Icons.captureCamera) {
         {
@@ -1022,4 +1115,11 @@ extends AbstractReferenceFeederConfigurationWizard {
     private JButton btnSetPartByOcr;
     private JComboBox pipelineType;
     private JLabel lblVisionType;
+    private JLabel lblVisionLocationOffset;
+    private JLabel lblVisionOffsetX;
+    private JLabel lblVisionOffsetY;
+    private JTextField textFieldVisionOffsetX;
+    private JTextField textFieldVisionOffsetY;
+    private JButton btnMoveCameraToVisionOffset;
+    private JButton btnCaptureVisionOffset;
 }

--- a/src/main/java/org/openpnp/util/FeederVisionHelper.java
+++ b/src/main/java/org/openpnp/util/FeederVisionHelper.java
@@ -106,6 +106,8 @@ public class FeederVisionHelper {
             public double calibrationToleranceMm = 1.95;
             // vision and comparison sprocket hole tolerance (in size, position)
             public double sprocketHoleToleranceMm = 0.6;
+            // optional offset applied to the camera position for vision operations
+            public Location visionLocationOffset = new Location(LengthUnit.Millimeters);
 
             public void resetPipeline(PipelineType type) {
                 this.pipelineType = type;
@@ -133,7 +135,7 @@ public class FeederVisionHelper {
  * - calibrationToleranceMm, sprocketHoleToleranceMm: calibration tolerance parameters, either used from internal constants or provided by the caller class *
  */
         public FeederVisionHelperParams(Camera camera, PipelineType pipelineType, CvPipeline pipeline, long showResultMilliseconds, boolean normalizePickLocation, boolean snapToAxis, Length partPitch, Length feedPitch, long feedMultiplier, Location partLocation, Location hole1Location, Location hole2Location
-                ,double calibrationToleranceMm, double sprocketHoleToleranceMm) {
+                ,double calibrationToleranceMm, double sprocketHoleToleranceMm, Location visionLocationOffset) {
             this.camera = camera;
             this.pipelineType = pipelineType;
             this.pipeline = pipeline;
@@ -152,6 +154,7 @@ public class FeederVisionHelper {
 
             this.calibrationToleranceMm = calibrationToleranceMm;
             this.sprocketHoleToleranceMm = sprocketHoleToleranceMm;
+            this.visionLocationOffset = visionLocationOffset;
         }
 
     }
@@ -539,8 +542,12 @@ public class FeederVisionHelper {
                     // sprocket holes than to the neighboring tape's holes.
                     // In Calibration mode we are between the the sprocket holes, and there is no minimum distance
                     // and the line must simply be within calibration tolerance.
-                    double distanceMm = camera.getLocation().convertToUnits(LengthUnit.Millimeters)
-                            .getLinearDistanceToLineSegment(aLocation, bLocation);
+                    Location referenceLocation = (autoSetupMode == FindFeaturesMode.FromPickLocationGetHoles
+                            ? partLocation
+                            : autoSetupMode == FindFeaturesMode.CalibrateHoles
+                                    ? camera.getLocation().subtract(this.settings.visionLocationOffset)
+                                    : camera.getLocation()).convertToUnits(LengthUnit.Millimeters);
+                    double distanceMm = referenceLocation.getLinearDistanceToLineSegment(aLocation, bLocation);
                     double minDistanceMm = (autoSetupMode == FindFeaturesMode.CalibrateHoles ?
                             0 : minSprocketHolesDistanceMm)
                             - sprocketHoleToleranceMm;
@@ -584,8 +591,11 @@ public class FeederVisionHelper {
                     Collections.sort(holes, new Comparator<Result.Circle>() {
                         @Override
                         public int compare(Result.Circle o1, Result.Circle o2) {
-                            double d1 = VisionUtils.getPixelLocation(camera, o1.x, o1.y).getLinearDistanceTo(camera.getLocation());
-                            double d2 = VisionUtils.getPixelLocation(camera, o2.x, o2.y).getLinearDistanceTo(camera.getLocation());
+                            Location referenceLocation = (autoSetupMode == FindFeaturesMode.FromPickLocationGetHoles
+                                    ? partLocation
+                                    : camera.getLocation()).convertToUnits(LengthUnit.Millimeters);
+                            double d1 = VisionUtils.getPixelLocation(camera, o1.x, o1.y).getLinearDistanceTo(referenceLocation);
+                            double d2 = VisionUtils.getPixelLocation(camera, o2.x, o2.y).getLinearDistanceTo(referenceLocation);
                             return Double.compare(d1, d2);
                         }
                     });
@@ -600,7 +610,9 @@ public class FeederVisionHelper {
                                 .convertToUnits(LengthUnit.Millimeters);
                         calibratedHole2Location = VisionUtils.getPixelLocation(camera, holes.get(1).x, holes.get(1).y)
                                 .convertToUnits(LengthUnit.Millimeters);
-                        Location pocketLocation = camera.getLocation().convertToUnits(LengthUnit.Millimeters);
+                        Location pocketLocation = (autoSetupMode == FindFeaturesMode.FromPickLocationGetHoles
+                                ? partLocation
+                                : camera.getLocation()).convertToUnits(LengthUnit.Millimeters);
                         double angle1 = Math.atan2(calibratedHole1Location.getY()-pocketLocation.getY(), calibratedHole1Location.getX()-pocketLocation.getX());
                         double angle2 = Math.atan2(calibratedHole2Location.getY()-pocketLocation.getY(), calibratedHole2Location.getX()-pocketLocation.getX());
                         double angleDiff = Utils2D.angleNorm(Math.toDegrees(angle2-angle1), 180);

--- a/src/test/java/VisionLocationOffsetTest.java
+++ b/src/test/java/VisionLocationOffsetTest.java
@@ -1,0 +1,908 @@
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.google.common.io.Files;
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+import javax.swing.Action;
+import javax.swing.Icon;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.openpnp.CameraListener;
+import org.openpnp.gui.support.Wizard;
+import org.openpnp.machine.pandaplacer.BambooFeederAutoVision;
+import org.openpnp.machine.reference.feeder.ReferencePushPullFeeder;
+import org.openpnp.model.Configuration;
+import org.openpnp.model.Length;
+import org.openpnp.model.LengthUnit;
+import org.openpnp.model.Location;
+import org.openpnp.spi.Actuator;
+import org.openpnp.spi.Camera;
+import org.openpnp.spi.FocusProvider;
+import org.openpnp.spi.Head;
+import org.openpnp.spi.HeadMountable;
+import org.openpnp.spi.PropertySheetHolder;
+import org.openpnp.spi.VisionProvider;
+import org.openpnp.spi.base.AbstractHeadMountable;
+import org.openpnp.util.FeederVisionHelper;
+import org.openpnp.util.FeederVisionHelper.FeederVisionHelperParams;
+import org.openpnp.util.FeederVisionHelper.FindFeaturesMode;
+import org.openpnp.util.FeederVisionHelper.PipelineType;
+import org.openpnp.vision.pipeline.CvPipeline;
+import org.openpnp.vision.pipeline.CvStage;
+
+public class VisionLocationOffsetTest {
+  private static final double DELTA = 1e-9;
+
+  @BeforeEach
+  public void before() throws Exception {
+    File workingDirectory = Files.createTempDir();
+    workingDirectory = new File(workingDirectory, ".openpnp");
+    Configuration.initialize(workingDirectory);
+    Configuration.get().load();
+  }
+
+  @Test
+  public void testParamsDefaultOffsetIsZero() {
+    FeederVisionHelperParams params = new FeederVisionHelperParams();
+    assertNotNull(params.visionLocationOffset);
+    assertEquals(0.0, params.visionLocationOffset.getX(), DELTA);
+    assertEquals(0.0, params.visionLocationOffset.getY(), DELTA);
+  }
+
+  @Test
+  public void testParamsConstructorStoresOffset() {
+    Location offset = new Location(LengthUnit.Millimeters, 1.5, -2.0, 0, 0);
+    FeederVisionHelperParams params =
+        new FeederVisionHelperParams(
+            null,
+            PipelineType.CircularSymmetry,
+            null,
+            2000,
+            true,
+            false,
+            new Length(4, LengthUnit.Millimeters),
+            new Length(4, LengthUnit.Millimeters),
+            1,
+            new Location(LengthUnit.Millimeters),
+            new Location(LengthUnit.Millimeters),
+            new Location(LengthUnit.Millimeters),
+            1.95,
+            0.6,
+            offset);
+    assertSame(offset, params.visionLocationOffset);
+    assertEquals(1.5, params.visionLocationOffset.getX(), DELTA);
+    assertEquals(-2.0, params.visionLocationOffset.getY(), DELTA);
+  }
+
+  @Test
+  public void testParamsConstructorNullOffsetStaysNull() {
+    FeederVisionHelperParams params =
+        new FeederVisionHelperParams(
+            null,
+            PipelineType.CircularSymmetry,
+            null,
+            2000,
+            true,
+            false,
+            new Length(4, LengthUnit.Millimeters),
+            new Length(4, LengthUnit.Millimeters),
+            1,
+            new Location(LengthUnit.Millimeters),
+            new Location(LengthUnit.Millimeters),
+            new Location(LengthUnit.Millimeters),
+            1.95,
+            0.6,
+            null);
+    assertNull(params.visionLocationOffset);
+  }
+
+  @Test
+  public void testMidpointWithPositiveOffset() {
+    Location hole1 = new Location(LengthUnit.Millimeters, 10, 20, 5, 0);
+    Location hole2 = new Location(LengthUnit.Millimeters, 30, 20, 5, 0);
+    Location offset = new Location(LengthUnit.Millimeters, 2.0, 3.0, 99.0, 45.0);
+
+    Location result = hole1.add(hole2).multiply(0.5).add(offset.derive(null, null, 0.0, 0.0));
+
+    assertEquals(22.0, result.getX(), DELTA);
+    assertEquals(23.0, result.getY(), DELTA);
+    assertEquals(5.0, result.getZ(), DELTA);
+    assertEquals(0.0, result.getRotation(), DELTA);
+  }
+
+  @Test
+  public void testCaptureOffsetRoundTrip() {
+    Location hole1 = new Location(LengthUnit.Millimeters, 10, 20, 5, 0);
+    Location hole2 = new Location(LengthUnit.Millimeters, 30, 20, 5, 0);
+    Location midPoint = hole1.add(hole2).multiply(0.5);
+    Location cameraLocation = new Location(LengthUnit.Millimeters, 23, 18, 3, 90);
+
+    Location capturedOffset = cameraLocation.subtract(midPoint).derive(null, null, 0.0, 0.0);
+    Location applied = midPoint.add(capturedOffset.derive(null, null, 0.0, 0.0));
+
+    assertEquals(3.0, capturedOffset.getX(), DELTA);
+    assertEquals(-2.0, capturedOffset.getY(), DELTA);
+    assertEquals(0.0, capturedOffset.getZ(), DELTA);
+    assertEquals(0.0, capturedOffset.getRotation(), DELTA);
+    assertEquals(cameraLocation.getX(), applied.getX(), DELTA);
+    assertEquals(cameraLocation.getY(), applied.getY(), DELTA);
+    assertEquals(midPoint.getZ(), applied.getZ(), DELTA);
+    assertEquals(midPoint.getRotation(), applied.getRotation(), DELTA);
+  }
+
+  @Test
+  public void testOffsetWithDifferentUnits() {
+    Location hole1 = new Location(LengthUnit.Millimeters, 10, 20, 0, 0);
+    Location hole2 = new Location(LengthUnit.Millimeters, 30, 20, 0, 0);
+    Location offset = new Location(LengthUnit.Inches, 0.1, -0.1, 0, 0);
+
+    Location result = hole1.add(hole2).multiply(0.5).add(offset.derive(null, null, 0.0, 0.0));
+
+    assertEquals(22.54, result.getX(), DELTA);
+    assertEquals(17.46, result.getY(), DELTA);
+  }
+
+  @Test
+  public void testReferencePushPullFeederOffsetProperty() {
+    ReferencePushPullFeeder feeder = new ReferencePushPullFeeder();
+
+    assertNotNull(feeder.getVisionLocationOffset());
+    assertEquals(0.0, feeder.getVisionLocationOffset().getX(), DELTA);
+    assertEquals(0.0, feeder.getVisionLocationOffset().getY(), DELTA);
+
+    Location offset = new Location(LengthUnit.Millimeters, 3.0, -2.0, 0, 0);
+    feeder.setVisionLocationOffset(offset);
+    assertSame(offset, feeder.getVisionLocationOffset());
+    assertEquals(3.0, feeder.getVisionLocationOffset().getX(), DELTA);
+    assertEquals(-2.0, feeder.getVisionLocationOffset().getY(), DELTA);
+  }
+
+  @Test
+  public void testReferencePushPullFeederOffsetPropertyChange() {
+    ReferencePushPullFeeder feeder = new ReferencePushPullFeeder();
+
+    final boolean[] fired = {false};
+    final String[] propName = {null};
+    feeder.addPropertyChangeListener(
+        evt -> {
+          if ("visionLocationOffset".equals(evt.getPropertyName())) {
+            fired[0] = true;
+            propName[0] = evt.getPropertyName();
+          }
+        });
+
+    feeder.setVisionLocationOffset(new Location(LengthUnit.Millimeters, 1, 2, 0, 0));
+
+    assertTrue(fired[0], "PropertyChangeEvent should have fired for visionLocationOffset");
+    assertEquals("visionLocationOffset", propName[0]);
+  }
+
+  @Test
+  public void testReferencePushPullFeederParamsIncludeOffset() throws Exception {
+    TestReferencePushPullFeeder feeder = new TestReferencePushPullFeeder(new StubCamera());
+    Location offset = new Location(LengthUnit.Millimeters, 3.25, -1.75, 5, 90);
+    feeder.setVisionLocationOffset(offset);
+
+    FeederVisionHelperParams params =
+        invokeVisionHelperParams(feeder, ReferencePushPullFeeder.class);
+
+    assertSame(offset, params.visionLocationOffset);
+  }
+
+  @Test
+  public void testReferencePushPullFeederNominalVisionLocationAppliesOffset() throws Exception {
+    TestReferencePushPullFeeder feeder =
+        new TestReferencePushPullFeeder(
+            new StubCamera(new Location(LengthUnit.Millimeters, 100, 200, 300, 45)));
+    feeder.setLocation(new Location(LengthUnit.Millimeters, 40, 50, 6, 12));
+    feeder.setRotationInFeeder(7.0);
+    feeder.setHole1Location(new Location(LengthUnit.Millimeters, 10, 20, 1, 2));
+    feeder.setHole2Location(new Location(LengthUnit.Millimeters, 30, 20, 9, 8));
+    feeder.setVisionLocationOffset(new Location(LengthUnit.Millimeters, 2.0, -3.0, 99.0, 45.0));
+
+    Location nominal = feeder.getNominalVisionLocation();
+
+    assertEquals(22.0, nominal.getX(), DELTA);
+    assertEquals(17.0, nominal.getY(), DELTA);
+    assertEquals(6.0, nominal.getZ(), DELTA);
+    assertEquals(19.0, nominal.getRotation(), DELTA);
+  }
+
+  @Test
+  public void testBambooFeederOffsetProperty() {
+    BambooFeederAutoVision feeder = new BambooFeederAutoVision();
+
+    assertNotNull(feeder.getVisionLocationOffset());
+    assertEquals(0.0, feeder.getVisionLocationOffset().getX(), DELTA);
+    assertEquals(0.0, feeder.getVisionLocationOffset().getY(), DELTA);
+
+    Location offset = new Location(LengthUnit.Millimeters, 5.0, -3.0, 0, 0);
+    feeder.setVisionLocationOffset(offset);
+    assertSame(offset, feeder.getVisionLocationOffset());
+  }
+
+  @Test
+  public void testBambooFeederOffsetPropertyChange() {
+    BambooFeederAutoVision feeder = new BambooFeederAutoVision();
+
+    final boolean[] fired = {false};
+    feeder.addPropertyChangeListener(
+        evt -> {
+          if ("visionLocationOffset".equals(evt.getPropertyName())) {
+            fired[0] = true;
+          }
+        });
+
+    feeder.setVisionLocationOffset(new Location(LengthUnit.Millimeters, 1, 2, 0, 0));
+    assertTrue(fired[0], "PropertyChangeEvent should have fired for visionLocationOffset");
+  }
+
+  @Test
+  public void testBambooFeederParamsIncludeOffset() throws Exception {
+    TestBambooFeederAutoVision feeder = new TestBambooFeederAutoVision(new StubCamera());
+    Location offset = new Location(LengthUnit.Millimeters, -4.5, 1.25, 6, 15);
+    feeder.setVisionLocationOffset(offset);
+
+    FeederVisionHelperParams params =
+        invokeVisionHelperParams(
+            feeder,
+            Class.forName("org.openpnp.machine.pandaplacer.AbstractPandaplacerVisionFeeder"));
+
+    assertSame(offset, params.visionLocationOffset);
+  }
+
+  @Test
+  public void testBambooFeederNominalVisionLocationAppliesOffset() throws Exception {
+    TestBambooFeederAutoVision feeder =
+        new TestBambooFeederAutoVision(
+            new StubCamera(new Location(LengthUnit.Millimeters, 100, 200, 300, 45)));
+    feeder.setLocation(new Location(LengthUnit.Millimeters, 40, 50, 4, 18));
+    feeder.setRotationInFeeder(-3.0);
+    feeder.setHole1Location(new Location(LengthUnit.Millimeters, 10, 20, 1, 2));
+    feeder.setHole2Location(new Location(LengthUnit.Millimeters, 30, 20, 9, 8));
+    feeder.setVisionLocationOffset(new Location(LengthUnit.Millimeters, -1.0, 2.5, 99.0, 45.0));
+
+    Location nominal = feeder.getNominalVisionLocation();
+
+    assertEquals(19.0, nominal.getX(), DELTA);
+    assertEquals(22.5, nominal.getY(), DELTA);
+    assertEquals(4.0, nominal.getZ(), DELTA);
+    assertEquals(15.0, nominal.getRotation(), DELTA);
+  }
+
+  @Test
+  public void testSearchRangeNotExpandedByOffset() {
+    // The search range should be the same regardless of offset because the search
+    // center is shifted to the holes midpoint via sprocketHole.center, not the
+    // camera position. The radius stays half_hole_distance + pitch.
+    Location hole1 = new Location(LengthUnit.Millimeters, 10, 20, 0, 0);
+    Location hole2 = new Location(LengthUnit.Millimeters, 30, 20, 0, 0);
+    double sprocketHolePitchMm = 4.0;
+
+    Length range = hole1.getLinearLengthTo(hole2)
+            .multiply(0.5)
+            .add(new Length(sprocketHolePitchMm, LengthUnit.Millimeters));
+
+    // hole distance = 20mm, half = 10mm, + pitch 4mm = 14mm
+    assertEquals(14.0, range.getValue(), DELTA);
+  }
+
+  @Test
+  public void testSearchCenterIsHolesMidpointNotCameraPosition() {
+    // The search center should be the midpoint of the holes, so the search area
+    // is shifted to be symmetric around the holes regardless of the camera offset.
+    Location hole1 = new Location(LengthUnit.Millimeters, 10, 20, 0, 0);
+    Location hole2 = new Location(LengthUnit.Millimeters, 30, 20, 0, 0);
+    Location offset = new Location(LengthUnit.Millimeters, 5.0, 0, 0, 0);
+
+    Location searchCenter = hole1.add(hole2).multiply(0.5);
+    Location cameraPos = searchCenter.add(offset.derive(null, null, 0.0, 0.0));
+
+    // Search center is the midpoint (20, 20), not the camera position (25, 20)
+    assertEquals(20.0, searchCenter.getX(), DELTA);
+    assertEquals(20.0, searchCenter.getY(), DELTA);
+    assertEquals(25.0, cameraPos.getX(), DELTA);
+
+    // Both holes are equidistant from the search center
+    double d1 = searchCenter.getLinearDistanceTo(hole1);
+    double d2 = searchCenter.getLinearDistanceTo(hole2);
+    assertEquals(d1, d2, DELTA);
+    assertEquals(10.0, d1, DELTA);
+
+    // Range of 14mm (half distance + pitch) covers both holes from the midpoint
+    double range = 14.0;
+    assertTrue(range > d1, "Range covers hole1 from midpoint");
+    assertTrue(range > d2, "Range covers hole2 from midpoint");
+  }
+
+  @Test
+  public void testCalibrationLoopMidpointIncludesOffset() {
+    // Simulates the midpoint calculation in the calibration loop
+    Location runningHole1 = new Location(LengthUnit.Millimeters, 10, 20, 0, 0);
+    Location runningHole2 = new Location(LengthUnit.Millimeters, 30, 20, 0, 0);
+    Location cameraLocation = new Location(LengthUnit.Millimeters, 50, 50, 5, 0);
+    Location runningPickLocation = new Location(LengthUnit.Millimeters, 20, 15, 6, 12);
+    double rotationInFeeder = 3.0;
+    Location offset = new Location(LengthUnit.Millimeters, 2.0, -1.0, 99.0, 45.0);
+
+    // This mirrors the calibration loop code:
+    // midPoint = runningHole1.add(runningHole2).multiply(0.5, 0.5, 0, 0)
+    //         .add(offset.derive(null, null, 0.0, 0.0))
+    //         .derive(camera, false, false, true, false)
+    //         .derive(null, null, null, rotation+rotationInFeeder);
+    Location midPoint = runningHole1.add(runningHole2).multiply(0.5, 0.5, 0, 0)
+            .add(offset.derive(null, null, 0.0, 0.0))
+            .derive(cameraLocation, false, false, true, false)
+            .derive(null, null, null, runningPickLocation.getRotation() + rotationInFeeder);
+
+    // midpoint of holes = (20, 20), + offset (2, -1) = (22, 19)
+    assertEquals(22.0, midPoint.getX(), DELTA);
+    assertEquals(19.0, midPoint.getY(), DELTA);
+    // Z from camera
+    assertEquals(5.0, midPoint.getZ(), DELTA);
+    // Rotation = pick rotation + rotationInFeeder = 12 + 3 = 15
+    assertEquals(15.0, midPoint.getRotation(), DELTA);
+  }
+
+  @Test
+  public void testCalibrationLoopMidpointWithZeroOffset() {
+    Location runningHole1 = new Location(LengthUnit.Millimeters, 10, 20, 0, 0);
+    Location runningHole2 = new Location(LengthUnit.Millimeters, 30, 20, 0, 0);
+    Location cameraLocation = new Location(LengthUnit.Millimeters, 50, 50, 5, 0);
+    Location runningPickLocation = new Location(LengthUnit.Millimeters, 20, 15, 6, 12);
+    double rotationInFeeder = 3.0;
+    Location zeroOffset = new Location(LengthUnit.Millimeters);
+
+    Location midPoint = runningHole1.add(runningHole2).multiply(0.5, 0.5, 0, 0)
+            .add(zeroOffset.derive(null, null, 0.0, 0.0))
+            .derive(cameraLocation, false, false, true, false)
+            .derive(null, null, null, runningPickLocation.getRotation() + rotationInFeeder);
+
+    // Without offset, midpoint is just (20, 20)
+    assertEquals(20.0, midPoint.getX(), DELTA);
+    assertEquals(20.0, midPoint.getY(), DELTA);
+  }
+
+  @Test
+  public void testCalibrateHolesReferenceLocationSubtractsOffset() {
+    // In CalibrateHoles mode, the reference location for line-distance is:
+    // camera.getLocation().subtract(visionLocationOffset)
+    // This undoes the offset so the reference is at the true midpoint of holes.
+    Location cameraLocation = new Location(LengthUnit.Millimeters, 22, 19, 5, 0);
+    Location offset = new Location(LengthUnit.Millimeters, 2.0, -1.0, 0, 0);
+
+    Location referenceLocation = cameraLocation.subtract(offset);
+
+    // Camera is at midpoint+offset=(22,19), subtract offset gives midpoint=(20,20)
+    assertEquals(20.0, referenceLocation.getX(), DELTA);
+    assertEquals(20.0, referenceLocation.getY(), DELTA);
+  }
+
+  @Test
+  public void testCalibrateHolesReferenceLocationUnchangedWithZeroOffset() {
+    Location cameraLocation = new Location(LengthUnit.Millimeters, 20, 20, 5, 0);
+    Location zeroOffset = new Location(LengthUnit.Millimeters);
+
+    Location referenceLocation = cameraLocation.subtract(zeroOffset);
+
+    assertEquals(20.0, referenceLocation.getX(), DELTA);
+    assertEquals(20.0, referenceLocation.getY(), DELTA);
+  }
+
+  @Test
+  public void testNominalVisionLocationWithZeroOffset() throws Exception {
+    // Both feeders should return the same result as before when offset is zero
+    TestReferencePushPullFeeder feeder =
+        new TestReferencePushPullFeeder(
+            new StubCamera(new Location(LengthUnit.Millimeters, 100, 200, 300, 45)));
+    feeder.setLocation(new Location(LengthUnit.Millimeters, 40, 50, 6, 12));
+    feeder.setRotationInFeeder(7.0);
+    feeder.setHole1Location(new Location(LengthUnit.Millimeters, 10, 20, 1, 2));
+    feeder.setHole2Location(new Location(LengthUnit.Millimeters, 30, 20, 9, 8));
+    // Leave offset as default zero
+
+    Location nominal = feeder.getNominalVisionLocation();
+
+    // midpoint = (20, 20), no offset, Z from pick location, rotation = 12 + 7
+    assertEquals(20.0, nominal.getX(), DELTA);
+    assertEquals(20.0, nominal.getY(), DELTA);
+    assertEquals(6.0, nominal.getZ(), DELTA);
+    assertEquals(19.0, nominal.getRotation(), DELTA);
+  }
+
+  @Test
+  public void testBambooNominalVisionLocationWithZeroOffset() throws Exception {
+    TestBambooFeederAutoVision feeder =
+        new TestBambooFeederAutoVision(
+            new StubCamera(new Location(LengthUnit.Millimeters, 100, 200, 300, 45)));
+    feeder.setLocation(new Location(LengthUnit.Millimeters, 40, 50, 4, 18));
+    feeder.setRotationInFeeder(-3.0);
+    feeder.setHole1Location(new Location(LengthUnit.Millimeters, 10, 20, 1, 2));
+    feeder.setHole2Location(new Location(LengthUnit.Millimeters, 30, 20, 9, 8));
+
+    Location nominal = feeder.getNominalVisionLocation();
+
+    // midpoint = (20, 20), no offset
+    assertEquals(20.0, nominal.getX(), DELTA);
+    assertEquals(20.0, nominal.getY(), DELTA);
+    assertEquals(4.0, nominal.getZ(), DELTA);
+    assertEquals(15.0, nominal.getRotation(), DELTA);
+  }
+
+  @Test
+  public void testBothFeedersNominalVisionLocationEquivalent() throws Exception {
+    // Given the same inputs, both feeders should produce the same nominal vision location
+    Location cameraLoc = new Location(LengthUnit.Millimeters, 100, 200, 300, 45);
+    Location pickLoc = new Location(LengthUnit.Millimeters, 40, 50, 6, 12);
+    Location hole1 = new Location(LengthUnit.Millimeters, 10, 20, 1, 2);
+    Location hole2 = new Location(LengthUnit.Millimeters, 30, 20, 9, 8);
+    Location offset = new Location(LengthUnit.Millimeters, 2.5, -1.5, 99, 45);
+    double rotInFeeder = 7.0;
+
+    TestReferencePushPullFeeder rppf = new TestReferencePushPullFeeder(new StubCamera(cameraLoc));
+    rppf.setLocation(pickLoc);
+    rppf.setRotationInFeeder(rotInFeeder);
+    rppf.setHole1Location(hole1);
+    rppf.setHole2Location(hole2);
+    rppf.setVisionLocationOffset(offset);
+
+    TestBambooFeederAutoVision bamboo = new TestBambooFeederAutoVision(new StubCamera(cameraLoc));
+    bamboo.setLocation(pickLoc);
+    bamboo.setRotationInFeeder(rotInFeeder);
+    bamboo.setHole1Location(hole1);
+    bamboo.setHole2Location(hole2);
+    bamboo.setVisionLocationOffset(offset);
+
+    Location nominalRppf = rppf.getNominalVisionLocation();
+    Location nominalBamboo = bamboo.getNominalVisionLocation();
+
+    assertEquals(nominalBamboo.getX(), nominalRppf.getX(), DELTA);
+    assertEquals(nominalBamboo.getY(), nominalRppf.getY(), DELTA);
+    assertEquals(nominalBamboo.getZ(), nominalRppf.getZ(), DELTA);
+    assertEquals(nominalBamboo.getRotation(), nominalRppf.getRotation(), DELTA);
+  }
+
+  // ---- End-to-end tests: run findFeatures with fake pipeline results ----
+
+  /**
+   * Helper: build a FeederVisionHelperParams with a pipeline that returns a line of
+   * sprocket-hole circles at 4mm pitch along the X axis at the given Y coordinate.
+   * The StubCamera has UPP=1mm/px, 640x480, so pixel = world with simple transform.
+   *
+   * Holes are placed from worldHole1.x to worldHole2.x at 4mm intervals, all at
+   * worldHole1.y (same Y). hole1/hole2 in params are the two endpoint holes.
+   */
+  private static FeederVisionHelper runFindFeatures(
+      Location cameraLocation, Location pickLocation,
+      Location hole1, Location hole2, Location offset,
+      Location worldHole1, Location worldHole2,
+      FindFeaturesMode mode) throws Exception {
+
+    StubCamera camera = new StubCamera(cameraLocation);
+
+    double sprocketDiameterPx = 1.5; // 1.5mm at 1mm/px
+    double pitchMm = 4.0;
+
+    // Place a line of holes from worldHole1.x to worldHole2.x at 4mm pitch, all at same Y.
+    List<CvStage.Result.Circle> circles = new ArrayList<>();
+    double startX = Math.min(worldHole1.getX(), worldHole2.getX());
+    double endX = Math.max(worldHole1.getX(), worldHole2.getX());
+    double holeY = worldHole1.getY();
+    for (double wx = startX; wx <= endX + 0.01; wx += pitchMm) {
+      double px = 320 + (wx - cameraLocation.getX());
+      double py = 240 - (holeY - cameraLocation.getY());
+      circles.add(new CvStage.Result.Circle(px, py, sprocketDiameterPx));
+    }
+
+    CvPipeline pipeline = new CvPipeline();
+    pipeline.add("results", new FakeResultsStage(circles));
+    pipeline.setProperty("camera", camera);
+
+    FeederVisionHelperParams params = new FeederVisionHelperParams(
+        camera, PipelineType.CircularSymmetry, pipeline, 0,
+        true, false,
+        new Length(4, LengthUnit.Millimeters),  // partPitch
+        new Length(4, LengthUnit.Millimeters),  // feedPitch
+        1,                                       // feedMultiplier
+        pickLocation, hole1, hole2,
+        1.95, 0.6, offset);
+
+    FeederVisionHelper helper = new FeederVisionHelper(params);
+    helper.findFeatures(mode);
+    return helper;
+  }
+
+  @Test
+  public void testFindFeaturesCalibrationWithOffset() throws Exception {
+    // Holes at world (10,20) and (30,20). Midpoint = (20,20).
+    // Offset = (2,-1). Camera at midpoint+offset = (22,19).
+    // CalibrateHoles mode: the reference location should be the midpoint (20,20)
+    // after subtracting the offset — so the line is accepted.
+    Location hole1 = new Location(LengthUnit.Millimeters, 10, 20, 0, 0);
+    Location hole2 = new Location(LengthUnit.Millimeters, 30, 20, 0, 0);
+    Location offset = new Location(LengthUnit.Millimeters, 2, -1, 0, 0);
+    Location cameraAt = new Location(LengthUnit.Millimeters, 22, 19, 5, 0);
+    Location pickLoc = new Location(LengthUnit.Millimeters, 20, 16, 5, 0);
+
+    FeederVisionHelper result = assertDoesNotThrow(() ->
+        runFindFeatures(cameraAt, pickLoc, hole1, hole2, offset,
+            hole1, hole2, FindFeaturesMode.CalibrateHoles));
+
+    assertNotNull(result.getCalibratedHole1Location());
+    assertNotNull(result.getCalibratedHole2Location());
+  }
+
+  @Test
+  public void testFindFeaturesCalibrationWithZeroOffset() throws Exception {
+    // Same setup but no offset — camera is at the midpoint.
+    Location hole1 = new Location(LengthUnit.Millimeters, 10, 20, 0, 0);
+    Location hole2 = new Location(LengthUnit.Millimeters, 30, 20, 0, 0);
+    Location zeroOffset = new Location(LengthUnit.Millimeters);
+    Location cameraAt = new Location(LengthUnit.Millimeters, 20, 20, 5, 0);
+    Location pickLoc = new Location(LengthUnit.Millimeters, 20, 16, 5, 0);
+
+    FeederVisionHelper result = assertDoesNotThrow(() ->
+        runFindFeatures(cameraAt, pickLoc, hole1, hole2, zeroOffset,
+            hole1, hole2, FindFeaturesMode.CalibrateHoles));
+
+    assertNotNull(result.getCalibratedHole1Location());
+    assertNotNull(result.getCalibratedHole2Location());
+  }
+
+  @Test
+  public void testFindFeaturesCalibrationWithLargeOffset() throws Exception {
+    // Large offset — makes sure even big offsets work when reference is corrected.
+    Location hole1 = new Location(LengthUnit.Millimeters, 10, 20, 0, 0);
+    Location hole2 = new Location(LengthUnit.Millimeters, 30, 20, 0, 0);
+    Location offset = new Location(LengthUnit.Millimeters, 8, -5, 0, 0);
+    Location cameraAt = new Location(LengthUnit.Millimeters, 28, 15, 5, 0);
+    Location pickLoc = new Location(LengthUnit.Millimeters, 20, 16, 5, 0);
+
+    FeederVisionHelper result = assertDoesNotThrow(() ->
+        runFindFeatures(cameraAt, pickLoc, hole1, hole2, offset,
+            hole1, hole2, FindFeaturesMode.CalibrateHoles));
+
+    assertNotNull(result.getCalibratedHole1Location());
+    assertNotNull(result.getCalibratedHole2Location());
+  }
+
+  @Test
+  public void testFindFeaturesAutoSetupWithOffset() throws Exception {
+    // FromPickLocationGetHoles mode uses partLocation as reference.
+    // Camera is at pick location (not offset) for auto-setup.
+    Location hole1 = new Location(LengthUnit.Millimeters, 10, 20, 0, 0);
+    Location hole2 = new Location(LengthUnit.Millimeters, 30, 20, 0, 0);
+    Location offset = new Location(LengthUnit.Millimeters, 2, -1, 0, 0);
+    Location pickLoc = new Location(LengthUnit.Millimeters, 20, 16, 5, 0);
+    // In auto-setup the camera is at the pick location
+    Location cameraAt = new Location(LengthUnit.Millimeters, 20, 16, 5, 0);
+
+    FeederVisionHelper result = assertDoesNotThrow(() ->
+        runFindFeatures(cameraAt, pickLoc, hole1, hole2, offset,
+            hole1, hole2, FindFeaturesMode.FromPickLocationGetHoles));
+
+    assertNotNull(result.getCalibratedHole1Location());
+    assertNotNull(result.getCalibratedHole2Location());
+    assertNotNull(result.getCalibratedPickLocation());
+  }
+
+  @Test
+  public void testFindFeaturesAutoSetupWithZeroOffset() throws Exception {
+    Location hole1 = new Location(LengthUnit.Millimeters, 10, 20, 0, 0);
+    Location hole2 = new Location(LengthUnit.Millimeters, 30, 20, 0, 0);
+    Location zeroOffset = new Location(LengthUnit.Millimeters);
+    Location pickLoc = new Location(LengthUnit.Millimeters, 20, 16, 5, 0);
+    Location cameraAt = new Location(LengthUnit.Millimeters, 20, 16, 5, 0);
+
+    FeederVisionHelper result = assertDoesNotThrow(() ->
+        runFindFeatures(cameraAt, pickLoc, hole1, hole2, zeroOffset,
+            hole1, hole2, FindFeaturesMode.FromPickLocationGetHoles));
+
+    assertNotNull(result.getCalibratedHole1Location());
+    assertNotNull(result.getCalibratedHole2Location());
+    assertNotNull(result.getCalibratedPickLocation());
+  }
+
+  @Test
+  public void testFindFeaturesCalibrationResultsAccurateWithOffset() throws Exception {
+    // Verify the calibrated hole locations match the input world positions.
+    Location hole1 = new Location(LengthUnit.Millimeters, 10, 20, 0, 0);
+    Location hole2 = new Location(LengthUnit.Millimeters, 30, 20, 0, 0);
+    Location offset = new Location(LengthUnit.Millimeters, 2, -1, 0, 0);
+    Location cameraAt = new Location(LengthUnit.Millimeters, 22, 19, 5, 0);
+    Location pickLoc = new Location(LengthUnit.Millimeters, 20, 16, 5, 0);
+
+    FeederVisionHelper result = runFindFeatures(cameraAt, pickLoc, hole1, hole2, offset,
+        hole1, hole2, FindFeaturesMode.CalibrateHoles);
+
+    assertEquals(10.0, result.getCalibratedHole1Location().getX(), 0.5);
+    assertEquals(20.0, result.getCalibratedHole1Location().getY(), 0.5);
+    assertEquals(30.0, result.getCalibratedHole2Location().getX(), 0.5);
+    assertEquals(20.0, result.getCalibratedHole2Location().getY(), 0.5);
+  }
+
+  @Test
+  public void testFindFeaturesCalibrationResultsAccurateWithZeroOffset() throws Exception {
+    Location hole1 = new Location(LengthUnit.Millimeters, 10, 20, 0, 0);
+    Location hole2 = new Location(LengthUnit.Millimeters, 30, 20, 0, 0);
+    Location zeroOffset = new Location(LengthUnit.Millimeters);
+    Location cameraAt = new Location(LengthUnit.Millimeters, 20, 20, 5, 0);
+    Location pickLoc = new Location(LengthUnit.Millimeters, 20, 16, 5, 0);
+
+    FeederVisionHelper result = runFindFeatures(cameraAt, pickLoc, hole1, hole2, zeroOffset,
+        hole1, hole2, FindFeaturesMode.CalibrateHoles);
+
+    assertEquals(10.0, result.getCalibratedHole1Location().getX(), 0.5);
+    assertEquals(20.0, result.getCalibratedHole1Location().getY(), 0.5);
+    assertEquals(30.0, result.getCalibratedHole2Location().getX(), 0.5);
+    assertEquals(20.0, result.getCalibratedHole2Location().getY(), 0.5);
+  }
+
+  // A CvStage that returns pre-defined circles as its result.
+  private static class FakeResultsStage extends CvStage {
+    private final List<Result.Circle> circles;
+
+    FakeResultsStage(List<Result.Circle> circles) {
+      this.circles = circles;
+    }
+
+    @Override
+    public Result process(CvPipeline pipeline) throws Exception {
+      return new Result(null, new ArrayList<>(circles));
+    }
+  }
+
+  private static FeederVisionHelperParams invokeVisionHelperParams(
+      Object feeder, Class<?> ownerClass) throws Exception {
+    Method method =
+        ownerClass.getDeclaredMethod(
+            "getVisionHelperParams", Camera.class, org.openpnp.vision.pipeline.CvPipeline.class);
+    method.setAccessible(true);
+    return (FeederVisionHelperParams) method.invoke(feeder, null, null);
+  }
+
+  private static class TestReferencePushPullFeeder extends ReferencePushPullFeeder {
+    private final Camera camera;
+
+    private TestReferencePushPullFeeder(Camera camera) {
+      this.camera = camera;
+    }
+
+    @Override
+    public Camera getCamera() {
+      return camera;
+    }
+  }
+
+  private static class TestBambooFeederAutoVision extends BambooFeederAutoVision {
+    private final Camera camera;
+
+    private TestBambooFeederAutoVision(Camera camera) {
+      this.camera = camera;
+    }
+
+    @Override
+    public Camera getCamera() {
+      return camera;
+    }
+  }
+
+  private static class StubCamera extends AbstractHeadMountable implements Camera {
+    private final Location location;
+
+    private StubCamera() {
+      this(new Location(LengthUnit.Millimeters));
+    }
+
+    private StubCamera(Location location) {
+      this.location = location;
+    }
+
+    @Override
+    public String getId() {
+      return null;
+    }
+
+    @Override
+    public Head getHead() {
+      return null;
+    }
+
+    @Override
+    public void setHead(Head head) {}
+
+    @Override
+    public Location getLocation() {
+      return location;
+    }
+
+    @Override
+    public Location getLocation(HeadMountable tool) {
+      if (tool != null) {
+        return getLocation().subtract(tool.getCameraToolCalibratedOffset(this));
+      }
+      return getLocation();
+    }
+
+    @Override
+    public Location getCameraToolCalibratedOffset(Camera camera) {
+      return new Location(camera.getUnitsPerPixel().getUnits());
+    }
+
+    @Override
+    public Wizard getConfigurationWizard() {
+      return null;
+    }
+
+    @Override
+    public String getPropertySheetHolderTitle() {
+      return null;
+    }
+
+    @Override
+    public PropertySheetHolder[] getChildPropertySheetHolders() {
+      return null;
+    }
+
+    @Override
+    public PropertySheet[] getPropertySheets() {
+      return null;
+    }
+
+    @Override
+    public Action[] getPropertySheetHolderActions() {
+      return null;
+    }
+
+    @Override
+    public String getName() {
+      return null;
+    }
+
+    @Override
+    public void setName(String name) {}
+
+    @Override
+    public Looking getLooking() {
+      return null;
+    }
+
+    @Override
+    public void setLooking(Looking looking) {}
+
+    @Override
+    public Location getUnitsPerPixel() {
+      return new Location(LengthUnit.Millimeters, 1, 1, 0, 0);
+    }
+
+    @Override
+    public void setUnitsPerPixel(Location unitsPerPixel) {}
+
+    @Override
+    public BufferedImage capture() {
+      return null;
+    }
+
+    @Override
+    public BufferedImage captureTransformed() {
+      return null;
+    }
+
+    @Override
+    public BufferedImage captureRaw() {
+      return null;
+    }
+
+    @Override
+    public void startContinuousCapture(CameraListener listener) {}
+
+    @Override
+    public void stopContinuousCapture(CameraListener listener) {}
+
+    @Override
+    public void setVisionProvider(VisionProvider visionProvider) {}
+
+    @Override
+    public VisionProvider getVisionProvider() {
+      return null;
+    }
+
+    @Override
+    public int getWidth() {
+      return 640;
+    }
+
+    @Override
+    public int getHeight() {
+      return 480;
+    }
+
+    @Override
+    public Icon getPropertySheetHolderIcon() {
+      return null;
+    }
+
+    @Override
+    public void close() throws IOException {}
+
+    @Override
+    public BufferedImage settleAndCapture(SettleOption settleOption) throws Exception {
+      return null;
+    }
+
+    @Override
+    public BufferedImage lightSettleAndCapture() {
+      return null;
+    }
+
+    @Override
+    public void actuateLightBeforeCapture(Object light) throws Exception {}
+
+    @Override
+    public void actuateLightAfterCapture() throws Exception {}
+
+    @Override
+    public Length getSafeZ() {
+      return null;
+    }
+
+    @Override
+    public Location getHeadOffsets() {
+      return null;
+    }
+
+    @Override
+    public void setHeadOffsets(Location headOffsets) {}
+
+    @Override
+    public void home() throws Exception {}
+
+    @Override
+    public Actuator getLightActuator() {
+      return null;
+    }
+
+    @Override
+    public void ensureCameraVisible() {}
+
+    @Override
+    public boolean hasNewFrame() {
+      return true;
+    }
+
+    @Override
+    public Location getUnitsPerPixel(Length z) {
+      return new Location(LengthUnit.Millimeters, 1, 1, 0, 0)
+          .derive(null, null, z.getValue(), null);
+    }
+
+    @Override
+    public Length getDefaultZ() {
+      return new Length(0.0, LengthUnit.Millimeters);
+    }
+
+    @Override
+    public boolean isShownInMultiCameraView() {
+      return false;
+    }
+
+    @Override
+    public FocusProvider getFocusProvider() {
+      return null;
+    }
+
+    @Override
+    public Length getRoamingRadius() {
+      return new Length(10, LengthUnit.Millimeters);
+    }
+  }
+}


### PR DESCRIPTION
# Description
This adds an XY offset for the vision operations of ReferencePushPullFeeder and BambooFeederAutoVision to allow them to read clear tape better. Very similar idea to parallax for strip feeders and fiducials, just a simpler implementation as it doesn't attempt to cancel out the error with multiple vision reads. 

# Justification
This should be useful to anyone having issue with clear tape in PushPull feeders. This feature has no effect on typical operation or existing setups and only serves to deal with difficult situations. If there's a better existing solution I did not find it(admittedly I'm very new to openpnp)

# Instructions for Use
Jog away from the typical vision point(between the two holes) until the tape appears brightly lit around both holes. Note the distance you jogged into the X and Y vision offset fields. Use `Preview Vision Features` to verify that this worked and can read the circles.


# Implementation Details
1. How did you test the change? Be descriptive. Untested code will not be accepted.
 Tested this heavily on my PandaPlacer and BambooFeeders. It works well for clear tape and does not cause enough misalignment to be a problem(at least not on my component sizes). Tested both the positive and negative case as well as adding pretty extensive unit tests. Verified that manual setup, auto setup, vision preview, and actual picking all respected the new property Did my best to ensure parity between ReferencePushPullFeeder and the BambooFeeders but I was unable to test ReferencePushPullFeeder directly. 
If need be I can remove the the changes to ReferencePushPullFeeder but I included them here as they are likely still useful. Also I had to touch some dependencies and didn't want to completely bifurcate nearly identical code just to avoid the reference classes.


2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)? **I think so. Hard to be 100% sure and google auto formatting really wanted to mangle some existing files.**

3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing.
**No changes**

4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted.
**All tests pass**