### PR TITLE
Add continuous vacuum mode for contact probe nozzle sniffling

### DIFF
--- a/src/main/java/org/openpnp/machine/reference/ContactProbeNozzle.java
+++ b/src/main/java/org/openpnp/machine/reference/ContactProbeNozzle.java
@@ -80,6 +80,9 @@ public class ContactProbeNozzle extends ReferenceNozzle {
     private String contactProbeActuatorName = "";
     private boolean isDisabled; // for scripts: temporarily disable probing 
 
+    @Attribute(required=false)
+    private boolean continuousVacuum = false; 
+
     @Element(required = false)
     private Length contactProbeStartOffsetZ = new Length(1, LengthUnit.Millimeters);
 
@@ -405,6 +408,14 @@ public class ContactProbeNozzle extends ReferenceNozzle {
         isDisabled = set;
     }
 
+    public boolean isContinuousVacuum() {
+        return continuousVacuum;
+    }
+    
+    public void setContinuousVacuum(boolean continuousVacuum) {
+        this.continuousVacuum = continuousVacuum;
+    }
+    
     public Length getContactProbeStartOffsetZ() {
         return contactProbeStartOffsetZ;
     }
@@ -535,9 +546,29 @@ public class ContactProbeNozzle extends ReferenceNozzle {
                         0, 0, sniffleIncrementZ.convertToUnits(LengthUnit.Millimeters).getValue(), 0);
 
                 // Establish initially free nozzle.
-                if (!isPartOff()) {
-                    throw new Exception("Nozzle "+getName()+" first sniffle-probe was already sensing contact. Check the settings."); 
+                if (continuousVacuum) {
+                    // if the method needs it, store one measurement up front
+                    storeBeforePickVacuumLevel();
+                    
+                    // enable the vacuum
+                    actuateVacuumValve(true);
+
+                    // wait for the Dwell Time and/or make sure the vacuum level builds up to the desired range (with timeout)
+                    establishPickVacuumLevel(this.getPickDwellMilliseconds() + nozzleTip.getPickDwellMilliseconds());
+
+                    // wait for the sniffle dwell time to ensure a steady state
+                    delay(sniffleDwellTime);
+                    
+                    if (isPartOn()) {
+                        actuateVacuumValve(false);
+                        throw new Exception("Nozzle "+getName()+" first sniffle-probe was already sensing contact. Check the settings.");
+                    }
+                } else {
+                    if (!isPartOff()) {
+                        throw new Exception("Nozzle "+getName()+" first sniffle-probe was already sensing contact. Check the settings."); 
+                    }
                 }
+                
                 // We allow two times the offset, i.e. it is a +/- range we probe.   
                 int count = (int) Math.ceil(contactProbeDepthZ.divide(sniffleIncrementZ));
                 Location probedLocation = getLocation();
@@ -545,12 +576,27 @@ public class ContactProbeNozzle extends ReferenceNozzle {
                     probedLocation = probedLocation.subtract(probeIncrement);
                     moveTo(probedLocation);
                     delay(sniffleDwellTime);
-                    if (! isPartOff()) {
+                    
+                    boolean contact = false;
+                    if (continuousVacuum) {
+                        if (isPartOn()) {
+                            contact = true;
+                            actuateVacuumValve(false);
+                        }
+                    } else {
+                        if (!isPartOff()) {
+                            contact = true;
+                        }
+                    }
+                    if (contact) {
                         // We got contact.
                         probedLocation = probedLocation.add(new Location(contactProbeAdjustZ .getUnits(), 0, 0, contactProbeAdjustZ.getValue(), 0));
                         moveTo(probedLocation);
                         return probedLocation;
                     }
+                }
+                if (continuousVacuum) {
+                    actuateVacuumValve(false);
                 }
                 throw new Exception("Nozzle "+getName()+" sniffle-probing made no contact. Check the settings."); 
             }

--- a/src/main/java/org/openpnp/machine/reference/wizards/ContactProbeNozzleWizard.java
+++ b/src/main/java/org/openpnp/machine/reference/wizards/ContactProbeNozzleWizard.java
@@ -126,6 +126,13 @@ public class ContactProbeNozzleWizard extends AbstractConfigurationWizard {
         comboBoxContactProbeActuator.setMaximumRowCount(15);
         comboBoxContactProbeActuator.setModel(new ActuatorsComboBoxModel(nozzle.getHead()));
         panel.add(comboBoxContactProbeActuator, "4, 4, default, top");
+
+        lblContinuousVacuum = new JLabel("Continuous Vacuum");
+        lblContinuousVacuum.setToolTipText("<html>When enabled, the vacuum runs continuously using \"Part On\" rules to determine contact.<br/>\r\nWhen disabled, the vacuum runs in a series of bursts using \"Part Off\" rules to determine contact.</html>");
+        panel.add(lblContinuousVacuum, "2, 4, right, default");
+
+        continuousVacuum = new JCheckBox("");
+        panel.add(continuousVacuum, "4, 4");
         
         lblProbeSpeed = new JLabel("Probe Speed");
         lblProbeSpeed.setToolTipText("<html>Probing speed factor.<br/>\r\n<strong>NOTE:</strong> this setting will only become effective, once you<br/>\r\naccept the Issues & Solutions G-code suggestion.</html>");
@@ -215,6 +222,8 @@ public class ContactProbeNozzleWizard extends AbstractConfigurationWizard {
 
         lblContactProbeActuator.setVisible(isActuator);
         comboBoxContactProbeActuator.setVisible(isActuator);
+        lblContinuousVacuum.setVisible(isVacuum);
+        continuousVacuum.setVisible(isVacuum);        
         lblStartOffset.setVisible(isProbing);
         contactProbeStartOffsetZ.setVisible(isProbing);
         lblSniffleIncrement.setVisible(isVacuum);
@@ -250,6 +259,7 @@ public class ContactProbeNozzleWizard extends AbstractConfigurationWizard {
         addWrappedBinding(nozzle, "contactProbeMethod", contactProbeMethod, "selectedItem");
         addWrappedBinding(nozzle, "contactProbeActuator", comboBoxContactProbeActuator, "selectedItem", actuatorConverter);
 
+        addWrappedBinding(nozzle, "continuousVacuum", continuousVacuum, "selected");
         addWrappedBinding(nozzle, "contactProbeStartOffsetZ", contactProbeStartOffsetZ, "text", lengthConverter);
         addWrappedBinding(nozzle, "contactProbeDepthZ", contactProbeDepthZ, "text", lengthConverter);
         addWrappedBinding(nozzle, "contactProbeSpeed", contactProbeSpeed, "text", doubleConverter);
@@ -289,6 +299,8 @@ public class ContactProbeNozzleWizard extends AbstractConfigurationWizard {
     private JPanel panel;
     private JLabel lblContactProbeActuator;
     private JComboBox comboBoxContactProbeActuator;
+    private JLabel lblContinuousVacuum;
+    private JCheckBox continuousVacuum;
     private JLabel lblStartOffset;
     private JTextField contactProbeStartOffsetZ;
     private JLabel lblProbeDepth;


### PR DESCRIPTION
# Description
Adds the option to use continuous vacuum sensing when using the VacuumSense contact probing mode in [ContactProbeNozzle](https://github.com/openpnp/openpnp/wiki/Contact-Probing-Nozzle).

Currently the "sniffling" feature for vacuum-based Z detection with `ContactProbeNozzle` is based on the "`isPartOff()`" process. This does a series of independent vacuum on/sense/off cycles, which can be quite time consuming.

This change offers an additional option to use an "isPartOn()" based process where the vacuum remains running throughout the entire sniffling cycle. Doing it this way speeds up the VacuumSense probing process.

This addresses the issue noted in #1979

# Justification
Using vacuum sense based contact probing is currently a very slow process.  This is because it takes time for the vacuum pump/valve to turn on and stabilize, and it currently does this for every single sniffle increment until contact is detected.
By keeping the vacuum on continuously, it only needs to stabilize once, which makes everything go faster.

# Instructions for Use
- Configure the machine to use a `ContactProbeNozzle` (documented elsewhere)
- Make sure the "Part On Vacuum Sensing" thresholds are configured for the nozzle tips
- Configure the Contact Probing method to be "VacuumSense"
- Check the "Continuous Vacuum" checkbox, and click apply
- Do Z offset calibration as before

<img width="646" height="409" alt="contact-probe-continuous-vac" src="https://github.com/user-attachments/assets/5a9db3a4-ae9a-4f67-9ac3-b77227dc648a" />

Note: This should be followed up by additional notes on the [Contact Probing Nozzle](https://github.com/openpnp/openpnp/wiki/Contact-Probing-Nozzle) documentation page in the user manual, pointing out the additional mode as described here.

# Implementation Details
1. How did you test the change?
Tested the code on my LumenPnP, and it produced the same results as the old method.  I suggest others test it as well, as its entirely possible there are corner cases or other circumstances I did not consider.

3. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)?
Yes.  Even imported the formatting settings into my Eclipse setup.

5. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing.
Changes were only to `org.openpnp.machine.reference.ContactProbeNozzle` and `org.openpnp.machine.reference.wizards.ContactProbeNozzleWizard`

7. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted.
Done

It should also be noted that ContactProbeNozzleWizard is full of user-facing strings that are not in the translation files.  Fixing this should probably be done as a completely separate task, so I didn't touch those.