### PR TITLE
Add feeder firmware version query for Photon feeders

### DIFF
--- a/src/main/java/org/openpnp/machine/photon/PhotonFeeder.java
+++ b/src/main/java/org/openpnp/machine/photon/PhotonFeeder.java
@@ -41,6 +41,8 @@ public class PhotonFeeder extends ReferenceFeeder {
 
     protected Integer slotAddress = null;
 
+    protected String firmwareVersion = null;
+    
     @Attribute(required = false)
     protected int partPitch = 4;
 
@@ -227,6 +229,62 @@ public class PhotonFeeder extends ReferenceFeeder {
         }
     }
 
+    public void queryFirmwareVersion() throws Exception {
+        findSlotAddressIfNeeded();
+        initializeIfNeeded();
+
+        if (!initialized) {
+            return;
+        }
+
+        StringBuilder builder = new StringBuilder();
+        boolean complete = false;
+
+        // Loop through each byte of the version string and query it
+        for (int i = 0; i <= 0x0F; i++) {
+            for (int j = 0; j <= photonProperties.getFeederCommunicationMaxRetry(); j++) {
+                VendorOptions vendorOptions = new VendorOptions(getSlotAddress(), new int[] { i });
+                VendorOptions.Response response = vendorOptions.send(photonBus);
+
+                if (response == null) {
+                    continue; // Timeout. retry after delay.
+                }
+
+                if (response.error == ErrorTypes.NONE) {
+                    if (response.data != null && response.data.length > 0) {
+                        for (int k = 0; k < response.data.length; k++) {
+                            if (response.data[k] == 0) {
+                                complete = true;
+                                break;
+                            }
+                            builder.append((char)(response.data[k] & 0xFF));
+                        }
+                    } else {
+                        complete = true;
+                    }
+                    break;
+                } else {
+                    Logger.error("{}: Could not send version command to feeder: {}", getSlotAddress(), response.error.name());
+                    return;
+                }
+            }
+            if (complete) {
+                break;
+            }
+        }
+        setFirmwareVersion(builder.toString());
+    }
+    
+    private void setFirmwareVersion(String firmwareVersion) {
+        String oldValue = this.firmwareVersion;
+        this.firmwareVersion = firmwareVersion;
+        firePropertyChange("firmwareVersion", oldValue, firmwareVersion);
+    }
+    
+    public String getFirmwareVersion() {
+        return this.firmwareVersion;
+    }
+    
     public void initializeIfNeeded() throws Exception {
         if (initialized || slotAddress == null) {
             return;
@@ -604,6 +662,8 @@ public class PhotonFeeder extends ReferenceFeeder {
                 otherFeeder.setSlotAddress(address);
 
                 Logger.trace("Found feeder with hardware uuid " + otherFeeder.getHardwareId() + " at address " + otherFeeder.getSlotAddress());
+                
+                otherFeeder.queryFirmwareVersion();
             }
         }
 

--- a/src/main/java/org/openpnp/machine/photon/protocol/PacketBuilder.java
+++ b/src/main/java/org/openpnp/machine/photon/protocol/PacketBuilder.java
@@ -43,6 +43,13 @@ public class PacketBuilder {
         return this;
     }
 
+    public PacketBuilder putArray(int[] data) {
+    	for (int element : data) {
+    		payloadBuffer.put(element & 0xFF);
+    	}
+    	return this;
+    }
+    
     public PacketBuilder putUint16(int data) {
         payloadBuffer.put((data >> 8) & 0xFF);
         payloadBuffer.put(data & 0xFF);

--- a/src/main/java/org/openpnp/machine/photon/protocol/commands/VendorOptions.java
+++ b/src/main/java/org/openpnp/machine/photon/protocol/commands/VendorOptions.java
@@ -1,0 +1,59 @@
+package org.openpnp.machine.photon.protocol.commands;
+
+import java.util.Arrays;
+
+import org.openpnp.machine.photon.protocol.Command;
+import org.openpnp.machine.photon.protocol.ErrorTypes;
+import org.openpnp.machine.photon.protocol.Packet;
+import org.openpnp.machine.photon.protocol.PacketBuilder;
+
+public class VendorOptions extends Command<VendorOptions.Response> {
+    public static final int COMMAND_ID = 0xBF;
+    private final int toAddress;
+    private final int[] options;
+
+    public VendorOptions(int toAddress, int[] options) {
+        this.toAddress = toAddress;
+        this.options = options;
+    }
+
+    @Override
+    public Packet toPacket() {
+        return PacketBuilder.command(COMMAND_ID, toAddress)
+                .putArray(options)
+                .toPacket();
+    }
+
+    @Override
+    protected Response decodePacket(Packet responsePacket) {
+        return new Response(responsePacket);
+    }
+
+    public static class Response {
+        public final boolean valid;
+        public final int toAddress;
+        public final int fromAddress;
+        public final int[] data;
+        public final ErrorTypes error;
+
+        public Response(Packet packet) {
+            toAddress = packet.toAddress;
+            fromAddress = packet.fromAddress;
+
+            if (packet.payloadLength > 1) {
+                data = Arrays.copyOfRange(packet.payload, 1, packet.payloadLength - 1);
+            } else {
+                data = null;
+                if(packet.payloadLength < 1) {
+                    valid = false;
+                    error = null;
+                    return;
+                }
+            }
+
+            valid = true;
+
+            error = ErrorTypes.fromId(packet.payload[0]);
+        }
+    }
+}

--- a/src/main/java/org/openpnp/machine/photon/sheets/gui/FeederConfigurationWizard.java
+++ b/src/main/java/org/openpnp/machine/photon/sheets/gui/FeederConfigurationWizard.java
@@ -30,6 +30,7 @@ import org.openpnp.machine.photon.PhotonFeeder;
 import org.openpnp.model.Configuration;
 import org.openpnp.model.Part;
 import org.openpnp.util.UiUtils;
+import org.openpnp.util.UiUtils.Thrunnable;
 
 import com.jgoodies.forms.layout.ColumnSpec;
 import com.jgoodies.forms.layout.FormLayout;
@@ -41,6 +42,7 @@ public class FeederConfigurationWizard extends AbstractConfigurationWizard {
 	
 	private final JLabel hardwareIdValue;
 	private final JLabel slotAddressValue;
+	private final JLabel firmwareVersionValue;
 	private final JComboBox partCb;
 	private final JTextField partPitchTf;
 	private final JTextField feedRetryCountTf;
@@ -82,6 +84,8 @@ public class FeederConfigurationWizard extends AbstractConfigurationWizard {
 			new RowSpec[] {
 				FormSpecs.RELATED_GAP_ROWSPEC,
 				FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+                FormSpecs.DEFAULT_ROWSPEC,
 				FormSpecs.RELATED_GAP_ROWSPEC,
 				FormSpecs.DEFAULT_ROWSPEC,}));
 		
@@ -102,6 +106,12 @@ public class FeederConfigurationWizard extends AbstractConfigurationWizard {
 
 		JButton identifyButton = new JButton(identifyFeederAction);
 		infoPanel.add(identifyButton, "8, 4"); //$NON-NLS-1$
+
+		JLabel firmwareVersionLabel = new JLabel(Translations.getString("FeederConfigurationWizard.InfoPanel.firmwareVersionLabel.text")); //$NON-NLS-1$
+        infoPanel.add(firmwareVersionLabel, "2, 6, left, center"); //$NON-NLS-1$
+        
+        firmwareVersionValue = new JLabel(""); //$NON-NLS-1$
+        infoPanel.add(firmwareVersionValue, "4, 6, 5, 1, left, center"); //$NON-NLS-1$
 		
 		JPanel partPanel = new JPanel();
 		partPanel.setBorder(new TitledBorder(null, Translations.getString("FeederConfigurationWizard.PartPanel.Border.title"), TitledBorder.LEADING, TitledBorder.TOP, null, new Color(0, 0, 0))); //$NON-NLS-1$
@@ -280,6 +290,7 @@ public class FeederConfigurationWizard extends AbstractConfigurationWizard {
 		addWrappedBinding(feeder, "hardwareId", hardwareIdValue, "text"); //$NON-NLS-1$ //$NON-NLS-2$
 		bind(UpdateStrategy.READ, slotProxy, "slotAddress", slotAddressValue, "text"); //$NON-NLS-1$ //$NON-NLS-2$
 		bind(UpdateStrategy.READ, slotProxy, "enabled", identifyFeederAction, "enabled"); //$NON-NLS-1$ //$NON-NLS-2$
+		addWrappedBinding(feeder, "firmwareVersion", firmwareVersionValue, "text"); //$NON-NLS-1$ //$NON-NLS-2$
 
 		addWrappedBinding(feeder, "part", partCb, "selectedItem"); //$NON-NLS-1$ //$NON-NLS-2$
 		addWrappedBinding(feeder, "partPitch", partPitchTf, "text", intConverter); //$NON-NLS-1$ //$NON-NLS-2$
@@ -322,7 +333,12 @@ public class FeederConfigurationWizard extends AbstractConfigurationWizard {
 	private final Action findSlotAddressAction = new AbstractAction(Translations.getString("FeederConfigurationWizard.FindSlotAddressAction.Name")) { //$NON-NLS-1$
 		@Override
 		public void actionPerformed(ActionEvent e) {
-			UiUtils.submitUiMachineTask(feeder::findSlotAddress);
+		    UiUtils.submitUiMachineTask(new Thrunnable() {
+                public void thrun() throws Exception {
+                    feeder.findSlotAddress();
+                    feeder.queryFirmwareVersion();
+                }
+            });
 		}
 	};
 

--- a/src/main/resources/org/openpnp/translations.properties
+++ b/src/main/resources/org/openpnp/translations.properties
@@ -383,6 +383,7 @@ FeederConfigurationWizard.FeedOneMmAction.Name=Feed 1mm
 FeederConfigurationWizard.FindSlotAddressAction.Name=Find
 FeederConfigurationWizard.IdentifyFeederAction.Name=Identify
 FeederConfigurationWizard.InfoPanel.Border.title=Info
+FeederConfigurationWizard.InfoPanel.firmwareVersionLabel.text=Firmware Version\:
 FeederConfigurationWizard.InfoPanel.hardwareIdLabel.text=Hardware ID\: 
 FeederConfigurationWizard.InfoPanel.slotAddressLabel.text=Slot Address\:
 FeederConfigurationWizard.LocationPanel.Border.title=Location

--- a/src/test/java/org/openpnp/machine/photon/PhotonFeederTest.java
+++ b/src/test/java/org/openpnp/machine/photon/PhotonFeederTest.java
@@ -19,6 +19,7 @@ import org.openpnp.spi.Actuator;
 import org.openpnp.spi.Machine;
 import org.openpnp.spi.Nozzle;
 import org.openpnp.spi.PropertySheetHolder;
+import org.pmw.tinylog.Logger;
 
 import java.io.File;
 import java.util.*;
@@ -29,6 +30,8 @@ import static org.mockito.Mockito.*;
 public class PhotonFeederTest {
     private final String hardwareId = "00112233445566778899AABB";
     private final int feederAddress = 5;
+    private final int[] firmwareVersionBytes = new int[] { 'v', '1', '.', '0', '.', '0', 0, 0 };
+    private final String firmwareVersionString = "v1.0.0";
 
     private PhotonFeeder feeder;
 
@@ -994,6 +997,10 @@ public class PhotonFeederTest {
             uuids.put(address, uuid);
             bus.when(new GetFeederId(address))
                     .reply(responses.getFeederId.ok(address, uuid));
+            bus.when(new InitializeFeeder(address, uuid))
+                    .reply(responses.initializeFeeder.ok(address, uuid));
+            bus.when(new VendorOptions(address, new int[] { 0x00 }))
+                    .reply(responses.vendorOptions.ok(address, firmwareVersionBytes));
         }
 
         PhotonFeeder.findAllFeeders(null);
@@ -1008,6 +1015,7 @@ public class PhotonFeederTest {
             assertSame(byUUID, byAddress);
             assertEquals(address, byUUID.getSlotAddress());
             assertEquals(expectedUUID, byAddress.getHardwareId());
+            assertEquals(firmwareVersionString, byAddress.getFirmwareVersion());
         }
 
         bus.verifyInMockedOrder();
@@ -1032,8 +1040,20 @@ public class PhotonFeederTest {
         bus.when(new GetFeederId(1))
                 .reply(responses.getFeederId.ok(1, newHardwareUuid));
 
+        bus.when(new InitializeFeeder(1, newHardwareUuid))
+                .reply(responses.initializeFeeder.ok(1, newHardwareUuid));
+        
+        bus.when(new VendorOptions(1, new int[] { 0x00 }))
+                .reply(responses.vendorOptions.ok(1, firmwareVersionBytes));
+
         bus.when(new GetFeederId(2))
                 .reply(responses.getFeederId.ok(2, hardwareId));
+
+        bus.when(new InitializeFeeder(2, hardwareId))
+                .reply(responses.initializeFeeder.ok(2, hardwareId));
+        
+        bus.when(new VendorOptions(2, new int[] { 0x00 }))
+                .reply(responses.vendorOptions.ok(2, firmwareVersionBytes));
 
         for (int i = 3; i <= maxFeederAddress; i++) {
             bus.when(new GetFeederId(i)).timeout();
@@ -1074,9 +1094,21 @@ public class PhotonFeederTest {
 
         bus.when(new GetFeederId(1))
                 .reply(responses.getFeederId.ok(1, hardwareId));
+        
+        bus.when(new InitializeFeeder(1, hardwareId))
+                .reply(responses.initializeFeeder.ok(1, hardwareId));
+        
+        bus.when(new VendorOptions(1, new int[] { 0x00 }))
+                .reply(responses.vendorOptions.ok(1, firmwareVersionBytes));
 
         bus.when(new GetFeederId(2))
                 .reply(responses.getFeederId.ok(2, newHardwareUuid));
+
+        bus.when(new InitializeFeeder(2, newHardwareUuid))
+                .reply(responses.initializeFeeder.ok(2, newHardwareUuid));
+        
+        bus.when(new VendorOptions(2, new int[] { 0x00 }))
+                .reply(responses.vendorOptions.ok(2, firmwareVersionBytes));
 
         PhotonFeeder.findAllFeeders(null);
 

--- a/src/test/java/org/openpnp/machine/photon/protocol/helpers/ResponsesHelper.java
+++ b/src/test/java/org/openpnp/machine/photon/protocol/helpers/ResponsesHelper.java
@@ -19,6 +19,7 @@ public class ResponsesHelper {
     public final MoveFeedStatus moveFeedStatus = new MoveFeedStatus();
     public final GetFeederAddress getFeederAddress = new GetFeederAddress();
     public final IdentifyFeeder identifyFeeder = new IdentifyFeeder();
+    public final VendorOptions vendorOptions = new VendorOptions();
     public final ProgramFeederFloor programFeederFloor = new ProgramFeederFloor();
 
     public ResponsesHelper(int toAddress) {
@@ -116,6 +117,15 @@ public class ResponsesHelper {
         public Packet ok(int feederAddress) {
             return PacketBuilder.response(toAddress, feederAddress)
                     .putOk()
+                    .toPacket();
+        }
+    }
+
+    public class VendorOptions {
+        public Packet ok(int feederAddress, int[] data) {
+            return PacketBuilder.response(toAddress, feederAddress)
+                    .putOk()
+                    .putArray(data)
                     .toPacket();
         }
     }


### PR DESCRIPTION
# Description
The Opulo Photon feeders have a command that can be used to query their firmware version, implemented in a slightly awkward way under their "vendor" command code.  This change implements that command code, and wraps it with all the necessary logic to actually do a version string query.  It then runs these commands as part of a feeder search/find, and shows them in the related feeder info panel.

# Justification
Lately Opulo has been releasing regular firmware updates for their Photon feeders as they refine their next version.  As its common to have many such feeders, some on and some off the PnP machine, it can be quite easy to lose track of what firmware versions you have installed on each.  As such, I really wanted an easy way to just query all my feeders to find out.

# Instructions for Use
The version query happens implicitly as part of the feeder search/find process, and is displayed as an additional row in each feeder's "Info" panel.

# Implementation Details
1. Added a `VendorOptions` class to wrap the "vendor" command provided by the Photon feeders
2. Added code to `PhotonFeeder` to wrap this command with the necessary setup and loops to fully tease out the Photon firmware version string.  This can take multiple commands, but in practice never takes more than one as the version string is always of reasonable length.
3. Added code to `PhotonFeeder` to run this query as part of the feeder search/find processes.
4. Updated `PhotonFeederTest` and related classes to do very rudimentary testing of this new operation, by adding mocked commands to existing unit tests that implicitly trigger it.

The unit tests pass and I've tested this change on my own LumenPnP system.

Its possible there are additional concerns with how I've implemented this, so feel free to review in case any of those are apparent.  However, I wanted to toss this out there in case it is useful to anyone else.
