### PR TITLE
Add "Identify" button to Photon feeder info page

### DIFF
--- a/src/main/java/org/openpnp/machine/photon/PhotonFeeder.java
+++ b/src/main/java/org/openpnp/machine/photon/PhotonFeeder.java
@@ -200,6 +200,33 @@ public class PhotonFeeder extends ReferenceFeeder {
         findSlotAddress(false);
     }
 
+    public void identifyFeeder() throws Exception {
+        for (int i = 0; i <= photonProperties.getFeederCommunicationMaxRetry(); i++) {
+            findSlotAddressIfNeeded();
+            initializeIfNeeded();
+
+            if (!initialized) {
+                continue;
+            }
+
+            verifyFeederLocationIsFullyConfigured();
+
+            IdentifyFeeder identifyFeeder = new IdentifyFeeder(hardwareId);
+            IdentifyFeeder.Response response = identifyFeeder.send(photonBus);
+
+            if (response == null) {
+                continue; // Timeout. retry after delay.
+            }
+
+            if (response.error == ErrorTypes.NONE) {
+                return;
+            } else {
+                Logger.error("{}: Could not identify feeder: {}", getSlotAddress(), response.error.name());
+                return;
+            }
+        }
+    }
+
     public void initializeIfNeeded() throws Exception {
         if (initialized || slotAddress == null) {
             return;

--- a/src/main/java/org/openpnp/machine/photon/sheets/gui/FeederConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/photon/sheets/gui/FeederConfigurationWizard.java
@@ -75,6 +75,8 @@ public class FeederConfigurationWizard extends AbstractConfigurationWizard {
 				FormSpecs.RELATED_GAP_COLSPEC,
 				FormSpecs.BUTTON_COLSPEC,
 				FormSpecs.RELATED_GAP_COLSPEC,
+				FormSpecs.BUTTON_COLSPEC,
+				FormSpecs.RELATED_GAP_COLSPEC,
 				FormSpecs.PREF_COLSPEC,
 				FormSpecs.RELATED_GAP_COLSPEC,},
 			new RowSpec[] {
@@ -97,6 +99,9 @@ public class FeederConfigurationWizard extends AbstractConfigurationWizard {
 
 		JButton findButton = new JButton(findSlotAddressAction);
 		infoPanel.add(findButton, "6, 4"); //$NON-NLS-1$
+
+		JButton identifyButton = new JButton(identifyFeederAction);
+		infoPanel.add(identifyButton, "8, 4"); //$NON-NLS-1$
 		
 		JPanel partPanel = new JPanel();
 		partPanel.setBorder(new TitledBorder(null, Translations.getString("FeederConfigurationWizard.PartPanel.Border.title"), TitledBorder.LEADING, TitledBorder.TOP, null, new Color(0, 0, 0))); //$NON-NLS-1$
@@ -274,6 +279,7 @@ public class FeederConfigurationWizard extends AbstractConfigurationWizard {
 
 		addWrappedBinding(feeder, "hardwareId", hardwareIdValue, "text"); //$NON-NLS-1$ //$NON-NLS-2$
 		bind(UpdateStrategy.READ, slotProxy, "slotAddress", slotAddressValue, "text"); //$NON-NLS-1$ //$NON-NLS-2$
+		bind(UpdateStrategy.READ, slotProxy, "enabled", identifyFeederAction, "enabled"); //$NON-NLS-1$ //$NON-NLS-2$
 
 		addWrappedBinding(feeder, "part", partCb, "selectedItem"); //$NON-NLS-1$ //$NON-NLS-2$
 		addWrappedBinding(feeder, "partPitch", partPitchTf, "text", intConverter); //$NON-NLS-1$ //$NON-NLS-2$
@@ -317,6 +323,13 @@ public class FeederConfigurationWizard extends AbstractConfigurationWizard {
 		@Override
 		public void actionPerformed(ActionEvent e) {
 			UiUtils.submitUiMachineTask(feeder::findSlotAddress);
+		}
+	};
+
+	private final Action identifyFeederAction = new AbstractAction(Translations.getString("FeederConfigurationWizard.IdentifyFeederAction.Name")) { //$NON-NLS-1$
+		@Override
+		public void actionPerformed(ActionEvent e) {
+			UiUtils.submitUiMachineTask(feeder::identifyFeeder);
 		}
 	};
 

--- a/src/main/resources/org/openpnp/translations.properties
+++ b/src/main/resources/org/openpnp/translations.properties
@@ -381,6 +381,7 @@ ExistingBoardOrPanelDialog.boardOrPanel.Panel=panel
 FeederConfigurationWizard.FeedAction.Name=Feed
 FeederConfigurationWizard.FeedOneMmAction.Name=Feed 1mm
 FeederConfigurationWizard.FindSlotAddressAction.Name=Find
+FeederConfigurationWizard.IdentifyFeederAction.Name=Identify
 FeederConfigurationWizard.InfoPanel.Border.title=Info
 FeederConfigurationWizard.InfoPanel.hardwareIdLabel.text=Hardware ID\: 
 FeederConfigurationWizard.InfoPanel.slotAddressLabel.text=Slot Address\:


### PR DESCRIPTION
# Description

This change adds support for the "Identify" command provided by the LumenPnP's Photon feeders to the OpenPnP UI.  This command causes an indicator LED on the feeder itself to blink, as a way of informing the user which feeder they have selected.

The command is already implemented in the feeder firmware and in the OpenPnP protocol code for Photon feeders. It was just never hooked up to the UI, so there is no way for a user to trigger it.

# Justification

This change makes it easier for users to identify a specific feeder on their machine when they have its entry selected in the OpenPnP UI.

# Instructions for Use

1. Connect to a LumenPnP machine
2. Click on the "Feeders" tab
3. Click on a feeder entry
4. If necessary, click the "Find" button (or go to the "Global Config") page and click "Search") to make sure the feeder has been detected.
5. Click the "Identify" button in the feeder's Info panel
6. Observe the indicator LED on top of the feeder blink in response

This is documentation for a user, not for a developer.

# Implementation Details

1. Added a button to `FeederConfigurationWizard` to trigger the "Identify" command, and added wrapper code to `PhotonFeeder` to invoke this command.  The actual command object was already there.
2. Coding style is the same as all the surrounding code, which should match the official project style.
3. Tested the implementation on my LumenPnP/PhotonFeeder setup.  This is a simple one-way command, with no obvious place to add it into the unit tests on top of what was already there.
4. `mvn test` passes, but nothing it runs has been updated.

It is potentially an open question as to whether there are obvious unit tests to add or changes in error handling/reporting for this command.  However, it is a very simple convenience feature that simply sends a one-way command for which the primary output is a blinking LED on the feeder.
