### PR TITLE
Correct calibration compensation handling during nozzle tip unload

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/ReferenceNozzle.java
+++ b/src/main/java/org/openpnp/machine/reference/ReferenceNozzle.java
@@ -123,6 +123,13 @@ public class ReferenceNozzle extends AbstractNozzle implements HeadMountable {
 
     protected ReferenceNozzleTip nozzleTip;
 
+    // When true, getCalibrationNozzleTip() returns overrideCalibrationNozzleTip
+    // instead of the loaded nozzle tip. Used during unload moves to fall back to
+    // the "unloaded" stand-in calibration (or null for no compensation),
+    // mirroring how ContactProbeNozzle handles Z calibration during unloads.
+    private transient boolean useCalibrationOverride = false;
+    private transient ReferenceNozzleTip overrideCalibrationNozzleTip = null;
+
     public ReferenceNozzle() {
         super();
     }
@@ -448,6 +455,11 @@ public class ReferenceNozzle extends AbstractNozzle implements HeadMountable {
     }
     
     public ReferenceNozzleTip getCalibrationNozzleTip() {
+        if (useCalibrationOverride) {
+            // During unload moves, use the "unloaded" stand-in's calibration
+            // (or null if no stand-in exists, meaning no compensation).
+            return overrideCalibrationNozzleTip;
+        }
         if (nozzleTip != null) {
             // normally we have the loaded nozzle tip as the calibration nozzle tip
             ReferenceNozzleTip calibrationNozzleTip = null;
@@ -769,52 +781,62 @@ public class ReferenceNozzle extends AbstractNozzle implements HeadMountable {
 
                     ensureZCalibrated(false);
 
+                    // During unload, fall back to the "unloaded" stand-in's
+                    // runout calibration (or no compensation if none exists),
+                    // since the loaded tip's calibration is no longer valid
+                    // once the tip is being removed from the nozzle.
+                    useCalibrationOverride = true;
+                    overrideCalibrationNozzleTip = getUnloadedNozzleTipStandin();
+                    try {
+                        Location endLocation = nt.getChangerEndLocationCalibrated(true);
+                        if (endLocation.isInitialized()) {
+                            Logger.debug("{}.unloadNozzleTip(): moveTo End Location", getName());
+                            MovableUtils.moveToLocationAtSafeZ(this, endLocation, speed);
+                        }
 
-                    Location endLocation = nt.getChangerEndLocationCalibrated(true);
-                    if (endLocation.isInitialized()) {
-                        Logger.debug("{}.unloadNozzleTip(): moveTo End Location", getName());
-                        MovableUtils.moveToLocationAtSafeZ(this, endLocation, speed);
+                        Actuator tcPostThreeActuator = getMachine().getActuatorByName(nt.getChangerActuatorPostStepThree());
+                        if (tcPostThreeActuator !=null) {
+                            tcPostThreeActuator.actuate(false);
+                        }
+
+                        Location midLocation2 = nt.getChangerMidLocation2Calibrated(false);
+                        if (midLocation2.isInitialized()) {
+                            Logger.debug("{}.unloadNozzleTip(): moveTo Mid Location 2", getName());
+                            moveTo(midLocation2, nt.getChangerMid2ToEndSpeed() * speed);
+                        }
+
+                        Actuator tcPostTwoActuator = getMachine().getActuatorByName(nt.getChangerActuatorPostStepTwo());
+                        if (tcPostTwoActuator !=null) {
+                            tcPostTwoActuator.actuate(false);
+                        }
+
+                        Location midLocation = nt.getChangerMidLocationCalibrated(false);
+                        if (midLocation.isInitialized()) {
+                            Logger.debug("{}.unloadNozzleTip(): moveTo Mid Location", getName());
+                            moveTo(midLocation, nt.getChangerMidToMid2Speed() * speed);
+                        }
+
+                        Actuator tcPostOneActuator = getMachine().getActuatorByName(nt.getChangerActuatorPostStepOne());
+                        if (tcPostOneActuator != null) {
+                            tcPostOneActuator.actuate(false);
+                        }
+
+                        Location startLocation = nt.getChangerStartLocationCalibrated(false);
+                        if (startLocation.isInitialized()) {
+                            Logger.debug("{}.unloadNozzleTip(): moveTo Start Location", getName());
+                            moveTo(startLocation, nt.getChangerStartToMidSpeed() * speed);
+                        }
+                        moveToSafeZ(getHead().getMachine().getSpeed());
+
+                        Logger.debug("{}.unloadNozzleTip(): Finished", getName());
+
+                        Configuration.get()
+                        .getScripting()
+                        .on("NozzleTip.Unloaded", globals);
+                    } finally {
+                        useCalibrationOverride = false;
+                        overrideCalibrationNozzleTip = null;
                     }
-
-                    Actuator tcPostThreeActuator = getMachine().getActuatorByName(nt.getChangerActuatorPostStepThree());
-                    if (tcPostThreeActuator !=null) {
-                        tcPostThreeActuator.actuate(false);
-                    }
-
-                    Location midLocation2 = nt.getChangerMidLocation2Calibrated(false);
-                    if (midLocation2.isInitialized()) {
-                        Logger.debug("{}.unloadNozzleTip(): moveTo Mid Location 2", getName());
-                        moveTo(midLocation2, nt.getChangerMid2ToEndSpeed() * speed);
-                    }
-
-                    Actuator tcPostTwoActuator = getMachine().getActuatorByName(nt.getChangerActuatorPostStepTwo());
-                    if (tcPostTwoActuator !=null) {
-                        tcPostTwoActuator.actuate(false);
-                    }
-
-                    Location midLocation = nt.getChangerMidLocationCalibrated(false);
-                    if (midLocation.isInitialized()) {
-                        Logger.debug("{}.unloadNozzleTip(): moveTo Mid Location", getName());
-                        moveTo(midLocation, nt.getChangerMidToMid2Speed() * speed);
-                    }
-
-                    Actuator tcPostOneActuator = getMachine().getActuatorByName(nt.getChangerActuatorPostStepOne());
-                    if (tcPostOneActuator != null) {
-                        tcPostOneActuator.actuate(false);
-                    }
-
-                    Location startLocation = nt.getChangerStartLocationCalibrated(false);
-                    if (startLocation.isInitialized()) {
-                        Logger.debug("{}.unloadNozzleTip(): moveTo Start Location", getName());
-                        moveTo(startLocation, nt.getChangerStartToMidSpeed() * speed);
-                    }
-                    moveToSafeZ(getHead().getMachine().getSpeed());
-
-                    Logger.debug("{}.unloadNozzleTip(): Finished", getName());
-
-                    Configuration.get()
-                    .getScripting()
-                    .on("NozzleTip.Unloaded", globals);
                 }
                 else {
                     Logger.debug("{}.unloadNozzleTip({}): moveTo manual Location",


### PR DESCRIPTION
# Description
This change aligns ReferenceNozzle unload behavior with the ContactProbeNozzle approach for calibration handling during nozzle tip unload moves. During unload, runout compensation no longer uses the loaded tip calibration. Instead, unload uses the unloaded stand-in calibration when configured, or no compensation when no unloaded stand-in exists. This is similar to how the ContactProbeNozzle handles z offsets to ensure unload locations align with load locations. 

This fix is in reference to issue 1949 - https://github.com/openpnp/openpnp/issues/1949

# Justification
This fixes a bug where loaded-tip runout compensation could be applied to unload path locations during nozzle tip changes. The result is that unload path positions remain consistent with configured changer geometry, reducing the risk of unload misalignment or collision on nozzles with significant runout. 

# Instructions for Use
No user workflow changes are required. Existing nozzle tip changer setup remains the same. Users may optionally configure an unloaded nozzle tip stand-in as before.

# Implementation Details
1. How did you test the change? 
I tested this on my machine for nearly two months using a custom nozzle tip with approximately 2 mm runout. I reviewed unload XY locations in logs after jobs and verified behavior on:
one nozzle with an unloaded stand-in configured
one nozzle without an unloaded stand-in configured
Both unload paths are confirmed to use unload location x,y that match the load position x,y and I have not had any unload misalignment problems throughout my testing. 

2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)?
Yes, to the best of my ability, following the project coding style guidance.

3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing.
No changes were made in org.openpnp.spi or org.openpnp.model.

4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted.
mvn test was run, all tests pass
