### PR TITLE
Feeder table row should refresh when the feeder name changes

### DIFF
--- a/src/main/java/org/openpnp/gui/tablemodel/FeedersTableModel.java
+++ b/src/main/java/org/openpnp/gui/tablemodel/FeedersTableModel.java
@@ -24,6 +24,7 @@ import java.util.List;
 
 import org.openpnp.ConfigurationListener;
 import org.openpnp.Translations;
+import org.openpnp.model.AbstractModelObject;
 import org.openpnp.model.Configuration;
 import org.openpnp.model.Part;
 import org.openpnp.spi.Feeder;
@@ -60,6 +61,11 @@ public class FeedersTableModel extends AbstractObjectTableModel {
     public void refresh() {
         feeders = new ArrayList<>(configuration.getMachine().getFeeders());
         for (Feeder f : feeders) {
+            if (f instanceof AbstractModelObject) {
+                ((AbstractModelObject)f).addPropertyChangeListener("name",  event-> {
+                    fireTableRowsUpdated(0, feeders.size()-1);
+                });
+            }
             if ((f instanceof ReferenceFeeder) && ((ReferenceFeeder)f).supportsFeedOptions()) {
                 ((ReferenceFeeder)f).addPropertyChangeListener("feedOptions",  event-> {
                     fireTableRowsUpdated(0, feeders.size()-1);


### PR DESCRIPTION
# Description
Some feeders can change their name property as part of their operation. The table model should listen for this name change, and automatically update the corresponding row in the feeders table. Otherwise, the row won't refresh until the user explicitly clicks around the table area.

# Justification
This change is basic GUI fit and finish.

When the user performs an action that is expected to change the feeder's name string, and the UI does not automatically update, it is easy to think that this action did not work correctly for some reason.  Currently, the only way to force this refresh is to follow up this action by further interaction with the UI to force a refresh (e.g. by clicking on the table).

The most obvious case for encountering this issue is doing a "Find" or "Search" for Photon feeders on a LumenPnP.
Right now, after performing the scan, the feeder table does not refresh to show the detected slots.  This can easily make a new user think that the scan did not work correctly.  With this change, the slot numbers in the feeder name fields now update as the feeders are found.

There are some other feeder types that are also able to update their names, so this should be a generally helpful addition.

# Instructions for Use
This is not a new feature, but rather simple UI update polish.  As such, there aren't any specific instructions for use.

# Implementation Details
1. Tested the change on my LumenPnP / PhotonFeeder setup, by doing "Find" and "Search" actions and observing the table actually updating.
2. Followed style of surrounding code, and the change itself is rather simple.
3. This change is simply having the `FeedersTableModel` add a listener for the "name" property for any feeder object that implements `AbstractModelObject`.  This listener then calls the method that notifies of a table row update.  It is similar to how the "feedOptions" field updates are handled, but done in the most general way.
4. There do not appear to be unit tests covering GUI components such as this, so none have been added.
