### PR TITLE
Remove Java Options incompatible with OpenJDK 25

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -429,7 +429,7 @@
 				<artifactId>maven-surefire-plugin</artifactId>
 				<version>2.22.2</version>
 				<configuration>
-					<argLine>-Xmx1024m -XX:+UnlockDiagnosticVMOptions -XX:GCLockerRetryAllocationCount=100 --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.desktop/java.awt=ALL-UNNAMED --add-opens=java.desktop/java.awt.color=ALL-UNNAMED</argLine>
+					<argLine>-Xmx1024m --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.desktop/java.awt=ALL-UNNAMED --add-opens=java.desktop/java.awt.color=ALL-UNNAMED</argLine>
 				</configuration>
 			</plugin>
 


### PR DESCRIPTION
# Read This First

To submit a Pull Request for OpenPnP you must use this template or it will not be accepted. 

Be sure to review the [Developers Guide](https://github.com/openpnp/openpnp/wiki/Developers-Guide)
and the [Contributing Guidelines](https://github.com/openpnp/openpnp/blob/develop/CONTRIBUTING.md).

Make your Pull Request as small as possible. Only include one bug or feature.

If you would like to add a new feature to OpenPnP that changes core or reference functionality,
please create a topic on the [discussion group](http://groups.google.com/group/openpnp) to discuss
the feature first. Also consider if your feature can be implemented as a new subclass of
a Reference class, or an entirely new class, instead of changing or adding to the Reference
class.

Fill out all the details below. All sections below are required. If they are not included your Pull Request
will not be accepted.

-----------------------------------------------------------------------

_I did not find instructions to delete above section, and I am scared my PR will be rejected if I delete portions of the template, so it stays I guess_

# Description
Removes a Java Option from `pom.xml` that was removed between OpenJDK 21 (where it still works) and OpenJDK 25 (where the option is no longer recognised).

# Justification
This change should be included to make sure that people using the latest LTS release of OpenJDK. Otherwise, people that just use the Java version that comes with their Linux Distribution (in my case Fedora) will see the following error message:

```
Unrecognized VM option 'GCLockerRetryAllocationCount=100'
Error: Could not create the Java Virtual Machine.
Error: A fatal exception has occurred. Program will exit.
```

# Instructions for Use
No instructions necessary. This is not a new feature. Not even a code change.

# Implementation Details
1. How did you test the change? _Not a code change_
2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)? _Still not a code change_
3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing. _One more time, not a code change, not relevant, and I really want to delete irrelevant portions of this annoying template ..._
4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted. _I did. Using OpenJDK 25._
