### PR TITLE
Flatlaf update

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -212,17 +212,17 @@
 		<dependency>
 			<groupId>com.formdev</groupId>
 			<artifactId>flatlaf</artifactId>
-			<version>1.0</version>
+			<version>3.7.2</version>
 		</dependency>
 		<dependency>
 			<groupId>com.formdev</groupId>
 			<artifactId>flatlaf-extras</artifactId>
-			<version>1.0</version>
+			<version>3.7.2</version>
 		</dependency>
 		<dependency>
 			<groupId>com.formdev</groupId>
 			<artifactId>svgSalamander</artifactId>
-			<version>1.1.2.4</version>
+			<version>1.1.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.mockito</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -221,6 +221,11 @@
 		</dependency>
 		<dependency>
 			<groupId>com.formdev</groupId>
+			<artifactId>flatlaf-intellij-themes</artifactId>
+			<version>3.7.2</version>
+		</dependency>
+		<dependency>
+			<groupId>com.formdev</groupId>
 			<artifactId>svgSalamander</artifactId>
 			<version>1.1.4</version>
 		</dependency>

--- a/src/main/java/org/openpnp/gui/components/ThemeSettingsPanel.java
+++ b/src/main/java/org/openpnp/gui/components/ThemeSettingsPanel.java
@@ -42,6 +42,8 @@ import com.formdev.flatlaf.FlatLightLaf;
 import com.formdev.flatlaf.FlatPropertiesLaf;
 import com.formdev.flatlaf.IntelliJTheme;
 import com.formdev.flatlaf.extras.FlatAnimatedLafChange;
+import com.formdev.flatlaf.themes.FlatMacLightLaf;
+import com.formdev.flatlaf.themes.FlatMacDarkLaf;
 import com.formdev.flatlaf.util.StringUtils;
 
 public class ThemeSettingsPanel extends JPanel {
@@ -263,7 +265,9 @@ public class ThemeSettingsPanel extends JPanel {
         themes.add(new ThemeInfo("Dark", null, true, null, FlatDarkLaf.class.getName()));
         themes.add(new ThemeInfo("IntelliJ Light", null, false, null, FlatIntelliJLaf.class.getName()));
         themes.add(new ThemeInfo("Darcula", null, true, null, FlatDarculaLaf.class.getName()));
-
+        themes.add(new ThemeInfo("macOS Light", null, false, null, FlatMacLightLaf.class.getName()));
+        themes.add(new ThemeInfo("macOS Dark", null, true, null, FlatMacDarkLaf.class.getName()));
+        
         File themesDirectory = new File(Configuration.get().getConfigurationDirectory(), "themes");
         if (!themesDirectory.exists() || !themesDirectory.isDirectory()) {
             themesDirectory.mkdirs();

--- a/src/main/java/org/openpnp/gui/components/ThemeSettingsPanel.java
+++ b/src/main/java/org/openpnp/gui/components/ThemeSettingsPanel.java
@@ -42,6 +42,8 @@ import com.formdev.flatlaf.FlatLightLaf;
 import com.formdev.flatlaf.FlatPropertiesLaf;
 import com.formdev.flatlaf.IntelliJTheme;
 import com.formdev.flatlaf.extras.FlatAnimatedLafChange;
+import com.formdev.flatlaf.intellijthemes.FlatAllIJThemes;
+import com.formdev.flatlaf.intellijthemes.FlatAllIJThemes.FlatIJLookAndFeelInfo;
 import com.formdev.flatlaf.themes.FlatMacLightLaf;
 import com.formdev.flatlaf.themes.FlatMacDarkLaf;
 import com.formdev.flatlaf.util.StringUtils;
@@ -267,6 +269,11 @@ public class ThemeSettingsPanel extends JPanel {
         themes.add(new ThemeInfo("Darcula", null, true, null, FlatDarculaLaf.class.getName()));
         themes.add(new ThemeInfo("macOS Light", null, false, null, FlatMacLightLaf.class.getName()));
         themes.add(new ThemeInfo("macOS Dark", null, true, null, FlatMacDarkLaf.class.getName()));
+        
+        themes.add(new ThemeInfo(Translations.getString("Theme.Section.IntelliJ"), null, false, null, null)); //$NON-NLS-1$
+        for (FlatIJLookAndFeelInfo info : FlatAllIJThemes.INFOS) {
+        	themes.add(new ThemeInfo(info.getName(), null, info.isDark(), null, info.getClassName()));
+        }        
         
         File themesDirectory = new File(Configuration.get().getConfigurationDirectory(), "themes");
         if (!themesDirectory.exists() || !themesDirectory.isDirectory()) {

--- a/src/main/resources/org/openpnp/translations.properties
+++ b/src/main/resources/org/openpnp/translations.properties
@@ -1950,6 +1950,7 @@ Theme.FontSize.Default=Default
 Theme.Save=Save
 Theme.Section.Extra=Extra Themes
 Theme.Section.FontSize=Font Size
+Theme.Section.IntelliJ=IntelliJ Themes
 Theme.Section.System=System Themes
 Theme.Section.Theme=Theme
 Theme.Section.User=User Themes


### PR DESCRIPTION
# Description
This updates the FlatLaf library, and associated modules, to their latest versions. It also adds additional themes that were added in recent versions of FlatLaf as well as the extra IntelliJ themes pack provided by that project.

# Justification
OpenPnP currently uses a very old version of FlatLaf.  Since then, the upstream project has made various minor cosmetic improvements to there themes (such as fixing the visibility of table header dividers), and also added several additional themes.

# Instructions for Use
Simply rebuild OpenPnP and notice new options in the Appearance Settings dialog.

# Implementation Details
1. Change as been tested on local machine, but I encourage others to give it a try.
2. This was a few minor updates to `pom.xml` and a few additional lines in `ThemesSettingsPanel`.  Fortunately, the upstream project provided a built-in list of IntelliJ themes so that was a relatively easy addition.
3. This change has been split into 3 separate commits, making it easier to separate the various elements of it if the project maintainers don't want to pick up all of it.