### PR TITLE
Add macOS camera entitlement for hardened runtime

### DIFF
--- a/.github/entitlements.plist
+++ b/.github/entitlements.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "https://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.device.camera</key>
+    <true/>
+</dict>
+</plist>

--- a/OpenPnP.install4j
+++ b/OpenPnP.install4j
@@ -70,7 +70,7 @@
     </entries>
   </files>
   <launchers>
-    <launcher name="OpenPnP" id="23" icnsFile="./src/main/resources/icons/OpenPnP-logo.icns">
+    <launcher name="OpenPnP" id="23" icnsFile="./src/main/resources/icons/OpenPnP-logo.icns" addMacEntitlements="true" macEntitlementsFile="./.github/entitlements.plist">
       <executable name="OpenPnP" iconSet="true" executableMode="gui" singleInstance="true" dpiAware="false" />
       <splashScreen bitmapFile="./logo/OpenPnP-logo.iconset/icon_128x128.png" />
       <java mainClass="org.openpnp.Main" vmParameters="--add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.desktop/java.awt=ALL-UNNAMED --add-opens=java.desktop/java.awt.color=ALL-UNNAMED">


### PR DESCRIPTION
## Summary

- Adds `com.apple.security.device.camera` entitlement to the macOS app bundle via install4j's custom entitlements support
- Creates `.github/entitlements.plist` containing the camera entitlement, which install4j merges with its default JVM entitlements during code signing

## Problem

The macOS build is notarized, which requires hardened runtime. Under hardened runtime, macOS blocks camera access unless the `com.apple.security.device.camera` entitlement is explicitly signed into the binary.

The existing `NSCameraUsageDescription` in Info.plist only provides the user-facing permission dialog text — it does not grant the entitlement itself. Without the entitlement, macOS denies camera access at the system level and never shows the permission prompt.

Fixes #1938 and #1559.

## Changes

- **`.github/entitlements.plist`** (new) — plist containing `com.apple.security.device.camera`
- **`OpenPnP.install4j`** — adds `addMacEntitlements="true"` and `macEntitlementsFile` to the launcher element

No changes to the GitHub Actions workflow are needed.

## Test plan

- Built macOS Single Bundle Archive with install4j and verified signed entitlements via `codesign -d --entitlements -`
- Confirmed all five entitlements present: four default JVM entitlements plus `com.apple.security.device.camera`
- Tested camera access with `CaptureTest` utility — macOS granted permission and detected camera successfully