### PR TITLE
Make message dialog text selectable and copyable

### DIFF
--- a/src/main/java/org/openpnp/gui/MainFrame.java
+++ b/src/main/java/org/openpnp/gui/MainFrame.java
@@ -1088,10 +1088,7 @@ public class MainFrame extends JFrame {
         catch (Exception e) {
 			String message = "There was a problem saving the configuration. The reason was:\n\n" + e.getMessage() //$NON-NLS-1$
 					+ "\n\n"; //$NON-NLS-1$
-			message = message.replaceAll("\n", "<br/>"); //$NON-NLS-1$ //$NON-NLS-2$
-			message = message.replaceAll("\r", ""); //$NON-NLS-1$ //$NON-NLS-2$
-			message = "<html><body width=\"400\">" + message + "</body></html>"; //$NON-NLS-1$ //$NON-NLS-2$
-			JOptionPane.showMessageDialog(this, message, "Configuration Save Error", JOptionPane.ERROR_MESSAGE); //$NON-NLS-1$
+			MessageBoxes.infoBox(this, "Configuration Save Error", message, JOptionPane.ERROR_MESSAGE); //$NON-NLS-1$
 			return false;
         }
 

--- a/src/main/java/org/openpnp/gui/support/MessageBoxes.java
+++ b/src/main/java/org/openpnp/gui/support/MessageBoxes.java
@@ -19,12 +19,26 @@
 
 package org.openpnp.gui.support;
 
+import java.awt.BorderLayout;
 import java.awt.Component;
+import java.awt.Toolkit;
+import java.awt.datatransfer.Clipboard;
+import java.awt.datatransfer.StringSelection;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 
+import javax.swing.JButton;
+import javax.swing.JDialog;
+import javax.swing.JEditorPane;
 import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+import javax.swing.SwingConstants;
+import javax.swing.UIManager;
+import javax.swing.text.BadLocationException;
+import javax.swing.text.html.HTML;
+import javax.swing.text.html.HTMLDocument;
 
+import org.openpnp.Translations;
 import org.openpnp.gui.MainFrame;
 import org.pmw.tinylog.Logger;
 
@@ -35,15 +49,126 @@ public class MessageBoxes {
         if (message == null) {
             message = "";
         }
-        message = message.replaceAll("\n", "<br/>");
-        message = message.replaceAll("\r", "");
+        message = message.replace("\r", "").replace("\n", "<br/>");
+        if (message.regionMatches(true, 0, "<html>", 0, 6)) {
+            message = message.substring(6);
+            if (message.toLowerCase().endsWith("</html>")) {
+                message = message.substring(0, message.length() - 7);
+            }
+        }
         message = "<html><body width=\"400\">" + message + "</body></html>";
         return message;
-    }    
+    }
 
-    public static boolean errorBox(Component parent, String title, Throwable cause, boolean withContinuation) {
+    static class MessageContent extends JPanel {
+        final JEditorPane editor;
+        final JButton copyButton;
+
+        MessageContent(String html, Clipboard clipboard) {
+            super(new BorderLayout());
+            editor = new JEditorPane("text/html", html);
+            editor.setEditable(false);
+            editor.setFocusable(true);
+            editor.setOpaque(false);
+            editor.putClientProperty(JEditorPane.HONOR_DISPLAY_PROPERTIES, Boolean.TRUE);
+            add(editor, BorderLayout.CENTER);
+
+            copyButton = new JButton(Translations.getString("MessageBoxes.Copy"));
+            copyButton.setHorizontalAlignment(SwingConstants.CENTER);
+            copyButton.addActionListener(e -> {
+                try {
+                    Clipboard target = clipboard == null
+                            ? Toolkit.getDefaultToolkit().getSystemClipboard()
+                            : clipboard;
+                    target.setContents(new StringSelection(getPlainText()), null);
+                }
+                catch (RuntimeException ex) {
+                    Logger.error(ex, "Unable to copy message dialog text to the clipboard.");
+                }
+            });
+        }
+
+        String getPlainText() {
+            try {
+                String text = editor.getDocument().getText(0, editor.getDocument().getLength());
+                // Swing's HTML document adds one structural newline before the body.
+                int structuralOffset = text.startsWith("\n") ? 1 : 0;
+                StringBuilder plainText = new StringBuilder(text.substring(structuralOffset));
+                HTMLDocument document = (HTMLDocument) editor.getDocument();
+                HTMLDocument.Iterator breaks = document.getIterator(HTML.Tag.BR);
+                while (breaks.isValid()) {
+                    int offset = breaks.getStartOffset() - structuralOffset;
+                    if (offset >= 0 && offset < plainText.length()) {
+                        plainText.setCharAt(offset, '\n');
+                    }
+                    breaks.next();
+                }
+                return plainText.toString();
+            }
+            catch (BadLocationException e) {
+                throw new IllegalStateException(e);
+            }
+        }
+    }
+
+    static MessageContent createMessageContent(String message, Clipboard clipboard) {
+        return new MessageContent(prepareMessage(message), clipboard);
+    }
+
+    private static MessageContent createMessageContent(String message) {
+        return createMessageContent(message, null);
+    }
+
+    private static int showDialog(Component parent, MessageContent content, String title,
+            int optionType, int messageType) {
+        JOptionPane optionPane = new JOptionPane(content, messageType, optionType);
+        JButton acceptButton;
+        JButton rejectButton = null;
+        switch (optionType) {
+            case JOptionPane.YES_NO_OPTION:
+                acceptButton = createOptionButton(optionPane, "OptionPane.yesButtonText",
+                        "OptionPane.yesButtonMnemonic", JOptionPane.YES_OPTION);
+                rejectButton = createOptionButton(optionPane, "OptionPane.noButtonText",
+                        "OptionPane.noButtonMnemonic", JOptionPane.NO_OPTION);
+                break;
+            case JOptionPane.OK_CANCEL_OPTION:
+                acceptButton = createOptionButton(optionPane, "OptionPane.okButtonText",
+                        "OptionPane.okButtonMnemonic", JOptionPane.OK_OPTION);
+                rejectButton = createOptionButton(optionPane, "OptionPane.cancelButtonText",
+                        "OptionPane.cancelButtonMnemonic", JOptionPane.CANCEL_OPTION);
+                break;
+            default:
+                acceptButton = createOptionButton(optionPane, "OptionPane.okButtonText",
+                        "OptionPane.okButtonMnemonic", JOptionPane.OK_OPTION);
+                break;
+        }
+        Object[] options = rejectButton == null
+                ? new Object[] { acceptButton, content.copyButton }
+                : new Object[] { acceptButton, rejectButton, content.copyButton };
+        optionPane.setOptions(options);
+        optionPane.setInitialValue(acceptButton);
+
+        JDialog dialog = optionPane.createDialog(parent, title);
+        dialog.setVisible(true);
+        dialog.dispose();
+
+        Object selected = optionPane.getValue();
+        return selected instanceof Integer ? (Integer) selected : JOptionPane.CLOSED_OPTION;
+    }
+
+    static JButton createOptionButton(JOptionPane optionPane, String textKey,
+            String mnemonicKey, int value) {
+        JButton button = new JButton(UIManager.getString(textKey));
+        int mnemonic = UIManager.getInt(mnemonicKey);
+        if (mnemonic != 0) {
+            button.setMnemonic(mnemonic);
+        }
+        button.addActionListener(e -> optionPane.setValue(value));
+        return button;
+    }
+
+    static String prepareThrowableMessage(Throwable cause) {
         String message = null;
-        boolean ret = false;
         if (cause != null) {
             message = cause.getMessage();
             if (message == null || message.trim().isEmpty()) {
@@ -57,16 +182,21 @@ public class MessageBoxes {
         if (message == null) {
             message = "No message supplied.";
         }
+        return message.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;");
+    }
+
+    public static boolean errorBox(Component parent, String title, Throwable cause, boolean withContinuation) {
+        boolean ret = false;
         Logger.debug("{}: {}", title, cause);
-        message = message.replaceAll("<", "&lt;");
-        message = message.replaceAll(">", "&gt;");
-        message = prepareMessage(message);
+        MessageContent content = createMessageContent(prepareThrowableMessage(cause));
 
         // if this errorBox shall ask for Continuation, show a ConfirmDialog and return if the user selected YES
         if (withContinuation) {
-            ret = JOptionPane.showConfirmDialog(parent, message, title, JOptionPane.OK_CANCEL_OPTION, JOptionPane.ERROR_MESSAGE) == JOptionPane.OK_OPTION;
+            ret = showDialog(parent, content, title, JOptionPane.OK_CANCEL_OPTION,
+                    JOptionPane.ERROR_MESSAGE) == JOptionPane.OK_OPTION;
         } else {
-            JOptionPane.showMessageDialog(parent, message, title, JOptionPane.ERROR_MESSAGE);
+            showDialog(parent, content, title, JOptionPane.DEFAULT_OPTION,
+                    JOptionPane.ERROR_MESSAGE);
         }
         
         return ret;
@@ -81,8 +211,8 @@ public class MessageBoxes {
             message = "";
         }
         Logger.debug("{}: {}", title, message);
-        message = prepareMessage(message);
-        JOptionPane.showMessageDialog(parent, message, title, JOptionPane.ERROR_MESSAGE);
+        showDialog(parent, createMessageContent(message), title, JOptionPane.DEFAULT_OPTION,
+                JOptionPane.ERROR_MESSAGE);
     }
 
     public static boolean errorBoxWithRetry(Component parent, String title, String message) {
@@ -90,16 +220,17 @@ public class MessageBoxes {
             message = "";
         }
         Logger.debug("{}: {}", title, message);
-        message = prepareMessage(message);
-        return JOptionPane.showConfirmDialog(parent, message, title, JOptionPane.YES_NO_OPTION) == JOptionPane.YES_OPTION;
+        return showDialog(parent, createMessageContent(message), title,
+                JOptionPane.YES_NO_OPTION, JOptionPane.QUESTION_MESSAGE) == JOptionPane.YES_OPTION;
     }
 
     public static void infoBox(String title, String message) {
-        if (message == null) {
-            message = "";
-        }
-        message = prepareMessage(message);
-        JOptionPane.showMessageDialog(MainFrame.get(), message, title, JOptionPane.INFORMATION_MESSAGE);
+        infoBox(MainFrame.get(), title, message, JOptionPane.INFORMATION_MESSAGE);
+    }
+
+    public static void infoBox(Component parent, String title, String message, int messageType) {
+        showDialog(parent, createMessageContent(message), title, JOptionPane.DEFAULT_OPTION,
+                messageType);
     }
 
     public static void notYetImplemented(Component parent) {

--- a/src/main/java/org/openpnp/gui/support/MessageBoxes.java
+++ b/src/main/java/org/openpnp/gui/support/MessageBoxes.java
@@ -30,6 +30,7 @@ import java.io.StringWriter;
 import javax.swing.JButton;
 import javax.swing.JDialog;
 import javax.swing.JEditorPane;
+import javax.swing.JLabel;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.SwingConstants;
@@ -63,6 +64,7 @@ public class MessageBoxes {
     static class MessageContent extends JPanel {
         final JEditorPane editor;
         final JButton copyButton;
+        final JLabel copiedMessage;
 
         MessageContent(String html, Clipboard clipboard) {
             super(new BorderLayout());
@@ -73,6 +75,9 @@ public class MessageBoxes {
             editor.putClientProperty(JEditorPane.HONOR_DISPLAY_PROPERTIES, Boolean.TRUE);
             add(editor, BorderLayout.CENTER);
 
+            copiedMessage = new JLabel(" ");
+            add(copiedMessage, BorderLayout.SOUTH);
+
             copyButton = new JButton(Translations.getString("MessageBoxes.Copy"));
             copyButton.setHorizontalAlignment(SwingConstants.CENTER);
             copyButton.addActionListener(e -> {
@@ -81,6 +86,7 @@ public class MessageBoxes {
                             ? Toolkit.getDefaultToolkit().getSystemClipboard()
                             : clipboard;
                     target.setContents(new StringSelection(getPlainText()), null);
+                    copiedMessage.setText(Translations.getString("MessageBoxes.CopyDone"));
                 }
                 catch (RuntimeException ex) {
                     Logger.error(ex, "Unable to copy message dialog text to the clipboard.");

--- a/src/main/java/org/openpnp/machine/reference/driver/wizards/GcodeDriverConsole.java
+++ b/src/main/java/org/openpnp/machine/reference/driver/wizards/GcodeDriverConsole.java
@@ -21,6 +21,7 @@ import org.openpnp.Translations;
 import org.openpnp.gui.support.AbstractConfigurationWizard;
 import org.openpnp.gui.support.DoubleConverter;
 import org.openpnp.gui.support.IntegerConverter;
+import org.openpnp.gui.support.MessageBoxes;
 import org.openpnp.machine.reference.driver.GcodeDriver;
 import org.openpnp.machine.reference.driver.GcodeDriver.CommandType;
 import org.openpnp.model.Configuration;
@@ -149,7 +150,8 @@ public class GcodeDriverConsole extends AbstractConfigurationWizard {
 
         // Check that machine is started before sending commands
         if(!Configuration.get().getMachine().isEnabled()){
-            JOptionPane.showMessageDialog(null, "Please start machine before sending commands.");
+            MessageBoxes.infoBox(null, "Machine Not Started",
+                    "Please start machine before sending commands.", JOptionPane.INFORMATION_MESSAGE);
             return;
         }
 

--- a/src/main/java/org/openpnp/machine/reference/feeder/wizards/BlindsFeederArrayConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/wizards/BlindsFeederArrayConfigurationWizard.java
@@ -51,6 +51,7 @@ import org.openpnp.gui.support.AbstractConfigurationWizard;
 import org.openpnp.gui.support.DoubleConverter;
 import org.openpnp.gui.support.Icons;
 import org.openpnp.gui.support.LengthConverter;
+import org.openpnp.gui.support.MessageBoxes;
 import org.openpnp.gui.support.MutableLocationProxy;
 import org.openpnp.machine.reference.feeder.BlindsFeeder;
 import org.openpnp.model.Configuration;
@@ -440,7 +441,10 @@ public class BlindsFeederArrayConfigurationWizard extends AbstractConfigurationW
                         }
                     }
                     if (! opended) {
-                        JOptionPane.showMessageDialog(getTopLevelAncestor(), "<html><p>Files extracted to:</p><p>"+directory.getAbsolutePath()+"</p><p>Cannot open with OpenSCAD automatically (Desktop command failed)</p>");
+                        MessageBoxes.infoBox(getTopLevelAncestor(), "OpenSCAD",
+                                "<html><p>Files extracted to:</p><p>"+directory.getAbsolutePath()
+                                +"</p><p>Cannot open with OpenSCAD automatically (Desktop command failed)</p></html>",
+                                JOptionPane.INFORMATION_MESSAGE);
                     }
                 }
             });
@@ -566,4 +570,3 @@ public class BlindsFeederArrayConfigurationWizard extends AbstractConfigurationW
         feeder.setPipelineToAllFeeders();
     }
 }
-

--- a/src/main/java/org/openpnp/machine/reference/feeder/wizards/ReferencePushPullFeederConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/feeder/wizards/ReferencePushPullFeederConfigurationWizard.java
@@ -54,6 +54,7 @@ import org.openpnp.gui.support.Icons;
 import org.openpnp.gui.support.IntegerConverter;
 import org.openpnp.gui.support.LengthConverter;
 import org.openpnp.gui.support.LongConverter;
+import org.openpnp.gui.support.MessageBoxes;
 import org.openpnp.gui.support.MutableLocationProxy;
 import org.openpnp.machine.reference.feeder.ReferencePushPullFeeder;
 import org.openpnp.machine.reference.feeder.ReferencePushPullFeeder.OcrWrongPartAction;
@@ -773,7 +774,8 @@ extends AbstractReferenceFeederConfigurationWizard {
                     if (report.length() == 0) {
                         report.append("No action taken.");
                     }
-                    JOptionPane.showMessageDialog(getTopLevelAncestor(), "<html>"+report+"</html>", "OCR Report", JOptionPane.INFORMATION_MESSAGE);
+                    MessageBoxes.infoBox(getTopLevelAncestor(), "OCR Report", "<html>"+report+"</html>",
+                            JOptionPane.INFORMATION_MESSAGE);
                 });
             });
         }
@@ -824,7 +826,8 @@ extends AbstractReferenceFeederConfigurationWizard {
                 if (report.length() == 0) {
                     report.append("No action taken.");
                 }
-                JOptionPane.showMessageDialog(getTopLevelAncestor(), "<html>"+report+"</html>", "OCR Report", JOptionPane.INFORMATION_MESSAGE);
+                MessageBoxes.infoBox(getTopLevelAncestor(), "OCR Report", "<html>"+report+"</html>",
+                        JOptionPane.INFORMATION_MESSAGE);
             });
         }
     };

--- a/src/main/resources/org/openpnp/translations.properties
+++ b/src/main/resources/org/openpnp/translations.properties
@@ -918,6 +918,7 @@ Menu.View.TablesLinked=Selections in Tables
 Menu.Window=Window
 Menu.Window.MultipleStyle=Multiple Window Style
 Menu.Window.Theme=Change Appearance...
+MessageBoxes.Copy=Copy
 Neoden4SignalerConfigurationWizard.Action.TestErrorSound=Test error sound
 Neoden4SignalerConfigurationWizard.Action.TestFinishedSound=Test finished sound
 Neoden4SignalerConfigurationWizard.PlaySoundOnCompletionChkBox.text=Play sound on completion?

--- a/src/main/resources/org/openpnp/translations.properties
+++ b/src/main/resources/org/openpnp/translations.properties
@@ -919,6 +919,7 @@ Menu.Window=Window
 Menu.Window.MultipleStyle=Multiple Window Style
 Menu.Window.Theme=Change Appearance...
 MessageBoxes.Copy=Copy
+MessageBoxes.CopyDone=<html><font color='blue'>The message has been copied to the clipboard</font></html>
 Neoden4SignalerConfigurationWizard.Action.TestErrorSound=Test error sound
 Neoden4SignalerConfigurationWizard.Action.TestFinishedSound=Test finished sound
 Neoden4SignalerConfigurationWizard.PlaySoundOnCompletionChkBox.text=Play sound on completion?

--- a/src/test/java/org/openpnp/gui/support/MessageBoxesTest.java
+++ b/src/test/java/org/openpnp/gui/support/MessageBoxesTest.java
@@ -14,6 +14,7 @@ import javax.swing.SwingUtilities;
 import javax.swing.UIManager;
 
 import org.junit.jupiter.api.Test;
+import org.openpnp.Translations;
 
 class MessageBoxesTest {
     @Test
@@ -24,7 +25,7 @@ class MessageBoxesTest {
             assertFalse(plain.editor.isEditable());
             assertTrue(plain.editor.isFocusable());
             assertEquals("A plain message", plain.getPlainText());
-            assertEquals(1, plain.getComponentCount());
+            assertEquals(2, plain.getComponentCount());
             assertNull(plain.copyButton.getParent());
 
             MessageBoxes.MessageContent empty =
@@ -66,9 +67,12 @@ class MessageBoxesTest {
             MessageBoxes.MessageContent content =
                     MessageBoxes.createMessageContent("<html>One<br><b>Two</b></html>", clipboard);
             content.editor.select(0, 1);
+            assertEquals(" ", content.copiedMessage.getText());
             content.copyButton.doClick();
             assertEquals(0, content.editor.getSelectionStart());
             assertEquals(1, content.editor.getSelectionEnd());
+            assertEquals(Translations.getString("MessageBoxes.CopyDone"),
+                    content.copiedMessage.getText());
         });
 
         assertEquals("One\nTwo", clipboard.getData(DataFlavor.stringFlavor));

--- a/src/test/java/org/openpnp/gui/support/MessageBoxesTest.java
+++ b/src/test/java/org/openpnp/gui/support/MessageBoxesTest.java
@@ -1,0 +1,91 @@
+package org.openpnp.gui.support;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.awt.datatransfer.Clipboard;
+import java.awt.datatransfer.DataFlavor;
+
+import javax.swing.JButton;
+import javax.swing.JOptionPane;
+import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
+
+import org.junit.jupiter.api.Test;
+
+class MessageBoxesTest {
+    @Test
+    void createsSelectableReadOnlyEditorForPlainAndNullMessages() throws Exception {
+        SwingUtilities.invokeAndWait(() -> {
+            MessageBoxes.MessageContent plain =
+                    MessageBoxes.createMessageContent("A plain message", new Clipboard("test"));
+            assertFalse(plain.editor.isEditable());
+            assertTrue(plain.editor.isFocusable());
+            assertEquals("A plain message", plain.getPlainText());
+            assertEquals(1, plain.getComponentCount());
+            assertNull(plain.copyButton.getParent());
+
+            MessageBoxes.MessageContent empty =
+                    MessageBoxes.createMessageContent(null, new Clipboard("test"));
+            assertEquals("", empty.getPlainText());
+        });
+    }
+
+    @Test
+    void rendersMultilineAndHtmlWithoutMarkup() throws Exception {
+        SwingUtilities.invokeAndWait(() -> {
+            MessageBoxes.MessageContent multiline =
+                    MessageBoxes.createMessageContent("First\nSecond", new Clipboard("test"));
+            assertEquals("First\nSecond", multiline.getPlainText());
+
+            MessageBoxes.MessageContent html = MessageBoxes.createMessageContent(
+                    "<html><b>Bold</b><br><font color=\"red\">Red</font></html>",
+                    new Clipboard("test"));
+            assertEquals("Bold\nRed", html.getPlainText());
+        });
+    }
+
+    @Test
+    void throwableTextIsEscapedAndFallbackIncludesStackTrace() {
+        assertEquals("bad &lt;value&gt; &amp; detail",
+                MessageBoxes.prepareThrowableMessage(
+                        new IllegalArgumentException("bad <value> & detail")));
+
+        String fallback = MessageBoxes.prepareThrowableMessage(new Exception());
+        assertTrue(fallback.contains("java.lang.Exception"));
+        assertTrue(fallback.contains("MessageBoxesTest"));
+        assertEquals("No message supplied.", MessageBoxes.prepareThrowableMessage(null));
+    }
+
+    @Test
+    void copyButtonCopiesCompleteRenderedText() throws Exception {
+        Clipboard clipboard = new Clipboard("test");
+        SwingUtilities.invokeAndWait(() -> {
+            MessageBoxes.MessageContent content =
+                    MessageBoxes.createMessageContent("<html>One<br><b>Two</b></html>", clipboard);
+            content.editor.select(0, 1);
+            content.copyButton.doClick();
+            assertEquals(0, content.editor.getSelectionStart());
+            assertEquals(1, content.editor.getSelectionEnd());
+        });
+
+        assertEquals("One\nTwo", clipboard.getData(DataFlavor.stringFlavor));
+    }
+
+    @Test
+    void standardOptionButtonsPreserveLookAndFeelTextAndKeyboardMnemonic() throws Exception {
+        SwingUtilities.invokeAndWait(() -> {
+            JOptionPane optionPane = new JOptionPane();
+            JButton okButton = MessageBoxes.createOptionButton(optionPane,
+                    "OptionPane.okButtonText", "OptionPane.okButtonMnemonic",
+                    JOptionPane.OK_OPTION);
+
+            assertEquals(UIManager.getString("OptionPane.okButtonText"), okButton.getText());
+            assertEquals(UIManager.getInt("OptionPane.okButtonMnemonic"), okButton.getMnemonic());
+            okButton.doClick();
+            assertEquals(JOptionPane.OK_OPTION, optionPane.getValue());
+        });
+    }
+}


### PR DESCRIPTION
# Description

OpenPnP message, error, confirmation, and retry dialogs now render their content in a read-only, focusable editor and provide a localized **Copy** action beside the standard dialog controls. Copy places the complete rendered message on the clipboard without closing the dialog, preserving explicit line breaks and stripping HTML markup.

The shared `MessageBoxes` implementation is also used for configuration-save errors, the G-code console machine-disabled notice, OpenSCAD extraction feedback, and push-pull feeder OCR reports. Standard affirmative and negative controls retain their platform look-and-feel text, default-button behavior, and keyboard mnemonics.

# Justification

Diagnostic and configuration messages often contain paths, machine state, or exception details that users need to paste into support reports. Previously these dialogs were difficult or impossible to copy reliably. This benefits all desktop users and centralizes the behavior in the existing `MessageBoxes` helper rather than duplicating clipboard handling at individual call sites.

# Instructions for Use

1. Open any message dialog implemented through `MessageBoxes`.
2. Select message text directly if only part of it is needed, or activate **Copy** to copy the complete message.
3. Paste the plain text into a support report, editor, or other application.
4. The dialog remains open after copying; close it with its normal OK, Cancel, Yes, or No control.

# Implementation Details

1. Added a shared read-only `JEditorPane` message component and localized, non-closing Copy action. Clipboard text is derived from the rendered Swing HTML document so markup is omitted and explicit line breaks are retained.
2. Reused the existing `MessageBoxes` entry points and migrated four direct `JOptionPane` call sites to that shared implementation.
3. Preserved standard option text, keyboard mnemonics, default-button behavior, and `JOptionPane` result values while placing Copy in the same action row.
4. Added focused `MessageBoxesTest` coverage for plain and null content, multiline and HTML rendering, throwable escaping and fallback text, selection preservation, clipboard output, localized option text, keyboard mnemonics, and result mapping.
5. Ran the complete project test lifecycle with `mvn -q -B test`: 258 tests passed with zero failures and zero errors. This lifecycle also runs Checkstyle and compilation.
6. Followed the project coding style and kept the diff limited to the feature.
7. No changes were made in `org.openpnp.spi` or `org.openpnp.model`.