### PR TITLE
Fix unwritable sniffle dwell time binding

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/ContactProbeNozzle.java
+++ b/src/main/java/org/openpnp/machine/reference/ContactProbeNozzle.java
@@ -437,7 +437,7 @@ public class ContactProbeNozzle extends ReferenceNozzle {
         this.sniffleIncrementZ = sniffleIncrementZ;
     }
 
-    public long getSniffleDwellTime() {
+    public int getSniffleDwellTime() {
         return sniffleDwellTime;
     }
 

--- a/src/main/java/org/openpnp/machine/reference/wizards/ContactProbeNozzleWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/wizards/ContactProbeNozzleWizard.java
@@ -40,8 +40,8 @@ import org.openpnp.gui.support.AbstractConfigurationWizard;
 import org.openpnp.gui.support.ActuatorsComboBoxModel;
 import org.openpnp.gui.support.DoubleConverter;
 import org.openpnp.gui.support.Icons;
+import org.openpnp.gui.support.IntegerConverter;
 import org.openpnp.gui.support.LengthConverter;
-import org.openpnp.gui.support.LongConverter;
 import org.openpnp.gui.support.NamedConverter;
 import org.openpnp.machine.reference.ContactProbeNozzle;
 import org.openpnp.machine.reference.ContactProbeNozzle.ContactProbeMethod;
@@ -243,7 +243,7 @@ public class ContactProbeNozzleWizard extends AbstractConfigurationWizard {
     @Override
     public void createBindings() {
         LengthConverter lengthConverter = new LengthConverter();
-        LongConverter longConverter = new LongConverter();
+        IntegerConverter integerConverter = new IntegerConverter();
         DoubleConverter doubleConverter = new DoubleConverter(Configuration.get().getLengthDisplayFormat());
         NamedConverter<Actuator> actuatorConverter = (new NamedConverter<>(nozzle.getHead().getActuators()));
 
@@ -254,7 +254,7 @@ public class ContactProbeNozzleWizard extends AbstractConfigurationWizard {
         addWrappedBinding(nozzle, "contactProbeDepthZ", contactProbeDepthZ, "text", lengthConverter);
         addWrappedBinding(nozzle, "contactProbeSpeed", contactProbeSpeed, "text", doubleConverter);
         addWrappedBinding(nozzle, "sniffleIncrementZ", sniffleIncrementZ, "text", lengthConverter);
-        addWrappedBinding(nozzle, "sniffleDwellTime", sniffleDwellTime, "text", longConverter);
+        addWrappedBinding(nozzle, "sniffleDwellTime", sniffleDwellTime, "text", integerConverter);
         addWrappedBinding(nozzle, "contactProbeAdjustZ", contactProbeAdjustZ, "text", lengthConverter);
 
         addWrappedBinding(nozzle, "feederHeightProbing", feederHeightProbing, "selectedItem");


### PR DESCRIPTION
# Description

Fixes #1944.

`ContactProbeNozzle` stores `sniffleDwellTime` as an `int`, and its setter accepts an `int`, but its getter returned a `long`. This accessor type mismatch caused JavaBeans to expose `sniffleDwellTime` as a read-only property.

When the Contact Probe wizard attempted to save its wrapped bindings, saving `sniffleDwellTime` threw:

```text
java.lang.UnsupportedOperationException: Unwritable
```

This stopped the remaining bindings from being saved, including `contactProbeAdjustZ` ("Final Adjustment"). The same exception also occurred when using "Calibrate now", because that action applies the wizard settings before submitting the calibration task.

This change:

- Changes `getSniffleDwellTime()` to return `int`, matching the backing field and setter.
- Changes the wizard binding from `LongConverter` to `IntegerConverter`.

# Justification

This bug can affect any user configuring a `ContactProbeNozzle` ; It is not specific to one machine or configuration.

The change restores a valid writable JavaBean property and allows all Contact Probe settings, including "Final Adjustment", to be applied normally. It also prevents "Calibrate now" from failing before the calibration task is submitted.

# Instructions for Use

No new feature in this request.

1. Open the Contact Probe configuration for a contact-probing nozzle.
2. Change "Sniffle Dwell Time", "Final Adjustment", or another Contact Probe setting.
3. Click "Apply", or use "Calibrate now".
4. The settings should now be applied without an `UnsupportedOperationException`.

# Implementation Details
1. How did you test the change? Be descriptive. Untested code will not be accepted.

- Reproduced the original issue on commit `5bd404c` using the `ContactProbeNozzleWizard` binding path.
- Verified that clicking "Apply" and using "Calibrate now" previously threw `UnsupportedOperationException: Unwritable` and left the model unchanged.
- With this change, "Apply" completes successfully, `sniffleDwellTime` and `contactProbeAdjustZ` are updated and serialized, and "Calibrate now" proceeds past Apply and submits the machine task without the binding exception.
- Ran the complete Maven test suite:
```text
Tests run: 254, Failures: 0, Errors: 0, Skipped: 0
```

2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)?

Yes, the existing coding style was followed, and Maven Checkstyle passed.

3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing.

No. This pull request does not change any files in `org.openpnp.spi` or `org.openpnp.model`.

4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted.

Yes. `mvn -q -B test` completed successfully.